### PR TITLE
resyncing guides source with what is currently live

### DIFF
--- a/guides/v2.15.0/configuring-ember/debugging.md
+++ b/guides/v2.15.0/configuring-ember/debugging.md
@@ -133,13 +133,8 @@ Backburner has support for stitching the stacktraces together so that you can
 track down where an erroring `Ember.run.later` is being initiated from. Unfortunately,
 this is quite slow and is not appropriate for production or even normal development.
 
-To enable full stacktrace mode in Backburner, and thus determine the stack of the task
-when it was scheduled onto the run loop, you can set:
+To enable this mode you can set:
 
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
-
-Once the `DEBUG` value is set to `true`, when you are at a breakpoint you can navigate
-back up the stack to the `flush` method in and check the `errorRecordedForStack.stack`
-value, which will be the captured stack when this job was scheduled.

--- a/guides/v2.15.0/getting-started/index.md
+++ b/guides/v2.15.0/getting-started/index.md
@@ -5,7 +5,7 @@ This tool provides:
 * Modern application asset management (including concatenation, minification, and versioning).
 * Generators to help create components, routes, and more.
 * A conventional project layout, making existing Ember applications easy to approach.
-* Support for ES2015/ES6 JavaScript via the [Babel](https://babeljs.io/learn-es2015/) project. This includes support for [JavaScript modules](http://exploringjs.com/es6/ch_modules.html), which are used throughout this guide.
+* Support for ES2015/ES6 JavaScript via the [Babel](http://babeljs.io/docs/learn-es2015/) project. This includes support for [JavaScript modules](http://exploringjs.com/es6/ch_modules.html), which are used throughout this guide.
 * A complete [QUnit](https://qunitjs.com/) test harness.
 * The ability to consume a growing ecosystem of [Ember Addons](https://emberobserver.com/).
 
@@ -35,8 +35,7 @@ If you get a *"command not found"* error or an outdated version for Node:
 
 * Windows or Mac users can download and run [this Node.js installer](http://nodejs.org/en/download/).
 * Mac users often prefer to install Node using [Homebrew](http://brew.sh/). After
-installing Homebrew, run `brew install node` to install Node.js. Alternatively, installer packages are available directly
-from [Node.js](https://nodejs.org/en/download/).
+installing Homebrew, run `brew install node` to install Node.js.
 * Linux users can use [this guide for Node.js installation on Linux](https://nodejs.org/en/download/package-manager/).
 
 If you get an outdated version of npm, run `npm install -g npm`.
@@ -44,6 +43,11 @@ If you get an outdated version of npm, run `npm install -g npm`.
 ### Watchman (optional)
 
 On Mac and Linux, you can improve file watching performance by installing [Watchman](https://facebook.github.io/watchman/docs/install.html).
+
+### PhantomJS (optional)
+
+You can run your tests from the command line with PhantomJS, without the
+need for a browser to be open. Consult the [PhantomJS download instructions](http://phantomjs.org/download.html).
 
 ## Installation
 

--- a/guides/v2.15.0/getting-started/quick-start.md
+++ b/guides/v2.15.0/getting-started/quick-start.md
@@ -1,7 +1,3 @@
----
-title: Quick Start
----
-
 This guide will teach you how to build a simple app using Ember from scratch.
 
 We'll cover these steps:
@@ -52,7 +48,7 @@ Let's make sure everything is working properly.
 
 ```sh
 cd ember-quickstart
-ember serve
+ember server
 ```
 
 After a few seconds, you should see output that looks like this:
@@ -72,7 +68,7 @@ We will start by editing the `application` template.
 This template is always on screen while the user has your application loaded.
 In your editor, open `app/templates/application.hbs` and change it to the following:
 
-```app/templates/application.hbs{.line-numbers}
+```app/templates/application.hbs
 <h1>PeopleTracker</h1>
 
 {{outlet}}
@@ -90,7 +86,7 @@ To do that, the first step is to create a route.
 For now, you can think of routes as being the different pages that make up your application.
 
 Ember comes with _generators_ that automate the boilerplate code for common tasks.
-To generate a route, type this in a new terminal window in your `ember-quickstart` directory:
+To generate a route, type this in your terminal:
 
 ```sh
 ember generate route scientists

--- a/guides/v2.15.0/index.md
+++ b/guides/v2.15.0/index.md
@@ -1,6 +1,3 @@
----
-title: Guides and Tutorials
----
 Welcome to the Ember.js Guides! This documentation will take you from
 total beginner to Ember expert.
 

--- a/guides/v2.15.0/routing/loading-and-error-substates.md
+++ b/guides/v2.15.0/routing/loading-and-error-substates.md
@@ -128,27 +128,6 @@ export default Ember.Route.extend({
 });
 ```
 
-In case we want both custom logic and the default behaviour for the loading substate,
-we can implement the `loading` action and let it bubble by returning `true`.
-
-```app/routes/foo-slow-model.js
-import Ember from 'ember';
-
-export default Ember.Route.extend({
-  ...
-  actions: {
-    loading(transition) {
-      let start = new Date();
-      transition.promise.finally(() => {
-        this.get('notifier').notify(`Took ${new Date() - start}ms to load`);
-      });
-
-      return true;
-    }
-  }
-});
-```
-
 ## `error` substates
 
 Ember provides an analogous approach to `loading` substates in
@@ -226,23 +205,3 @@ export default Ember.Route.extend({
 
 Analogous to the `loading` event, you could manage the `error` event
 at the application level to avoid writing the same code for multiple routes.
-
-In case we want to run some custom logic and have the default behaviour of rendering the error template,
-we can handle the `error` event and let it bubble by returning `true`.
-
-```app/routes/articles-overview.js
-import Ember from 'ember';
-
-export default Ember.Route.extend({
-  model(params) {
-    return this.get('store').findAll('privileged-model');
-  },
-  actions: {
-    error(error) {
-      this.get('notifier').error(error);
-
-      return true;
-    }
-  }
-});
-```

--- a/guides/v2.15.0/tutorial/autocomplete-component.md
+++ b/guides/v2.15.0/tutorial/autocomplete-component.md
@@ -244,7 +244,7 @@ export default Ember.Controller.extend({
 In the `filterByCity` function in the rental controller above,
 we've added a new property called `query` to the filter results instead of just returning an array of rentals as before.
 
-```app/components/list-filter.js{-18,+9,+10,+11,+19,+20,+21,+22}
+```app/components/list-filter.js{+9,+10,+11,+19,+20,+21}
 import Ember from 'ember';
 
 export default Ember.Component.extend({
@@ -262,10 +262,9 @@ export default Ember.Component.extend({
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
-      filterAction(filterInputValue).then((filterResults) => {
-        if (filterResults.query === this.get('value')) {
-          this.set('results', filterResults.results);
+      filterAction(filterInputValue).then((resultsObj) => {
+        if (resultsObj.query === this.get('value')) {
+          this.set('results', resultsObj.results);
         }
       });
     }
@@ -397,12 +396,12 @@ import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import RSVP from 'rsvp';
 
-const ITEMS = [{city: 'San Francisco'}, {city: 'Portland'}, {city: 'Seattle'}];
-const FILTERED_ITEMS = [{city: 'San Francisco'}];
-
 moduleForComponent('list-filter', 'Integration | Component | filter listing', {
   integration: true
 });
+
+const ITEMS = [{city: 'San Francisco'}, {city: 'Portland'}, {city: 'Seattle'}];
+const FILTERED_ITEMS = [{city: 'San Francisco'}];
 
 test('should initially load all listings', function (assert) {
   // we want our actions to return promises, since they are potentially fetching data asynchronously

--- a/guides/v2.15.0/tutorial/ember-cli.md
+++ b/guides/v2.15.0/tutorial/ember-cli.md
@@ -112,7 +112,7 @@ Once we have a new project in place, we can confirm everything is working by
 starting the Ember development server:
 
 ```shell
-ember serve
+ember server
 ```
 
 or, for short:

--- a/guides/v2.15.0/tutorial/hbs-helper.md
+++ b/guides/v2.15.0/tutorial/hbs-helper.md
@@ -61,12 +61,8 @@ Instead, our default template helper is returning back our `rental.propertyType`
 Let's update our helper to look if a property exists in an array of `communityPropertyTypes`,
 if so, we'll return either `'Community'` or `'Standalone'`:
 
-```app/helpers/rental-property-type.js{-3,-4,-5,+7,+8,+9,+10,+11,+13,+14,+15,+16,+17,+18,+19}
+```app/helpers/rental-property-type.js
 import Ember from 'ember';
-
-export function rentalPropertyType(params/*, hash*/) {
-  return params;
-}
 
 const communityPropertyTypes = [
   'Condo',

--- a/guides/v2.15.0/tutorial/model-hook.md
+++ b/guides/v2.15.0/tutorial/model-hook.md
@@ -125,7 +125,7 @@ test('should list available rentals.', function (assert) {
 
 Run the tests again using the command `ember t -s`, and toggle "Hide passed tests" to show your new passing test.
 
-Now we are listing rentals, and verifying it with an acceptance test.
+Now we are listing rentals, and and verifying it with an acceptance test.
 This leaves us with 2 remaining acceptance test failures (and 1 eslint failure):
 
 ![list rentals test passing](../../images/model-hook/model-hook.png)

--- a/guides/v2.15.0/tutorial/service.md
+++ b/guides/v2.15.0/tutorial/service.md
@@ -128,7 +128,7 @@ export default Ember.Service.extend({
   },
 
   getMapElement(location) {
-    let camelizedLocation = Ember.String.camelize(location);
+    let camelizedLocation = location.camelize();
     let element = this.get(`cachedMaps.${camelizedLocation}`);
     if (!element) {
       element = this.createMapElement();


### PR DESCRIPTION
This updates guides source to be in sync with the **deployed** v2.15.0 of the guides. We can choose if we would rather not sync because some of these changes are improvements 👍 

I figured out the checkout that is currently deployed is: https://github.com/emberjs/guides/commit/b77a3027d161eca3a8fe16f96ac6f3d43dbb8f21

Also, this removes some unnecessary changes we made while testing the new guides-app.

https://github.com/ember-learn/guides-app/issues/4