### PR TITLE
fix faulty urls that were too deeply nested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules

--- a/guides/v1.10.0/application/index.md
+++ b/guides/v1.10.0/application/index.md
@@ -18,10 +18,8 @@ What does creating an `Ember.Application` instance get you?
    `App.PostsView` and `App.PostsController`). This helps to prevent
    polluting the global scope.
 2. It adds event listeners to the document and is responsible for
-   delegating events to your views. (See [The View
-   Layer](../understanding-ember/the-view-layer)
+   delegating events to your views. (See [The View Layer](../understanding-ember/the-view-layer)
   for a detailed description.)
-3. It automatically renders the [application
-   template](../templates/the-application-template).
+3. It automatically renders the [application template](../templates/the-application-template).
 4. It automatically creates a router and begins routing, choosing which
    template and model to display based on the current URL.

--- a/guides/v1.10.0/components/customizing-a-components-element.md
+++ b/guides/v1.10.0/components/customizing-a-components-element.md
@@ -162,4 +162,4 @@ red background:
 <a class="jsbin-embed" href="http://jsbin.com/duzala/1/embed?live">JS Bin</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 **Note:** The binding functionality in this very simple example could also be implemented without
-the use of `Ember.Component` but by simply [binding element attributes](../../templates/binding-element-attributes) or [binding element class names](../../templates/binding-element-class-names).
+the use of `Ember.Component` but by simply [binding element attributes](../templates/binding-element-attributes) or [binding element class names](../templates/binding-element-class-names).

--- a/guides/v1.10.0/components/defining-a-component.md
+++ b/guides/v1.10.0/components/defining-a-component.md
@@ -36,7 +36,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ### Defining a Component Subclass

--- a/guides/v1.10.0/components/handling-user-interaction-with-actions.md
+++ b/guides/v1.10.0/components/handling-user-interaction-with-actions.md
@@ -7,7 +7,7 @@ users of your application to interact with it.
 
 You can make elements in your component interactive by using the
 `{{action}}` helper. This is the [same `{{action}}` helper you use in
-application templates](../../templates/actions), but it has an
+application templates](../templates/actions), but it has an
 important difference when used inside a component.
 
 Instead of sending an action to the template's controller, then bubbling
@@ -42,4 +42,4 @@ The `{{action}}` helper can accept arguments, listen for different event
 types, control how action bubbling occurs, and more.
 
 For details about using the `{{action}}` helper, see the [Actions
-section](../../templates/actions) of the Templates chapter.
+section](../templates/actions) of the Templates chapter.

--- a/guides/v1.10.0/components/sending-actions-from-components-to-your-application.md
+++ b/guides/v1.10.0/components/sending-actions-from-components-to-your-application.md
@@ -8,7 +8,7 @@ first go to the template's controller. If the controller does not
 implement a handler for that action, it will bubble to the template's
 route, and then up the route hierarchy. For more information about this
 bubbling behavior, see [Action
-Bubbling](../../templates/actions/#toc_action-bubbling).
+Bubbling](../templates/actions/#toc_action-bubbling).
 
 Components are designed to be reusable across different parts of your
 application. In order to achieve this reusability, it's important that

--- a/guides/v1.10.0/components/wrapping-content-in-a-component.md
+++ b/guides/v1.10.0/components/wrapping-content-in-a-component.md
@@ -21,7 +21,7 @@ in another template:
 <a class="jsbin-embed" href="http://jsbin.com/cojuk/embed?live">JS Bin</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v1.10.0/concepts/naming-conventions.md
+++ b/guides/v1.10.0/concepts/naming-conventions.md
@@ -2,9 +2,9 @@ Ember.js uses naming conventions to wire up your objects without a
 lot of boilerplate. You will want to use these conventional names
 for your routes, controllers and templates.
 
-You can usually guess the names, but this guide outlines, in one place, 
-all of the naming conventions. In the following examples 'App' is a name 
-that we chose to namespace or represent our Ember application when it was 
+You can usually guess the names, but this guide outlines, in one place,
+all of the naming conventions. In the following examples 'App' is a name
+that we chose to namespace or represent our Ember application when it was
 created, but you can choose any name you want for your application.
 We will show you later how to create an Ember application, but for now we
 will focus on conventions.
@@ -25,17 +25,17 @@ the controller.
 
 If your app provides an `App.ApplicationRoute`, Ember.js will invoke
 [the][1] [router's][2] [hooks][3] first, before rendering the
-`application` template. Hooks are implemented as methods and provide 
-you access points within an Ember object's lifecycle to intercept and 
-execute code to modify the default behavior at these points to meet 
+`application` template. Hooks are implemented as methods and provide
+you access points within an Ember object's lifecycle to intercept and
+execute code to modify the default behavior at these points to meet
 your needs. Ember provides several hooks for you to utilize for various
-purposes (e.g. `model`, `setupController`, etc). In the example below 
-`App.ApplicationRoute`, which is an `Ember.Route` object, implements 
+purposes (e.g. `model`, `setupController`, etc). In the example below
+`App.ApplicationRoute`, which is an `Ember.Route` object, implements
 the `setupController` hook.
 
-[1]: /guides/routing/specifying-a-routes-model
-[2]: /guides/routing/setting-up-a-controller
-[3]: /guides/routing/rendering-a-template
+[1]: ../routing/specifying-a-routes-model
+[2]: ../routing/setting-up-a-controller
+[3]: ../routing/rendering-a-template
 
 Here's a simple example that uses a route, controller, and template:
 
@@ -68,7 +68,7 @@ your entire application shares a single instance of each controller.
 
 ## Simple Routes
 
-Each of your routes will have a controller, and a template with the 
+Each of your routes will have a controller, and a template with the
 same name as the route.
 
 Let's start with a simple router:
@@ -179,8 +179,8 @@ handlers.
   application's namespace (`post` becomes `App.Post`). It will
   then call `find` on that class with the value of the dynamic
   segment.
-* The default behaviour of the `serialize` hook is to replace 
-  the route's dynamic segment with the value of the model 
+* The default behaviour of the `serialize` hook is to replace
+  the route's dynamic segment with the value of the model
   object's `id` property.
 
 ## Route, Controller and Template Defaults

--- a/guides/v1.10.0/configuring-ember/embedding-applications.md
+++ b/guides/v1.10.0/configuring-ember/embedding-applications.md
@@ -6,8 +6,7 @@ existing page, or run alongside other JavaScript frameworks?
 
 ### Changing the Root Element
 
-By default, your application will render the [application
-template](../../templates/the-application-template) and attach it to
+By default, your application will render the [application template](../templates/the-application-template) and attach it to
 the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -25,8 +24,8 @@ string](http://api.jquery.com/category/selectors/).
 
 ### Disabling URL Management
 
-You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../../routing/specifying-the-location-api) to
+You can prevent Ember from making changes to the URL by
+[changing the routers `location`](../routing/specifying-the-location-api) to
 `none`:
 
 ```js

--- a/guides/v1.10.0/controllers/dependencies-between-controllers.md
+++ b/guides/v1.10.0/controllers/dependencies-between-controllers.md
@@ -60,6 +60,6 @@ App.AnotherController = Ember.Controller.extend({
 ```
 
 For more information about dependecy injection and `needs` in Ember.js,
-see the [dependency injection guide](../../understanding-ember/dependency-injection-and-service-lookup).
+see the [dependency injection guide](../understanding-ember/dependency-injection-and-service-lookup).
 For more information about aliases, see the API docs for
 [aliased properties](http://emberjs.com/api/#method_computed_alias).

--- a/guides/v1.10.0/cookbook/user_interface_and_interaction/adding_css_classes_to_your_components.md
+++ b/guides/v1.10.0/cookbook/user_interface_and_interaction/adding_css_classes_to_your_components.md
@@ -32,4 +32,4 @@ classNames: ['bold', 'italic', 'blue']
 
 <a class="jsbin-embed" href="http://emberjs.jsbin.com/ifUDExu/2/edit?js,output">JS Bin</a>
 
-See [Customizing a Component's Element](../../components/customizing-a-components-element/) for further examples.
+See [Customizing a Component's Element](../../components/customizing-a-components-element) for further examples.

--- a/guides/v1.10.0/cookbook/user_interface_and_interaction/adding_css_classes_to_your_components_based_on_properties.md
+++ b/guides/v1.10.0/cookbook/user_interface_and_interaction/adding_css_classes_to_your_components_based_on_properties.md
@@ -33,4 +33,4 @@ isRelatedBinding: "content.isRelated" // value resolves to boolean
 
 <a class="jsbin-embed" href="http://emberjs.jsbin.com/AwAYUwe/2/edit?js,output">JS Bin</a>
 
-See [Customizing a Component's Element](../../components/customizing-a-components-element/) for further examples.
+See [Customizing a Component's Element](../../components/customizing-a-components-element) for further examples.

--- a/guides/v1.10.0/cookbook/user_interface_and_interaction/converting_strings_to_currency_with_accounting_js.md
+++ b/guides/v1.10.0/cookbook/user_interface_and_interaction/converting_strings_to_currency_with_accounting_js.md
@@ -25,6 +25,6 @@ formattedAmount: function(key, value) {
 
 <a class="jsbin-embed" href="http://emberjs.jsbin.com/AqeVuZI/2/embed?live,js,output">JS Bin</a>
 
-[setters]: /guides/object-model/computed-properties/
+[setters]: ../../object-model/computed-properties/
 [accounting]: http://josscrowcroft.github.io/accounting.js/
 

--- a/guides/v1.10.0/enumerables/index.md
+++ b/guides/v1.10.0/enumerables/index.md
@@ -55,7 +55,7 @@ Usually, objects that represent lists implement the Enumerable interface. Some e
 
  * **Array** - Ember extends the native JavaScript `Array` with the
    Enumerable interface (unless you [disable prototype
-   extensions.](../../configuring-ember/disabling-prototype-extensions/))
+   extensions.](../configuring-ember/disabling-prototype-extensions/))
  * **Ember.ArrayController** - A controller that wraps an underlying array and
    adds additional functionality for the view layer.
  * **Ember.Set** - A data structure that can efficiently answer whether it

--- a/guides/v1.10.0/getting-started/accepting-edits.md
+++ b/guides/v1.10.0/getting-started/accepting-edits.md
@@ -40,7 +40,7 @@ In `index.html` replace the static `<input>` element with our custom `{{edit-tod
 
 Pressing the `<enter>` key  will trigger the `acceptChanges` event on the instance of `TodoController`. Moving focus away from the `<input>` will trigger the `focus-out` event, calling a method `acceptChanges` on this view's instance of `TodoController`.
 
-Additionally, we connect the `value` property of this `<input>` to the `title` property of this instance of `TodoController`. We will not implement a `title` property on the controller so it will retain the default behavior of [proxying all requests](../../controllers/#toc_representing-models) to its `model`.
+Additionally, we connect the `value` property of this `<input>` to the `title` property of this instance of `TodoController`. We will not implement a `title` property on the controller so it will retain the default behavior of [proxying all requests](../controllers/#toc_representing-models) to its `model`.
 
 A CSS class `edit` is applied for styling.
 
@@ -78,5 +78,5 @@ This method will set the controller's `isEditing` property to false and commit a
 ### Additional Resources
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/a7e2f40da4d75342358acdfcbda7a05ccc90f348)
-  * [Controller Guide](../../controllers)
+  * [Controller Guide](../controllers)
   * [Ember.TextField API documentation](http://emberjs.com/api/classes/Ember.TextField.html)

--- a/guides/v1.10.0/getting-started/adding-a-route-and-template.md
+++ b/guides/v1.10.0/getting-started/adding-a-route-and-template.md
@@ -52,6 +52,6 @@ Reload your web browser to ensure that all files have been referenced correctly 
 ### Additional Resources
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/8775d1bf4c05eb82adf178be4429e5b868ac145b)
-  * [Handlebars Guide](../../templates/handlebars-basics)
-  * [Ember.Application Guide](../../application)
+  * [Handlebars Guide](../templates/handlebars-basics)
+  * [Ember.Application Guide](../application)
   * [Ember.Application API Documentation](http://emberjs.com/api/classes/Ember.Application.html)

--- a/guides/v1.10.0/getting-started/adding-child-routes.md
+++ b/guides/v1.10.0/getting-started/adding-child-routes.md
@@ -58,7 +58,7 @@ Todos.TodosIndexRoute = Ember.Route.extend({
 When the application loads at the url `'/'` Ember.js will enter the `todos` route and render the `todos` template as before. It will also transition into the `todos.index` route and fill the `{{outlet}}` in the `todos` template with the `todos/index` template.  The model data for this template is the result of the `model` method of `TodosIndexRoute`, which indicates that the
 model for this route is the same model as for the `TodosRoute`.
 
-This mapping is described in more detail in the [Naming Conventions Guide](../../concepts/naming-conventions).
+This mapping is described in more detail in the [Naming Conventions Guide](../concepts/naming-conventions).
 
 ### Live Preview
 <a class="jsbin-embed" href="http://jsbin.com/teheni/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
@@ -66,6 +66,6 @@ This mapping is described in more detail in the [Naming Conventions Guide](../..
 ### Additional Resources
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/3bab8f1519ffc1ca2d5a12d1de35e4c764c91f05)
-  * [Ember Router Guide](../../routing)
-  * [Ember Controller Guide](../../controllers)
+  * [Ember Router Guide](../routing)
+  * [Ember Controller Guide](../controllers)
   * [outlet API documentation](http://emberjs.com/api/classes/Ember.Handlebars.helpers.html#method_outlet)

--- a/guides/v1.10.0/getting-started/creating-a-new-model.md
+++ b/guides/v1.10.0/getting-started/creating-a-new-model.md
@@ -16,11 +16,11 @@ This will render an `<input>` element at this location with the same `id` and `p
 
 Additionally, we connect user interaction (pressing the `<enter>` key) to a method `createTodo` on this template's controller.
 
-Because we have not needed a custom controller behavior until this point, Ember.js provided a default controller object for this template. To handle our new behavior, we can implement the controller class Ember.js expects to find [according to its naming conventions](../../concepts/naming-conventions) and add our custom behavior. This new controller class will automatically be associated with this template for us.
+Because we have not needed a custom controller behavior until this point, Ember.js provided a default controller object for this template. To handle our new behavior, we can implement the controller class Ember.js expects to find [according to its naming conventions](../concepts/naming-conventions) and add our custom behavior. This new controller class will automatically be associated with this template for us.
 
 Add a `js/controllers/todos_controller.js` file. You may place this file anywhere you like (even just putting all code into the same file), but this guide will assume you have created the file and named it as indicated.
 
-Inside `js/controllers/todos_controller.js` implement the controller Ember.js expects to find [according to its naming conventions](../../concepts/naming-conventions):
+Inside `js/controllers/todos_controller.js` implement the controller Ember.js expects to find [according to its naming conventions](../concepts/naming-conventions):
 
 ```javascript
 Todos.TodosController = Ember.ArrayController.extend({
@@ -67,5 +67,5 @@ Reload your web browser to ensure that all files have been referenced correctly 
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/60feb5f369c8eecd9df3f561fbd01595353ce803)
   * [Ember.TextField API documention](http://emberjs.com/api/classes/Ember.TextField.html)
-  * [Ember Controller Guide](../../controllers)
-  * [Naming Conventions Guide](../../concepts/naming-conventions)
+  * [Ember Controller Guide](../controllers)
+  * [Naming Conventions Guide](../concepts/naming-conventions)

--- a/guides/v1.10.0/getting-started/display-a-button-to-remove-completed-todos.md
+++ b/guides/v1.10.0/getting-started/display-a-button-to-remove-completed-todos.md
@@ -44,5 +44,5 @@ Reload your web browser to ensure that there are no errors and the behavior desc
 ### Additional Resources
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/1da450a8d693f083873a086d0d21e031ee3c129e)
-  * [Handlebars Conditionals Guide](../../templates/conditionals)
-  * [Enumerables Guide](../../enumerables)
+  * [Handlebars Conditionals Guide](../templates/conditionals)
+  * [Enumerables Guide](../enumerables)

--- a/guides/v1.10.0/getting-started/displaying-model-data.md
+++ b/guides/v1.10.0/getting-started/displaying-model-data.md
@@ -11,7 +11,7 @@ Todos.TodosRoute = Ember.Route.extend({
 });
 ```
 
-Because we hadn't implemented this class before, Ember.js provided a `Route` for us with the default behavior of rendering a matching template named `todos` using its [naming conventions for object creation](../../concepts/naming-conventions/).
+Because we hadn't implemented this class before, Ember.js provided a `Route` for us with the default behavior of rendering a matching template named `todos` using its [naming conventions for object creation](../concepts/naming-conventions/).
 
 Now that we need custom behavior (returning a specific set of models), we implement the class and add the desired behavior.
 
@@ -40,6 +40,6 @@ Reload your web browser to ensure that all files have been referenced correctly 
 ### Additional Resources
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/87bd57700110d9dd0b351c4d4855edf90baac3a8)
-  * [Templates Guide](../../templates/handlebars-basics)
-  * [Controllers Guide](../../controllers)
-  * [Naming Conventions Guide](../../concepts/naming-conventions)
+  * [Templates Guide](../templates/handlebars-basics)
+  * [Controllers Guide](../controllers)
+  * [Naming Conventions Guide](../concepts/naming-conventions)

--- a/guides/v1.10.0/getting-started/displaying-the-number-of-incomplete-todos.md
+++ b/guides/v1.10.0/getting-started/displaying-the-number-of-incomplete-todos.md
@@ -39,4 +39,4 @@ The `inflection` property will return either a plural or singular version of the
 ### Additional Resources
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/b418407ed9666714c82d894d6b70f785674f7a45)
-  * [Computed Properties Guide](../../object-model/computed-properties/)
+  * [Computed Properties Guide](../object-model/computed-properties/)

--- a/guides/v1.10.0/getting-started/marking-a-model-as-complete-incomplete.md
+++ b/guides/v1.10.0/getting-started/marking-a-model-as-complete-incomplete.md
@@ -39,7 +39,7 @@ Todos.TodoController = Ember.ObjectController.extend({
 
 When called from the template to display the current `isCompleted` state of the todo, this property will [proxy that question](http://emberjs.com/api/classes/Ember.ObjectController.html) to its underlying `model`. When called with a value because a user has toggled the checkbox in the template, this property will set the `isCompleted` property of its `model` to the passed value (`true` or `false`), persist the model update, and return the passed value so the checkbox will display correctly.
 
-The `isCompleted` function is marked a [computed property](../../object-model/computed-properties/) whose value is dependent on the value of `model.isCompleted`.
+The `isCompleted` function is marked a [computed property](../object-model/computed-properties/) whose value is dependent on the value of `model.isCompleted`.
 
 In `index.html` include `js/controllers/todo_controller.js` as a dependency:
 
@@ -61,6 +61,6 @@ In `index.html` include `js/controllers/todo_controller.js` as a dependency:
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/8d469c04c237f39a58903a3856409a2592cc18a9)
   * [Ember.Checkbox API documentation](http://emberjs.com/api/classes/Ember.Checkbox.html)
-  * [Ember Controller Guide](../../controllers)
-  * [Computed Properties Guide](../../object-model/computed-properties/)
-  * [Naming Conventions Guide](../../concepts/naming-conventions)
+  * [Ember Controller Guide](../controllers)
+  * [Computed Properties Guide](../object-model/computed-properties/)
+  * [Naming Conventions Guide](../concepts/naming-conventions)

--- a/guides/v1.10.0/getting-started/modeling-data.md
+++ b/guides/v1.10.0/getting-started/modeling-data.md
@@ -30,4 +30,4 @@ Reload your web browser to ensure that all files have been referenced correctly 
 ### Additional Resources
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/a1ccdb43df29d316a7729321764c00b8d850fcd1)
-  * [Models Guide](../../models)
+  * [Models Guide](../models)

--- a/guides/v1.10.0/getting-started/obtaining-emberjs-and-dependencies.md
+++ b/guides/v1.10.0/getting-started/obtaining-emberjs-and-dependencies.md
@@ -19,7 +19,7 @@ For this example, all of these resources should be stored in the folder `js/libs
 
 Reload your web browser to ensure that all files have been referenced correctly and no errors occur.
 
-If you are using a package manager, such as [bower](http://bower.io), make sure to checkout the [Getting Ember](../../getting-ember) guide for info on other ways to get Ember.js (this guide is dependant on ember-data v1.0 or greater so please be sure to use the latest beta).
+If you are using a package manager, such as [bower](http://bower.io), make sure to checkout the [Getting Ember](../getting-ember) guide for info on other ways to get Ember.js (this guide is dependant on ember-data v1.0 or greater so please be sure to use the latest beta).
 
 ### Live Preview
 <a class="jsbin-embed" href="http://jsbin.com/ijefig/2/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>

--- a/guides/v1.10.0/getting-started/show-only-complete-todos.md
+++ b/guides/v1.10.0/getting-started/show-only-complete-todos.md
@@ -56,4 +56,4 @@ Reload your web browser to ensure that there are no errors and the behavior desc
   * [link-to API documentation](http://emberjs.com/api/classes/Ember.Handlebars.helpers.html#method_link-to)
   * [Route#renderTemplate API documentation](http://emberjs.com/api/classes/Ember.Route.html#method_renderTemplate)
   * [Route#render API documentation](http://emberjs.com/api/classes/Ember.Route.html#method_render)
-  * [Ember Router Guide](../../routing)
+  * [Ember Router Guide](../routing)

--- a/guides/v1.10.0/getting-started/show-only-incomplete-todos.md
+++ b/guides/v1.10.0/getting-started/show-only-incomplete-todos.md
@@ -54,4 +54,4 @@ Reload your web browser to ensure that there are no errors and the behavior desc
   * [link-to API documentation](http://emberjs.com/api/classes/Ember.Handlebars.helpers.html#method_link-to)
   * [Route#renderTemplate API documentation](http://emberjs.com/api/classes/Ember.Route.html#method_renderTemplate)
   * [Route#render API documentation](http://emberjs.com/api/classes/Ember.Route.html#method_render)
-  * [Ember Router Guide](../../routing)
+  * [Ember Router Guide](../routing)

--- a/guides/v1.10.0/getting-started/toggle-all-todos.md
+++ b/guides/v1.10.0/getting-started/toggle-all-todos.md
@@ -29,4 +29,4 @@ Reload your web browser to ensure that there are no errors and the behavior desc
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/47b289bb9f669edaa39abd971f5e884142988663)
   * [Ember.Checkbox API documentation](http://emberjs.com/api/classes/Ember.Checkbox.html)
-  * [Computed Properties Guide](../../object-model/computed-properties/)
+  * [Computed Properties Guide](../object-model/computed-properties/)

--- a/guides/v1.10.0/getting-started/toggle-todo-editing-state.md
+++ b/guides/v1.10.0/getting-started/toggle-todo-editing-state.md
@@ -45,7 +45,7 @@ Reload your web browser to ensure that no errors occur. You can now double-click
 ### Additional Resources
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/616bc4f22900bbaa2bf9bdb8de53ba41209d8cc0)
-  * [Handlebars Conditionals Guide](../../templates/conditionals)
+  * [Handlebars Conditionals Guide](../templates/conditionals)
   * [bind-attr API documentation](http://emberjs.com/api/classes/Ember.Handlebars.helpers.html#method_bind-attr)
   * [action API documentation](http://emberjs.com/api/classes/Ember.Handlebars.helpers.html#method_action)
   * [bind and bindAttr article by Peter Wagenet](http://www.emberist.com/2012/04/06/bind-and-bindattr.html)

--- a/guides/v1.10.0/models/defining-models.md
+++ b/guides/v1.10.0/models/defining-models.md
@@ -81,7 +81,7 @@ App.Person = DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 If you don't specify the type of the attribute, it will be whatever was
 provided by the server. You can make sure that an attribute is always
@@ -96,7 +96,7 @@ App.Person = DS.Model.extend({
 The default adapter supports attribute types of `string`,
 `number`, `boolean`, and `date`. Custom adapters may offer additional
 attribute types, and new types can be registered as transforms. See the
-[documentation section on the REST Adapter](../../models/the-rest-adapter).
+[documentation section on the REST Adapter](../the-rest-adapter).
 
 **Please note:** Ember Data serializes and deserializes dates according to
                  [ISO 8601][]. For example: `2014-05-27T12:54:01`

--- a/guides/v1.10.0/models/defining-models.md
+++ b/guides/v1.10.0/models/defining-models.md
@@ -96,7 +96,7 @@ App.Person = DS.Model.extend({
 The default adapter supports attribute types of `string`,
 `number`, `boolean`, and `date`. Custom adapters may offer additional
 attribute types, and new types can be registered as transforms. See the
-[documentation section on the REST Adapter](../the-rest-adapter).
+[documentation section on the REST Adapter](the-rest-adapter).
 
 **Please note:** Ember Data serializes and deserializes dates according to
                  [ISO 8601][]. For example: `2014-05-27T12:54:01`

--- a/guides/v1.10.0/models/finding-records.md
+++ b/guides/v1.10.0/models/finding-records.md
@@ -56,7 +56,7 @@ var peters = this.store.find('person', { name: "Peter" }); // => GET to /persons
 As discussed in [Specifying a Route's Model][3], routes are
 responsible for telling their template which model to render.
 
-[3]: ../../routing/specifying-a-routes-model
+[3]: ../routing/specifying-a-routes-model
 
 `Ember.Route`'s `model` hook supports asynchronous values
 out-of-the-box. If you return a promise from the `model` hook, the

--- a/guides/v1.10.0/models/index.md
+++ b/guides/v1.10.0/models/index.md
@@ -5,7 +5,7 @@ implementing a route's `model` hook, by passing the model as an argument
 to `{{link-to}}`, or by calling a route's `transitionTo()` method.
 
 See [Specifying a Route's
-Model](../../routing/specifying-a-routes-model) for more information
+Model](../routing/specifying-a-routes-model) for more information
 on setting a route's model.
 
 For simple applications, you can get by using jQuery to load JSON data

--- a/guides/v1.10.0/models/the-fixture-adapter.md
+++ b/guides/v1.10.0/models/the-fixture-adapter.md
@@ -72,6 +72,6 @@ a uniquely identifiable field. By default, Ember Data assumes this key
 is called `id`. Should you not provide an `id` field in your fixtures, or
 not override the primary key, the Fixture Adapter will throw an error.
 
-[1]: models/defining-models
-[2]: models/finding-records
+[1]: defining-models
+[2]: finding-records
 [3]: the-rest-adapter

--- a/guides/v1.10.0/models/the-fixture-adapter.md
+++ b/guides/v1.10.0/models/the-fixture-adapter.md
@@ -72,6 +72,6 @@ a uniquely identifiable field. By default, Ember Data assumes this key
 is called `id`. Should you not provide an `id` field in your fixtures, or
 not override the primary key, the Fixture Adapter will throw an error.
 
-[1]: /guides/models/defining-models
-[2]: /guides/models/finding-records
-[3]: /guides/models/the-rest-adapter
+[1]: models/defining-models
+[2]: models/finding-records
+[3]: the-rest-adapter

--- a/guides/v1.10.0/object-model/computed-properties.md
+++ b/guides/v1.10.0/object-model/computed-properties.md
@@ -32,7 +32,7 @@ Whenever you access the `fullName` property, this function gets called, and it r
 
 #### Alternate invocation
 
-At this point, you might be wondering how you are able to call the `.property` function on a function.  This is possible because Ember extends the `function` prototype.  More information about extending native prototypes is available in the [disabling prototype extensions guide](../../configuring-ember/disabling-prototype-extensions/). If you'd like to replicate the declaration from above without using these extensions you could do so with the following:
+At this point, you might be wondering how you are able to call the `.property` function on a function.  This is possible because Ember extends the `function` prototype.  More information about extending native prototypes is available in the [disabling prototype extensions guide](../configuring-ember/disabling-prototype-extensions/). If you'd like to replicate the declaration from above without using these extensions you could do so with the following:
 
 ```javascript
   fullName: Ember.computed('firstName', 'lastName', function() {

--- a/guides/v1.10.0/routing/generated-objects.md
+++ b/guides/v1.10.0/routing/generated-objects.md
@@ -3,7 +3,7 @@ Ember.js attempts to find corresponding Route, Controller, View, and Template
 classes named according to naming conventions. If an implementation of any of
 these objects is not found, appropriate objects will be generated in memory for you.
 
-[1]: /guides/routing/defining-your-routes
+[1]: defining-your-routes
 
 #### Generated routes
 
@@ -41,8 +41,8 @@ The type of controller Ember.js chooses to generate for you depends on your rout
 - If it does not return anything, an instance of `Ember.Controller` will be generated.
 
 
-[2]: /guides/controllers/representing-a-single-model-with-objectcontroller
-[3]: /guides/controllers/representing-multiple-models-with-arraycontroller
+[2]: ../controllers/representing-a-single-model-with-objectcontroller
+[3]: ../controllers/representing-multiple-models-with-arraycontroller
 
 
 ##### Custom Generated Controllers
@@ -64,6 +64,3 @@ as an `outlet` so that nested routes can be seamlessly inserted.  It is equivale
 ```handlebars
 {{outlet}}
 ```
-
-
-

--- a/guides/v1.10.0/routing/loading-and-error-substates.md
+++ b/guides/v1.10.0/routing/loading-and-error-substates.md
@@ -1,5 +1,5 @@
 In addition to the techniques described in the
-[Asynchronous Routing Guide](../asynchronous-routing/),
+[Asynchronous Routing Guide](asynchronous-routing/),
 the Ember Router provides powerful yet overridable
 conventions for customizing asynchronous transitions
 between routes by making use of `error` and `loading`
@@ -9,7 +9,7 @@ substates.
 
 The Ember Router allows you to return promises from the various
 `beforeModel`/`model`/`afterModel` hooks in the course of a transition
-(described [here](../asynchronous-routing/)).
+(described [here](asynchronous-routing/)).
 These promises pause the transition until they fulfill, at which point
 the transition will resume.
 

--- a/guides/v1.10.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v1.10.0/routing/preventing-and-retrying-transitions.md
@@ -47,7 +47,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v1.10.0/routing/redirection.md
+++ b/guides/v1.10.0/routing/redirection.md
@@ -2,13 +2,13 @@
 
 Calling `transitionTo` from a route or `transitionToRoute` from a controller
 will stop any transition currently in progress and start a new one, functioning
-as a redirect. `transitionTo` takes parameters and behaves exactly like the [link-to](../../templates/links) helper:
+as a redirect. `transitionTo` takes parameters and behaves exactly like the [link-to](../templates/links) helper:
 
 * If you transition into a route without dynamic segments that route's `model` hook
 will always run.
 
 * If the new route has dynamic segments, you need to pass either a _model_ or an _identifier_ for each segment.
-Passing a model will skip that segment's `model` hook.  Passing an identifier will run the `model` hook and you'll be able to access the identifier in the params. See [Links](../../templates/links) for more detail.
+Passing a model will skip that segment's `model` hook.  Passing an identifier will run the `model` hook and you'll be able to access the identifier in the params. See [Links](../templates/links) for more detail.
 
 ### Before the model is known
 

--- a/guides/v1.10.0/routing/setting-up-a-controller.md
+++ b/guides/v1.10.0/routing/setting-up-a-controller.md
@@ -45,7 +45,7 @@ App.SpecialPostRoute = Ember.Route.extend({
 As a second argument, it receives the route handler's model. For more
 information, see [Specifying a Route's Model][1].
 
-[1]: /guides/routing/specifying-a-routes-model
+[1]: specifying-a-routes-model
 
 The default `setupController` hook sets the `model` property of the
 associated controller to the route handler's model.

--- a/guides/v1.10.0/routing/specifying-a-routes-model.md
+++ b/guides/v1.10.0/routing/specifying-a-routes-model.md
@@ -50,7 +50,7 @@ eventually returned over the network. Ember uses this promise object to
 know when it has enough data to continue rendering.
 
 For more about promises, see [A Word on
-Promises](../../routing/asynchronous-routing/#toc_a-word-on-promises)
+Promises](../routing/asynchronous-routing/#toc_a-word-on-promises)
 in the Asynchronous Routing guide.
 
 Let's look at an example in action. Here's a route that loads the most
@@ -114,7 +114,7 @@ default behavior. Note that if you override the default behavior and do
 not set the `model` property on a controller, your template will not
 have any data to render!
 
-[1]: ../setting-up-a-controller
+[1]: setting-up-a-controller
 
 ### Dynamic Models
 
@@ -151,7 +151,7 @@ When the user goes to the `photo` route to display a particular photo
 model (usually via the `{{link-to}}` helper), that model's ID will be
 placed into the URL automatically.
 
-See [Links](../../templates/links) for more information about linking
+See [Links](../templates/links) for more information about linking
 to a route with a model using the `{{link-to}}` helper.
 
 For example, if you transitioned to the `photo` route with a model whose
@@ -197,7 +197,7 @@ when it is entered via the URL. If the route is entered through a transition
 already provided and the hook is not executed. Routes without dynamic segments
 will always execute the model hook.
 
-[2]: ../../templates/links
+[2]: ../templates/links
 
 
 ### Refreshing your model
@@ -222,4 +222,4 @@ significantly improving the performance of your application.
 
 One popular model library built for Ember is Ember Data. To learn more
 about using Ember Data to manage your models, see the
-[Models](../../models) guide.
+[Models](../models) guide.

--- a/guides/v1.10.0/templates/actions.md
+++ b/guides/v1.10.0/templates/actions.md
@@ -167,7 +167,7 @@ You can specify an alternative event by using the `on` option.
 You should use the normalized event names [listed in the View guide][1].
 In general, two-word event names (like `keypress`) become `keyPress`.
 
-[1]: /guides/understanding-ember/the-view-layer/#toc_adding-new-events
+[1]: ../understanding-ember/the-view-layer/#toc_adding-new-events
 
 ### Specifying Whitelisted Modifier Keys
 

--- a/guides/v1.10.0/templates/handlebars-basics.md
+++ b/guides/v1.10.0/templates/handlebars-basics.md
@@ -29,7 +29,7 @@ template inside your HTML by putting it inside a `<script>` tag, like so:
 ```
 
 This template will be compiled automatically and become your
-[application template](../../templates/the-application-template),
+[application template](../templates/the-application-template),
 which will be displayed on the page when your app loads.
 
 You can also define templates by name that can be used later. For

--- a/guides/v1.10.0/templates/input-helpers.md
+++ b/guides/v1.10.0/templates/input-helpers.md
@@ -116,4 +116,4 @@ Will bind the value of the text area to `name` on the current context.
 See the [Built-in Views][4] section of these guides to learn how to further
 extend these views.
 
-[4]: ../../views/built-in-views
+[4]: ../views/built-in-views

--- a/guides/v1.10.0/templates/links.md
+++ b/guides/v1.10.0/templates/links.md
@@ -39,10 +39,10 @@ The `{{link-to}}` helper takes:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   If there is no model to pass to the helper, you can provide an explicit identifier value instead.
-  The value will be filled into the [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments)
+  The value will be filled into the [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments)
   of the route, and will make sure that the `model` hook is triggered.
 * An optional title which will be bound to the `a` title attribute
 

--- a/guides/v1.10.0/templates/rendering-with-helpers.md
+++ b/guides/v1.10.0/templates/rendering-with-helpers.md
@@ -72,7 +72,7 @@ When using `{{view "author"}}`:
 * An instance of App.AuthorView will be created
 * It will be rendered here, using the template associated with that view (the default template being "author")
 
-For more information, see [Inserting Views in Templates](../../views/inserting-views-in-templates)
+For more information, see [Inserting Views in Templates](../views/inserting-views-in-templates)
 
 ### The `{{render}}` Helper
 

--- a/guides/v1.10.0/templates/the-application-template.md
+++ b/guides/v1.10.0/templates/the-application-template.md
@@ -27,7 +27,7 @@ contents of the `<div>` will change depending on if the user is
 currently at `/posts` or `/posts/15`, for example.
 
 For more information about how outlets are filled in by the router, see
-[Routing](../../routing).
+[Routing](../routing).
 
 If you are keeping your templates in HTML, create a `<script>` tag
 without a template name. Ember will use the template without a name as the application template and it will automatically be compiled and appended

--- a/guides/v1.10.0/testing/testing-components.md
+++ b/guides/v1.10.0/testing/testing-components.md
@@ -366,6 +366,6 @@ with Embedded Components</a>
 
 <script src="http://static.jsbin.com/js/embed.js"></script>
 
-[Unit Testing Basics]: /guides/testing/unit-testing-basics
-[Integration Test Helpers]: /guides/testing/test-helpers
+[Unit Testing Basics]: unit-testing-basics
+[Integration Test Helpers]: test-helpers
 [layout]: http://emberjs.com/api/classes/Ember.Component.html#property_layout

--- a/guides/v1.10.0/testing/testing-controllers.md
+++ b/guides/v1.10.0/testing/testing-controllers.md
@@ -130,5 +130,5 @@ test('modify the post', function() {
 
 <script src="http://static.jsbin.com/js/embed.js"></script>
 
-[Unit Testing Basics]: /guides/testing/unit-testing-basics
-[needs]: /guides/controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v1.10.0/testing/testing-models.md
+++ b/guides/v1.10.0/testing/testing-models.md
@@ -90,5 +90,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: /guides/testing/unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/packages/ember-data/tests

--- a/guides/v1.10.0/testing/testing-routes.md
+++ b/guides/v1.10.0/testing/testing-routes.md
@@ -71,5 +71,5 @@ test('Alert is called on displayAlert', function() {
 
 <script src="http://static.jsbin.com/js/embed.js"></script>
 
-[Unit Testing Basics]: /guides/testing/unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v1.10.0/testing/testing-xhr.md
+++ b/guides/v1.10.0/testing/testing-xhr.md
@@ -2,7 +2,7 @@ Testing with asynchronous calls and promises in Ember may seem tricky at first, 
 
 ### Promises, Ember and the Run Loop
 
-In order to fully explain testing promises & asynchronous code, it's important that you have a clear grasp of the Ember run loop. If you haven't yet done so, please read about them in the [Promises](http://emberjs.com/api/classes/Ember.RSVP.Promise.html) and [Understanding Ember run loop guide](../../understanding-ember/run-loop/).
+In order to fully explain testing promises & asynchronous code, it's important that you have a clear grasp of the Ember run loop. If you haven't yet done so, please read about them in the [Promises](http://emberjs.com/api/classes/Ember.RSVP.Promise.html) and [Understanding Ember run loop guide](../understanding-ember/run-loop/).
 
 Now that you grasp the general concepts regarding the run loop, recall from reading about the basics of testing Ember applications that the run loop is suspended when in testing mode.  This helps ensure the procedure of your code and the tests you write around that code. Note that in testing promises and asynchronous code, you're effectively "stepping through" your application in chunks.
 

--- a/guides/v1.10.0/understanding-ember/managing-asynchrony.md
+++ b/guides/v1.10.0/understanding-ember/managing-asynchrony.md
@@ -341,4 +341,4 @@ definition if possible.
 ### Routing
 
 There's an entire page dedicated to managing async within the Ember
-Router: [Asynchronous Routing](../../routing/asynchronous-routing)
+Router: [Asynchronous Routing](../routing/asynchronous-routing)

--- a/guides/v1.10.0/views/built-in-views.md
+++ b/guides/v1.10.0/views/built-in-views.md
@@ -1,4 +1,4 @@
-Ember comes pre-packaged with a set of views for building a basic controls like text inputs, check boxes, and select lists. Usually, these views will be used via the [input helpers](../../templates/input-helpers/). However, the base views may be helpful in creating custom form behaviors.
+Ember comes pre-packaged with a set of views for building a basic controls like text inputs, check boxes, and select lists. Usually, these views will be used via the [input helpers](../templates/input-helpers/). However, the base views may be helpful in creating custom form behaviors.
 
 * [Ember.Checkbox](http://emberjs.com/api/classes/Ember.Checkbox.html)
 * [Ember.TextField](http://emberjs.com/api/classes/Ember.TextField.html)

--- a/guides/v1.10.0/wip/rails.md
+++ b/guides/v1.10.0/wip/rails.md
@@ -11,7 +11,7 @@ In this guide, we'll show you how to build a simple, personal photoblog applicat
 
 Ember.js is a front-end javascript model-view-controller framework. It is designed to help you create ambitious web applications which run inside the browser. These applications can use AJAX as their primary mechanism for communicating with an API, much like a desktop or mobile application.
 
-Ruby on Rails is a Ruby-based full stack web framework. It also uses a model-view-controller paradigm to architect applications built on top of it, but in a much different way than Ember.js. The differences are beyond the scope of this guide, but you can read about them in our [Ember MVC guide](../../ember_mvc/). What is critical to understand is that Ruby on Rails runs on the server, not the client. It is an excellent platform to build websites and APIs.
+Ruby on Rails is a Ruby-based full stack web framework. It also uses a model-view-controller paradigm to architect applications built on top of it, but in a much different way than Ember.js. The differences are beyond the scope of this guide, but you can read about them in our [Ember MVC guide](../ember_mvc/). What is critical to understand is that Ruby on Rails runs on the server, not the client. It is an excellent platform to build websites and APIs.
 
 In the next few steps, we'll create a Ruby on Rails application which does two distinct but equally important things: It acts as a host for the Ember.js application we will write, and it acts as an API with which the application will communicate. 
 

--- a/guides/v1.11.0/application/index.md
+++ b/guides/v1.11.0/application/index.md
@@ -5,10 +5,8 @@ This object is located at `./app/app.js` inside your project.
 What does creating an `Ember.Application` instance get you?
 
 1. It adds event listeners to the document and is responsible for
-   delegating events to your views. (See [The View
-   Layer](../understanding-ember/the-view-layer)
+   delegating events to your views. (See [The View Layer](../understanding-ember/the-view-layer)
   for a detailed description.)
-1. It automatically renders the [application
-   template](../templates/the-application-template).
+1. It automatically renders the [application template](../templates/the-application-template).
 1. It automatically creates a router and begins routing, choosing which
    template and model to display based on the current URL.

--- a/guides/v1.11.0/components/customizing-a-components-element.md
+++ b/guides/v1.11.0/components/customizing-a-components-element.md
@@ -161,4 +161,4 @@ red background:
 <a class="jsbin-embed" href="http://jsbin.com/duzala/1/embed?live">JS Bin</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 **Note:** The binding functionality in this very simple example could also be implemented without
-the use of `Ember.Component` but by simply [binding element attributes](../../templates/binding-element-attributes) or [binding element class names](../../templates/binding-element-class-names). -->
+the use of `Ember.Component` but by simply [binding element attributes](../templates/binding-element-attributes) or [binding element class names](../templates/binding-element-class-names). -->

--- a/guides/v1.11.0/components/defining-a-component.md
+++ b/guides/v1.11.0/components/defining-a-component.md
@@ -61,7 +61,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ### Defining a Component Subclass

--- a/guides/v1.11.0/components/handling-user-interaction-with-actions.md
+++ b/guides/v1.11.0/components/handling-user-interaction-with-actions.md
@@ -7,7 +7,7 @@ users of your application to interact with it.
 
 You can make elements in your component interactive by using the
 `{{action}}` helper. This is the [same `{{action}}` helper you use in
-application templates](../../templates/actions), but it has an
+application templates](../templates/actions), but it has an
 important difference when used inside a component.
 
 Instead of sending an action to the template's controller, then bubbling
@@ -41,4 +41,4 @@ The `{{action}}` helper can accept arguments, listen for different event
 types, control how action bubbling occurs, and more.
 
 For details about using the `{{action}}` helper, see the [Actions
-section](../../templates/actions) of the Templates chapter.
+section](../templates/actions) of the Templates chapter.

--- a/guides/v1.11.0/components/sending-actions-from-components-to-your-application.md
+++ b/guides/v1.11.0/components/sending-actions-from-components-to-your-application.md
@@ -8,7 +8,7 @@ first go to the template's controller. If the controller does not
 implement a handler for that action, it will bubble to the template's
 route, and then up the route hierarchy. For more information about this
 bubbling behavior, see [Action
-Bubbling](../../templates/actions/#toc_action-bubbling).
+Bubbling](../templates/actions/#toc_action-bubbling).
 
 Components are designed to be reusable across different parts of your
 application. In order to achieve this reusability, it's important that

--- a/guides/v1.11.0/components/wrapping-content-in-a-component.md
+++ b/guides/v1.11.0/components/wrapping-content-in-a-component.md
@@ -19,7 +19,7 @@ in another template:
 <!---<a class="jsbin-embed" href="http://jsbin.com/hihunemapu/2/embed?live">JS Bin</a><script src="http://static.jsbin.com/js/embed.js"></script>-->
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v1.11.0/concepts/naming-conventions.md
+++ b/guides/v1.11.0/concepts/naming-conventions.md
@@ -30,9 +30,9 @@ purposes (e.g. `model`, `setupController`, etc). In the example below
 `route:application` Route, which is an `Ember.Route` object, implements
 the `setupController` hook.
 
-[1]: ../../routing/specifying-a-routes-model
-[2]: ../../routing/setting-up-a-controller
-[3]: ../../routing/rendering-a-template
+[1]: ../routing/specifying-a-routes-model
+[2]: ../routing/setting-up-a-controller
+[3]: ../routing/rendering-a-template
 
 Here's a simple example that uses a route, controller, and template:
 

--- a/guides/v1.11.0/configuring-ember/embedding-applications.md
+++ b/guides/v1.11.0/configuring-ember/embedding-applications.md
@@ -6,7 +6,7 @@ existing page, or run alongside other JavaScript frameworks?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../templates/the-application-template)
+By default, your application will render the [application template](../templates/the-application-template)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -24,8 +24,8 @@ string](http://api.jquery.com/category/selectors/).
 
 ### Disabling URL Management
 
-You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../../routing/specifying-the-location-api) to
+You can prevent Ember from making changes to the URL by
+[changing the router's `location`](../routing/specifying-the-location-api) to
 `none`:
 
 ```config/environment.js

--- a/guides/v1.11.0/controllers/dependencies-between-controllers.md
+++ b/guides/v1.11.0/controllers/dependencies-between-controllers.md
@@ -64,6 +64,6 @@ export default Ember.Controller.extend({
 ```
 
 For more information about dependecy injection and `needs` in Ember.js,
-see the [dependency injection guide](../../understanding-ember/dependency-injection-and-service-lookup).
+see the [dependency injection guide](../understanding-ember/dependency-injection-and-service-lookup).
 For more information about aliases, see the API docs for
 [aliased properties](http://emberjs.com/api/#method_computed_alias).

--- a/guides/v1.11.0/cookbook/contributing/participating_if_you_dont_know_ember.md
+++ b/guides/v1.11.0/cookbook/contributing/participating_if_you_dont_know_ember.md
@@ -2,7 +2,7 @@
 You are new to Ember, but want to help write the Cookbook.
 
 ### Solution
-Suggest and/or submit pull requests with a _problem_ statement (see [Suggesting A Recipe](../suggesting_a_recipe)). You do not need to worry about providing a solution or discussion. Someone more experienced with Ember will be able to take your _problem_ and provide a _solution_ and _discussion_.
+Suggest and/or submit pull requests with a _problem_ statement (see [Suggesting A Recipe](suggesting_a_recipe)). You do not need to worry about providing a solution or discussion. Someone more experienced with Ember will be able to take your _problem_ and provide a _solution_ and _discussion_.
 
 ### Discussion
 The first version of the Ember Cookbook will be completed in a few phases. First, we will be accepting

--- a/guides/v1.11.0/cookbook/contributing/participating_if_you_know_ember.md
+++ b/guides/v1.11.0/cookbook/contributing/participating_if_you_know_ember.md
@@ -17,7 +17,7 @@ Based on your experience and knowledge of Ember, we recommend submitting pull re
   <dd><em>Problem</em>, <em>Solution</em> &amp; <em>Discussion</em> is the right way to help if you have a deeper understanding of the topic and can write cogently about why the solution is a good idea, explain pitfalls of other solutions, etc.</dd>
 </dl>
 
-You will be able to suggest possible recipes by forking this project and submitting a pull request with a new recipe (see [Suggesting a Recipe](../suggesting_a_recipe)).
+You will be able to suggest possible recipes by forking this project and submitting a pull request with a new recipe (see [Suggesting a Recipe](suggesting_a_recipe)).
 
 [fork_repo]: https://github.com/emberjs/website
 [suggesting_a_recipe]: ./suggesting_a_recipe

--- a/guides/v1.11.0/cookbook/user_interface_and_interaction/adding_css_classes_to_your_components.md
+++ b/guides/v1.11.0/cookbook/user_interface_and_interaction/adding_css_classes_to_your_components.md
@@ -32,4 +32,4 @@ classNames: ['bold', 'italic', 'blue']
 
 <a class="jsbin-embed" href="http://jsbin.com/gihupoqeja/2/embed?live">JS Bin</a>
 
-See [Customizing a Component's Element](../../components/customizing-a-components-element/) for further examples. -->
+See [Customizing a Component's Element](../../components/customizing-a-components-element) for further examples. -->

--- a/guides/v1.11.0/cookbook/user_interface_and_interaction/adding_css_classes_to_your_components_based_on_properties.md
+++ b/guides/v1.11.0/cookbook/user_interface_and_interaction/adding_css_classes_to_your_components_based_on_properties.md
@@ -33,4 +33,4 @@ isRelatedBinding: "content.isRelated" // value resolves to boolean
 
 <a class="jsbin-embed" href="http://jsbin.com/jogizaqepe/2/embed?live">JS Bin</a>
 
-See [Customizing a Component's Element](../../components/customizing-a-components-element/) for further examples. -->
+See [Customizing a Component's Element](../../components/customizing-a-components-element) for further examples. -->

--- a/guides/v1.11.0/cookbook/user_interface_and_interaction/converting_strings_to_currency_with_accounting_js.md
+++ b/guides/v1.11.0/cookbook/user_interface_and_interaction/converting_strings_to_currency_with_accounting_js.md
@@ -24,6 +24,6 @@ formattedAmount: function(key, value) {
 <!---#### Example
 
 <a class="jsbin-embed" href="http://emberjs.jsbin.com/AqeVuZI/2/embed?live">JS Bin</a>-->
-[setters]: /guides/object-model/computed-properties/
+[setters]: ../../object-model/computed-properties/
 [accounting]: http://josscrowcroft.github.io/accounting.js/
 

--- a/guides/v1.11.0/enumerables/index.md
+++ b/guides/v1.11.0/enumerables/index.md
@@ -55,7 +55,7 @@ Usually, objects that represent lists implement the Enumerable interface. Some e
 
  * **Array** - Ember extends the native JavaScript `Array` with the
    Enumerable interface (unless you [disable prototype
-   extensions.](../../configuring-ember/disabling-prototype-extensions/))
+   extensions.](../configuring-ember/disabling-prototype-extensions/))
  * **Ember.ArrayController** - A controller that wraps an underlying array and
    adds additional functionality for the view layer.
  * **Ember.Set** - A data structure that can efficiently answer whether it

--- a/guides/v1.11.0/models/defining-models.md
+++ b/guides/v1.11.0/models/defining-models.md
@@ -92,7 +92,7 @@ export default DS.Model.extend({
 The default adapter supports attribute types of `string`,
 `number`, `boolean`, and `date`. Custom adapters may offer additional
 attribute types, and new types can be registered as transforms. See the
-[documentation section on the REST Adapter](../the-rest-adapter).
+[documentation section on the REST Adapter](the-rest-adapter).
 
 **Please note:** Ember Data serializes and deserializes dates according to
                  [ISO 8601][]. For example: `2014-05-27T12:54:01`

--- a/guides/v1.11.0/models/defining-models.md
+++ b/guides/v1.11.0/models/defining-models.md
@@ -77,7 +77,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 If you don't specify the type of the attribute, it will be whatever was
 provided by the server. You can make sure that an attribute is always
@@ -92,7 +92,7 @@ export default DS.Model.extend({
 The default adapter supports attribute types of `string`,
 `number`, `boolean`, and `date`. Custom adapters may offer additional
 attribute types, and new types can be registered as transforms. See the
-[documentation section on the REST Adapter](../../models/the-rest-adapter).
+[documentation section on the REST Adapter](../the-rest-adapter).
 
 **Please note:** Ember Data serializes and deserializes dates according to
                  [ISO 8601][]. For example: `2014-05-27T12:54:01`

--- a/guides/v1.11.0/models/finding-records.md
+++ b/guides/v1.11.0/models/finding-records.md
@@ -56,7 +56,7 @@ var peters = this.store.find('person', { name: "Peter" }); // => GET to /persons
 As discussed in [Specifying a Route's Model][3], routes are
 responsible for telling their template which model to render.
 
-[3]: ../../routing/specifying-a-routes-model
+[3]: ../routing/specifying-a-routes-model
 
 `Ember.Route`'s `model` hook supports asynchronous values
 out-of-the-box. If you return a promise from the `model` hook, the

--- a/guides/v1.11.0/models/index.md
+++ b/guides/v1.11.0/models/index.md
@@ -5,7 +5,7 @@ implementing a route's `model` hook, by passing the model as an argument
 to `{{link-to}}`, or by calling a route's `transitionTo()` method.
 
 See [Specifying a Route's
-Model](../../routing/specifying-a-routes-model) for more information
+Model](../routing/specifying-a-routes-model) for more information
 on setting a route's model.
 
 For simple applications, you can get by using jQuery to load JSON data

--- a/guides/v1.11.0/models/the-fixture-adapter.md
+++ b/guides/v1.11.0/models/the-fixture-adapter.md
@@ -79,6 +79,6 @@ a uniquely identifiable field. By default, Ember Data assumes this key
 is called `id`. Should you not provide an `id` field in your fixtures, or
 not override the primary key, the Fixture Adapter will throw an error.
 
-[1]: ../defining-models
-[2]: ../finding-records
-[3]: ../the-rest-adapter
+[1]: defining-models
+[2]: finding-records
+[3]: the-rest-adapter

--- a/guides/v1.11.0/object-model/computed-properties.md
+++ b/guides/v1.11.0/object-model/computed-properties.md
@@ -32,7 +32,7 @@ Whenever you access the `fullName` property, this function gets called, and it r
 
 #### Alternate invocation
 
-At this point, you might be wondering how you are able to call the `.property` function on a function.  This is possible because Ember extends the `function` prototype.  More information about extending native prototypes is available in the [disabling prototype extensions guide](../../configuring-ember/disabling-prototype-extensions/). If you'd like to replicate the declaration from above without using these extensions you could do so with the following:
+At this point, you might be wondering how you are able to call the `.property` function on a function.  This is possible because Ember extends the `function` prototype.  More information about extending native prototypes is available in the [disabling prototype extensions guide](../configuring-ember/disabling-prototype-extensions/). If you'd like to replicate the declaration from above without using these extensions you could do so with the following:
 
 ```javascript
   fullName: Ember.computed('firstName', 'lastName', function() {

--- a/guides/v1.11.0/routing/defining-your-routes.md
+++ b/guides/v1.11.0/routing/defining-your-routes.md
@@ -7,7 +7,7 @@ The [map](http://emberjs.com/api/classes/Ember.Router.html#method_map) method
 of your Ember application's router can be invoked to define URL mappings. When
 calling `map`, you should pass a function that will be invoked with the value
 `this` set to an object which you can use to create
-[routes](../defining-your-routes/).
+[routes](defining-your-routes/).
 
 ```app/router.js
 Router.map(function() {

--- a/guides/v1.11.0/routing/generated-objects.md
+++ b/guides/v1.11.0/routing/generated-objects.md
@@ -1,4 +1,4 @@
-As explained in the [routing guide](../defining-your-routes), whenever you define a new route,
+As explained in the [routing guide](defining-your-routes), whenever you define a new route,
 Ember.js attempts to find corresponding Route, Controller, View, and Template
 classes named according to naming conventions. If an implementation of any of
 these objects is not found, appropriate objects will be generated in memory for you.

--- a/guides/v1.11.0/routing/loading-and-error-substates.md
+++ b/guides/v1.11.0/routing/loading-and-error-substates.md
@@ -1,5 +1,5 @@
 In addition to the techniques described in the
-[Asynchronous Routing Guide](../asynchronous-routing/),
+[Asynchronous Routing Guide](asynchronous-routing/),
 the Ember Router provides powerful yet overridable
 conventions for customizing asynchronous transitions
 between routes by making use of `error` and `loading`
@@ -9,7 +9,7 @@ substates.
 
 The Ember Router allows you to return promises from the various
 `beforeModel`/`model`/`afterModel` hooks in the course of a transition
-(described [here](../asynchronous-routing/)).
+(described [here](asynchronous-routing/)).
 These promises pause the transition until they fulfill, at which point
 the transition will resume.
 

--- a/guides/v1.11.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v1.11.0/routing/preventing-and-retrying-transitions.md
@@ -47,7 +47,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v1.11.0/routing/redirection.md
+++ b/guides/v1.11.0/routing/redirection.md
@@ -2,13 +2,13 @@
 
 Calling `transitionTo` from a route or `transitionToRoute` from a controller
 will stop any transition currently in progress and start a new one, functioning
-as a redirect. `transitionTo` takes parameters and behaves exactly like the [link-to](../../templates/links) helper:
+as a redirect. `transitionTo` takes parameters and behaves exactly like the [link-to](../templates/links) helper:
 
 * If you transition into a route without dynamic segments that route's `model` hook
 will always run.
 
 * If the new route has dynamic segments, you need to pass either a _model_ or an _identifier_ for each segment.
-Passing a model will skip that segment's `model` hook.  Passing an identifier will run the `model` hook and you'll be able to access the identifier in the params. See [Links](../../templates/links) for more detail.
+Passing a model will skip that segment's `model` hook.  Passing an identifier will run the `model` hook and you'll be able to access the identifier in the params. See [Links](../templates/links) for more detail.
 
 ### Before the model is known
 

--- a/guides/v1.11.0/routing/setting-up-a-controller.md
+++ b/guides/v1.11.0/routing/setting-up-a-controller.md
@@ -45,7 +45,7 @@ export default Ember.Route.extend({
 ```
 
 As a second argument, it receives the route handler's model. For more
-information, see [Specifying a Route's Model](../specifying-a-routes-model/).
+information, see [Specifying a Route's Model](specifying-a-routes-model/).
 
 The default `setupController` hook sets the `model` property of the
 associated controller to the route handler's model.

--- a/guides/v1.11.0/routing/specifying-a-routes-model.md
+++ b/guides/v1.11.0/routing/specifying-a-routes-model.md
@@ -50,7 +50,7 @@ eventually returned over the network. Ember uses this promise object to
 know when it has enough data to continue rendering.
 
 For more about promises, see [A Word on
-Promises](../../routing/asynchronous-routing/#toc_a-word-on-promises)
+Promises](../routing/asynchronous-routing/#toc_a-word-on-promises)
 in the Asynchronous Routing guide.
 
 Let's look at an example in action. Here's a route that loads the most
@@ -114,7 +114,7 @@ default behavior. Note that if you override the default behavior and do
 not set the `model` property on a controller, your template will not
 have any data to render!
 
-[1]: ../setting-up-a-controller
+[1]: setting-up-a-controller
 
 ### Dynamic Models
 
@@ -151,7 +151,7 @@ When the user goes to the `photo` route to display a particular photo
 model (usually via the `{{link-to}}` helper), that model's ID will be
 placed into the URL automatically.
 
-See [Links](../../templates/links) for more information about linking
+See [Links](../templates/links) for more information about linking
 to a route with a model using the `{{link-to}}` helper.
 
 For example, if you transitioned to the `photo` route with a model whose
@@ -195,7 +195,7 @@ return a promise for the JSON model data.
 
 Note: A route with a dynamic segment will only have its `model` hook called
 when it is entered via the URL. If the route is entered through a transition
-(e.g. when using the [link-to](../../templates/links) Handlebars helper), then a model context is
+(e.g. when using the [link-to](../templates/links) Handlebars helper), then a model context is
 already provided and the hook is not executed. Routes without dynamic segments
 will always execute the model hook.
 
@@ -221,4 +221,4 @@ significantly improving the performance of your application.
 
 One popular model library built for Ember is Ember Data. To learn more
 about using Ember Data to manage your models, see the
-[Models](../../models) guide.
+[Models](../models) guide.

--- a/guides/v1.11.0/templates/actions.md
+++ b/guides/v1.11.0/templates/actions.md
@@ -165,7 +165,7 @@ You can specify an alternative event by using the `on` option.
 You should use the normalized event names [listed in the View guide][1].
 In general, two-word event names (like `keypress`) become `keyPress`.
 
-[1]: ../../understanding-ember/the-view-layer/#toc_adding-new-events
+[1]: ../understanding-ember/the-view-layer/#toc_adding-new-events
 
 ### Specifying Whitelisted Modifier Keys
 

--- a/guides/v1.11.0/templates/binding-element-attributes.md
+++ b/guides/v1.11.0/templates/binding-element-attributes.md
@@ -34,7 +34,7 @@ the specified attribute. For example, given this template:
 ```
 
 For further control over how these values are applied, see the [inline-if syntax
-documentation on the Conditionals page](../conditionals/#toc_inline-if-syntax).
+documentation on the Conditionals page](conditionals/#toc_inline-if-syntax).
 
 ### Adding data attributes
 

--- a/guides/v1.11.0/templates/handlebars-basics.md
+++ b/guides/v1.11.0/templates/handlebars-basics.md
@@ -11,9 +11,9 @@ write any additional code to make sure it keeps up-to-date.
 
 ### Defining Templates
 
-By default, adjust your [application template](../the-application-template), that is created automatically for you and will be displayed on the page when your app loads.
+By default, adjust your [application template](the-application-template), that is created automatically for you and will be displayed on the page when your app loads.
 
-You can also define templates by name that can be used later. If you would like to create a template that is shared across many areas of your site, you should investigate [components](../../components/defining-a-component/). The components section information on creating a re-usable template.
+You can also define templates by name that can be used later. If you would like to create a template that is shared across many areas of your site, you should investigate [components](../components/defining-a-component/). The components section information on creating a re-usable template.
 
 ### Handlebars Expressions
 

--- a/guides/v1.11.0/templates/input-helpers.md
+++ b/guides/v1.11.0/templates/input-helpers.md
@@ -116,4 +116,4 @@ Will bind the value of the text area to `name` on the current context.
 See the [Built-in Views][4] section of these guides to learn how to further
 extend these views.
 
-[4]: ../../views/built-in-views
+[4]: ../views/built-in-views

--- a/guides/v1.11.0/templates/links.md
+++ b/guides/v1.11.0/templates/links.md
@@ -37,10 +37,10 @@ The `{{link-to}}` helper takes:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   If there is no model to pass to the helper, you can provide an explicit identifier value instead.
-  The value will be filled into the [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments)
+  The value will be filled into the [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments)
   of the route, and will make sure that the `model` hook is triggered.
 * An optional title which will be bound to the `a` title attribute
 

--- a/guides/v1.11.0/templates/rendering-with-helpers.md
+++ b/guides/v1.11.0/templates/rendering-with-helpers.md
@@ -69,7 +69,7 @@ When using `{{view "author"}}`:
 * An instance of author view will be created
 * It will be rendered here, using the template associated with that view (the default template being "author")
 
-For more information, see [Inserting Views in Templates](../../views/inserting-views-in-templates)
+For more information, see [Inserting Views in Templates](../views/inserting-views-in-templates)
 
 ### The `{{render}}` Helper
 

--- a/guides/v1.11.0/templates/the-application-template.md
+++ b/guides/v1.11.0/templates/the-application-template.md
@@ -27,6 +27,6 @@ contents of the `<div>` will change depending on if the user is
 currently at `/posts` or `/posts/15`, for example.
 
 For more information about how outlets are filled in by the router, see
-[Routing](../../routing).
+[Routing](../routing).
 
 Ember CLI will create `application.hbs` for you by default in `app/templates/application.hbs`.

--- a/guides/v1.11.0/testing/testing-components.md
+++ b/guides/v1.11.0/testing/testing-components.md
@@ -281,4 +281,4 @@ test('renders kittens', function(assert) {
 ```
 -->
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics

--- a/guides/v1.11.0/testing/testing-controllers.md
+++ b/guides/v1.11.0/testing/testing-controllers.md
@@ -28,8 +28,8 @@ export default Ember.Controller.extend({
 });
 ```
 
-`setProps` sets a property on the controller and also calls a method. In our 
-generated test, ember-cli already uses the `moduleFor` helper to setup a test 
+`setProps` sets a property on the controller and also calls a method. In our
+generated test, ember-cli already uses the `moduleFor` helper to setup a test
 container:
 
 ```tests/unit/controllers/posts-test.js
@@ -123,5 +123,5 @@ test('modify the post', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: /guides/testing/unit-testing-basics
-[needs]: /guides/controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v1.11.0/testing/testing-models.md
+++ b/guides/v1.11.0/testing/testing-models.md
@@ -84,5 +84,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: /guides/testing/unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v1.11.0/testing/testing-routes.md
+++ b/guides/v1.11.0/testing/testing-routes.md
@@ -67,5 +67,5 @@ test('Alert is called on displayAlert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: /guides/testing/unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v1.11.0/testing/testing-xhr.md
+++ b/guides/v1.11.0/testing/testing-xhr.md
@@ -2,7 +2,7 @@ Testing with asynchronous calls and promises in Ember may seem tricky at first, 
 
 ### Promises, Ember and the Run Loop
 
-In order to fully explain testing promises & asynchronous code, it's important that you have a clear grasp of the Ember run loop. If you haven't yet done so, please read about them in the [Promises](http://emberjs.com/api/classes/Ember.RSVP.Promise.html) and [Understanding Ember run loop guide](../../understanding-ember/run-loop/).
+In order to fully explain testing promises & asynchronous code, it's important that you have a clear grasp of the Ember run loop. If you haven't yet done so, please read about them in the [Promises](http://emberjs.com/api/classes/Ember.RSVP.Promise.html) and [Understanding Ember run loop guide](../understanding-ember/run-loop/).
 
 Now that you grasp the general concepts regarding the run loop, recall from reading about the basics of testing Ember applications that the run loop is suspended when in testing mode.  This helps ensure the procedure of your code and the tests you write around that code. Note that in testing promises and asynchronous code, you're effectively "stepping through" your application in chunks.
 

--- a/guides/v1.11.0/testing/unit-testing-basics.md
+++ b/guides/v1.11.0/testing/unit-testing-basics.md
@@ -42,7 +42,7 @@ test('computedFoo correctly concats foo', function(assert) {
 });
 ```
 
-See that we have used `moduleFor` one of the several [unit-test helpers](../unit-test-helpers) provided
+See that we have used `moduleFor` one of the several [unit-test helpers](unit-test-helpers) provided
 by Ember-Qunit.
 
 ### Testing Object Methods

--- a/guides/v1.11.0/understanding-ember/managing-asynchrony.md
+++ b/guides/v1.11.0/understanding-ember/managing-asynchrony.md
@@ -255,4 +255,4 @@ the parts of the render process outside of these callbacks.
 ### Routing
 
 There's an entire page dedicated to managing async within the Ember
-Router: [Asynchronous Routing](../../routing/asynchronous-routing)
+Router: [Asynchronous Routing](../routing/asynchronous-routing)

--- a/guides/v1.11.0/views/built-in-views.md
+++ b/guides/v1.11.0/views/built-in-views.md
@@ -1,4 +1,4 @@
-Ember comes pre-packaged with a set of views for building basic controls like text inputs, check boxes, and select lists. Usually, these views will be used via the [input helpers](../../templates/input-helpers/). However, the base views may be helpful in creating custom form behaviors.
+Ember comes pre-packaged with a set of views for building basic controls like text inputs, check boxes, and select lists. Usually, these views will be used via the [input helpers](../templates/input-helpers/). However, the base views may be helpful in creating custom form behaviors.
 
 * [Ember.Checkbox](http://emberjs.com/api/classes/Ember.Checkbox.html)
 * [Ember.TextField](http://emberjs.com/api/classes/Ember.TextField.html)

--- a/guides/v1.12.0/application/index.md
+++ b/guides/v1.12.0/application/index.md
@@ -5,10 +5,8 @@ This object is located at `./app/app.js` inside your project.
 What does creating an `Ember.Application` instance get you?
 
 1. It adds event listeners to the document and is responsible for
-   delegating events to your views. (See [The View
-   Layer](../understanding-ember/the-view-layer)
+   delegating events to your views. (See [The View Layer](../understanding-ember/the-view-layer)
   for a detailed description.)
-1. It automatically renders the [application
-   template](../templates/the-application-template).
+1. It automatically renders the [application template](../templates/the-application-template).
 1. It automatically creates a router and begins routing, choosing which
    template and model to display based on the current URL.

--- a/guides/v1.12.0/components/customizing-a-components-element.md
+++ b/guides/v1.12.0/components/customizing-a-components-element.md
@@ -161,4 +161,4 @@ red background:
 <a class="jsbin-embed" href="http://jsbin.com/duzala/1/embed?live">JS Bin</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 **Note:** The binding functionality in this very simple example could also be implemented without
-the use of `Ember.Component` but by simply [binding element attributes](../../templates/binding-element-attributes) or [binding element class names](../../templates/binding-element-class-names). -->
+the use of `Ember.Component` but by simply [binding element attributes](../templates/binding-element-attributes) or [binding element class names](../templates/binding-element-class-names). -->

--- a/guides/v1.12.0/components/defining-a-component.md
+++ b/guides/v1.12.0/components/defining-a-component.md
@@ -60,7 +60,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ### Defining a Component Subclass

--- a/guides/v1.12.0/components/handling-user-interaction-with-actions.md
+++ b/guides/v1.12.0/components/handling-user-interaction-with-actions.md
@@ -7,7 +7,7 @@ users of your application to interact with it.
 
 You can make elements in your component interactive by using the
 `{{action}}` helper. This is the [same `{{action}}` helper you use in
-application templates](../../templates/actions), but it has an
+application templates](../templates/actions), but it has an
 important difference when used inside a component.
 
 Instead of sending an action to the template's controller, then bubbling
@@ -41,4 +41,4 @@ The `{{action}}` helper can accept arguments, listen for different event
 types, control how action bubbling occurs, and more.
 
 For details about using the `{{action}}` helper, see the [Actions
-section](../../templates/actions) of the Templates chapter.
+section](../templates/actions) of the Templates chapter.

--- a/guides/v1.12.0/components/sending-actions-from-components-to-your-application.md
+++ b/guides/v1.12.0/components/sending-actions-from-components-to-your-application.md
@@ -8,7 +8,7 @@ first go to the template's controller. If the controller does not
 implement a handler for that action, it will bubble to the template's
 route, and then up the route hierarchy. For more information about this
 bubbling behavior, see [Action
-Bubbling](../../templates/actions/#toc_action-bubbling).
+Bubbling](../templates/actions/#toc_action-bubbling).
 
 Components are designed to be reusable across different parts of your
 application. In order to achieve this reusability, it's important that

--- a/guides/v1.12.0/components/wrapping-content-in-a-component.md
+++ b/guides/v1.12.0/components/wrapping-content-in-a-component.md
@@ -19,7 +19,7 @@ in another template:
 <!---<a class="jsbin-embed" href="http://jsbin.com/hihunemapu/2/embed?live">JS Bin</a><script src="http://static.jsbin.com/js/embed.js"></script>-->
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v1.12.0/concepts/naming-conventions.md
+++ b/guides/v1.12.0/concepts/naming-conventions.md
@@ -30,9 +30,9 @@ purposes (e.g. `model`, `setupController`, etc). In the example below
 `route:application` Route, which is an `Ember.Route` object, implements
 the `setupController` hook.
 
-[1]: ../../routing/specifying-a-routes-model
-[2]: ../../routing/setting-up-a-controller
-[3]: ../../routing/rendering-a-template
+[1]: ../routing/specifying-a-routes-model
+[2]: ../routing/setting-up-a-controller
+[3]: ../routing/rendering-a-template
 
 Here's a simple example that uses a route, controller, and template:
 

--- a/guides/v1.12.0/configuring-ember/embedding-applications.md
+++ b/guides/v1.12.0/configuring-ember/embedding-applications.md
@@ -6,7 +6,7 @@ existing page, or run alongside other JavaScript frameworks?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../templates/the-application-template)
+By default, your application will render the [application template](../templates/the-application-template)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -24,8 +24,8 @@ string](http://api.jquery.com/category/selectors/).
 
 ### Disabling URL Management
 
-You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../../routing/specifying-the-location-api) to
+You can prevent Ember from making changes to the URL by
+[changing the router's `location`](../routing/specifying-the-location-api) to
 `none`:
 
 ```config/environment.js

--- a/guides/v1.12.0/controllers/dependencies-between-controllers.md
+++ b/guides/v1.12.0/controllers/dependencies-between-controllers.md
@@ -60,6 +60,6 @@ export default Ember.Controller.extend({
 ```
 
 For more information about dependency injection and `needs` in Ember.js,
-see the [dependency injection guide](../../understanding-ember/dependency-injection-and-service-lookup).
+see the [dependency injection guide](../understanding-ember/dependency-injection-and-service-lookup).
 For more information about aliases, see the API docs for
 [aliased properties](http://emberjs.com/api/#method_computed_alias).

--- a/guides/v1.12.0/cookbook/contributing/participating_if_you_dont_know_ember.md
+++ b/guides/v1.12.0/cookbook/contributing/participating_if_you_dont_know_ember.md
@@ -2,7 +2,7 @@
 You are new to Ember, but want to help write the Cookbook.
 
 ### Solution
-Suggest and/or submit pull requests with a _problem_ statement (see [Suggesting A Recipe](../suggesting_a_recipe)). You do not need to worry about providing a solution or discussion. Someone more experienced with Ember will be able to take your _problem_ and provide a _solution_ and _discussion_.
+Suggest and/or submit pull requests with a _problem_ statement (see [Suggesting A Recipe](suggesting_a_recipe)). You do not need to worry about providing a solution or discussion. Someone more experienced with Ember will be able to take your _problem_ and provide a _solution_ and _discussion_.
 
 ### Discussion
 The first version of the Ember Cookbook will be completed in a few phases. First, we will be accepting

--- a/guides/v1.12.0/cookbook/contributing/participating_if_you_know_ember.md
+++ b/guides/v1.12.0/cookbook/contributing/participating_if_you_know_ember.md
@@ -17,7 +17,7 @@ Based on your experience and knowledge of Ember, we recommend submitting pull re
   <dd><em>Problem</em>, <em>Solution</em> &amp; <em>Discussion</em> is the right way to help if you have a deeper understanding of the topic and can write cogently about why the solution is a good idea, explain pitfalls of other solutions, etc.</dd>
 </dl>
 
-You will be able to suggest possible recipes by forking this project and submitting a pull request with a new recipe (see [Suggesting a Recipe](../suggesting_a_recipe)).
+You will be able to suggest possible recipes by forking this project and submitting a pull request with a new recipe (see [Suggesting a Recipe](suggesting_a_recipe)).
 
 [fork_repo]: https://github.com/emberjs/website
 [suggesting_a_recipe]: ./suggesting_a_recipe

--- a/guides/v1.12.0/cookbook/user_interface_and_interaction/adding_css_classes_to_your_components.md
+++ b/guides/v1.12.0/cookbook/user_interface_and_interaction/adding_css_classes_to_your_components.md
@@ -32,4 +32,4 @@ classNames: ['bold', 'italic', 'blue']
 
 <a class="jsbin-embed" href="http://jsbin.com/gihupoqeja/2/embed?live">JS Bin</a>
 
-See [Customizing a Component's Element](../../components/customizing-a-components-element/) for further examples. -->
+See [Customizing a Component's Element](../../components/customizing-a-components-element) for further examples. -->

--- a/guides/v1.12.0/cookbook/user_interface_and_interaction/adding_css_classes_to_your_components_based_on_properties.md
+++ b/guides/v1.12.0/cookbook/user_interface_and_interaction/adding_css_classes_to_your_components_based_on_properties.md
@@ -33,4 +33,4 @@ isRelatedBinding: "content.isRelated" // value resolves to boolean
 
 <a class="jsbin-embed" href="http://jsbin.com/jogizaqepe/2/embed?live">JS Bin</a>
 
-See [Customizing a Component's Element](../../components/customizing-a-components-element/) for further examples. -->
+See [Customizing a Component's Element](../../components/customizing-a-components-element) for further examples. -->

--- a/guides/v1.12.0/cookbook/user_interface_and_interaction/converting_strings_to_currency_with_accounting_js.md
+++ b/guides/v1.12.0/cookbook/user_interface_and_interaction/converting_strings_to_currency_with_accounting_js.md
@@ -24,6 +24,6 @@ formattedAmount: function(key, value) {
 <!---#### Example
 
 <a class="jsbin-embed" href="http://emberjs.jsbin.com/AqeVuZI/2/embed?live">JS Bin</a>-->
-[setters]: /guides/object-model/computed-properties/
+[setters]: ../../object-model/computed-properties/
 [accounting]: http://josscrowcroft.github.io/accounting.js/
 

--- a/guides/v1.12.0/ember-inspector/troubleshooting.md
+++ b/guides/v1.12.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this happens:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](/guides/ember-inspector/installation#toc_file-protocol).
+follow [these steps](installation#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using Jsbin, follow [these steps](#toc_using-the-inspector-with-jsbin).
 
@@ -48,7 +48,7 @@ It means that you are either not using a data persistence library
 (such as Ember Data), or the library you're using does not support the
 Ember Inspector.
 
-If you are the library's author, [see this section](/guides/ember-inspector/data#toc_building-a-data-custom-adapter) on how to add Ember Inspector support.
+If you are the library's author, [see this section](data#toc_building-a-data-custom-adapter) on how to add Ember Inspector support.
 
 ### Promises Not Detected
 

--- a/guides/v1.12.0/ember-inspector/view-tree.md
+++ b/guides/v1.12.0/ember-inspector/view-tree.md
@@ -11,7 +11,7 @@ Click on the `View Tree` menu on the left to see your views.
 You can click on any model, controller, view, or component
 to send them to the [object inspector][object-inspector-guide].
 
-[object-inspector-guide]: /guides/ember-inspector/object-inspector
+[object-inspector-guide]: object-inspector
 
 
 <img src="/images/guides/ember-inspector/view-tree-object-inspector.png" width="680">
@@ -85,4 +85,3 @@ Instrumentation however adds its own delay to rendering, so the
 numbers you see are not an exact representation of production apps.
 These numbers should be used to compare rendering times, and not as a
 replacement for performance benchmarking.
-

--- a/guides/v1.12.0/enumerables/index.md
+++ b/guides/v1.12.0/enumerables/index.md
@@ -50,7 +50,7 @@ Usually, objects that represent lists implement the Enumerable interface. Some e
 
  * **Array** - Ember extends the native JavaScript `Array` with the
    Enumerable interface (unless you [disable prototype
-   extensions.](../../configuring-ember/disabling-prototype-extensions/))
+   extensions.](../configuring-ember/disabling-prototype-extensions/))
  * **Ember.ArrayController** - A controller that wraps an underlying array and
    adds additional functionality for the view layer.
  * **Ember.Set** - A data structure that can efficiently answer whether it

--- a/guides/v1.12.0/models/defining-models.md
+++ b/guides/v1.12.0/models/defining-models.md
@@ -92,7 +92,7 @@ export default DS.Model.extend({
 The default adapter supports attribute types of `string`,
 `number`, `boolean`, and `date`. Custom adapters may offer additional
 attribute types, and new types can be registered as transforms. See the
-[documentation section on the REST Adapter](../the-rest-adapter).
+[documentation section on the REST Adapter](the-rest-adapter).
 
 **Please note:** Ember Data serializes and deserializes dates according to
                  [ISO 8601][]. For example: `2014-05-27T12:54:01`

--- a/guides/v1.12.0/models/defining-models.md
+++ b/guides/v1.12.0/models/defining-models.md
@@ -77,7 +77,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 If you don't specify the type of the attribute, it will be whatever was
 provided by the server. You can make sure that an attribute is always
@@ -92,7 +92,7 @@ export default DS.Model.extend({
 The default adapter supports attribute types of `string`,
 `number`, `boolean`, and `date`. Custom adapters may offer additional
 attribute types, and new types can be registered as transforms. See the
-[documentation section on the REST Adapter](../../models/the-rest-adapter).
+[documentation section on the REST Adapter](../the-rest-adapter).
 
 **Please note:** Ember Data serializes and deserializes dates according to
                  [ISO 8601][]. For example: `2014-05-27T12:54:01`

--- a/guides/v1.12.0/models/finding-records.md
+++ b/guides/v1.12.0/models/finding-records.md
@@ -56,7 +56,7 @@ var peters = this.store.find('person', { name: "Peter" }); // => GET to /persons
 As discussed in [Specifying a Route's Model][3], routes are
 responsible for telling their template which model to render.
 
-[3]: ../../routing/specifying-a-routes-model
+[3]: ../routing/specifying-a-routes-model
 
 `Ember.Route`'s `model` hook supports asynchronous values
 out-of-the-box. If you return a promise from the `model` hook, the

--- a/guides/v1.12.0/object-model/computed-properties.md
+++ b/guides/v1.12.0/object-model/computed-properties.md
@@ -32,7 +32,7 @@ Whenever you access the `fullName` property, this function gets called, and it r
 
 #### Alternate invocation
 
-At this point, you might be wondering how you are able to call the `.property` function on a function.  This is possible because Ember extends the `function` prototype.  More information about extending native prototypes is available in the [disabling prototype extensions guide](../../configuring-ember/disabling-prototype-extensions/). If you'd like to replicate the declaration from above without using these extensions you could do so with the following:
+At this point, you might be wondering how you are able to call the `.property` function on a function.  This is possible because Ember extends the `function` prototype.  More information about extending native prototypes is available in the [disabling prototype extensions guide](../configuring-ember/disabling-prototype-extensions/). If you'd like to replicate the declaration from above without using these extensions you could do so with the following:
 
 ```javascript
   fullName: Ember.computed('firstName', 'lastName', function() {

--- a/guides/v1.12.0/routing/defining-your-routes.md
+++ b/guides/v1.12.0/routing/defining-your-routes.md
@@ -7,7 +7,7 @@ The [map](http://emberjs.com/api/classes/Ember.Router.html#method_map) method
 of your Ember application's router can be invoked to define URL mappings. When
 calling `map`, you should pass a function that will be invoked with the value
 `this` set to an object which you can use to create
-[routes](../defining-your-routes/).
+[routes](defining-your-routes/).
 
 ```app/router.js
 Router.map(function() {

--- a/guides/v1.12.0/routing/generated-objects.md
+++ b/guides/v1.12.0/routing/generated-objects.md
@@ -1,4 +1,4 @@
-As explained in the [routing guide](../defining-your-routes), whenever you define a new route,
+As explained in the [routing guide](defining-your-routes), whenever you define a new route,
 Ember.js attempts to find corresponding Route, Controller, View, and Template
 classes named according to naming conventions. If an implementation of any of
 these objects is not found, appropriate objects will be generated in memory for you.

--- a/guides/v1.12.0/routing/loading-and-error-substates.md
+++ b/guides/v1.12.0/routing/loading-and-error-substates.md
@@ -1,5 +1,5 @@
 In addition to the techniques described in the
-[Asynchronous Routing Guide](../asynchronous-routing/),
+[Asynchronous Routing Guide](asynchronous-routing/),
 the Ember Router provides powerful yet overridable
 conventions for customizing asynchronous transitions
 between routes by making use of `error` and `loading`
@@ -9,7 +9,7 @@ substates.
 
 The Ember Router allows you to return promises from the various
 `beforeModel`/`model`/`afterModel` hooks in the course of a transition
-(described [here](../asynchronous-routing/)).
+(described [here](asynchronous-routing/)).
 These promises pause the transition until they fulfill, at which point
 the transition will resume.
 

--- a/guides/v1.12.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v1.12.0/routing/preventing-and-retrying-transitions.md
@@ -47,7 +47,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v1.12.0/routing/redirection.md
+++ b/guides/v1.12.0/routing/redirection.md
@@ -2,13 +2,13 @@
 
 Calling `transitionTo` from a route or `transitionToRoute` from a controller
 will stop any transition currently in progress and start a new one, functioning
-as a redirect. `transitionTo` takes parameters and behaves exactly like the [link-to](../../templates/links) helper:
+as a redirect. `transitionTo` takes parameters and behaves exactly like the [link-to](../templates/links) helper:
 
 * If you transition into a route without dynamic segments that route's `model` hook
 will always run.
 
 * If the new route has dynamic segments, you need to pass either a _model_ or an _identifier_ for each segment.
-Passing a model will skip that segment's `model` hook.  Passing an identifier will run the `model` hook and you'll be able to access the identifier in the params. See [Links](../../templates/links) for more detail.
+Passing a model will skip that segment's `model` hook.  Passing an identifier will run the `model` hook and you'll be able to access the identifier in the params. See [Links](../templates/links) for more detail.
 
 ### Before the model is known
 

--- a/guides/v1.12.0/routing/setting-up-a-controller.md
+++ b/guides/v1.12.0/routing/setting-up-a-controller.md
@@ -44,7 +44,7 @@ export default Ember.Route.extend({
 ```
 
 As a second argument, it receives the route handler's model. For more
-information, see [Specifying a Route's Model](../specifying-a-routes-model/).
+information, see [Specifying a Route's Model](specifying-a-routes-model/).
 
 The default `setupController` hook sets the `model` property of the
 associated controller to the route handler's model.

--- a/guides/v1.12.0/routing/specifying-a-routes-model.md
+++ b/guides/v1.12.0/routing/specifying-a-routes-model.md
@@ -50,7 +50,7 @@ eventually returned over the network. Ember uses this promise object to
 know when it has enough data to continue rendering.
 
 For more about promises, see [A Word on
-Promises](../../routing/asynchronous-routing/#toc_a-word-on-promises)
+Promises](../routing/asynchronous-routing/#toc_a-word-on-promises)
 in the Asynchronous Routing guide.
 
 Let's look at an example in action. Here's a route that loads the most
@@ -114,7 +114,7 @@ default behavior. Note that if you override the default behavior and do
 not set the `model` property on a controller, your template will not
 have any data to render!
 
-[1]: ../setting-up-a-controller
+[1]: setting-up-a-controller
 
 ### Dynamic Models
 
@@ -151,7 +151,7 @@ When the user goes to the `photo` route to display a particular photo
 model (usually via the `{{link-to}}` helper), that model's ID will be
 placed into the URL automatically.
 
-See [Links](../../templates/links) for more information about linking
+See [Links](../templates/links) for more information about linking
 to a route with a model using the `{{link-to}}` helper.
 
 For example, if you transitioned to the `photo` route with a model whose
@@ -195,7 +195,7 @@ return a promise for the JSON model data.
 
 Note: A route with a dynamic segment will only have its `model` hook called
 when it is entered via the URL. If the route is entered through a transition
-(e.g. when using the [link-to](../../templates/links) Handlebars helper), then a model context is
+(e.g. when using the [link-to](../templates/links) Handlebars helper), then a model context is
 already provided and the hook is not executed. Routes without dynamic segments
 will always execute the model hook.
 
@@ -221,4 +221,4 @@ significantly improving the performance of your application.
 
 One popular model library built for Ember is Ember Data. To learn more
 about using Ember Data to manage your models, see the
-[Models](../../models) guide.
+[Models](../models) guide.

--- a/guides/v1.12.0/templates/handlebars-basics.md
+++ b/guides/v1.12.0/templates/handlebars-basics.md
@@ -11,9 +11,9 @@ write any additional code to make sure it keeps up-to-date.
 
 ### Defining Templates
 
-By default, adjust your [application template](../the-application-template), that is created automatically for you and will be displayed on the page when your app loads.
+By default, adjust your [application template](the-application-template), that is created automatically for you and will be displayed on the page when your app loads.
 
-You can also define templates by name that can be used later. If you would like to create a template that is shared across many areas of your site, you should investigate [components](../../components/defining-a-component/). The components section contains information on creating re-usable templates.
+You can also define templates by name that can be used later. If you would like to create a template that is shared across many areas of your site, you should investigate [components](../components/defining-a-component/). The components section contains information on creating re-usable templates.
 
 ### Handlebars Expressions
 

--- a/guides/v1.12.0/templates/input-helpers.md
+++ b/guides/v1.12.0/templates/input-helpers.md
@@ -116,4 +116,4 @@ Will bind the value of the text area to `name` on the current context.
 See the [Built-in Views][4] section of these guides to learn how to further
 extend these views.
 
-[4]: ../../views/built-in-views
+[4]: ../views/built-in-views

--- a/guides/v1.12.0/templates/links.md
+++ b/guides/v1.12.0/templates/links.md
@@ -33,7 +33,7 @@ The `{{link-to}}` helper takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the helper, you can provide

--- a/guides/v1.12.0/templates/rendering-with-helpers.md
+++ b/guides/v1.12.0/templates/rendering-with-helpers.md
@@ -71,7 +71,7 @@ When using `{{view "author"}}`:
 * An instance of author view will be created
 * It will be rendered here, using the template associated with that view (the default template being "author")
 
-For more information, see [Inserting Views in Templates](../../views/inserting-views-in-templates).
+For more information, see [Inserting Views in Templates](../views/inserting-views-in-templates).
 
 ### The `{{render}}` Helper
 

--- a/guides/v1.12.0/templates/the-application-template.md
+++ b/guides/v1.12.0/templates/the-application-template.md
@@ -27,6 +27,6 @@ contents of the `<div>` will change depending on if the user is
 currently at `/posts` or `/posts/15`, for example.
 
 For more information about how outlets are filled in by the router, see
-[Routing](../../routing).
+[Routing](../routing).
 
 Ember CLI will create `application.hbs` for you by default in `app/templates/application.hbs`.

--- a/guides/v1.12.0/testing/testing-components.md
+++ b/guides/v1.12.0/testing/testing-components.md
@@ -281,4 +281,4 @@ test('renders kittens', function(assert) {
 ```
 -->
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics

--- a/guides/v1.12.0/testing/testing-controllers.md
+++ b/guides/v1.12.0/testing/testing-controllers.md
@@ -123,5 +123,5 @@ test('modify the post', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: /guides/controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v1.12.0/testing/testing-models.md
+++ b/guides/v1.12.0/testing/testing-models.md
@@ -84,5 +84,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v1.12.0/testing/testing-routes.md
+++ b/guides/v1.12.0/testing/testing-routes.md
@@ -67,5 +67,5 @@ test('Alert is called on displayAlert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v1.12.0/testing/testing-xhr.md
+++ b/guides/v1.12.0/testing/testing-xhr.md
@@ -2,7 +2,7 @@ Testing with asynchronous calls and promises in Ember may seem tricky at first, 
 
 ### Promises, Ember and the Run Loop
 
-In order to fully explain testing promises & asynchronous code, it's important that you have a clear grasp of the Ember run loop. If you haven't yet done so, please read about them in the [Promises](http://emberjs.com/api/classes/Ember.RSVP.Promise.html) and [Understanding Ember run loop guide](../../understanding-ember/run-loop/).
+In order to fully explain testing promises & asynchronous code, it's important that you have a clear grasp of the Ember run loop. If you haven't yet done so, please read about them in the [Promises](http://emberjs.com/api/classes/Ember.RSVP.Promise.html) and [Understanding Ember run loop guide](../understanding-ember/run-loop/).
 
 Now that you grasp the general concepts regarding the run loop, recall from reading about the basics of testing Ember applications that the run loop is suspended when in testing mode.  This helps ensure the procedure of your code and the tests you write around that code. Note that in testing promises and asynchronous code, you're effectively "stepping through" your application in chunks.
 

--- a/guides/v1.12.0/testing/unit-testing-basics.md
+++ b/guides/v1.12.0/testing/unit-testing-basics.md
@@ -42,7 +42,7 @@ test('computedFoo correctly concats foo', function(assert) {
 });
 ```
 
-See that we have used `moduleFor` one of the several [unit-test helpers](../unit-test-helpers) provided
+See that we have used `moduleFor` one of the several [unit-test helpers](unit-test-helpers) provided
 by Ember-Qunit.
 
 ### Testing Object Methods

--- a/guides/v1.12.0/understanding-ember/managing-asynchrony.md
+++ b/guides/v1.12.0/understanding-ember/managing-asynchrony.md
@@ -267,4 +267,4 @@ the parts of the render process outside of these callbacks.
 ### Routing
 
 There's an entire page dedicated to managing async within the Ember
-Router: [Asynchronous Routing](../../routing/asynchronous-routing)
+Router: [Asynchronous Routing](../routing/asynchronous-routing)

--- a/guides/v1.12.0/views/built-in-views.md
+++ b/guides/v1.12.0/views/built-in-views.md
@@ -1,4 +1,4 @@
-Ember comes pre-packaged with a set of views for building basic controls like text inputs, check boxes, and select lists. Usually, these views will be used via the [input helpers](../../templates/input-helpers/). However, the base views may be helpful in creating custom form behaviors.
+Ember comes pre-packaged with a set of views for building basic controls like text inputs, check boxes, and select lists. Usually, these views will be used via the [input helpers](../templates/input-helpers/). However, the base views may be helpful in creating custom form behaviors.
 
 * [Ember.Checkbox](http://emberjs.com/api/classes/Ember.Checkbox.html)
 * [Ember.TextField](http://emberjs.com/api/classes/Ember.TextField.html)

--- a/guides/v1.13.0/components/customizing-a-components-element.md
+++ b/guides/v1.13.0/components/customizing-a-components-element.md
@@ -161,4 +161,4 @@ red background:
 <a class="jsbin-embed" href="http://jsbin.com/duzala/1/embed?live">JS Bin</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 **Note:** The binding functionality in this very simple example could also be implemented without
-the use of `Ember.Component` but by simply [binding element attributes](../../templates/binding-element-attributes) or [binding element class names](../../templates/binding-element-class-names). -->
+the use of `Ember.Component` but by simply [binding element attributes](../templates/binding-element-attributes) or [binding element class names](../templates/binding-element-class-names). -->

--- a/guides/v1.13.0/components/defining-a-component.md
+++ b/guides/v1.13.0/components/defining-a-component.md
@@ -59,7 +59,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ### Defining a Component Subclass

--- a/guides/v1.13.0/components/handling-user-interaction-with-actions.md
+++ b/guides/v1.13.0/components/handling-user-interaction-with-actions.md
@@ -7,7 +7,7 @@ users of your application to interact with it.
 
 You can make elements in your component interactive by using the
 `{{action}}` helper. This is the [same `{{action}}` helper you use in
-application templates](../../templates/actions), but it has an
+application templates](../templates/actions), but it has an
 important difference when used inside a component.
 
 Instead of sending an action to the template's controller, then bubbling
@@ -41,4 +41,4 @@ The `{{action}}` helper can accept arguments, listen for different event
 types, control how action bubbling occurs, and more.
 
 For details about using the `{{action}}` helper, see the [Actions
-section](../../templates/actions) of the Templates chapter.
+section](../templates/actions) of the Templates chapter.

--- a/guides/v1.13.0/components/sending-actions-from-components-to-your-application.md
+++ b/guides/v1.13.0/components/sending-actions-from-components-to-your-application.md
@@ -8,7 +8,7 @@ first go to the template's controller. If the controller does not
 implement a handler for that action, it will bubble to the template's
 route, and then up the route hierarchy. For more information about this
 bubbling behavior, see [Action
-Bubbling](../../templates/actions/#toc_action-bubbling).
+Bubbling](../templates/actions/#toc_action-bubbling).
 
 Components are designed to be reusable across different parts of your
 application. In order to achieve this reusability, it's important that

--- a/guides/v1.13.0/components/wrapping-content-in-a-component.md
+++ b/guides/v1.13.0/components/wrapping-content-in-a-component.md
@@ -19,7 +19,7 @@ in another template:
 <!---<a class="jsbin-embed" href="http://jsbin.com/hihunemapu/2/embed?live">JS Bin</a><script src="http://static.jsbin.com/js/embed.js"></script>-->
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v1.13.0/configuring-ember/embedding-applications.md
+++ b/guides/v1.13.0/configuring-ember/embedding-applications.md
@@ -6,7 +6,7 @@ existing page, or run alongside other JavaScript frameworks?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../templates/the-application-template)
+By default, your application will render the [application template](../templates/the-application-template)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -24,8 +24,8 @@ string](http://api.jquery.com/category/selectors/).
 
 ### Disabling URL Management
 
-You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../../routing/specifying-the-location-api) to
+You can prevent Ember from making changes to the URL by
+[changing the router's `location`](../routing/specifying-the-location-api) to
 `none`:
 
 ```config/environment.js

--- a/guides/v1.13.0/controllers/dependencies-between-controllers.md
+++ b/guides/v1.13.0/controllers/dependencies-between-controllers.md
@@ -50,6 +50,6 @@ export default Ember.Controller.extend({
 ```
 
 For more information about dependency injection in Ember.js,
-see the [dependency injection guide](../../understanding-ember/dependency-injection-and-service-lookup).
+see the [dependency injection guide](../understanding-ember/dependency-injection-and-service-lookup).
 For more information about aliases, see the API docs for
 [aliased properties](http://emberjs.com/api/#method_computed_alias).

--- a/guides/v1.13.0/ember-inspector/troubleshooting.md
+++ b/guides/v1.13.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this happens:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using Jsbin, follow [these steps](#toc_using-the-inspector-with-jsbin).
 
@@ -48,7 +48,7 @@ It means that you are either not using a data persistence library
 (such as Ember Data), or the library you're using does not support the
 Ember Inspector.
 
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Ember Inspector support.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Ember Inspector support.
 
 ### Promises Not Detected
 

--- a/guides/v1.13.0/ember-inspector/view-tree.md
+++ b/guides/v1.13.0/ember-inspector/view-tree.md
@@ -11,7 +11,7 @@ Click on the `View Tree` menu on the left to see your views.
 You can click on any model, controller, view, or component
 to send them to the [object inspector][object-inspector-guide].
 
-[object-inspector-guide]: ../object-inspector
+[object-inspector-guide]: object-inspector
 
 
 <img src="/images/guides/ember-inspector/view-tree-object-inspector.png" width="680">

--- a/guides/v1.13.0/getting-started/naming-conventions.md
+++ b/guides/v1.13.0/getting-started/naming-conventions.md
@@ -24,9 +24,9 @@ purposes (e.g. `model`, `setupController`, etc). In the example below
 `route:application` Route, which is an `Ember.Route` object, implements
 the `setupController` hook.
 
-[1]: ../../routing/specifying-a-routes-model
-[2]: ../../routing/setting-up-a-controller
-[3]: ../../routing/rendering-a-template
+[1]: ../routing/specifying-a-routes-model
+[2]: ../routing/setting-up-a-controller
+[3]: ../routing/rendering-a-template
 
 Here's a simple example that uses a route, controller, and template:
 

--- a/guides/v1.13.0/models/defining-models.md
+++ b/guides/v1.13.0/models/defining-models.md
@@ -92,7 +92,7 @@ export default DS.Model.extend({
 The default adapter supports attribute types of `string`,
 `number`, `boolean`, and `date`. Custom adapters may offer additional
 attribute types, and new types can be registered as transforms. See the
-[documentation section on the REST Adapter](../the-rest-adapter).
+[documentation section on the REST Adapter](the-rest-adapter).
 
 **Please note:** Ember Data serializes and deserializes dates according to
                  [ISO 8601][]. For example: `2014-05-27T12:54:01`

--- a/guides/v1.13.0/models/defining-models.md
+++ b/guides/v1.13.0/models/defining-models.md
@@ -77,7 +77,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 If you don't specify the type of the attribute, it will be whatever was
 provided by the server. You can make sure that an attribute is always
@@ -92,7 +92,7 @@ export default DS.Model.extend({
 The default adapter supports attribute types of `string`,
 `number`, `boolean`, and `date`. Custom adapters may offer additional
 attribute types, and new types can be registered as transforms. See the
-[documentation section on the REST Adapter](../../models/the-rest-adapter).
+[documentation section on the REST Adapter](../the-rest-adapter).
 
 **Please note:** Ember Data serializes and deserializes dates according to
                  [ISO 8601][]. For example: `2014-05-27T12:54:01`

--- a/guides/v1.13.0/models/finding-records.md
+++ b/guides/v1.13.0/models/finding-records.md
@@ -61,7 +61,7 @@ var peters = this.store.query('person', { name: 'Peter' }); // => GET to /person
 As discussed in [Specifying a Route's Model][3], routes are
 responsible for telling their template which model to render.
 
-[3]: ../../routing/specifying-a-routes-model
+[3]: ../routing/specifying-a-routes-model
 
 `Ember.Route`'s `model` hook supports asynchronous values
 out-of-the-box. If you return a promise from the `model` hook, the

--- a/guides/v1.13.0/models/index.md
+++ b/guides/v1.13.0/models/index.md
@@ -163,7 +163,7 @@ designed to work out of the box with [JSON API][json-api]. JSON API is a
 formal specification for building conventional, robust, and performant
 APIs that allow clients and servers to communicate model data.
 
-[json-api]: jsonapi.org
+[json-api]: http://jsonapi.org
 
 JSON API standardizes how JavaScript applications talk to servers, so
 you decrease the coupling between your frontend and backend, and have

--- a/guides/v1.13.0/routing/defining-your-routes.md
+++ b/guides/v1.13.0/routing/defining-your-routes.md
@@ -7,7 +7,7 @@ The [map](http://emberjs.com/api/classes/Ember.Router.html#method_map) method
 of your Ember application's router can be invoked to define URL mappings. When
 calling `map`, you should pass a function that will be invoked with the value
 `this` set to an object which you can use to create
-[routes](../defining-your-routes/).
+[routes](defining-your-routes/).
 
 ```app/router.js
 Router.map(function() {

--- a/guides/v1.13.0/routing/generated-objects.md
+++ b/guides/v1.13.0/routing/generated-objects.md
@@ -1,4 +1,4 @@
-As explained in the [routing guide](../defining-your-routes), whenever
+As explained in the [routing guide](defining-your-routes), whenever
 you define a new path in your router, Ember.js attempts to find a
 corresponding route, controller, and template, each named according to
 naming conventions. If an implementation of any of these objects is not

--- a/guides/v1.13.0/routing/loading-and-error-substates.md
+++ b/guides/v1.13.0/routing/loading-and-error-substates.md
@@ -1,5 +1,5 @@
 In addition to the techniques described in the
-[Asynchronous Routing Guide](../asynchronous-routing/),
+[Asynchronous Routing Guide](asynchronous-routing/),
 the Ember Router provides powerful yet overridable
 conventions for customizing asynchronous transitions
 between routes by making use of `error` and `loading`
@@ -9,7 +9,7 @@ substates.
 
 The Ember Router allows you to return promises from the various
 `beforeModel`/`model`/`afterModel` hooks in the course of a transition
-(described [here](../asynchronous-routing/)).
+(described [here](asynchronous-routing/)).
 These promises pause the transition until they fulfill, at which point
 the transition will resume.
 

--- a/guides/v1.13.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v1.13.0/routing/preventing-and-retrying-transitions.md
@@ -47,7 +47,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v1.13.0/routing/redirection.md
+++ b/guides/v1.13.0/routing/redirection.md
@@ -2,13 +2,13 @@
 
 Calling `transitionTo` from a route or `transitionToRoute` from a controller
 will stop any transition currently in progress and start a new one, functioning
-as a redirect. `transitionTo` takes parameters and behaves exactly like the [link-to](../../templates/links) helper:
+as a redirect. `transitionTo` takes parameters and behaves exactly like the [link-to](../templates/links) helper:
 
 * If you transition into a route without dynamic segments that route's `model` hook
 will always run.
 
 * If the new route has dynamic segments, you need to pass either a _model_ or an _identifier_ for each segment.
-Passing a model will skip that segment's `model` hook.  Passing an identifier will run the `model` hook and you'll be able to access the identifier in the params. See [Links](../../templates/links) for more detail.
+Passing a model will skip that segment's `model` hook.  Passing an identifier will run the `model` hook and you'll be able to access the identifier in the params. See [Links](../templates/links) for more detail.
 
 ### Before the model is known
 

--- a/guides/v1.13.0/routing/setting-up-a-controller.md
+++ b/guides/v1.13.0/routing/setting-up-a-controller.md
@@ -42,7 +42,7 @@ export default Ember.Route.extend({
 As a second argument, it receives the route handler's model. For more
 information, see [Specifying a Route's Model][1].
 
-[1]: ../specifying-a-routes-model/
+[1]: specifying-a-routes-model
 The default `setupController` hook sets the `model` property of the
 associated controller to the route handler's model.
 

--- a/guides/v1.13.0/routing/specifying-a-routes-model.md
+++ b/guides/v1.13.0/routing/specifying-a-routes-model.md
@@ -50,7 +50,7 @@ eventually returned over the network. Ember uses this promise object to
 know when it has enough data to continue rendering.
 
 For more about promises, see [A Word on
-Promises](../../routing/asynchronous-routing/#toc_a-word-on-promises)
+Promises](../routing/asynchronous-routing/#toc_a-word-on-promises)
 in the Asynchronous Routing guide.
 
 Let's look at an example in action. Here's a route that loads the most
@@ -114,7 +114,7 @@ default behavior. Note that if you override the default behavior and do
 not set the `model` property on a controller, your template will not
 have any data to render!
 
-[1]: ../setting-up-a-controller
+[1]: setting-up-a-controller
 
 ### Dynamic Models
 
@@ -151,7 +151,7 @@ When the user goes to the `photo` route to display a particular photo
 model (usually via the `{{link-to}}` helper), that model's ID will be
 placed into the URL automatically.
 
-See [Links](../../templates/links) for more information about linking
+See [Links](../templates/links) for more information about linking
 to a route with a model using the `{{link-to}}` helper.
 
 For example, if you transitioned to the `photo` route with a model whose
@@ -195,7 +195,7 @@ return a promise for the JSON model data.
 
 Note: A route with a dynamic segment will only have its `model` hook called
 when it is entered via the URL. If the route is entered through a transition
-(e.g. when using the [link-to](../../templates/links) Handlebars helper), then a model context is
+(e.g. when using the [link-to](../templates/links) Handlebars helper), then a model context is
 already provided and the hook is not executed. Routes without dynamic segments
 will always execute the model hook.
 
@@ -221,4 +221,4 @@ significantly improving the performance of your application.
 
 One popular model library built for Ember is Ember Data. To learn more
 about using Ember Data to manage your models, see the
-[Models](../../models) guide.
+[Models](../models) guide.

--- a/guides/v1.13.0/templates/handlebars-basics.md
+++ b/guides/v1.13.0/templates/handlebars-basics.md
@@ -11,11 +11,10 @@ write any additional code to make sure it keeps up-to-date.
 
 ### Defining Templates
 
-The first thing you should change is your [application template](../the-application-template) that is created
+The first thing you should change is your [application template](the-application-template) that is created
 automatically for you and is displayed when your app loads.
 
-Next, you can define templates in the `app/templates` folder. Remember from
-[Naming Convetions](../../concepts/naming-conventions/#toc_route-controller-and-template-defaults) that by default,
+Next, you can define templates in the `app/templates` folder. By default,
 a route will render a template with the same name as the route.
 
 ```app/templates/kittens.hbs
@@ -23,7 +22,7 @@ a route will render a template with the same name as the route.
 <p>Kittens are the cutest!</p>
 ```
 
-If you would like to create a template that is shared across many areas of your site, you should investigate [components](../../components/defining-a-component/).
+If you would like to create a template that is shared across many areas of your site, you should investigate [components](../components/defining-a-component/).
 
 ### Handlebars Expressions
 

--- a/guides/v1.13.0/templates/links.md
+++ b/guides/v1.13.0/templates/links.md
@@ -33,7 +33,7 @@ The `{{link-to}}` helper takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the helper, you can provide

--- a/guides/v1.13.0/templates/the-application-template.md
+++ b/guides/v1.13.0/templates/the-application-template.md
@@ -27,6 +27,6 @@ contents of the `<div>` will change depending on if the user is
 currently at `/posts` or `/posts/15`, for example.
 
 For more information about how outlets are filled in by the router, see
-[Routing](../../routing).
+[Routing](../routing).
 
 Ember CLI will create `application.hbs` for you by default in `app/templates/application.hbs`.

--- a/guides/v1.13.0/testing/testing-components.md
+++ b/guides/v1.13.0/testing/testing-components.md
@@ -313,4 +313,4 @@ test('renders kittens', function(assert) {
 ```
 -->
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics

--- a/guides/v1.13.0/testing/testing-controllers.md
+++ b/guides/v1.13.0/testing/testing-controllers.md
@@ -28,8 +28,8 @@ export default Ember.Controller.extend({
 });
 ```
 
-`setProps` sets a property on the controller and also calls a method. In our 
-generated test, ember-cli already uses the `moduleFor` helper to setup a test 
+`setProps` sets a property on the controller and also calls a method. In our
+generated test, ember-cli already uses the `moduleFor` helper to setup a test
 container:
 
 ```tests/unit/controllers/posts-test.js
@@ -123,5 +123,5 @@ test('modify the post', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v1.13.0/testing/testing-models.md
+++ b/guides/v1.13.0/testing/testing-models.md
@@ -84,5 +84,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v1.13.0/testing/testing-routes.md
+++ b/guides/v1.13.0/testing/testing-routes.md
@@ -67,5 +67,5 @@ test('Alert is called on displayAlert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v1.13.0/testing/unit-testing-basics.md
+++ b/guides/v1.13.0/testing/unit-testing-basics.md
@@ -42,7 +42,7 @@ test('computedFoo correctly concats foo', function(assert) {
 });
 ```
 
-See that we have used `moduleFor` one of the several [unit-test helpers](../unit-test-helpers) provided
+See that we have used `moduleFor` one of the several [unit-test helpers](unit-test-helpers) provided
 by Ember-Qunit.
 
 ### Testing Object Methods

--- a/guides/v2.0.0/components/defining-a-component.md
+++ b/guides/v2.0.0/components/defining-a-component.md
@@ -41,7 +41,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.0.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.0.0/components/triggering-changes-with-actions.md
@@ -66,7 +66,7 @@ the button. In this case, we'll find the user's account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -74,7 +74,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js

--- a/guides/v2.0.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.0.0/components/wrapping-content-in-a-component.md
@@ -17,7 +17,7 @@ in another template:
 ```
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v2.0.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.0.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current enviroment (`development`,`production` or `test`).
 

--- a/guides/v2.0.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.0.0/configuring-ember/disabling-prototype-extensions.md
@@ -106,7 +106,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.0.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.0.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../templates/the-application-template)
+By default, your application will render the application template
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -25,8 +25,8 @@ string](http://api.jquery.com/category/selectors/).
 
 ### Disabling URL Management
 
-You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../../routing/specifying-the-location-api) to
+You can prevent Ember from making changes to the URL by
+changing the router's `location` to
 `none`:
 
 ```config/environment.js

--- a/guides/v2.0.0/controllers/dependencies-between-controllers.md
+++ b/guides/v2.0.0/controllers/dependencies-between-controllers.md
@@ -46,4 +46,4 @@ export default Ember.Controller.extend({
 ```
 
 For more information about aliases, see the API docs for
-[aliased properties](http://emberjs.com/api/#method_computed_alias). If you need have more extensive "data sharing" needs across your app, see the [services page](../../services/), which largely replaces injected controllers.
+[aliased properties](http://emberjs.com/api/#method_computed_alias). If you need have more extensive "data sharing" needs across your app, see the [services page](../applications/services/), which largely replaces injected controllers.

--- a/guides/v2.0.0/ember-inspector/object-inspector.md
+++ b/guides/v2.0.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.0.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.0.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-jsbin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.0.0/ember-inspector/view-tree.md
+++ b/guides/v2.0.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.0.0/models/customizing-adapters.md
+++ b/guides/v2.0.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.0.0/models/defining-models.md
+++ b/guides/v2.0.0/models/defining-models.md
@@ -19,8 +19,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -56,7 +56,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.0.0/routing/defining-your-routes.md
+++ b/guides/v2.0.0/routing/defining-your-routes.md
@@ -178,7 +178,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post. See [Specifying a Route's
-Model](../specifying-a-routes-model) for
+Model](specifying-a-routes-model) for
 more about how to load a model.
 
 ## Wildcard / globbing routes

--- a/guides/v2.0.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.0.0/routing/preventing-and-retrying-transitions.md
@@ -47,7 +47,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.0.0/routing/redirection.md
+++ b/guides/v2.0.0/routing/redirection.md
@@ -1,6 +1,6 @@
 Calling `transitionTo` from a route or `transitionToRoute` from a controller
 will stop any transition currently in progress and start a new one, functioning
-as a redirect. `transitionTo` behaves exactly like the [link-to](../../templates/links) helper.
+as a redirect. `transitionTo` behaves exactly like the [link-to](../templates/links) helper.
 
 If the new route has dynamic segments, you need to pass either a _model_ or an _identifier_ for each segment.
 Passing a model will skip that segment's `model` hook (since the model is
@@ -26,7 +26,7 @@ export default Ember.Route.extend({
 ```
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.0.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.0.0/routing/specifying-a-routes-model.md
@@ -20,7 +20,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember
 Data records are promises), or a plain JavaScript object or array. Ember will
 wait until the data finishes loading (until the promise is resolved) before
@@ -55,7 +55,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -83,7 +83,7 @@ method.
 
 Note: A route with a dynamic segment will only have its `model` hook called
 when it is entered via the URL. If the route is entered through a transition
-(e.g. when using the [link-to](../../templates/links) Handlebars helper), then a model context is
+(e.g. when using the [link-to](../templates/links) Handlebars helper), then a model context is
 already provided and the hook is not executed. Routes without dynamic segments
 will always execute the model hook.
 

--- a/guides/v2.0.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.0.0/templates/displaying-a-list-of-items.md
@@ -42,7 +42,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays.
 
 ### Accessing an item's `index`

--- a/guides/v2.0.0/templates/handlebars-basics.md
+++ b/guides/v2.0.0/templates/handlebars-basics.md
@@ -54,4 +54,4 @@ controllers and components.
 
 Helpers bring a minimum of logic into Ember templating. Ember ships with several
 built-in helpers, which are explained in the following guides, and also allows
-you to [write your own helpers](../writing-helpers/).
+you to [write your own helpers](writing-helpers/).

--- a/guides/v2.0.0/templates/links.md
+++ b/guides/v2.0.0/templates/links.md
@@ -33,7 +33,7 @@ The `{{link-to}}` helper takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the helper, you can provide

--- a/guides/v2.0.0/testing/testing-controllers.md
+++ b/guides/v2.0.0/testing/testing-controllers.md
@@ -126,5 +126,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.0.0/testing/testing-models.md
+++ b/guides/v2.0.0/testing/testing-models.md
@@ -96,5 +96,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.0.0/testing/testing-routes.md
+++ b/guides/v2.0.0/testing/testing-routes.md
@@ -82,5 +82,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.0.0/testing/unit-testing-basics.md
+++ b/guides/v2.0.0/testing/unit-testing-basics.md
@@ -43,7 +43,7 @@ test('should correctly concat foo', function(assert) {
 });
 ```
 
-See that we have used `moduleFor`, one of the several [unit-test helpers](../unit-test-helpers) provided by Ember-Qunit.
+See that we have used `moduleFor`, one of the several unit-test helpers provided by Ember-Qunit.
 Test helpers provide us with some conveniences, such the subject function that handles lookup and instantiation for our object under test.
 Note that in a unit test you can customize the initialization of your object under test by passing to the
 subject function an object containing the instance variables you would like to initialize.  For example, to initialize

--- a/guides/v2.1.0/components/defining-a-component.md
+++ b/guides/v2.1.0/components/defining-a-component.md
@@ -41,7 +41,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.1.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.1.0/components/triggering-changes-with-actions.md
@@ -66,7 +66,7 @@ the button. In this case, we'll find the user's account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -74,7 +74,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js

--- a/guides/v2.1.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.1.0/components/wrapping-content-in-a-component.md
@@ -17,7 +17,7 @@ in another template:
 ```
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v2.1.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.1.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current enviroment (`development`,`production` or `test`).
 

--- a/guides/v2.1.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.1.0/configuring-ember/disabling-prototype-extensions.md
@@ -106,7 +106,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.1.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.1.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../templates/the-application-template)
+By default, your application will render the application template
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -25,9 +25,8 @@ string](http://api.jquery.com/category/selectors/).
 
 ### Disabling URL Management
 
-You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../../routing/specifying-the-location-api) to
-`none`:
+You can prevent Ember from making changes to the URL by
+changing the router's `location` to `none`:
 
 ```config/environment.js
 var ENV = {

--- a/guides/v2.1.0/controllers/dependencies-between-controllers.md
+++ b/guides/v2.1.0/controllers/dependencies-between-controllers.md
@@ -46,4 +46,4 @@ export default Ember.Controller.extend({
 ```
 
 For more information about aliases, see the API docs for
-[aliased properties](http://emberjs.com/api/#method_computed_alias). If you need have more extensive "data sharing" needs across your app, see the [services page](../../services/), which largely replaces injected controllers.
+[aliased properties](http://emberjs.com/api/#method_computed_alias). If you need have more extensive "data sharing" needs across your app, see the [services page](../applications/services/), which largely replaces injected controllers.

--- a/guides/v2.1.0/ember-inspector/object-inspector.md
+++ b/guides/v2.1.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.1.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.1.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-jsbin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.1.0/ember-inspector/view-tree.md
+++ b/guides/v2.1.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.1.0/models/customizing-adapters.md
+++ b/guides/v2.1.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.1.0/models/defining-models.md
+++ b/guides/v2.1.0/models/defining-models.md
@@ -19,8 +19,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -56,7 +56,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.1.0/routing/defining-your-routes.md
+++ b/guides/v2.1.0/routing/defining-your-routes.md
@@ -178,7 +178,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post. See [Specifying a Route's
-Model](../specifying-a-routes-model) for
+Model](specifying-a-routes-model) for
 more about how to load a model.
 
 ## Wildcard / globbing routes

--- a/guides/v2.1.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.1.0/routing/preventing-and-retrying-transitions.md
@@ -47,7 +47,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.1.0/routing/redirection.md
+++ b/guides/v2.1.0/routing/redirection.md
@@ -1,6 +1,6 @@
 Calling `transitionTo` from a route or `transitionToRoute` from a controller
 will stop any transition currently in progress and start a new one, functioning
-as a redirect. `transitionTo` behaves exactly like the [link-to](../../templates/links) helper.
+as a redirect. `transitionTo` behaves exactly like the [link-to](../templates/links) helper.
 
 If the new route has dynamic segments, you need to pass either a _model_ or an _identifier_ for each segment.
 Passing a model will skip that segment's `model` hook (since the model is
@@ -26,7 +26,7 @@ export default Ember.Route.extend({
 ```
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.1.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.1.0/routing/specifying-a-routes-model.md
@@ -20,7 +20,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember
 Data records are promises), or a plain JavaScript object or array. Ember will
 wait until the data finishes loading (until the promise is resolved) before
@@ -55,7 +55,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -83,7 +83,7 @@ method.
 
 Note: A route with a dynamic segment will only have its `model` hook called
 when it is entered via the URL. If the route is entered through a transition
-(e.g. when using the [link-to](../../templates/links) Handlebars helper), then a model context is
+(e.g. when using the [link-to](../templates/links) Handlebars helper), then a model context is
 already provided and the hook is not executed. Routes without dynamic segments
 will always execute the model hook.
 

--- a/guides/v2.1.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.1.0/templates/displaying-a-list-of-items.md
@@ -42,7 +42,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays.
 
 ### Accessing an item's `index`

--- a/guides/v2.1.0/templates/handlebars-basics.md
+++ b/guides/v2.1.0/templates/handlebars-basics.md
@@ -54,4 +54,4 @@ controllers and components.
 
 Helpers bring a minimum of logic into Ember templating. Ember ships with several
 built-in helpers, which are explained in the following guides, and also allows
-you to [write your own helpers](../writing-helpers/).
+you to [write your own helpers](writing-helpers/).

--- a/guides/v2.1.0/templates/links.md
+++ b/guides/v2.1.0/templates/links.md
@@ -33,7 +33,7 @@ The `{{link-to}}` helper takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the helper, you can provide

--- a/guides/v2.1.0/testing/testing-controllers.md
+++ b/guides/v2.1.0/testing/testing-controllers.md
@@ -126,5 +126,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.1.0/testing/testing-models.md
+++ b/guides/v2.1.0/testing/testing-models.md
@@ -96,5 +96,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.1.0/testing/testing-routes.md
+++ b/guides/v2.1.0/testing/testing-routes.md
@@ -82,5 +82,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.1.0/testing/unit-testing-basics.md
+++ b/guides/v2.1.0/testing/unit-testing-basics.md
@@ -43,7 +43,7 @@ test('should correctly concat foo', function(assert) {
 });
 ```
 
-See that we have used `moduleFor`, one of the several [unit-test helpers](../unit-test-helpers) provided by Ember-Qunit.
+See that we have used `moduleFor`, one of the several unit test helpers provided by Ember-Qunit.
 Test helpers provide us with some conveniences, such the subject function that handles lookup and instantiation for our object under test.
 Note that in a unit test you can customize the initialization of your object under test by passing to the
 subject function an object containing the instance variables you would like to initialize.  For example, to initialize

--- a/guides/v2.10.0/applications/initializers.md
+++ b/guides/v2.10.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.10.0/applications/run-loop.md
+++ b/guides/v2.10.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.10.0/components/block-params.md
+++ b/guides/v2.10.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.10.0/components/defining-a-component.md
+++ b/guides/v2.10.0/components/defining-a-component.md
@@ -46,7 +46,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.10.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.10.0/components/triggering-changes-with-actions.md
@@ -63,7 +63,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -71,7 +71,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -245,7 +245,7 @@ The action helper will add the arguments provided in the template to the call.
 
 Action arguments curry, meaning that you can provide partial arguments to the action helper and provide the rest of the
 arguments when you call the function within the component javascript file.
-For example, our `button-with-confirmation` component will now [yield](../wrapping-content-in-a-component/) the content
+For example, our `button-with-confirmation` component will now [yield](wrapping-content-in-a-component/) the content
 of the confirmation dialog to collect extra information to be sent along with the `onConfirm` action:
 
 ```app/templates/components/button-with-confirmation.hbs

--- a/guides/v2.10.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.10.0/components/wrapping-content-in-a-component.md
@@ -17,7 +17,7 @@ in another template:
 ```
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v2.10.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.10.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.10.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.10.0/configuring-ember/disabling-prototype-extensions.md
@@ -107,7 +107,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.10.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.10.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -28,7 +28,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js

--- a/guides/v2.10.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.10.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.10.0/ember-inspector/object-inspector.md
+++ b/guides/v2.10.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.10.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.10.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.10.0/ember-inspector/view-tree.md
+++ b/guides/v2.10.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.10.0/getting-started/quick-start.md
+++ b/guides/v2.10.0/getting-started/quick-start.md
@@ -19,7 +19,7 @@ npm install -g ember-cli
 ```
 
 Don't have npm? [Learn how to install Node.js and npm here][npm].
-For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../../getting-started/) guide.
+For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../getting-started/) guide.
 
 [npm]: https://docs.npmjs.com/getting-started/installing-node
 

--- a/guides/v2.10.0/models/customizing-adapters.md
+++ b/guides/v2.10.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.10.0/models/defining-models.md
+++ b/guides/v2.10.0/models/defining-models.md
@@ -21,8 +21,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -62,7 +62,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.10.0/routing/defining-your-routes.md
+++ b/guides/v2.10.0/routing/defining-your-routes.md
@@ -246,7 +246,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.10.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.10.0/routing/preventing-and-retrying-transitions.md
@@ -49,7 +49,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.10.0/routing/redirection.md
+++ b/guides/v2.10.0/routing/redirection.md
@@ -10,7 +10,7 @@ Whatever the reason, Ember allows you that control with a combination of hooks a
 One of the methods is [`transitionTo()`](http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo).
 Calling `transitionTo()` from a route or
 [`transitionToRoute()`](http://emberjs.com/api/classes/Ember.Controller.html#method_transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
-`transitionTo()` behaves exactly like the [link-to](../../templates/links) helper.
+`transitionTo()` behaves exactly like the [link-to](../templates/links) helper.
 
 The other one is [`replaceWith()`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
@@ -45,11 +45,11 @@ export default Ember.Route.extend({
 This allows us to return the user back to the original route.
 For example, we might redirect a user to the login page when they try to edit their profile, and immediately redirect
 them back to the edit page once they have successfully logged in.
-See [Storing and Retrying a Transition](../preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
+See [Storing and Retrying a Transition](preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
 for how to do that.
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.10.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.10.0/routing/specifying-a-routes-model.md
@@ -24,7 +24,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember Data records are promises),
 or a plain JavaScript object or array.
 Ember will wait until the data finishes loading (until the promise is resolved) before rendering the template.
@@ -58,7 +58,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -87,7 +87,7 @@ photo's ID (`params.photo_id`) as an argument to Ember Data's `findRecord`
 method.
 
 Note: A route with a dynamic segment will always have its `model` hook called when it is entered via the URL.
-If the route is entered through a transition (e.g. when using the [link-to](../../templates/links) Handlebars helper),
+If the route is entered through a transition (e.g. when using the [link-to](../templates/links) Handlebars helper),
 and a model context is provided (second argument to `link-to`), then the hook is not executed.
 If an identifier (such as an id or slug) is provided instead then the model hook will be executed.
 

--- a/guides/v2.10.0/templates/actions.md
+++ b/guides/v2.10.0/templates/actions.md
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../../components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.10.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.10.0/templates/displaying-a-list-of-items.md
@@ -43,7 +43,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.10.0/templates/handlebars-basics.md
+++ b/guides/v2.10.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.10.0/templates/links.md
+++ b/guides/v2.10.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` helper takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the helper, you can provide

--- a/guides/v2.10.0/templates/writing-helpers.md
+++ b/guides/v2.10.0/templates/writing-helpers.md
@@ -81,7 +81,7 @@ helper again with the new values and keep the page up-to-date.
 
 ### Helper Names
 
-Unlike [components](/components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
+Unlike [components](../components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
 
 ### Helper Arguments
 

--- a/guides/v2.10.0/testing/testing-controllers.md
+++ b/guides/v2.10.0/testing/testing-controllers.md
@@ -132,5 +132,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.10.0/testing/testing-models.md
+++ b/guides/v2.10.0/testing/testing-models.md
@@ -102,5 +102,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.10.0/testing/testing-routes.md
+++ b/guides/v2.10.0/testing/testing-routes.md
@@ -84,5 +84,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.10.0/tutorial/acceptance-test.md
+++ b/guides/v2.10.0/tutorial/acceptance-test.md
@@ -14,7 +14,7 @@ We want our application to:
 * Link to contact information.
 * Filter the list of rentals by city.
 
-We can represent these goals as [Ember acceptance tests](../../testing/acceptance/).
+We can represent these goals as [Ember acceptance tests](../testing/acceptance/).
 Acceptance tests interact with our app like an actual person would, but can be automated, ensuring that our app doesn't break in the future.
 
 We'll start by using Ember CLI to generate a new acceptance test:
@@ -103,7 +103,7 @@ test('should redirect to rentals route', function (assert) {
 A few helpers are in play in this test:
 
 * The [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) helper loads the route specified for the given URL.
-* The [`andThen`](../../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
+* The [`andThen`](../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
 In this case, we need to wait for the page to load after `visit`, so that we can assert that the listings are displayed.
 * [`currentURL`](http://emberjs.com/api/classes/Ember.Test.html#method_currentURL) returns the URL that test application is currently visiting.
 
@@ -140,7 +140,7 @@ test('should link to contact information', function (assert) {
   });
 });
 ```
-Note that we can call two [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
+Note that we can call two [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
 This is because each asynchronous test helper is made to wait until other test helpers are complete.
 
 After testing URLs, we'll drill down on our main rental page to test that we can filter the list down according to a city search criteria.

--- a/guides/v2.10.0/tutorial/autocomplete-component.md
+++ b/guides/v2.10.0/tutorial/autocomplete-component.md
@@ -19,9 +19,9 @@ We want our component to call out to two actions: one action to provide a list o
 For our initial test, we will check that all the cities we provide are rendered and that the listing object is accessible from the template.
 
 Our action call to filter by city will be made asynchronously and we will have to accommodate for this in our test.
-We will leverage [actions](../../components/triggering-changes-with-actions/#toc_handling-action-completion) here to handle asynchronous action completion from our `filterByCity` call by returning a promise from our stubbed action.
+We will leverage [actions](../components/triggering-changes-with-actions/#toc_handling-action-completion) here to handle asynchronous action completion from our `filterByCity` call by returning a promise from our stubbed action.
 
-Note that we also need to add a `wait` call at the end of our test to assert the results. Ember's [`wait` helper](../../testing/testing-components/#toc_waiting-on-asynchronous-behavior) waits for all promises to resolve before running the given function callback and finishing the test.
+Note that we also need to add a `wait` call at the end of our test to assert the results. Ember's [`wait` helper](../testing/testing-components/#toc_waiting-on-asynchronous-behavior) waits for all promises to resolve before running the given function callback and finishing the test.
 
 ```tests/integration/components/list-filter-test.js
 import { moduleForComponent, test } from 'ember-qunit';
@@ -138,7 +138,7 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The `value` property of the `input` will be bound to the `value` property in our component.
 The `key-up` property will be bound to the `handleFilterEntry` action.
 
@@ -170,7 +170,7 @@ export default Ember.Component.extend({
 We use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls our filter action based on the `value` attribute set by our input helper.
 
-The `filter` action is [passed](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
+The `filter` action is [passed](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
 
 To implement these actions, we'll create a `rentals` controller.
 Controllers can contain actions and properties available to the template of its corresponding route.

--- a/guides/v2.10.0/tutorial/ember-data.md
+++ b/guides/v2.10.0/tutorial/ember-data.md
@@ -62,7 +62,7 @@ export default Ember.Route.extend({
 ```
 
 When we call `this.get('store').findAll('rental')`, Ember Data will make a GET request to `/rentals`.
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we're using Mirage in our development environment, Mirage will return the data we've provided.
 When we deploy our app to a production server, we will need to provide a backend for Ember Data to communicate with.

--- a/guides/v2.10.0/tutorial/routes-and-templates.md
+++ b/guides/v2.10.0/tutorial/routes-and-templates.md
@@ -213,7 +213,7 @@ installing route-test
 
 Unlike the other route handlers we've made so far, the `index` route is special:
 it does NOT require an entry in the router's mapping.
-We'll learn more about why the entry isn't required when we look at [nested routes](../subroutes) in Ember.
+We'll learn more about why the entry isn't required when we look at [nested routes](subroutes) in Ember.
 
 We can start by implementing the unit test for index.
 Since all we want to do is transition to `rentals`, our unit test will make sure that the route's [`replaceWith`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) method is called with the desired route.

--- a/guides/v2.10.0/tutorial/service.md
+++ b/guides/v2.10.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```app/components/location-map.js
@@ -118,7 +118,7 @@ export default Ember.Component.extend({
 At this point we should have a passing component integration test, but our acceptance test should now fail, unable to find our maps service.  In addition to our acceptance test failing, no maps show up when we view our web page.
 To actually generate the maps, we'll implement the maps service.
 
-Accessing our maps API through a [service](../../applications/services) will give us several benefits
+Accessing our maps API through a [service](../applications/services) will give us several benefits
 
 * It is injected with a [service locator](https://en.wikipedia.org/wiki/Service_locator_pattern), meaning it will abstract the maps API from the code that uses it, allowing for easier refactoring and maintenance.
 * It is lazy-loaded, meaning it won't be initialized until it is called the first time.
@@ -219,7 +219,7 @@ export default Ember.Service.extend({
 ### Making Google Maps Available
 
 Before implementing the map utility, we need to make the 3rd party map API available to our Ember app.
-There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
+There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
 
 Since Google provides its map API as a remote script, we'll use curl to download it into our project's vendor directory.
 
@@ -338,7 +338,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.10.0/tutorial/subroutes.md
+++ b/guides/v2.10.0/tutorial/subroutes.md
@@ -6,8 +6,8 @@ Up to this point, we've generated four top level routes.
 * The `index` route, which we've set up to redirect to the `rentals` route.
 
 Our `rentals` route is going to serve multiple functions.
-From our [acceptance tests](../acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
-To satisfy that requirement, we are going to make use of Ember's [nested route capability](../../routing/defining-your-routes/#toc_nested-routes).
+From our [acceptance tests](acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
+To satisfy that requirement, we are going to make use of Ember's [nested route capability](../routing/defining-your-routes/#toc_nested-routes).
 
 By the end of this section we want to have created the following new routes:
 
@@ -18,7 +18,7 @@ The `show` route will get substituted with the id of the rental being shown (for
 
 ## The Parent Route
 
-Previously, in the [Routes and Templates tutorial](../routes-and-templates), we set up a `rentals` route.
+Previously, in the [Routes and Templates tutorial](routes-and-templates), we set up a `rentals` route.
 
 Opening the template for this route reveals an outlet underneath the route's general page information.
 At the bottom of the template, you'll notice an `{{outlet}}` helper.
@@ -75,7 +75,7 @@ Ember knows that the default action is to take the user to the `index` route.
 However, you can add the `index` route if you want to customize it.
 For example, you can modify the `index` route's path by specifying `this.route('index', { path: '/custom-path'})`.
 
-In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
+In the section on [using Ember Data](ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
 Let's implement our newly generated `rentals/index` route by moving this `findAll` call from the parent `rentals` route to our new sub-route.
 
 ```app/routes/rentals.js{-2,-3,-4}
@@ -146,13 +146,13 @@ export default RentalsController;
 
 Next, we will want to create a sub-route that will list information for a specific rental.
 To do this, we will need to update a couple of files.
-To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../../models/finding-records/).
+To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../models/finding-records/).
 The `findRecord` function requires that we search by a unique key.
 
 While on the `show` route, we will also want to show additional information about our specific rental.
 
 In order to do this, we will need to modify the Mirage `config.js` file that we added
-back in the [Installing Addons section](../installing-addons). We will add a new route
+back in the [Installing Addons section](installing-addons). We will add a new route
 handler to return a specific rental:
 
 ```mirage/config.js{+57,+58,+59,+60}
@@ -288,7 +288,7 @@ export default Ember.Route.extend({
 ```
 
 Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook.
-When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../models/)).
 
 ## Adding the Rental To Our Template
 
@@ -355,10 +355,10 @@ Clicking on the title will load the detail page for that rental.
 
 ## Final Check
 
-At this point all our tests should pass, including the [list of acceptance tests](../acceptance-test) we created as our beginning requirements.
+At this point all our tests should pass, including the [list of acceptance tests](acceptance-test) we created as our beginning requirements.
 
 ![Acceptance Tests Pass](../../images/subroutes/all-acceptance-pass.png)
 
-At this point you can do a [deployment](../deploying) and share your Super Rentals application to the world
+At this point you can do a [deployment](deploying) and share your Super Rentals application to the world
 or you can use this as a base to explore other Ember features and addons.
 Regardless, we hope this has helped you get started with creating your own ambitious applications with Ember!

--- a/guides/v2.11.0/applications/initializers.md
+++ b/guides/v2.11.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.11.0/applications/run-loop.md
+++ b/guides/v2.11.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.11.0/components/block-params.md
+++ b/guides/v2.11.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.11.0/components/defining-a-component.md
+++ b/guides/v2.11.0/components/defining-a-component.md
@@ -46,7 +46,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.11.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.11.0/components/triggering-changes-with-actions.md
@@ -67,7 +67,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -75,7 +75,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -255,7 +255,7 @@ The action helper will add the arguments provided in the template to the call.
 
 Action arguments curry, meaning that you can provide partial arguments to the action helper and provide the rest of the
 arguments when you call the function within the component javascript file.
-For example, our `button-with-confirmation` component will now [yield](../wrapping-content-in-a-component/) the content
+For example, our `button-with-confirmation` component will now [yield](wrapping-content-in-a-component/) the content
 of the confirmation dialog to collect extra information to be sent along with the `onConfirm` action:
 
 ```app/templates/components/button-with-confirmation.hbs

--- a/guides/v2.11.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.11.0/components/wrapping-content-in-a-component.md
@@ -13,7 +13,7 @@ Now, we can use the `{{blog-post}}` component and pass it properties in another 
 {{blog-post title=title body=body}}
 ```
 
-See [Passing Properties to a Component](../passing-properties-to-a-component/) for more.
+See [Passing Properties to a Component](passing-properties-to-a-component/) for more.
 
 In this case, the content we wanted to display came from the model.
 But what if we want the developer using our component to be able to provide custom HTML content?

--- a/guides/v2.11.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.11.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.11.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.11.0/configuring-ember/disabling-prototype-extensions.md
@@ -107,7 +107,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.11.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.11.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -28,7 +28,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js

--- a/guides/v2.11.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.11.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.11.0/ember-inspector/object-inspector.md
+++ b/guides/v2.11.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.11.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.11.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.11.0/ember-inspector/view-tree.md
+++ b/guides/v2.11.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.11.0/getting-started/quick-start.md
+++ b/guides/v2.11.0/getting-started/quick-start.md
@@ -19,7 +19,7 @@ npm install -g ember-cli
 ```
 
 Don't have npm? [Learn how to install Node.js and npm here][npm].
-For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../../getting-started/) guide.
+For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../getting-started/) guide.
 
 [npm]: https://docs.npmjs.com/getting-started/installing-node
 

--- a/guides/v2.11.0/models/customizing-adapters.md
+++ b/guides/v2.11.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.11.0/models/defining-models.md
+++ b/guides/v2.11.0/models/defining-models.md
@@ -21,8 +21,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -62,7 +62,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.11.0/routing/defining-your-routes.md
+++ b/guides/v2.11.0/routing/defining-your-routes.md
@@ -245,7 +245,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.11.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.11.0/routing/preventing-and-retrying-transitions.md
@@ -49,7 +49,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.11.0/routing/redirection.md
+++ b/guides/v2.11.0/routing/redirection.md
@@ -10,7 +10,7 @@ Whatever the reason, Ember allows you that control with a combination of hooks a
 One of the methods is [`transitionTo()`](http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo).
 Calling `transitionTo()` from a route or
 [`transitionToRoute()`](http://emberjs.com/api/classes/Ember.Controller.html#method_transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
-`transitionTo()` behaves exactly like the [link-to](../../templates/links) helper.
+`transitionTo()` behaves exactly like the [link-to](../templates/links) helper.
 
 The other one is [`replaceWith()`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
@@ -45,11 +45,11 @@ export default Ember.Route.extend({
 This allows us to return the user back to the original route.
 For example, we might redirect a user to the login page when they try to edit their profile, and immediately redirect
 them back to the edit page once they have successfully logged in.
-See [Storing and Retrying a Transition](../preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
+See [Storing and Retrying a Transition](preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
 for how to do that.
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.11.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.11.0/routing/specifying-a-routes-model.md
@@ -24,7 +24,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember Data records are promises),
 or a plain JavaScript object or array.
 Ember will wait until the data finishes loading (until the promise is resolved) before rendering the template.
@@ -58,7 +58,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -87,7 +87,7 @@ photo's ID (`params.photo_id`) as an argument to Ember Data's `findRecord`
 method.
 
 Note: A route with a dynamic segment will always have its `model` hook called when it is entered via the URL.
-If the route is entered through a transition (e.g. when using the [link-to](../../templates/links) Handlebars helper),
+If the route is entered through a transition (e.g. when using the [link-to](../templates/links) Handlebars helper),
 and a model context is provided (second argument to `link-to`), then the hook is not executed.
 If an identifier (such as an id or slug) is provided instead then the model hook will be executed.
 

--- a/guides/v2.11.0/templates/actions.md
+++ b/guides/v2.11.0/templates/actions.md
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../../components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.11.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.11.0/templates/displaying-a-list-of-items.md
@@ -45,7 +45,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.11.0/templates/handlebars-basics.md
+++ b/guides/v2.11.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.11.0/templates/links.md
+++ b/guides/v2.11.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` component takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the component, you can provide

--- a/guides/v2.11.0/templates/writing-helpers.md
+++ b/guides/v2.11.0/templates/writing-helpers.md
@@ -81,7 +81,7 @@ helper again with the new values and keep the page up-to-date.
 
 ### Helper Names
 
-Unlike [components](/components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
+Unlike [components](../components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
 
 ### Helper Arguments
 

--- a/guides/v2.11.0/testing/testing-controllers.md
+++ b/guides/v2.11.0/testing/testing-controllers.md
@@ -132,5 +132,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.11.0/testing/testing-models.md
+++ b/guides/v2.11.0/testing/testing-models.md
@@ -102,5 +102,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.11.0/testing/testing-routes.md
+++ b/guides/v2.11.0/testing/testing-routes.md
@@ -84,5 +84,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.11.0/tutorial/acceptance-test.md
+++ b/guides/v2.11.0/tutorial/acceptance-test.md
@@ -14,7 +14,7 @@ We want our application to:
 * Link to contact information.
 * Filter the list of rentals by city.
 
-We can represent these goals as [Ember acceptance tests](../../testing/acceptance/).
+We can represent these goals as [Ember acceptance tests](../testing/acceptance/).
 Acceptance tests interact with our app like an actual person would, but can be automated, ensuring that our app doesn't break in the future.
 
 We'll start by using Ember CLI to generate a new acceptance test:
@@ -103,7 +103,7 @@ test('should redirect to rentals route', function (assert) {
 A few helpers are in play in this test:
 
 * The [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) helper loads the route specified for the given URL.
-* The [`andThen`](../../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
+* The [`andThen`](../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
 In this case, we need to wait for the page to load after `visit`, so that we can assert that the listings are displayed.
 * [`currentURL`](http://emberjs.com/api/classes/Ember.Test.html#method_currentURL) returns the URL that test application is currently visiting.
 
@@ -140,7 +140,7 @@ test('should link to contact information', function (assert) {
   });
 });
 ```
-Note that we can call two [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
+Note that we can call two [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
 This is because each asynchronous test helper is made to wait until other test helpers are complete.
 
 After testing URLs, we'll drill down on our main rental page to test that we can filter the list down according to a city search criteria.

--- a/guides/v2.11.0/tutorial/autocomplete-component.md
+++ b/guides/v2.11.0/tutorial/autocomplete-component.md
@@ -19,9 +19,9 @@ We want our component to call out to two actions: one action to provide a list o
 For our initial test, we will check that all the cities we provide are rendered and that the listing object is accessible from the template.
 
 Our action call to filter by city will be made asynchronously and we will have to accommodate for this in our test.
-We will leverage [actions](../../components/triggering-changes-with-actions/#toc_handling-action-completion) here to handle asynchronous action completion from our `filterByCity` call by returning a promise from our stubbed action.
+We will leverage [actions](../components/triggering-changes-with-actions/#toc_handling-action-completion) here to handle asynchronous action completion from our `filterByCity` call by returning a promise from our stubbed action.
 
-Note that we also need to add a `wait` call at the end of our test to assert the results. Ember's [`wait` helper](../../testing/testing-components/#toc_waiting-on-asynchronous-behavior) waits for all promises to resolve before running the given function callback and finishing the test.
+Note that we also need to add a `wait` call at the end of our test to assert the results. Ember's [`wait` helper](../testing/testing-components/#toc_waiting-on-asynchronous-behavior) waits for all promises to resolve before running the given function callback and finishing the test.
 
 ```tests/integration/components/list-filter-test.js
 import { moduleForComponent, test } from 'ember-qunit';
@@ -138,7 +138,7 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The `value` property of the `input` will be bound to the `value` property in our component.
 The `key-up` property will be bound to the `handleFilterEntry` action.
 
@@ -170,7 +170,7 @@ export default Ember.Component.extend({
 We use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls our filter action based on the `value` attribute set by our input helper.
 
-The `filter` action is [passed](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
+The `filter` action is [passed](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
 
 To implement these actions, we'll create a `rentals` controller.
 Controllers can contain actions and properties available to the template of its corresponding route.

--- a/guides/v2.11.0/tutorial/ember-cli.md
+++ b/guides/v2.11.0/tutorial/ember-cli.md
@@ -2,7 +2,7 @@ Welcome to the Ember Tutorial!
 This tutorial is meant to introduce basic Ember concepts while creating a professional looking application.
 If you get stuck at any point during the tutorial feel free to visit [https://github.com/ember-learn/super-rentals](https://github.com/ember-learn/super-rentals) for a working example of the completed app.
 
-You can install the latest version of `ember-cli` by following the [Quick Start](../../getting-started/quick-start/#toc_install-ember) guide "Installing Ember" section.
+You can install the latest version of `ember-cli` by following the [Quick Start](../getting-started/quick-start/#toc_install-ember) guide "Installing Ember" section.
 
 Ember CLI, Ember's command line interface, provides a standard project
 structure, a set of development tools, and an addon system.

--- a/guides/v2.11.0/tutorial/ember-data.md
+++ b/guides/v2.11.0/tutorial/ember-data.md
@@ -31,10 +31,10 @@ export default DS.Model.extend({
 });
 ```
 
-Let's define the structure of a rental object using the same attributes for our rental that we [previously used](../model-hook/) in our hard-coded array of JavaScript objects -
+Let's define the structure of a rental object using the same attributes for our rental that we [previously used](model-hook/) in our hard-coded array of JavaScript objects -
 _title_, _owner_, _city_, _type_, _image_, _bedrooms_ and _description_.
 Define attributes by giving them the result of the function [`DS.attr()`](http://emberjs.com/api/data/classes/DS.html#method_attr).
-For more information on Ember Data Attributes, read the section called [Defining Attributes](../../models/defining-models/#toc_defining-attributes) in the guides.
+For more information on Ember Data Attributes, read the section called [Defining Attributes](../models/defining-models/#toc_defining-attributes) in the guides.
 
 ```app/models/rental.js
 import DS from 'ember-data';
@@ -54,8 +54,8 @@ Now we have a model object that we can use for our Ember Data store.
 
 ### Updating the Model Hook
 
-To use our new Ember Data Model object, we need to update the `model` function we [previously defined](../model-hook/) in our route handler.
-Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../../models/#toc_the-store-and-a-single-source-of-truth).
+To use our new Ember Data Model object, we need to update the `model` function we [previously defined](model-hook/) in our route handler.
+Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../models/#toc_the-store-and-a-single-source-of-truth).
 The [store service](http://emberjs.com/api/data/classes/DS.Store.html) is injected into all routes and components in Ember.
 It is the main interface you use to interact with Ember Data.
 In this case, call the [`findAll`](http://emberjs.com/api/data/classes/DS.Store.html#method_findAll) function on the store and provide it with the name of your newly created rental model class.
@@ -100,7 +100,7 @@ export default Ember.Route.extend({
 
 When we call `findAll`, Ember Data will attempt to make a GET request to `/rentals`.
 
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we're using Mirage in our development environment, Mirage will return the data we've provided.
 When we deploy our app to a production server, we will need to provide a backend for Ember Data to communicate with.

--- a/guides/v2.11.0/tutorial/model-hook.md
+++ b/guides/v2.11.0/tutorial/model-hook.md
@@ -59,11 +59,11 @@ export default Ember.Route.extend({
 Note that here, we are using the ES6 shorthand method definition syntax: `model()` is the same as writing `model: function()`.
 
 Ember will use the model object returned above and save it as an attribute called `model`, 
-available to the rentals template we generated with our route in [Routes and Templates](../routes-and-templates/#toc_a-rentals-route).
+available to the rentals template we generated with our route in [Routes and Templates](routes-and-templates/#toc_a-rentals-route).
 
 Now, let's switch over to our rentals page template.
 We can use the model attribute to display our list of rentals.
-Here, we'll use another common Handlebars helper called [`{{each}}`](../../templates/displaying-a-list-of-items/).
+Here, we'll use another common Handlebars helper called [`{{each}}`](../templates/displaying-a-list-of-items/).
 This helper will let us loop through each of the rental objects in our model:
 
 ```app/templates/rentals.hbs{+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,+26,+27,+28,+29}

--- a/guides/v2.11.0/tutorial/routes-and-templates.md
+++ b/guides/v2.11.0/tutorial/routes-and-templates.md
@@ -1,7 +1,7 @@
 In Super Rentals we want to arrive at a home page which shows a list of rentals.
 From there, we should be able to navigate to an about page and a contact page.
 
-Ember provides a [robust routing mechanism](../../routing/) to define logical, addressable pages within our application.
+Ember provides a [robust routing mechanism](../routing/) to define logical, addressable pages within our application.
 
 ## An About Route
 
@@ -42,7 +42,7 @@ A route is composed of the following parts:
 Opening `/app/router.js` shows that there is a new line of code for the _about_ route, calling `this.route('about')` in the `map` function.
 Calling the function `this.route(routeName)`, tells the Ember router to load the specified route handler when the user navigates to the URI with the same name.
 In this case when the user navigates to `/about`, the route handler represented by `/app/routes/about.js` will be used.
-See the guide for [defining routes](../../routing/defining-your-routes/) for more details.
+See the guide for [defining routes](../routing/defining-your-routes/) for more details.
 
 ```app/router.js
 import Ember from 'ember';
@@ -123,7 +123,7 @@ so let's add some navigational links at the bottom of each page.
 Let's make a contact link on the about page and an about link on the contact page.
 
 Ember has built-in template **helpers** that provide functionality for interacting with the framework.
-The [`{{link-to}}`](../../templates/links/) helper provides special ease of use features in linking to Ember routes.
+The [`{{link-to}}`](../templates/links/) helper provides special ease of use features in linking to Ember routes.
 Here we will use the `{{link-to}}` helper in our code to perform a basic link between routes:
 
 ```app/templates/about.hbs{+9,+10,+11}
@@ -215,13 +215,13 @@ installing route-test
 
 Unlike the other route handlers we've made so far, the `index` route is special:
 it does NOT require an entry in the router's mapping.
-We'll learn more about why the entry isn't required when we look at [nested routes](../subroutes) in Ember.
+We'll learn more about why the entry isn't required when we look at [nested routes](subroutes) in Ember.
 
 Let's start by implementing the unit test for our new index route.
 
 Since all we want to do is transition people who visit `/` to `/rentals`,
 our unit test will make sure that the route's [`replaceWith`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) method is called with the desired route.
-`replaceWith` is similar to the route's [`transitionTo`](../../routing/redirection/#toc_transitioning-before-the-model-is-known) function; the difference being that `replaceWith` will replace the current URL in the browser's history, while `transitionTo` will add to the history.
+`replaceWith` is similar to the route's [`transitionTo`](../routing/redirection/#toc_transitioning-before-the-model-is-known) function; the difference being that `replaceWith` will replace the current URL in the browser's history, while `transitionTo` will add to the history.
 Since we want our `rentals` route to serve as our home page, we will use the `replaceWith` function.
 
 In our test, we'll make sure that our index route is redirecting by stubbing the `replaceWith` method for the route and asserting that the `rentals` route is passed when called.

--- a/guides/v2.11.0/tutorial/service.md
+++ b/guides/v2.11.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```app/components/location-map.js
@@ -118,7 +118,7 @@ export default Ember.Component.extend({
 At this point we should have a passing component integration test. However, no maps show up when we view our web page.
 To actually generate the maps, we'll implement the maps service.
 
-Accessing our maps API through a [service](../../applications/services) will give us several benefits
+Accessing our maps API through a [service](../applications/services) will give us several benefits
 
 * It is injected with a [service locator](https://en.wikipedia.org/wiki/Service_locator_pattern), meaning it will abstract the maps API from the code that uses it, allowing for easier refactoring and maintenance.
 * It is lazy-loaded, meaning it won't be initialized until it is called the first time.
@@ -219,7 +219,7 @@ export default Ember.Service.extend({
 ### Making Google Maps Available
 
 Before implementing the map utility, we need to make the 3rd party map API available to our Ember app.
-There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
+There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
 
 Since Google provides its map API as a remote script, we'll use curl to download it into our project's vendor directory.
 
@@ -341,7 +341,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.11.0/tutorial/subroutes.md
+++ b/guides/v2.11.0/tutorial/subroutes.md
@@ -6,8 +6,8 @@ Up to this point, we've generated four top level routes.
 * The `index` route, which we've set up to redirect to the `rentals` route.
 
 Our `rentals` route is going to serve multiple functions.
-From our [acceptance tests](../acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
-To satisfy that requirement, we are going to make use of Ember's [nested route capability](../../routing/defining-your-routes/#toc_nested-routes).
+From our [acceptance tests](acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
+To satisfy that requirement, we are going to make use of Ember's [nested route capability](../routing/defining-your-routes/#toc_nested-routes).
 
 By the end of this section we want to have created the following new routes:
 
@@ -18,7 +18,7 @@ The `show` route will get substituted with the id of the rental being shown (for
 
 ## The Parent Route
 
-Previously, in the [Routes and Templates tutorial](../routes-and-templates), we set up a `rentals` route.
+Previously, in the [Routes and Templates tutorial](routes-and-templates), we set up a `rentals` route.
 
 Opening the template for this route reveals an outlet underneath the route's general page information.
 At the bottom of the template, you'll notice an `{{outlet}}` helper.
@@ -76,7 +76,7 @@ Ember knows that the default action is to take the user to the `index` route.
 However, you can add the `index` route if you want to customize it.
 For example, you can modify the `index` route's path by specifying `this.route('index', { path: '/custom-path'})`.
 
-In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
+In the section on [using Ember Data](ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
 Let's implement our newly generated `rentals/index` route by moving this `findAll` call from the parent `rentals` route to our new sub-route.
 
 ```app/routes/rentals.js{-2,-3,-4}
@@ -147,13 +147,13 @@ export default RentalsController;
 
 Next, we will want to create a sub-route that will list information for a specific rental.
 To do this, we will need to update a couple of files.
-To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../../models/finding-records/).
+To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../models/finding-records/).
 The `findRecord` function requires that we search by a unique key.
 
 While on the `show` route, we will also want to show additional information about our specific rental.
 
 In order to do this, we will need to modify the Mirage `config.js` file that we added
-back in the [Installing Addons section](../installing-addons). We will add a new route
+back in the [Installing Addons section](installing-addons). We will add a new route
 handler to return a specific rental:
 
 ```mirage/config.js{+57,+58,+59,+60}
@@ -288,7 +288,7 @@ export default Ember.Route.extend({
 ```
 
 Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook.
-When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../models/)).
 
 ## Adding the Rental To Our Template
 
@@ -355,10 +355,10 @@ Clicking on the title will load the detail page for that rental.
 
 ## Final Check
 
-At this point all our tests should pass, including the [list of acceptance tests](../acceptance-test) we created as our beginning requirements.
+At this point all our tests should pass, including the [list of acceptance tests](acceptance-test) we created as our beginning requirements.
 
 ![Acceptance Tests Pass](../../images/subroutes/all-acceptance-pass.png)
 
-At this point you can do a [deployment](../deploying) and share your Super Rentals application to the world
+At this point you can do a [deployment](deploying) and share your Super Rentals application to the world
 or you can use this as a base to explore other Ember features and addons.
 Regardless, we hope this has helped you get started with creating your own ambitious applications with Ember!

--- a/guides/v2.12.0/applications/initializers.md
+++ b/guides/v2.12.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.12.0/applications/run-loop.md
+++ b/guides/v2.12.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.12.0/components/block-params.md
+++ b/guides/v2.12.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.12.0/components/defining-a-component.md
+++ b/guides/v2.12.0/components/defining-a-component.md
@@ -46,7 +46,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.12.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.12.0/components/triggering-changes-with-actions.md
@@ -67,7 +67,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -75,7 +75,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -255,7 +255,7 @@ The action helper will add the arguments provided in the template to the call.
 
 Action arguments curry, meaning that you can provide partial arguments to the action helper and provide the rest of the
 arguments when you call the function within the component javascript file.
-For example, our `button-with-confirmation` component will now [yield](../wrapping-content-in-a-component/) the content
+For example, our `button-with-confirmation` component will now [yield](wrapping-content-in-a-component/) the content
 of the confirmation dialog to collect extra information to be sent along with the `onConfirm` action:
 
 ```app/templates/components/button-with-confirmation.hbs

--- a/guides/v2.12.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.12.0/components/wrapping-content-in-a-component.md
@@ -13,7 +13,7 @@ Now, we can use the `{{blog-post}}` component and pass it properties in another 
 {{blog-post title=title body=body}}
 ```
 
-See [Passing Properties to a Component](../passing-properties-to-a-component/) for more.
+See [Passing Properties to a Component](passing-properties-to-a-component/) for more.
 
 In this case, the content we wanted to display came from the model.
 But what if we want the developer using our component to be able to provide custom HTML content?

--- a/guides/v2.12.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.12.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.12.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.12.0/configuring-ember/disabling-prototype-extensions.md
@@ -107,7 +107,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.12.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.12.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -28,7 +28,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js

--- a/guides/v2.12.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.12.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.12.0/ember-inspector/object-inspector.md
+++ b/guides/v2.12.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.12.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.12.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.12.0/ember-inspector/view-tree.md
+++ b/guides/v2.12.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.12.0/getting-started/quick-start.md
+++ b/guides/v2.12.0/getting-started/quick-start.md
@@ -19,7 +19,7 @@ npm install -g ember-cli
 ```
 
 Don't have npm? [Learn how to install Node.js and npm here][npm].
-For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../../getting-started/) guide.
+For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../getting-started/) guide.
 
 [npm]: https://docs.npmjs.com/getting-started/installing-node
 

--- a/guides/v2.12.0/models/customizing-adapters.md
+++ b/guides/v2.12.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.12.0/models/defining-models.md
+++ b/guides/v2.12.0/models/defining-models.md
@@ -21,8 +21,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -62,7 +62,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.12.0/routing/defining-your-routes.md
+++ b/guides/v2.12.0/routing/defining-your-routes.md
@@ -245,7 +245,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.12.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.12.0/routing/preventing-and-retrying-transitions.md
@@ -49,7 +49,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.12.0/routing/redirection.md
+++ b/guides/v2.12.0/routing/redirection.md
@@ -10,7 +10,7 @@ Whatever the reason, Ember allows you that control with a combination of hooks a
 One of the methods is [`transitionTo()`](http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo).
 Calling `transitionTo()` from a route or
 [`transitionToRoute()`](http://emberjs.com/api/classes/Ember.Controller.html#method_transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
-`transitionTo()` behaves exactly like the [link-to](../../templates/links) helper.
+`transitionTo()` behaves exactly like the [link-to](../templates/links) helper.
 
 The other one is [`replaceWith()`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
@@ -45,11 +45,11 @@ export default Ember.Route.extend({
 This allows us to return the user back to the original route.
 For example, we might redirect a user to the login page when they try to edit their profile, and immediately redirect
 them back to the edit page once they have successfully logged in.
-See [Storing and Retrying a Transition](../preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
+See [Storing and Retrying a Transition](preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
 for how to do that.
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.12.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.12.0/routing/specifying-a-routes-model.md
@@ -24,7 +24,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember Data records are promises),
 or a plain JavaScript object or array.
 Ember will wait until the data finishes loading (until the promise is resolved) before rendering the template.
@@ -58,7 +58,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -87,7 +87,7 @@ photo's ID (`params.photo_id`) as an argument to Ember Data's `findRecord`
 method.
 
 Note: A route with a dynamic segment will always have its `model` hook called when it is entered via the URL.
-If the route is entered through a transition (e.g. when using the [link-to](../../templates/links) Handlebars helper),
+If the route is entered through a transition (e.g. when using the [link-to](../templates/links) Handlebars helper),
 and a model context is provided (second argument to `link-to`), then the hook is not executed.
 If an identifier (such as an id or slug) is provided instead then the model hook will be executed.
 

--- a/guides/v2.12.0/templates/actions.md
+++ b/guides/v2.12.0/templates/actions.md
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../../components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.12.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.12.0/templates/displaying-a-list-of-items.md
@@ -45,7 +45,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.12.0/templates/handlebars-basics.md
+++ b/guides/v2.12.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.12.0/templates/links.md
+++ b/guides/v2.12.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` component takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the component, you can provide

--- a/guides/v2.12.0/templates/writing-helpers.md
+++ b/guides/v2.12.0/templates/writing-helpers.md
@@ -81,7 +81,7 @@ helper again with the new values and keep the page up-to-date.
 
 ### Helper Names
 
-Unlike [components](/components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
+Unlike [components](../components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
 
 ### Helper Arguments
 

--- a/guides/v2.12.0/testing/testing-controllers.md
+++ b/guides/v2.12.0/testing/testing-controllers.md
@@ -132,5 +132,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.12.0/testing/testing-models.md
+++ b/guides/v2.12.0/testing/testing-models.md
@@ -102,5 +102,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.12.0/testing/testing-routes.md
+++ b/guides/v2.12.0/testing/testing-routes.md
@@ -84,5 +84,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.12.0/tutorial/acceptance-test.md
+++ b/guides/v2.12.0/tutorial/acceptance-test.md
@@ -18,11 +18,11 @@ For the remainder of this page, we'll give you an introduction to testing in Emb
 On subsequent tutorial pages, the final sections of each page will be devoted to adding a test for the feature you just implemented.
 These sections aren't required for a working application and you may move on with the tutorial without writing them.
 
-At this point, you can continue to the [next page](../routes-and-templates/) or read more about Ember testing below.
+At this point, you can continue to the [next page](routes-and-templates/) or read more about Ember testing below.
 
 ### Testing Our Application As We Go
 
-We can represent the goals above as [Ember acceptance tests](../../testing/acceptance/).
+We can represent the goals above as [Ember acceptance tests](../testing/acceptance/).
 Acceptance tests interact with our app like an actual person would, but are automated, helping ensure that our app doesn't break in the future.
 
 When we create a new Ember Project using Ember CLI, it uses the [`QUnit`](https://qunitjs.com/) JavaScript test framework to define and run tests.

--- a/guides/v2.12.0/tutorial/autocomplete-component.md
+++ b/guides/v2.12.0/tutorial/autocomplete-component.md
@@ -1,5 +1,5 @@
 As they search for a rental, users might also want to narrow their search to a specific city.
-While our [initial](../simple-component/) rental listing component only displayed rental information, this new filter component will also allow the user to provide input in the form of filter criteria.
+While our [initial](simple-component/) rental listing component only displayed rental information, this new filter component will also allow the user to provide input in the form of filter criteria.
 
 To begin, let's generate our new component.
 We'll call this component `list-filter`, since all we want our component to do is filter the list of rentals based on input.
@@ -8,7 +8,7 @@ We'll call this component `list-filter`, since all we want our component to do i
 ember g component list-filter
 ```
 
-As before when we created the [`rental-listing` component](../simple-component), the "generate component" CLI command creates
+As before when we created the [`rental-listing` component](simple-component), the "generate component" CLI command creates
 
 * a Handlebars template (`app/templates/components/list-filter.hbs`),
 * a JavaScript file (`app/components/list-filter.js`),
@@ -17,7 +17,7 @@ As before when we created the [`rental-listing` component](../simple-component),
 In our `app/templates/rentals.hbs` template file, we'll add a reference to our new `list-filter` component.
 
 Notice that below we "wrap" our rentals markup inside the open and closing mentions of `list-filter` on lines 12 and 20.
-This is an example of the [**block form**](../../components/wrapping-content-in-a-component) of a component,
+This is an example of the [**block form**](../components/wrapping-content-in-a-component) of a component,
 which allows a Handlebars template to be rendered _inside_ the component's template wherever the `{{yield}}` expression appears.
 
 In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14).
@@ -56,10 +56,10 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The `value` property of the `input` will be kept in sync with the `value` property in the component. 
 
-Another way to say this is that the `value` property of `input` is [**bound**](../../object-model/bindings/) to the `value` property of the component.
+Another way to say this is that the `value` property of `input` is [**bound**](../object-model/bindings/) to the `value` property of the component.
 If the property changes, either by the user typing in the input field, or by assigning a new value to it in our program,
 the new value of the property is present in both the rendered web page and in the code.
 
@@ -93,7 +93,7 @@ export default Ember.Component.extend({
 We use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls a function called `filter` based on the `value` attribute set by the input helper.
 
-The `filter` function is passed in by the calling object. This is a pattern known as [closure actions](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component).
+The `filter` function is passed in by the calling object. This is a pattern known as [closure actions](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component).
 
 Notice the `then` function called on the result of calling the `filter` function.
 The code expects the `filter` function to return a promise.
@@ -103,7 +103,7 @@ To account for this, it provides functions, like `then` that let you give it cod
 
 
 To implement the `filter` function to do the actual filter of rentals by city, we'll create a `rentals` controller.
-[Controllers](../../controllers/) contain actions and properties available to the template of its corresponding route.
+[Controllers](../controllers/) contain actions and properties available to the template of its corresponding route.
 In our case we want to generate a controller called `rentals`.
 Ember will know that a controller with the name of `rentals` will apply to the route with the same name.
 
@@ -198,15 +198,15 @@ that will update the rental list as you type:
 
 ![home screen with filter component](../../images/autocomplete-component/styled-super-rentals-filter.png)
 
-You can now proceed on to implement the [next feature](../service/), or continue on to test our newly created filter component.
+You can now proceed on to implement the [next feature](service/), or continue on to test our newly created filter component.
 
 ### An Integration Test
 
 Now that we've created a new component for filtering a list,
 we want to create a test to verify it.
-Let's use a [component integration test](../../testing/testing-components)
+Let's use a [component integration test](../testing/testing-components)
 to verify our component behavior,
-similar to [how we tested our rental listing component earlier](../simple-component/#toc_an-integration-test).
+similar to [how we tested our rental listing component earlier](simple-component/#toc_an-integration-test).
 
 Lets begin by opening the component integration test created when we generated our `list-filter` component, `tests/integration/components/list-filter-test.js`.
 Remove the default test, and create a new test that verifies that by default, the component will list all items.
@@ -310,7 +310,7 @@ test('should initially load all listings', function (assert) {
 
 Finally we add a `wait` call at the end of our test to assert the results.
 
-Ember's [wait helper](../../testing/testing-components/#toc_waiting-on-asynchronous-behavior)
+Ember's [wait helper](../testing/testing-components/#toc_waiting-on-asynchronous-behavior)
 waits for all asynchronous tasks to complete before running the given function callback.
 It returns a promise that we also return from the test.
 
@@ -434,7 +434,7 @@ Our test fills out "Seattle" as the search criteria in the search field,
 and then sends a `keyup` event to the same field with a code of `69` (the `e` key) to simulate a user typing.
 
 The test locates the results of the search by finding elements with a class of `listing`,
-which we gave to our `rental-listing` component in the ["Building a Simple Component"](../simple-component) section of the tutorial.
+which we gave to our `rental-listing` component in the ["Building a Simple Component"](simple-component) section of the tutorial.
 
 Since our data is hard-coded in Mirage, we know that there is only one rental with a city name of "Seattle",
 so we assert that the number of listings is one and that the location it displays is named, "Seattle".

--- a/guides/v2.12.0/tutorial/ember-cli.md
+++ b/guides/v2.12.0/tutorial/ember-cli.md
@@ -2,7 +2,7 @@ Welcome to the Ember Tutorial!
 This tutorial is meant to introduce basic Ember concepts while creating a professional looking application.
 If you get stuck at any point during the tutorial, feel free to download [https://github.com/ember-learn/super-rentals](https://github.com/ember-learn/super-rentals) for a working example of the completed app.
 
-You can install the latest version of `ember-cli` by following the [Quick Start](../../getting-started/quick-start/#toc_install-ember) guide "Installing Ember" section.
+You can install the latest version of `ember-cli` by following the [Quick Start](../getting-started/quick-start/#toc_install-ember) guide "Installing Ember" section.
 
 Ember CLI, Ember's command line interface, provides a standard project
 structure, a set of development tools, and an addon system.

--- a/guides/v2.12.0/tutorial/ember-data.md
+++ b/guides/v2.12.0/tutorial/ember-data.md
@@ -31,10 +31,10 @@ export default DS.Model.extend({
 });
 ```
 
-Let's define the structure of a rental object using the same attributes for our rental that we [previously used](../model-hook/) in our hard-coded array of JavaScript objects -
+Let's define the structure of a rental object using the same attributes for our rental that we [previously used](model-hook/) in our hard-coded array of JavaScript objects -
 _title_, _owner_, _city_, _type_, _image_, _bedrooms_ and _description_.
 Define attributes by giving them the result of the function [`DS.attr()`](http://emberjs.com/api/data/classes/DS.html#method_attr).
-For more information on Ember Data Attributes, read the section called [Defining Attributes](../../models/defining-models/#toc_defining-attributes) in the guides.
+For more information on Ember Data Attributes, read the section called [Defining Attributes](../models/defining-models/#toc_defining-attributes) in the guides.
 
 ```app/models/rental.js
 import DS from 'ember-data';
@@ -54,8 +54,8 @@ We now have a model object that we can use for our Ember Data implementation.
 
 ### Updating the Model Hook
 
-To use our new Ember Data Model object, we need to update the `model` function we [previously defined](../model-hook/) in our route handler.
-Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../../models/#toc_the-store-and-a-single-source-of-truth).
+To use our new Ember Data Model object, we need to update the `model` function we [previously defined](model-hook/) in our route handler.
+Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../models/#toc_the-store-and-a-single-source-of-truth).
 The [store service](http://emberjs.com/api/data/classes/DS.Store.html) is injected into all routes and components in Ember.
 It is the main interface you use to interact with Ember Data.
 In this case, call the [`findAll`](http://emberjs.com/api/data/classes/DS.Store.html#method_findAll) function on the store and provide it with the name of your newly created rental model class.
@@ -99,9 +99,9 @@ export default Ember.Route.extend({
 ```
 
 When we call `findAll`, Ember Data will attempt to fetch rentals from `/api/rentals`. 
-If you recall, in the section titled [Installing Addons](../installing-addons/) we set up an adapter to route data requests through `/api`.
+If you recall, in the section titled [Installing Addons](installing-addons/) we set up an adapter to route data requests through `/api`.
 
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we have already set up Ember Mirage in our development environment, Mirage will return the data we requested without actually making a network request.
 

--- a/guides/v2.12.0/tutorial/installing-addons.md
+++ b/guides/v2.12.0/tutorial/installing-addons.md
@@ -10,7 +10,7 @@ For Super Rentals, we'll take advantage of two addons: [ember-cli-tutorial-style
 Instead of having you copy/paste in CSS to style Super Rentals, we've created an addon called [ember-cli-tutorial-style](https://github.com/ember-learn/ember-cli-tutorial-style) that instantly adds CSS to the tutorial.
 The addon works by generating a file called `ember-tutorial.css` and putting that file in the super-rentals `vendor` directory.
 
-The [`vendor` directory](../../addons-and-dependencies/managing-dependencies/#toc_other-assets) in Ember is a special directory where you can include content that gets compiled into your application.
+The [`vendor` directory](../addons-and-dependencies/managing-dependencies/#toc_other-assets) in Ember is a special directory where you can include content that gets compiled into your application.
 When Ember CLI builds our app from our source code, it copies `ember-tutorial.css` into a file called `vendor.css`.
 
 As Ember CLI runs, it takes the `ember-tutorial` CSS file and puts it in a file called `vendor.css`.

--- a/guides/v2.12.0/tutorial/model-hook.md
+++ b/guides/v2.12.0/tutorial/model-hook.md
@@ -59,11 +59,11 @@ export default Ember.Route.extend({
 Note that here, we are using the ES6 shorthand method definition syntax: `model()` is the same as writing `model: function()`.
 
 Ember will use the model object returned above and save it as an attribute called `model`,
-available to the rentals template we generated with our route in [Routes and Templates](../routes-and-templates/#toc_a-rentals-route).
+available to the rentals template we generated with our route in [Routes and Templates](routes-and-templates/#toc_a-rentals-route).
 
 Now, let's switch over to our rentals page template.
 We can use the model attribute to display our list of rentals.
-Here, we'll use another common Handlebars helper called [`{{each}}`](../../templates/displaying-a-list-of-items/).
+Here, we'll use another common Handlebars helper called [`{{each}}`](../templates/displaying-a-list-of-items/).
 This helper will let us loop through each of the rental objects in our model:
 
 ```app/templates/rentals.hbs{+12,+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,+26,+27,+28,+29}
@@ -101,7 +101,7 @@ In this template, we loop through each object.
 On each iteration, the current object gets stored in a variable called `rental`.
 From the rental variable in each step, we create a listing with information about the property.
 
-You may move onto the [next page](../installing-addons/) to keep implementing new features, or continue reading on testing the app you've created.
+You may move onto the [next page](installing-addons/) to keep implementing new features, or continue reading on testing the app you've created.
 
 ### Acceptance Testing the Rental List
 

--- a/guides/v2.12.0/tutorial/routes-and-templates.md
+++ b/guides/v2.12.0/tutorial/routes-and-templates.md
@@ -7,7 +7,7 @@ Let's start by building our "about" page.
 
 In Ember, when we want to make a new page that can be visited using a URL,
 we need to generate a "route" using Ember CLI. For a quick overview of how
-Ember structures things, see [our diagram on the Core Concepts page](../../getting-started/core-concepts/).
+Ember structures things, see [our diagram on the Core Concepts page](../getting-started/core-concepts/).
 
 Let's use Ember's route generator to start our `about` route.
 
@@ -120,7 +120,7 @@ Moving around our site is a bit of a pain right now, so let's make that easier.
 We'll put a link to the contact page on the about page, and a corresponding link to the about
 page on the contact page.
 
-To do that, we'll use a [`{{link-to}}`](../../templates/links/) helper that Ember provides
+To do that, we'll use a [`{{link-to}}`](../templates/links/) helper that Ember provides
 that makes it easy to link between our routes.  Let's adjust our `about.hbs` file:
 
 ```app/templates/about.hbs{+9,+10,+11}
@@ -213,7 +213,7 @@ installing route-test
 
 Unlike the other route handlers we've made so far, the `index` route is special:
 it does NOT require an entry in the router's mapping.
-We'll learn more about why the entry isn't required later on when we look at [nested routes](../subroutes) in Ember.
+We'll learn more about why the entry isn't required later on when we look at [nested routes](subroutes) in Ember.
 
 All we want to do when a user visits the root (`/`) URL is transition to `/rentals`.
 To do this we will add code to our index route handler by implementing a route lifecycle hook,
@@ -222,7 +222,7 @@ called `beforeModel`.
 Each route handler has a set of "lifecycle hooks", which are functions that are invoked at specific times during the loading of a page.
 The [`beforeModel`](http://emberjs.com/api/classes/Ember.Route.html#method_beforeModel)
 hook gets executed before the data gets fetched from the model hook, and before the page is rendered.
-See [the next section](../model-hook) for an explanation of the model hook.
+See [the next section](model-hook) for an explanation of the model hook.
 
 In our index route handler, we'll call the [`replaceWith`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) function.
 The `replaceWith` function is similar to the route's `transitionTo` function,
@@ -281,13 +281,13 @@ or `contact`) should be shown.
 
 At this point, we should be able to navigate between our `about`, `contact`, and `rentals` pages.
 
-From here you can move on to the [next page](../model-hook/) or dive into testing the new functionality we just added.
+From here you can move on to the [next page](model-hook/) or dive into testing the new functionality we just added.
 
 ## Implementing Acceptance Tests
 
 Now that we have various pages in our application, let's walk through how to build tests for them.
 
-As mentioned earlier on the [Planning the Application page](../acceptance-test/),
+As mentioned earlier on the [Planning the Application page](acceptance-test/),
 an Ember acceptance test automates interacting with our app in a similar way to a visitor.
 
 If you open the acceptance test we created (`/tests/acceptance/list-rentals-test.js`), you'll see our
@@ -323,7 +323,7 @@ Some of the helpers we'll use commonly are:
 
 * [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) - loads a given URL
 * [`click`](http://emberjs.com/api/classes/Ember.Test.html#method_click) - pretends to be a user clicking on a specific part of the screen
-* [`andThen`](../../testing/acceptance/#toc_wait-helpers) - waits for our previous commands to run before executing our function.
+* [`andThen`](../testing/acceptance/#toc_wait-helpers) - waits for our previous commands to run before executing our function.
   In our test below, we want to wait for our page to load after `click` is called so that we can double-check that the new page has loaded
 * [`currentURL`](http://emberjs.com/api/classes/Ember.Test.html#method_currentURL) - returns the URL of the page we're currently on
 
@@ -353,7 +353,7 @@ to see if two items (our first and second arguments) equal each other.  If they 
 The third optional argument allows us to provide a nicer message which we'll be shown if this test fails.
 
 In our tests, we also call two helpers (`visit` and `click`) one after another. Although Ember does a number
-of things when we make those calls, Ember hides those complexities by giving us these [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers).
+of things when we make those calls, Ember hides those complexities by giving us these [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers).
 
 If you left `ember test` running, it should have automatically updated to show the three tests related to
 navigating have now passed.

--- a/guides/v2.12.0/tutorial/service.md
+++ b/guides/v2.12.0/tutorial/service.md
@@ -9,7 +9,7 @@ To implement this feature, we will take advantage of several Ember concepts:
 
 Before implementing a map, we need to make a 3rd party map API available to our Ember app.
 There are several ways to include 3rd party libraries in Ember.
-See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/)
+See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/)
 as a starting point when you need to add one.
 
 The [Google Maps API](https://developers.google.com/maps/documentation/javascript/tutorial) requires us to reference its library from a script tag.
@@ -106,7 +106,7 @@ Now that we are able to generate a map element,
 we will implement a maps service that will keep a reference to the Map object we create,
 and attach the map to an element in our application
 
-Accessing our maps API through a [service](../../applications/services) will give us several benefits
+Accessing our maps API through a [service](../applications/services) will give us several benefits
 
 * It is injected with a [service locator](https://en.wikipedia.org/wiki/Service_locator_pattern),
   meaning it will abstract the maps API from the code that uses it,
@@ -186,13 +186,13 @@ This `div` will act as a place for the 3rd party map API to render the map to.
 Next, update the component to append the map output to the `div` element we created.
 
 We provide the maps service into our component by initializing a property of our component, called `maps`.
-Services are commonly made available in components and other Ember objects by ["service injection"](../../applications/services/#toc_accessing-services).
+Services are commonly made available in components and other Ember objects by ["service injection"](../applications/services/#toc_accessing-services).
 When you initialize a property with `Ember.inject.service()`,
 Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```app/components/location-map.js
@@ -242,7 +242,7 @@ After starting the server we should now see some end to end maps functionality s
 
 ![super rentals homepage with maps](../../images/service/style-super-rentals-maps.png)
 
-You may now either move onto the [next feature](../subroutes/), or continue here to test the maps feature we just added.
+You may now either move onto the [next feature](subroutes/), or continue here to test the maps feature we just added.
 
 ###  Unit testing a Service
 
@@ -344,10 +344,10 @@ test('should append map element to container element', function(assert) {
 });
 ```
 
-In the `beforeEach` function that runs before each test, we use the built-in function `this.register` to [register](../../applications/dependency-injection/#toc_factory-registrations) our stub service in place of the maps service.
+In the `beforeEach` function that runs before each test, we use the built-in function `this.register` to [register](../applications/dependency-injection/#toc_factory-registrations) our stub service in place of the maps service.
 Registration makes an object available to your Ember application for things like loading components from templates and injecting services in this case.
 
-The call to the function `this.inject.service` [injects](../../applications/dependency-injection/#toc_ad-hoc-injections) the service we just registered into the context of the tests, so each test may access it through `this.get('mapsService')`.
+The call to the function `this.inject.service` [injects](../applications/dependency-injection/#toc_ad-hoc-injections) the service we just registered into the context of the tests, so each test may access it through `this.get('mapsService')`.
 In the example we assert that `calledWithLocation` in our stub is set to the location we passed to the component.
 
 
@@ -384,7 +384,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.12.0/tutorial/simple-component.md
+++ b/guides/v2.12.0/tutorial/simple-component.md
@@ -159,7 +159,7 @@ Let's call this action `toggleImageSize`
 Clicking the anchor element will send the action to the component.
 Ember will then go into the `actions` hash and call the `toggleImageSize` function.
 
-An [actions hash](../../templates/actions/) is an object in the component that contains functions.
+An [actions hash](../templates/actions/) is an object in the component that contains functions.
 These functions are called when the user interacts with the UI, such as clicking.
 
 Let's create the `toggleImageSize` function and toggle the `isWide` property on our component:
@@ -183,13 +183,13 @@ When we click the enlarged image again, we see it smaller.
 
 ![rental listing with expand](../../images/simple-component/styled-rental-listings.png)
 
-Move on to the [next page](../hbs-helper/) for the next feature, or continue on here to test what you just wrote.
+Move on to the [next page](hbs-helper/) for the next feature, or continue on here to test what you just wrote.
 
 ### An Integration Test
 
-Ember components are commonly tested with [component integration tests](../../testing/testing-components/).
+Ember components are commonly tested with [component integration tests](../testing/testing-components/).
 Component integration tests verify the behavior of a component within the context of Ember's rendering engine.
-When running in an integration test, the component goes through its regular [render lifecycle](../../components/the-component-lifecycle/),
+When running in an integration test, the component goes through its regular [render lifecycle](../components/the-component-lifecycle/),
 and has access to dependent objects, loaded through Ember's resolver.
 
 Our component integration test will test two different behaviors:

--- a/guides/v2.12.0/tutorial/subroutes.md
+++ b/guides/v2.12.0/tutorial/subroutes.md
@@ -6,8 +6,8 @@ Up to this point, we've generated four top level routes.
 * The `index` route, which we've set up to redirect to the `rentals` route.
 
 Our `rentals` route is going to serve multiple functions.
-From our [acceptance tests](../acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
-To satisfy that requirement, we are going to make use of Ember's [nested route capability](../../routing/defining-your-routes/#toc_nested-routes).
+From our [acceptance tests](acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
+To satisfy that requirement, we are going to make use of Ember's [nested route capability](../routing/defining-your-routes/#toc_nested-routes).
 
 By the end of this section we want to have created the following new routes:
 
@@ -18,7 +18,7 @@ The `show` route will get substituted with the id of the rental being shown (for
 
 ## The Parent Route
 
-Previously, in the [Routes and Templates tutorial](../routes-and-templates), we set up a `rentals` route.
+Previously, in the [Routes and Templates tutorial](routes-and-templates), we set up a `rentals` route.
 
 Opening the template for this route reveals an outlet underneath the route's general page information.
 At the bottom of the template, you'll notice an `{{outlet}}` helper.
@@ -76,7 +76,7 @@ Ember knows that the default action is to take the user to the `index` route.
 However, you can add the `index` route if you want to customize it.
 For example, you can modify the `index` route's path by specifying `this.route('index', { path: '/custom-path'})`.
 
-In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
+In the section on [using Ember Data](ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
 Let's implement our newly generated `rentals/index` route by moving this `findAll` call from the parent `rentals` route to our new sub-route.
 
 ```app/routes/rentals.js{-2,-3,-4}
@@ -147,13 +147,13 @@ export default RentalsController;
 
 Next, we will want to create a sub-route that will list information for a specific rental.
 To do this, we will need to update a couple of files.
-To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../../models/finding-records/).
+To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../models/finding-records/).
 The `findRecord` function requires that we search by a unique key.
 
 While on the `show` route, we will also want to show additional information about our specific rental.
 
 In order to do this, we will need to modify the Mirage `config.js` file that we added
-back in the [Installing Addons section](../installing-addons). We will add a new route
+back in the [Installing Addons section](installing-addons). We will add a new route
 handler to return a specific rental:
 
 ```mirage/config.js{+57,+58,+59,+60}
@@ -288,7 +288,7 @@ export default Ember.Route.extend({
 ```
 
 Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook.
-When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../models/)).
 
 ## Adding the Rental To Our Template
 
@@ -353,7 +353,7 @@ Clicking on the title will load the detail page for that rental.
 ```
 ![Rental Page Nested Index Route](../../images/subroutes/subroutes-super-rentals-index.png)
 
-At this point you can do a [deployment](../deploying/) and share your Super Rentals application to the world
+At this point you can do a [deployment](deploying/) and share your Super Rentals application to the world
 or you can use this as a base to explore other Ember features and addons.
 Regardless, we hope this has helped you get started with creating your own ambitious applications with Ember!
 
@@ -374,6 +374,6 @@ test('should show details for a specific rental', function (assert) {
 });
 ```
 
-At this point all our tests should pass, including the [list of acceptance tests](../acceptance-test) we created as our beginning requirements.
+At this point all our tests should pass, including the [list of acceptance tests](acceptance-test) we created as our beginning requirements.
 
 ![Acceptance Tests Pass](../../images/subroutes/all-acceptance-pass.png)

--- a/guides/v2.13.0/applications/initializers.md
+++ b/guides/v2.13.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.13.0/applications/run-loop.md
+++ b/guides/v2.13.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.13.0/components/block-params.md
+++ b/guides/v2.13.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.13.0/components/defining-a-component.md
+++ b/guides/v2.13.0/components/defining-a-component.md
@@ -46,7 +46,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.13.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.13.0/components/triggering-changes-with-actions.md
@@ -67,7 +67,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -75,7 +75,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -320,7 +320,7 @@ export default Ember.Component.extend({
 In order for `confirmValue` to take on the value of the message text,
 we'll bind the property to the value of a user input field that will appear when the button is clicked.
 To accomplish this,
-we'll first modify the component so that it can be used in block form and we will [yield](../wrapping-content-in-a-component/) `confirmValue` to the block within the `"confirmDialog"` element:
+we'll first modify the component so that it can be used in block form and we will [yield](wrapping-content-in-a-component/) `confirmValue` to the block within the `"confirmDialog"` element:
 
 ```app/templates/components/button-with-confirmation.hbs
 <button {{action "launchConfirmDialog"}}>{{text}}</button>

--- a/guides/v2.13.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.13.0/components/wrapping-content-in-a-component.md
@@ -13,7 +13,7 @@ Now, we can use the `{{blog-post}}` component and pass it properties in another 
 {{blog-post title=title body=body}}
 ```
 
-See [Passing Properties to a Component](../passing-properties-to-a-component/) for more.
+See [Passing Properties to a Component](passing-properties-to-a-component/) for more.
 
 In this case, the content we wanted to display came from the model.
 But what if we want the developer using our component to be able to provide custom HTML content?

--- a/guides/v2.13.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.13.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.13.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.13.0/configuring-ember/disabling-prototype-extensions.md
@@ -107,7 +107,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.13.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.13.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -28,7 +28,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js

--- a/guides/v2.13.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.13.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.13.0/ember-inspector/object-inspector.md
+++ b/guides/v2.13.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.13.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.13.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.13.0/ember-inspector/view-tree.md
+++ b/guides/v2.13.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.13.0/getting-started/quick-start.md
+++ b/guides/v2.13.0/getting-started/quick-start.md
@@ -19,7 +19,7 @@ npm install -g ember-cli
 ```
 
 Don't have npm? [Learn how to install Node.js and npm here][npm].
-For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../../getting-started/) guide.
+For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../getting-started/) guide.
 
 [npm]: https://docs.npmjs.com/getting-started/installing-node
 

--- a/guides/v2.13.0/models/customizing-adapters.md
+++ b/guides/v2.13.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.13.0/models/defining-models.md
+++ b/guides/v2.13.0/models/defining-models.md
@@ -21,8 +21,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -62,7 +62,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.13.0/routing/defining-your-routes.md
+++ b/guides/v2.13.0/routing/defining-your-routes.md
@@ -245,7 +245,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.13.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.13.0/routing/preventing-and-retrying-transitions.md
@@ -49,7 +49,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.13.0/routing/redirection.md
+++ b/guides/v2.13.0/routing/redirection.md
@@ -10,7 +10,7 @@ Ember allows you to control that access with a combination of hooks and methods 
 One of the methods is [`transitionTo()`](http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo).
 Calling `transitionTo()` from a route or
 [`transitionToRoute()`](http://emberjs.com/api/classes/Ember.Controller.html#method_transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
-`transitionTo()` behaves exactly like the [link-to](../../templates/links) helper.
+`transitionTo()` behaves exactly like the [link-to](../templates/links) helper.
 
 The other one is [`replaceWith()`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
@@ -45,11 +45,11 @@ export default Ember.Route.extend({
 This allows us to return the user back to the original route.
 For example, we might redirect a user to the login page when they try to edit their profile, and immediately redirect
 them back to the edit page once they have successfully logged in.
-See [Storing and Retrying a Transition](../preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
+See [Storing and Retrying a Transition](preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
 for how to do that.
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.13.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.13.0/routing/specifying-a-routes-model.md
@@ -24,7 +24,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember Data records are promises),
 or a plain JavaScript object or array.
 Ember will wait until the data finishes loading (until the promise is resolved) before rendering the template.
@@ -58,7 +58,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -87,7 +87,7 @@ photo's ID (`params.photo_id`) as an argument to Ember Data's `findRecord`
 method.
 
 Note: A route with a dynamic segment will always have its `model` hook called when it is entered via the URL.
-If the route is entered through a transition (e.g. when using the [link-to](../../templates/links) Handlebars helper),
+If the route is entered through a transition (e.g. when using the [link-to](../templates/links) Handlebars helper),
 and a model context is provided (second argument to `link-to`), then the hook is not executed.
 If an identifier (such as an id or slug) is provided instead then the model hook will be executed.
 

--- a/guides/v2.13.0/templates/actions.md
+++ b/guides/v2.13.0/templates/actions.md
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../../components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.13.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.13.0/templates/displaying-a-list-of-items.md
@@ -45,7 +45,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.13.0/templates/handlebars-basics.md
+++ b/guides/v2.13.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.13.0/templates/links.md
+++ b/guides/v2.13.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` component takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the component, you can provide

--- a/guides/v2.13.0/templates/writing-helpers.md
+++ b/guides/v2.13.0/templates/writing-helpers.md
@@ -81,7 +81,7 @@ helper again with the new values and keep the page up-to-date.
 
 ### Helper Names
 
-Unlike [components](/components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
+Unlike [components](../components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
 
 ### Helper Arguments
 

--- a/guides/v2.13.0/testing/testing-controllers.md
+++ b/guides/v2.13.0/testing/testing-controllers.md
@@ -132,5 +132,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.13.0/testing/testing-helpers.md
+++ b/guides/v2.13.0/testing/testing-helpers.md
@@ -85,5 +85,5 @@ test('updates the currency sign when it changes', function(assert) {
 });
 ```
 
-[Testing Components]: ../unit-testing-basics
-[Writing Helpers]: ../../templates/writing-helpers
+[Testing Components]: unit-testing-basics
+[Writing Helpers]: ../templates/writing-helpers

--- a/guides/v2.13.0/testing/testing-models.md
+++ b/guides/v2.13.0/testing/testing-models.md
@@ -102,5 +102,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.13.0/testing/testing-routes.md
+++ b/guides/v2.13.0/testing/testing-routes.md
@@ -84,5 +84,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.13.0/tutorial/acceptance-test.md
+++ b/guides/v2.13.0/tutorial/acceptance-test.md
@@ -15,11 +15,11 @@ Let's work through what we want to do on the home page. We want our application 
 
 For the remainder of this page, we'll give you an introduction to testing in Ember and get you set up to add tests as we implement pieces of our app. On subsequent tutorial pages, the final sections of each page will be devoted to adding a test for the feature you just implemented. These sections aren't required for a working application and you may move on with the tutorial without writing them.
 
-At this point, you can continue to the [next page](../routes-and-templates/) or read more about Ember testing below.
+At this point, you can continue to the [next page](routes-and-templates/) or read more about Ember testing below.
 
 ### Testing Our Application As We Go
 
-We can represent the goals above as [Ember acceptance tests](../../testing/acceptance/). Acceptance tests interact with our app like an actual person would, but are automated, helping ensure that our app doesn't break in the future.
+We can represent the goals above as [Ember acceptance tests](../testing/acceptance/). Acceptance tests interact with our app like an actual person would, but are automated, helping ensure that our app doesn't break in the future.
 
 When we create a new Ember Project using Ember CLI, it uses the [`QUnit`](https://qunitjs.com/) JavaScript test framework to define and run tests.
 

--- a/guides/v2.13.0/tutorial/autocomplete-component.md
+++ b/guides/v2.13.0/tutorial/autocomplete-component.md
@@ -1,5 +1,5 @@
 As they search for a rental, users might also want to narrow their search to a specific city.
-While our [initial](../simple-component/) rental listing component only displayed rental information, this new filter component will also allow the user to provide input in the form of filter criteria.
+While our [initial](simple-component/) rental listing component only displayed rental information, this new filter component will also allow the user to provide input in the form of filter criteria.
 
 To begin, let's generate our new component.
 We'll call this component `list-filter`, since all we want our component to do is filter the list of rentals based on input.
@@ -8,7 +8,7 @@ We'll call this component `list-filter`, since all we want our component to do i
 ember g component list-filter
 ```
 
-As before when we created the [`rental-listing` component](../simple-component), the "generate component" CLI command creates
+As before when we created the [`rental-listing` component](simple-component), the "generate component" CLI command creates
 
 * a Handlebars template (`app/templates/components/list-filter.hbs`),
 * a JavaScript file (`app/components/list-filter.js`),
@@ -17,7 +17,7 @@ As before when we created the [`rental-listing` component](../simple-component),
 In our `app/templates/rentals.hbs` template file, we'll add a reference to our new `list-filter` component.
 
 Notice that below we "wrap" our rentals markup inside the open and closing mentions of `list-filter` on lines 12 and 20.
-This is an example of the [**block form**](../../components/wrapping-content-in-a-component) of a component,
+This is an example of the [**block form**](../components/wrapping-content-in-a-component) of a component,
 which allows a Handlebars template to be rendered _inside_ the component's template wherever the `{{yield}}` expression appears.
 
 In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14).
@@ -59,10 +59,10 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The `value` property of the `input` will be kept in sync with the `value` property in the component.
 
-Another way to say this is that the `value` property of `input` is [**bound**](../../object-model/bindings/) to the `value` property of the component.
+Another way to say this is that the `value` property of `input` is [**bound**](../object-model/bindings/) to the `value` property of the component.
 If the property changes, either by the user typing in the input field, or by assigning a new value to it in our program,
 the new value of the property is present in both the rendered web page and in the code.
 
@@ -96,7 +96,7 @@ export default Ember.Component.extend({
 We use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls a function called `filter` based on the `value` attribute set by the input helper.
 
-The `filter` function is passed in by the calling object. This is a pattern known as [closure actions](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component).
+The `filter` function is passed in by the calling object. This is a pattern known as [closure actions](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component).
 
 Notice the `then` function called on the result of calling the `filter` function.
 The code expects the `filter` function to return a promise.
@@ -106,7 +106,7 @@ To account for this, it provides functions, like `then` that let you give it cod
 
 
 To implement the `filter` function to do the actual filter of rentals by city, we'll create a `rentals` controller.
-[Controllers](../../controllers/) contain actions and properties available to the template of its corresponding route.
+[Controllers](../controllers/) contain actions and properties available to the template of its corresponding route.
 In our case we want to generate a controller called `rentals`.
 Ember will know that a controller with the name of `rentals` will apply to the route with the same name.
 
@@ -201,15 +201,15 @@ that will update the rental list as you type:
 
 ![home screen with filter component](../../images/autocomplete-component/styled-super-rentals-filter.png)
 
-You can now proceed on to implement the [next feature](../service/), or continue on to test our newly created filter component.
+You can now proceed on to implement the [next feature](service/), or continue on to test our newly created filter component.
 
 ### An Integration Test
 
 Now that we've created a new component for filtering a list,
 we want to create a test to verify it.
-Let's use a [component integration test](../../testing/testing-components)
+Let's use a [component integration test](../testing/testing-components)
 to verify our component behavior,
-similar to [how we tested our rental listing component earlier](../simple-component/#toc_an-integration-test).
+similar to [how we tested our rental listing component earlier](simple-component/#toc_an-integration-test).
 
 Lets begin by opening the component integration test created when we generated our `list-filter` component, `tests/integration/components/list-filter-test.js`.
 Remove the default test, and create a new test that verifies that by default, the component will list all items.
@@ -313,7 +313,7 @@ test('should initially load all listings', function (assert) {
 
 Finally we add a `wait` call at the end of our test to assert the results.
 
-Ember's [wait helper](../../testing/testing-components/#toc_waiting-on-asynchronous-behavior)
+Ember's [wait helper](../testing/testing-components/#toc_waiting-on-asynchronous-behavior)
 waits for all asynchronous tasks to complete before running the given function callback.
 It returns a promise that we also return from the test.
 
@@ -437,7 +437,7 @@ Our test fills out "Seattle" as the search criteria in the search field,
 and then sends a `keyup` event to the same field with a code of `69` (the `e` key) to simulate a user typing.
 
 The test locates the results of the search by finding elements with a class of `listing`,
-which we gave to our `rental-listing` component in the ["Building a Simple Component"](../simple-component) section of the tutorial.
+which we gave to our `rental-listing` component in the ["Building a Simple Component"](simple-component) section of the tutorial.
 
 Since our data is hard-coded in Mirage, we know that there is only one rental with a city name of "Seattle",
 so we assert that the number of listings is one and that the location it displays is named, "Seattle".

--- a/guides/v2.13.0/tutorial/ember-cli.md
+++ b/guides/v2.13.0/tutorial/ember-cli.md
@@ -2,7 +2,7 @@ Welcome to the Ember Tutorial!
 This tutorial is meant to introduce basic Ember concepts while creating a professional looking application.
 If you get stuck at any point during the tutorial, feel free to download [https://github.com/ember-learn/super-rentals](https://github.com/ember-learn/super-rentals) for a working example of the completed app.
 
-You can install the latest version of `ember-cli` by following the [Quick Start](../../getting-started/quick-start/#toc_install-ember) guide "Installing Ember" section.
+You can install the latest version of `ember-cli` by following the [Quick Start](../getting-started/quick-start/#toc_install-ember) guide "Installing Ember" section.
 
 Ember CLI, Ember's command line interface, provides a standard project
 structure, a set of development tools, and an addon system.

--- a/guides/v2.13.0/tutorial/ember-data.md
+++ b/guides/v2.13.0/tutorial/ember-data.md
@@ -31,10 +31,10 @@ export default DS.Model.extend({
 });
 ```
 
-Let's define the structure of a rental object using the same attributes for our rental that we [previously used](../model-hook/) in our hard-coded array of JavaScript objects -
+Let's define the structure of a rental object using the same attributes for our rental that we [previously used](model-hook/) in our hard-coded array of JavaScript objects -
 _title_, _owner_, _city_, _property type_, _image_, _bedrooms_ and _description_.
 Define attributes by giving them the result of the function [`DS.attr()`](http://emberjs.com/api/data/classes/DS.html#method_attr).
-For more information on Ember Data Attributes, read the section called [Defining Attributes](../../models/defining-models/#toc_defining-attributes) in the guides.
+For more information on Ember Data Attributes, read the section called [Defining Attributes](../models/defining-models/#toc_defining-attributes) in the guides.
 
 ```app/models/rental.js
 import DS from 'ember-data';
@@ -54,8 +54,8 @@ We now have a model object that we can use for our Ember Data implementation.
 
 ### Updating the Model Hook
 
-To use our new Ember Data Model object, we need to update the `model` function we [previously defined](../model-hook/) in our route handler.
-Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../../models/#toc_the-store-and-a-single-source-of-truth).
+To use our new Ember Data Model object, we need to update the `model` function we [previously defined](model-hook/) in our route handler.
+Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../models/#toc_the-store-and-a-single-source-of-truth).
 The [store service](http://emberjs.com/api/data/classes/DS.Store.html) is injected into all routes and components in Ember.
 It is the main interface you use to interact with Ember Data.
 In this case, call the [`findAll`](http://emberjs.com/api/data/classes/DS.Store.html#method_findAll) function on the store and provide it with the name of your newly created rental model class.
@@ -99,9 +99,9 @@ export default Ember.Route.extend({
 ```
 
 When we call `findAll`, Ember Data will attempt to fetch rentals from `/api/rentals`.
-If you recall, in the section titled [Installing Addons](../installing-addons/) we set up an adapter to route data requests through `/api`.
+If you recall, in the section titled [Installing Addons](installing-addons/) we set up an adapter to route data requests through `/api`.
 
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we have already set up Ember Mirage in our development environment, Mirage will return the data we requested without actually making a network request.
 

--- a/guides/v2.13.0/tutorial/installing-addons.md
+++ b/guides/v2.13.0/tutorial/installing-addons.md
@@ -10,7 +10,7 @@ For Super Rentals, we'll take advantage of two addons: [ember-cli-tutorial-style
 Instead of having you copy/paste in CSS to style Super Rentals, we've created an addon called [ember-cli-tutorial-style](https://github.com/ember-learn/ember-cli-tutorial-style) that instantly adds CSS to the tutorial.
 The addon works by generating a file called `ember-tutorial.css` and putting that file in the super-rentals `vendor` directory.
 
-The [`vendor` directory](../../addons-and-dependencies/managing-dependencies/#toc_other-assets) in Ember is a special directory where you can include content that gets compiled into your application.
+The [`vendor` directory](../addons-and-dependencies/managing-dependencies/#toc_other-assets) in Ember is a special directory where you can include content that gets compiled into your application.
 When Ember CLI builds our app from our source code, it copies `ember-tutorial.css` into a file called `vendor.css`.
 
 As Ember CLI runs, it takes the `ember-tutorial` CSS file and puts it in a file called `vendor.css`.
@@ -114,4 +114,4 @@ export default DS.JSONAPIAdapter.extend({
 
 If you were running `ember serve` in another shell, restart the server to include Mirage in your build.
 
-Note that at this point of the tutorial, the data is still provided by the `app/routes/rentals.js` file. We will make use of the mirage data we set up here in the upcoming section called [Using Ember Data](../ember-data/).
+Note that at this point of the tutorial, the data is still provided by the `app/routes/rentals.js` file. We will make use of the mirage data we set up here in the upcoming section called [Using Ember Data](ember-data/).

--- a/guides/v2.13.0/tutorial/model-hook.md
+++ b/guides/v2.13.0/tutorial/model-hook.md
@@ -59,11 +59,11 @@ export default Ember.Route.extend({
 Note that here, we are using the ES6 shorthand method definition syntax: `model()` is the same as writing `model: function()`.
 
 Ember will use the model object returned above and save it as an attribute called `model`,
-available to the rentals template we generated with our route in [Routes and Templates](../routes-and-templates/#toc_a-rentals-route).
+available to the rentals template we generated with our route in [Routes and Templates](routes-and-templates/#toc_a-rentals-route).
 
 Now, let's switch over to our rentals page template.
 We can use the model attribute to display our list of rentals.
-Here, we'll use another common Handlebars helper called [`{{each}}`](../../templates/displaying-a-list-of-items/).
+Here, we'll use another common Handlebars helper called [`{{each}}`](../templates/displaying-a-list-of-items/).
 This helper will let us loop through each of the rental objects in our model:
 
 ```app/templates/rentals.hbs{+12,+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,+26,+27,+28,+29}
@@ -101,7 +101,7 @@ In this template, we loop through each object.
 On each iteration, the current object gets stored in a variable called `rental`.
 From the rental variable in each step, we create a listing with information about the property.
 
-You may move onto the [next page](../installing-addons/) to keep implementing new features, or continue reading on testing the app you've created.
+You may move onto the [next page](installing-addons/) to keep implementing new features, or continue reading on testing the app you've created.
 
 ### Acceptance Testing the Rental List
 

--- a/guides/v2.13.0/tutorial/routes-and-templates.md
+++ b/guides/v2.13.0/tutorial/routes-and-templates.md
@@ -7,7 +7,7 @@ Let's start by building our "about" page.
 
 In Ember, when we want to make a new page that can be visited using a URL,
 we need to generate a "route" using Ember CLI. For a quick overview of how
-Ember structures things, see [our diagram on the Core Concepts page](../../getting-started/core-concepts/).
+Ember structures things, see [our diagram on the Core Concepts page](../getting-started/core-concepts/).
 
 Let's use Ember's route generator to start our `about` route.
 
@@ -120,7 +120,7 @@ Moving around our site is a bit of a pain right now, so let's make that easier.
 We'll put a link to the contact page on the about page, and a corresponding link to the about
 page on the contact page.
 
-To do that, we'll use a [`{{link-to}}`](../../templates/links/) helper that Ember provides
+To do that, we'll use a [`{{link-to}}`](../templates/links/) helper that Ember provides
 that makes it easy to link between our routes.  Let's adjust our `about.hbs` file:
 
 ```app/templates/about.hbs{+9,+10,+11}
@@ -213,7 +213,7 @@ installing route-test
 
 Unlike the other route handlers we've made so far, the `index` route is special:
 it does NOT require an entry in the router's mapping.
-We'll learn more about why the entry isn't required later on when we look at [nested routes](../subroutes) in Ember.
+We'll learn more about why the entry isn't required later on when we look at [nested routes](subroutes) in Ember.
 
 All we want to do when a user visits the root (`/`) URL is transition to `/rentals`.
 To do this we will add code to our index route handler by implementing a route lifecycle hook,
@@ -222,7 +222,7 @@ called `beforeModel`.
 Each route handler has a set of "lifecycle hooks", which are functions that are invoked at specific times during the loading of a page.
 The [`beforeModel`](http://emberjs.com/api/classes/Ember.Route.html#method_beforeModel)
 hook gets executed before the data gets fetched from the model hook, and before the page is rendered.
-See [the next section](../model-hook) for an explanation of the model hook.
+See [the next section](model-hook) for an explanation of the model hook.
 
 In our index route handler, we'll call the [`replaceWith`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) function.
 The `replaceWith` function is similar to the route's `transitionTo` function,
@@ -281,13 +281,13 @@ or `contact`) should be shown.
 
 At this point, we should be able to navigate between our `about`, `contact`, and `rentals` pages.
 
-From here you can move on to the [next page](../model-hook/) or dive into testing the new functionality we just added.
+From here you can move on to the [next page](model-hook/) or dive into testing the new functionality we just added.
 
 ## Implementing Acceptance Tests
 
 Now that we have various pages in our application, let's walk through how to build tests for them.
 
-As mentioned earlier on the [Planning the Application page](../acceptance-test/),
+As mentioned earlier on the [Planning the Application page](acceptance-test/),
 an Ember acceptance test automates interacting with our app in a similar way to a visitor.
 
 If you open the acceptance test we created (`/tests/acceptance/list-rentals-test.js`), you'll see our
@@ -323,7 +323,7 @@ Some of the helpers we'll use commonly are:
 
 * [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) - loads a given URL
 * [`click`](http://emberjs.com/api/classes/Ember.Test.html#method_click) - pretends to be a user clicking on a specific part of the screen
-* [`andThen`](../../testing/acceptance/#toc_wait-helpers) - waits for our previous commands to run before executing our function.
+* [`andThen`](../testing/acceptance/#toc_wait-helpers) - waits for our previous commands to run before executing our function.
   In our test below, we want to wait for our page to load after `click` is called so that we can double-check that the new page has loaded
 * [`currentURL`](http://emberjs.com/api/classes/Ember.Test.html#method_currentURL) - returns the URL of the page we're currently on
 
@@ -353,7 +353,7 @@ to see if two items (our first and second arguments) equal each other.  If they 
 The third optional argument allows us to provide a nicer message which we'll be shown if this test fails.
 
 In our tests, we also call two helpers (`visit` and `click`) one after another. Although Ember does a number
-of things when we make those calls, Ember hides those complexities by giving us these [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers).
+of things when we make those calls, Ember hides those complexities by giving us these [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers).
 
 If you left `ember test` running, it should have automatically updated to show the three tests related to
 navigating have now passed.

--- a/guides/v2.13.0/tutorial/service.md
+++ b/guides/v2.13.0/tutorial/service.md
@@ -9,7 +9,7 @@ To implement this feature, we will take advantage of several Ember concepts:
 
 Before implementing a map, we need to make a 3rd party map API available to our Ember app.
 There are several ways to include 3rd party libraries in Ember.
-See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/)
+See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/)
 as a starting point when you need to add one.
 
 The [Google Maps API](https://developers.google.com/maps/documentation/javascript/tutorial) requires us to reference its library from a script tag.
@@ -106,7 +106,7 @@ Now that we are able to generate a map element,
 we will implement a maps service that will keep a reference to the Map object we create,
 and attach the map to an element in our application
 
-Accessing our maps API through a [service](../../applications/services) will give us several benefits
+Accessing our maps API through a [service](../applications/services) will give us several benefits
 
 * It is injected with a [service locator](https://en.wikipedia.org/wiki/Service_locator_pattern),
   meaning it will abstract the maps API from the code that uses it,
@@ -186,13 +186,13 @@ This `div` will act as a place for the 3rd party map API to render the map to.
 Next, update the component to append the map output to the `div` element we created.
 
 We provide the maps service into our component by initializing a property of our component, called `maps`.
-Services are commonly made available in components and other Ember objects by ["service injection"](../../applications/services/#toc_accessing-services).
+Services are commonly made available in components and other Ember objects by ["service injection"](../applications/services/#toc_accessing-services).
 When you initialize a property with `Ember.inject.service()`,
 Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```app/components/location-map.js
@@ -243,7 +243,7 @@ After starting the server we should now see some end to end maps functionality s
 
 ![super rentals homepage with maps](../../images/service/style-super-rentals-maps.png)
 
-You may now either move onto the [next feature](../subroutes/), or continue here to test the maps feature we just added.
+You may now either move onto the [next feature](subroutes/), or continue here to test the maps feature we just added.
 
 ###  Unit testing a Service
 
@@ -345,10 +345,10 @@ test('should append map element to container element', function(assert) {
 });
 ```
 
-In the `beforeEach` function that runs before each test, we use the built-in function `this.register` to [register](../../applications/dependency-injection/#toc_factory-registrations) our stub service in place of the maps service.
+In the `beforeEach` function that runs before each test, we use the built-in function `this.register` to [register](../applications/dependency-injection/#toc_factory-registrations) our stub service in place of the maps service.
 Registration makes an object available to your Ember application for things like loading components from templates and injecting services in this case.
 
-The call to the function `this.inject.service` [injects](../../applications/dependency-injection/#toc_ad-hoc-injections) the service we just registered into the context of the tests, so each test may access it through `this.get('mapsService')`.
+The call to the function `this.inject.service` [injects](../applications/dependency-injection/#toc_ad-hoc-injections) the service we just registered into the context of the tests, so each test may access it through `this.get('mapsService')`.
 In the example we assert that `calledWithLocation` in our stub is set to the location we passed to the component.
 
 
@@ -385,7 +385,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.13.0/tutorial/simple-component.md
+++ b/guides/v2.13.0/tutorial/simple-component.md
@@ -159,7 +159,7 @@ Let's call this action `toggleImageSize`
 Clicking the anchor element will send the action to the component.
 Ember will then go into the `actions` hash and call the `toggleImageSize` function.
 
-An [actions hash](../../templates/actions/) is an object in the component that contains functions.
+An [actions hash](../templates/actions/) is an object in the component that contains functions.
 These functions are called when the user interacts with the UI, such as clicking.
 
 Let's create the `toggleImageSize` function and toggle the `isWide` property on our component:
@@ -183,13 +183,13 @@ When we click the enlarged image again, we see it smaller.
 
 ![rental listing with expand](../../images/simple-component/styled-rental-listings.png)
 
-Move on to the [next page](../hbs-helper/) for the next feature, or continue on here to test what you just wrote.
+Move on to the [next page](hbs-helper/) for the next feature, or continue on here to test what you just wrote.
 
 ### An Integration Test
 
-Ember components are commonly tested with [component integration tests](../../testing/testing-components/).
+Ember components are commonly tested with [component integration tests](../testing/testing-components/).
 Component integration tests verify the behavior of a component within the context of Ember's rendering engine.
-When running in an integration test, the component goes through its regular [render lifecycle](../../components/the-component-lifecycle/),
+When running in an integration test, the component goes through its regular [render lifecycle](../components/the-component-lifecycle/),
 and has access to dependent objects, loaded through Ember's resolver.
 
 Our component integration test will test two different behaviors:

--- a/guides/v2.13.0/tutorial/subroutes.md
+++ b/guides/v2.13.0/tutorial/subroutes.md
@@ -6,8 +6,8 @@ Up to this point, we've generated four top level routes.
 * The `index` route, which we've set up to redirect to the `rentals` route.
 
 Our `rentals` route is going to serve multiple functions.
-From our [acceptance tests](../acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
-To satisfy that requirement, we are going to make use of Ember's [nested route capability](../../routing/defining-your-routes/#toc_nested-routes).
+From our [acceptance tests](acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
+To satisfy that requirement, we are going to make use of Ember's [nested route capability](../routing/defining-your-routes/#toc_nested-routes).
 
 By the end of this section we want to have created the following new routes:
 
@@ -18,7 +18,7 @@ The `show` route will get substituted with the id of the rental being shown (for
 
 ## The Parent Route
 
-Previously, in the [Routes and Templates tutorial](../routes-and-templates), we set up a `rentals` route.
+Previously, in the [Routes and Templates tutorial](routes-and-templates), we set up a `rentals` route.
 
 Opening the template for this route reveals an outlet underneath the route's general page information.
 At the bottom of the template, you'll notice an `{{outlet}}` helper.
@@ -76,7 +76,7 @@ Ember knows that the default action is to take the user to the `index` route.
 However, you can add the `index` route if you want to customize it.
 For example, you can modify the `index` route's path by specifying `this.route('index', { path: '/custom-path'})`.
 
-In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
+In the section on [using Ember Data](ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
 Let's implement our newly generated `rentals/index` route by moving this `findAll` call from the parent `rentals` route to our new sub-route.
 
 ```app/routes/rentals.js{-2,-3,-4}
@@ -147,13 +147,13 @@ export default RentalsController;
 
 Next, we will want to create a sub-route that will list information for a specific rental.
 To do this, we will need to update a couple of files.
-To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../../models/finding-records/).
+To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../models/finding-records/).
 The `findRecord` function requires that we search by a unique key.
 
 While on the `show` route, we will also want to show additional information about our specific rental.
 
 In order to do this, we will need to modify the Mirage `config.js` file that we added
-back in the [Installing Addons section](../installing-addons). We will add a new route
+back in the [Installing Addons section](installing-addons). We will add a new route
 handler to return a specific rental:
 
 ```mirage/config.js{+57,+58,+59,+60}
@@ -288,7 +288,7 @@ export default Ember.Route.extend({
 ```
 
 Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook.
-When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../models/)).
 
 ## Adding the Rental To Our Template
 
@@ -354,7 +354,7 @@ Clicking on the title will load the detail page for that rental.
 ```
 ![Rental Page Nested Index Route](../../images/subroutes/subroutes-super-rentals-index.png)
 
-At this point you can do a [deployment](../deploying/) and share your Super Rentals application to the world
+At this point you can do a [deployment](deploying/) and share your Super Rentals application to the world
 or you can use this as a base to explore other Ember features and addons.
 Regardless, we hope this has helped you get started with creating your own ambitious applications with Ember!
 
@@ -375,6 +375,6 @@ test('should show details for a specific rental', function (assert) {
 });
 ```
 
-At this point all our tests should pass, including the [list of acceptance tests](../acceptance-test) we created as our beginning requirements.
+At this point all our tests should pass, including the [list of acceptance tests](acceptance-test) we created as our beginning requirements.
 
 ![Acceptance Tests Pass](../../images/subroutes/all-acceptance-pass.png)

--- a/guides/v2.14.0/applications/initializers.md
+++ b/guides/v2.14.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.14.0/applications/run-loop.md
+++ b/guides/v2.14.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.14.0/components/block-params.md
+++ b/guides/v2.14.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.14.0/components/defining-a-component.md
+++ b/guides/v2.14.0/components/defining-a-component.md
@@ -46,7 +46,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.14.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.14.0/components/triggering-changes-with-actions.md
@@ -67,7 +67,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -75,7 +75,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -320,7 +320,7 @@ export default Ember.Component.extend({
 In order for `confirmValue` to take on the value of the message text,
 we'll bind the property to the value of a user input field that will appear when the button is clicked.
 To accomplish this,
-we'll first modify the component so that it can be used in block form and we will [yield](../wrapping-content-in-a-component/) `confirmValue` to the block within the `"confirmDialog"` element:
+we'll first modify the component so that it can be used in block form and we will [yield](wrapping-content-in-a-component/) `confirmValue` to the block within the `"confirmDialog"` element:
 
 ```app/templates/components/button-with-confirmation.hbs
 <button {{action "launchConfirmDialog"}}>{{text}}</button>

--- a/guides/v2.14.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.14.0/components/wrapping-content-in-a-component.md
@@ -13,7 +13,7 @@ Now, we can use the `{{blog-post}}` component and pass it properties in another 
 {{blog-post title=title body=body}}
 ```
 
-See [Passing Properties to a Component](../passing-properties-to-a-component/) for more.
+See [Passing Properties to a Component](passing-properties-to-a-component/) for more.
 
 In this case, the content we wanted to display came from the model.
 But what if we want the developer using our component to be able to provide custom HTML content?

--- a/guides/v2.14.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.14.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.14.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.14.0/configuring-ember/disabling-prototype-extensions.md
@@ -107,7 +107,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.14.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.14.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -33,7 +33,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js{-8,+9}

--- a/guides/v2.14.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.14.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.14.0/ember-inspector/object-inspector.md
+++ b/guides/v2.14.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.14.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.14.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.14.0/ember-inspector/view-tree.md
+++ b/guides/v2.14.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.14.0/getting-started/quick-start.md
+++ b/guides/v2.14.0/getting-started/quick-start.md
@@ -19,7 +19,7 @@ npm install -g ember-cli
 ```
 
 Don't have npm? [Learn how to install Node.js and npm here][npm].
-For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../../getting-started/) guide.
+For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../getting-started/) guide.
 
 [npm]: https://docs.npmjs.com/getting-started/installing-node
 

--- a/guides/v2.14.0/models/customizing-adapters.md
+++ b/guides/v2.14.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.14.0/models/defining-models.md
+++ b/guides/v2.14.0/models/defining-models.md
@@ -21,8 +21,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -62,7 +62,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.14.0/routing/defining-your-routes.md
+++ b/guides/v2.14.0/routing/defining-your-routes.md
@@ -245,7 +245,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.14.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.14.0/routing/preventing-and-retrying-transitions.md
@@ -49,7 +49,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.14.0/routing/redirection.md
+++ b/guides/v2.14.0/routing/redirection.md
@@ -10,7 +10,7 @@ Ember allows you to control that access with a combination of hooks and methods 
 One of the methods is [`transitionTo()`](http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo).
 Calling `transitionTo()` from a route or
 [`transitionToRoute()`](http://emberjs.com/api/classes/Ember.Controller.html#method_transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
-`transitionTo()` behaves exactly like the [link-to](../../templates/links) helper.
+`transitionTo()` behaves exactly like the [link-to](../templates/links) helper.
 
 The other one is [`replaceWith()`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
@@ -45,11 +45,11 @@ export default Ember.Route.extend({
 This allows us to return the user back to the original route.
 For example, we might redirect a user to the login page when they try to edit their profile, and immediately redirect
 them back to the edit page once they have successfully logged in.
-See [Storing and Retrying a Transition](../preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
+See [Storing and Retrying a Transition](preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
 for how to do that.
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.14.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.14.0/routing/specifying-a-routes-model.md
@@ -24,7 +24,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember Data records are promises),
 or a plain JavaScript object or array.
 Ember will wait until the data finishes loading (until the promise is resolved) before rendering the template.
@@ -58,7 +58,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -87,7 +87,7 @@ photo's ID (`params.photo_id`) as an argument to Ember Data's `findRecord`
 method.
 
 Note: A route with a dynamic segment will always have its `model` hook called when it is entered via the URL.
-If the route is entered through a transition (e.g. when using the [link-to](../../templates/links) Handlebars helper),
+If the route is entered through a transition (e.g. when using the [link-to](../templates/links) Handlebars helper),
 and a model context is provided (second argument to `link-to`), then the hook is not executed.
 If an identifier (such as an id or slug) is provided instead then the model hook will be executed.
 

--- a/guides/v2.14.0/templates/actions.md
+++ b/guides/v2.14.0/templates/actions.md
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../../components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.14.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.14.0/templates/displaying-a-list-of-items.md
@@ -45,7 +45,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.14.0/templates/handlebars-basics.md
+++ b/guides/v2.14.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.14.0/templates/links.md
+++ b/guides/v2.14.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` component takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the component, you can provide

--- a/guides/v2.14.0/templates/writing-helpers.md
+++ b/guides/v2.14.0/templates/writing-helpers.md
@@ -81,7 +81,7 @@ helper again with the new values and keep the page up-to-date.
 
 ### Helper Names
 
-Unlike [components](/components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
+Unlike [components](../components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
 
 ### Helper Arguments
 

--- a/guides/v2.14.0/testing/testing-controllers.md
+++ b/guides/v2.14.0/testing/testing-controllers.md
@@ -132,5 +132,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.14.0/testing/testing-helpers.md
+++ b/guides/v2.14.0/testing/testing-helpers.md
@@ -85,5 +85,5 @@ test('updates the currency sign when it changes', function(assert) {
 });
 ```
 
-[Testing Components]: ../unit-testing-basics
-[Writing Helpers]: ../../templates/writing-helpers
+[Testing Components]: unit-testing-basics
+[Writing Helpers]: ../templates/writing-helpers

--- a/guides/v2.14.0/testing/testing-models.md
+++ b/guides/v2.14.0/testing/testing-models.md
@@ -102,5 +102,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.14.0/testing/testing-routes.md
+++ b/guides/v2.14.0/testing/testing-routes.md
@@ -84,5 +84,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.14.0/tutorial/acceptance-test.md
+++ b/guides/v2.14.0/tutorial/acceptance-test.md
@@ -15,11 +15,11 @@ Let's work through what we want to do on the home page. We want our application 
 
 For the remainder of this page, we'll give you an introduction to testing in Ember and get you set up to add tests as we implement pieces of our app. On subsequent tutorial pages, the final sections of each page will be devoted to adding a test for the feature you just implemented. These sections aren't required for a working application and you may move on with the tutorial without writing them.
 
-At this point, you can continue to the [next page](../routes-and-templates/) or read more about Ember testing below.
+At this point, you can continue to the [next page](routes-and-templates/) or read more about Ember testing below.
 
 ### Testing Our Application As We Go
 
-We can represent the goals above as [Ember acceptance tests](../../testing/acceptance/). Acceptance tests interact with our app like an actual person would, but are automated, helping ensure that our app doesn't break in the future.
+We can represent the goals above as [Ember acceptance tests](../testing/acceptance/). Acceptance tests interact with our app like an actual person would, but are automated, helping ensure that our app doesn't break in the future.
 
 When we create a new Ember Project using Ember CLI, it uses the [`QUnit`](https://qunitjs.com/) JavaScript test framework to define and run tests.
 

--- a/guides/v2.14.0/tutorial/autocomplete-component.md
+++ b/guides/v2.14.0/tutorial/autocomplete-component.md
@@ -1,5 +1,5 @@
 As they search for a rental, users might also want to narrow their search to a specific city.
-While our [initial](../simple-component/) rental listing component only displayed rental information, this new filter component will also allow the user to provide input in the form of filter criteria.
+While our [initial](simple-component/) rental listing component only displayed rental information, this new filter component will also allow the user to provide input in the form of filter criteria.
 
 To begin, let's generate our new component.
 We'll call this component `list-filter`, since all we want our component to do is filter the list of rentals based on input.
@@ -8,7 +8,7 @@ We'll call this component `list-filter`, since all we want our component to do i
 ember g component list-filter
 ```
 
-As before when we created the [`rental-listing` component](../simple-component), the "generate component" CLI command creates
+As before when we created the [`rental-listing` component](simple-component), the "generate component" CLI command creates
 
 * a Handlebars template (`app/templates/components/list-filter.hbs`),
 * a JavaScript file (`app/components/list-filter.js`),
@@ -17,7 +17,7 @@ As before when we created the [`rental-listing` component](../simple-component),
 In our `app/templates/rentals.hbs` template file, we'll add a reference to our new `list-filter` component.
 
 Notice that below we "wrap" our rentals markup inside the open and closing mentions of `list-filter` on lines 12 and 20.
-This is an example of the [**block form**](../../components/wrapping-content-in-a-component) of a component,
+This is an example of the [**block form**](../components/wrapping-content-in-a-component) of a component,
 which allows a Handlebars template to be rendered _inside_ the component's template wherever the `{{yield}}` expression appears.
 
 In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14).
@@ -59,10 +59,10 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The `value` property of the `input` will be kept in sync with the `value` property in the component.
 
-Another way to say this is that the `value` property of `input` is [**bound**](../../object-model/bindings/) to the `value` property of the component.
+Another way to say this is that the `value` property of `input` is [**bound**](../object-model/bindings/) to the `value` property of the component.
 If the property changes, either by the user typing in the input field, or by assigning a new value to it in our program,
 the new value of the property is present in both the rendered web page and in the code.
 
@@ -96,7 +96,7 @@ export default Ember.Component.extend({
 We use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls a function called `filter` based on the `value` attribute set by the input helper.
 
-The `filter` function is passed in by the calling object. This is a pattern known as [closure actions](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component).
+The `filter` function is passed in by the calling object. This is a pattern known as [closure actions](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component).
 
 Notice the `then` function called on the result of calling the `filter` function.
 The code expects the `filter` function to return a promise.
@@ -106,7 +106,7 @@ To account for this, it provides functions, like `then` that let you give it cod
 
 
 To implement the `filter` function to do the actual filter of rentals by city, we'll create a `rentals` controller.
-[Controllers](../../controllers/) contain actions and properties available to the template of its corresponding route.
+[Controllers](../controllers/) contain actions and properties available to the template of its corresponding route.
 In our case we want to generate a controller called `rentals`.
 Ember will know that a controller with the name of `rentals` will apply to the route with the same name.
 
@@ -201,15 +201,15 @@ that will update the rental list as you type:
 
 ![home screen with filter component](../../images/autocomplete-component/styled-super-rentals-filter.png)
 
-You can now proceed on to implement the [next feature](../service/), or continue on to test our newly created filter component.
+You can now proceed on to implement the [next feature](service/), or continue on to test our newly created filter component.
 
 ### An Integration Test
 
 Now that we've created a new component for filtering a list,
 we want to create a test to verify it.
-Let's use a [component integration test](../../testing/testing-components)
+Let's use a [component integration test](../testing/testing-components)
 to verify our component behavior,
-similar to [how we tested our rental listing component earlier](../simple-component/#toc_an-integration-test).
+similar to [how we tested our rental listing component earlier](simple-component/#toc_an-integration-test).
 
 Lets begin by opening the component integration test created when we generated our `list-filter` component, `tests/integration/components/list-filter-test.js`.
 Remove the default test, and create a new test that verifies that by default, the component will list all items.
@@ -313,7 +313,7 @@ test('should initially load all listings', function (assert) {
 
 Finally we add a `wait` call at the end of our test to assert the results.
 
-Ember's [wait helper](../../testing/testing-components/#toc_waiting-on-asynchronous-behavior)
+Ember's [wait helper](../testing/testing-components/#toc_waiting-on-asynchronous-behavior)
 waits for all asynchronous tasks to complete before running the given function callback.
 It returns a promise that we also return from the test.
 
@@ -437,7 +437,7 @@ Our test fills out "Seattle" as the search criteria in the search field,
 and then sends a `keyup` event to the same field with a code of `69` (the `e` key) to simulate a user typing.
 
 The test locates the results of the search by finding elements with a class of `listing`,
-which we gave to our `rental-listing` component in the ["Building a Simple Component"](../simple-component) section of the tutorial.
+which we gave to our `rental-listing` component in the ["Building a Simple Component"](simple-component) section of the tutorial.
 
 Since our data is hard-coded in Mirage, we know that there is only one rental with a city name of "Seattle",
 so we assert that the number of listings is one and that the location it displays is named, "Seattle".

--- a/guides/v2.14.0/tutorial/ember-cli.md
+++ b/guides/v2.14.0/tutorial/ember-cli.md
@@ -2,7 +2,7 @@ Welcome to the Ember Tutorial!
 This tutorial is meant to introduce basic Ember concepts while creating a professional looking application.
 If you get stuck at any point during the tutorial, feel free to download [https://github.com/ember-learn/super-rentals](https://github.com/ember-learn/super-rentals) for a working example of the completed app.
 
-You can install the latest version of `ember-cli` by following the [Quick Start](../../getting-started/quick-start/#toc_install-ember) guide "Installing Ember" section.
+You can install the latest version of `ember-cli` by following the [Quick Start](../getting-started/quick-start/#toc_install-ember) guide "Installing Ember" section.
 
 Ember CLI, Ember's command line interface, provides a standard project
 structure, a set of development tools, and an addon system.

--- a/guides/v2.14.0/tutorial/ember-data.md
+++ b/guides/v2.14.0/tutorial/ember-data.md
@@ -31,10 +31,10 @@ export default DS.Model.extend({
 });
 ```
 
-Let's define the structure of a rental object using the same attributes for our rental that we [previously used](../model-hook/) in our hard-coded array of JavaScript objects -
+Let's define the structure of a rental object using the same attributes for our rental that we [previously used](model-hook/) in our hard-coded array of JavaScript objects -
 _title_, _owner_, _city_, _property type_, _image_, _bedrooms_ and _description_.
 Define attributes by giving them the result of the function [`DS.attr()`](http://emberjs.com/api/data/classes/DS.html#method_attr).
-For more information on Ember Data Attributes, read the section called [Defining Attributes](../../models/defining-models/#toc_defining-attributes) in the guides.
+For more information on Ember Data Attributes, read the section called [Defining Attributes](../models/defining-models/#toc_defining-attributes) in the guides.
 
 ```app/models/rental.js
 import DS from 'ember-data';
@@ -54,8 +54,8 @@ We now have a model object that we can use for our Ember Data implementation.
 
 ### Updating the Model Hook
 
-To use our new Ember Data Model object, we need to update the `model` function we [previously defined](../model-hook/) in our route handler.
-Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../../models/#toc_the-store-and-a-single-source-of-truth).
+To use our new Ember Data Model object, we need to update the `model` function we [previously defined](model-hook/) in our route handler.
+Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../models/#toc_the-store-and-a-single-source-of-truth).
 The [store service](http://emberjs.com/api/data/classes/DS.Store.html) is injected into all routes and components in Ember.
 It is the main interface you use to interact with Ember Data.
 In this case, call the [`findAll`](http://emberjs.com/api/data/classes/DS.Store.html#method_findAll) function on the store and provide it with the name of your newly created rental model class.
@@ -99,9 +99,9 @@ export default Ember.Route.extend({
 ```
 
 When we call `findAll`, Ember Data will attempt to fetch rentals from `/api/rentals`.
-If you recall, in the section titled [Installing Addons](../installing-addons/) we set up an adapter to route data requests through `/api`.
+If you recall, in the section titled [Installing Addons](installing-addons/) we set up an adapter to route data requests through `/api`.
 
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we have already set up Ember Mirage in our development environment, Mirage will return the data we requested without actually making a network request.
 

--- a/guides/v2.14.0/tutorial/installing-addons.md
+++ b/guides/v2.14.0/tutorial/installing-addons.md
@@ -10,7 +10,7 @@ For Super Rentals, we'll take advantage of two addons: [ember-cli-tutorial-style
 Instead of having you copy/paste in CSS to style Super Rentals, we've created an addon called [ember-cli-tutorial-style](https://github.com/ember-learn/ember-cli-tutorial-style) that instantly adds CSS to the tutorial.
 The addon works by generating a file called `ember-tutorial.css` and putting that file in the super-rentals `vendor` directory.
 
-The [`vendor` directory](../../addons-and-dependencies/managing-dependencies/#toc_other-assets) in Ember is a special directory where you can include content that gets compiled into your application.
+The [`vendor` directory](../addons-and-dependencies/managing-dependencies/#toc_other-assets) in Ember is a special directory where you can include content that gets compiled into your application.
 When Ember CLI builds our app from our source code, it copies `ember-tutorial.css` into a file called `vendor.css`.
 
 As Ember CLI runs, it takes the `ember-tutorial` CSS file and puts it in a file called `vendor.css`.
@@ -125,7 +125,7 @@ Without this change, navigation to `/rentals` in our application would conflict 
 
 In order for this to work, we need our application to default to making requests to the namespace of `/api`.
 To do this, we want to generate an application adapter.
-An [Adapter](../../models/customizing-adapters) is an object that [Ember Data](../../models) uses to determines how we communicate with our backend.
+An [Adapter](../models/customizing-adapters) is an object that [Ember Data](../models) uses to determines how we communicate with our backend.
 We will cover Ember Data in more detail later in this tutorial.
 For now, let's generate an adapter for our application:
 
@@ -148,4 +148,4 @@ export default DS.JSONAPIAdapter.extend({
 
 If you were running `ember serve` in another shell, restart the server to include Mirage in your build.
 
-Note that at this point of the tutorial, the data is still provided by the `app/routes/rentals.js` file. We will make use of the mirage data we set up here in the upcoming section called [Using Ember Data](../ember-data/).
+Note that at this point of the tutorial, the data is still provided by the `app/routes/rentals.js` file. We will make use of the mirage data we set up here in the upcoming section called [Using Ember Data](ember-data/).

--- a/guides/v2.14.0/tutorial/model-hook.md
+++ b/guides/v2.14.0/tutorial/model-hook.md
@@ -61,11 +61,11 @@ export default Ember.Route.extend({
 Note that here, we are using the ES6 shorthand method definition syntax: `model()` is the same as writing `model: function()`.
 
 Ember will use the model object returned above and save it as an attribute called `model`,
-available to the rentals template we generated with our route in [Routes and Templates](../routes-and-templates/#toc_a-rentals-route).
+available to the rentals template we generated with our route in [Routes and Templates](routes-and-templates/#toc_a-rentals-route).
 
 Now, let's switch over to our rentals page template.
 We can use the model attribute to display our list of rentals.
-Here, we'll use another common Handlebars helper called [`{{each}}`](../../templates/displaying-a-list-of-items/).
+Here, we'll use another common Handlebars helper called [`{{each}}`](../templates/displaying-a-list-of-items/).
 This helper will let us loop through each of the rental objects in our model:
 
 ```app/templates/rentals.hbs{+12,+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,+26,+27,+28,+29}
@@ -103,7 +103,7 @@ In this template, we loop through each object.
 On each iteration, the current object gets stored in a variable called `rental`.
 From the rental variable in each step, we create a listing with information about the property.
 
-You may move onto the [next page](../installing-addons/) to keep implementing new features, or continue reading on testing the app you've created.
+You may move onto the [next page](installing-addons/) to keep implementing new features, or continue reading on testing the app you've created.
 
 ### Acceptance Testing the Rental List
 

--- a/guides/v2.14.0/tutorial/routes-and-templates.md
+++ b/guides/v2.14.0/tutorial/routes-and-templates.md
@@ -7,7 +7,7 @@ Let's start by building our "about" page.
 
 In Ember, when we want to make a new page that can be visited using a URL,
 we need to generate a "route" using Ember CLI. For a quick overview of how
-Ember structures things, see [our diagram on the Core Concepts page](../../getting-started/core-concepts/).
+Ember structures things, see [our diagram on the Core Concepts page](../getting-started/core-concepts/).
 
 Let's use Ember's route generator to start our `about` route.
 
@@ -120,7 +120,7 @@ Moving around our site is a bit of a pain right now, so let's make that easier.
 We'll put a link to the contact page on the about page, and a corresponding link to the about
 page on the contact page.
 
-To do that, we'll use a [`{{link-to}}`](../../templates/links/) helper that Ember provides
+To do that, we'll use a [`{{link-to}}`](../templates/links/) helper that Ember provides
 that makes it easy to link between our routes.  Let's adjust our `about.hbs` file:
 
 ```app/templates/about.hbs{+9,+10,+11}
@@ -213,7 +213,7 @@ installing route-test
 
 Unlike the other route handlers we've made so far, the `index` route is special:
 it does NOT require an entry in the router's mapping.
-We'll learn more about why the entry isn't required later on when we look at [nested routes](../subroutes) in Ember.
+We'll learn more about why the entry isn't required later on when we look at [nested routes](subroutes) in Ember.
 
 All we want to do when a user visits the root (`/`) URL is transition to `/rentals`.
 To do this we will add code to our index route handler by implementing a route lifecycle hook,
@@ -222,7 +222,7 @@ called `beforeModel`.
 Each route handler has a set of "lifecycle hooks", which are functions that are invoked at specific times during the loading of a page.
 The [`beforeModel`](http://emberjs.com/api/classes/Ember.Route.html#method_beforeModel)
 hook gets executed before the data gets fetched from the model hook, and before the page is rendered.
-See [the next section](../model-hook) for an explanation of the model hook.
+See [the next section](model-hook) for an explanation of the model hook.
 
 In our index route handler, we'll call the [`replaceWith`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) function.
 The `replaceWith` function is similar to the route's `transitionTo` function,
@@ -281,13 +281,13 @@ or `contact`) should be shown.
 
 At this point, we should be able to navigate between our `about`, `contact`, and `rentals` pages.
 
-From here you can move on to the [next page](../model-hook/) or dive into testing the new functionality we just added.
+From here you can move on to the [next page](model-hook/) or dive into testing the new functionality we just added.
 
 ## Implementing Acceptance Tests
 
 Now that we have various pages in our application, let's walk through how to build tests for them.
 
-As mentioned earlier on the [Planning the Application page](../acceptance-test/),
+As mentioned earlier on the [Planning the Application page](acceptance-test/),
 an Ember acceptance test automates interacting with our app in a similar way to a visitor.
 
 If you open the acceptance test we created (`/tests/acceptance/list-rentals-test.js`), you'll see our
@@ -325,7 +325,7 @@ Some of the helpers we'll use commonly are:
 
 * [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) - loads a given URL
 * [`click`](http://emberjs.com/api/classes/Ember.Test.html#method_click) - pretends to be a user clicking on a specific part of the screen
-* [`andThen`](../../testing/acceptance/#toc_wait-helpers) - waits for our previous commands to run before executing our function.
+* [`andThen`](../testing/acceptance/#toc_wait-helpers) - waits for our previous commands to run before executing our function.
   In our test below, we want to wait for our page to load after `click` is called so that we can double-check that the new page has loaded
 * [`currentURL`](http://emberjs.com/api/classes/Ember.Test.html#method_currentURL) - returns the URL of the page we're currently on
 
@@ -355,7 +355,7 @@ to see if two items (our first and second arguments) equal each other.  If they 
 The third optional argument allows us to provide a nicer message which we'll be shown if this test fails.
 
 In our tests, we also call two helpers (`visit` and `click`) one after another. Although Ember does a number
-of things when we make those calls, Ember hides those complexities by giving us these [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers).
+of things when we make those calls, Ember hides those complexities by giving us these [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers).
 
 If you left `ember test` running, it should have automatically updated to show the three tests related to
 navigating have now passed.

--- a/guides/v2.14.0/tutorial/service.md
+++ b/guides/v2.14.0/tutorial/service.md
@@ -9,7 +9,7 @@ To implement this feature, we will take advantage of several Ember concepts:
 
 Before implementing a map, we need to make a 3rd party map API available to our Ember app.
 There are several ways to include 3rd party libraries in Ember.
-See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/)
+See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/)
 as a starting point when you need to add one.
 
 
@@ -90,7 +90,7 @@ Now that we are able to generate a map element,
 we will implement a maps service that will keep a reference to the Map object we create,
 and attach the map to an element in our application
 
-Accessing our maps API through a [service](../../applications/services) will give us several benefits
+Accessing our maps API through a [service](../applications/services) will give us several benefits
 
 * It is injected with a [service locator](https://en.wikipedia.org/wiki/Service_locator_pattern),
   meaning it will abstract the maps API from the code that uses it,
@@ -170,13 +170,13 @@ This `div` will act as a place for the 3rd party map API to render the map to.
 Next, update the component to append the map output to the `div` element we created.
 
 We provide the maps service into our component by initializing a property of our component, called `maps`.
-Services are commonly made available in components and other Ember objects by ["service injection"](../../applications/services/#toc_accessing-services).
+Services are commonly made available in components and other Ember objects by ["service injection"](../applications/services/#toc_accessing-services).
 When you initialize a property with `Ember.inject.service()`,
 Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```app/components/location-map.js
@@ -227,7 +227,7 @@ After starting the server we should now see some end to end maps functionality s
 
 ![super rentals homepage with maps](../../images/service/style-super-rentals-maps.png)
 
-You may now either move onto the [next feature](../subroutes/), or continue here to test the maps feature we just added.
+You may now either move onto the [next feature](subroutes/), or continue here to test the maps feature we just added.
 
 ###  Unit testing a Service
 
@@ -329,10 +329,10 @@ test('should append map element to container element', function(assert) {
 });
 ```
 
-In the `beforeEach` function that runs before each test, we use the built-in function `this.register` to [register](../../applications/dependency-injection/#toc_factory-registrations) our stub service in place of the maps service.
+In the `beforeEach` function that runs before each test, we use the built-in function `this.register` to [register](../applications/dependency-injection/#toc_factory-registrations) our stub service in place of the maps service.
 Registration makes an object available to your Ember application for things like loading components from templates and injecting services in this case.
 
-The call to the function `this.inject.service` [injects](../../applications/dependency-injection/#toc_ad-hoc-injections) the service we just registered into the context of the tests, so each test may access it through `this.get('mapsService')`.
+The call to the function `this.inject.service` [injects](../applications/dependency-injection/#toc_ad-hoc-injections) the service we just registered into the context of the tests, so each test may access it through `this.get('mapsService')`.
 In the example we assert that `calledWithLocation` in our stub is set to the location we passed to the component.
 
 
@@ -369,7 +369,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.14.0/tutorial/simple-component.md
+++ b/guides/v2.14.0/tutorial/simple-component.md
@@ -161,7 +161,7 @@ Let's call this action `toggleImageSize`
 Clicking the anchor element will send the action to the component.
 Ember will then go into the `actions` hash and call the `toggleImageSize` function.
 
-An [actions hash](../../templates/actions/) is an object in the component that contains functions.
+An [actions hash](../templates/actions/) is an object in the component that contains functions.
 These functions are called when the user interacts with the UI, such as clicking.
 
 Let's create the `toggleImageSize` function and toggle the `isWide` property on our component:
@@ -186,13 +186,13 @@ When we click the enlarged image again, we see it smaller.
 
 ![rental listing with expand](../../images/simple-component/styled-rental-listings.png)
 
-Move on to the [next page](../hbs-helper/) for the next feature, or continue on here to test what you just wrote.
+Move on to the [next page](hbs-helper/) for the next feature, or continue on here to test what you just wrote.
 
 ### An Integration Test
 
-Ember components are commonly tested with [component integration tests](../../testing/testing-components/).
+Ember components are commonly tested with [component integration tests](../testing/testing-components/).
 Component integration tests verify the behavior of a component within the context of Ember's rendering engine.
-When running in an integration test, the component goes through its regular [render lifecycle](../../components/the-component-lifecycle/),
+When running in an integration test, the component goes through its regular [render lifecycle](../components/the-component-lifecycle/),
 and has access to dependent objects, loaded through Ember's resolver.
 
 Our component integration test will test two different behaviors:

--- a/guides/v2.14.0/tutorial/subroutes.md
+++ b/guides/v2.14.0/tutorial/subroutes.md
@@ -6,8 +6,8 @@ Up to this point, we've generated four top level routes.
 * The `index` route, which we've set up to redirect to the `rentals` route.
 
 Our `rentals` route is going to serve multiple functions.
-From our [acceptance tests](../acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
-To satisfy that requirement, we are going to make use of Ember's [nested route capability](../../routing/defining-your-routes/#toc_nested-routes).
+From our [acceptance tests](acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
+To satisfy that requirement, we are going to make use of Ember's [nested route capability](../routing/defining-your-routes/#toc_nested-routes).
 
 By the end of this section we want to have created the following new routes:
 
@@ -18,7 +18,7 @@ The `show` route will get substituted with the id of the rental being shown (for
 
 ## The Parent Route
 
-Previously, in the [Routes and Templates tutorial](../routes-and-templates), we set up a `rentals` route.
+Previously, in the [Routes and Templates tutorial](routes-and-templates), we set up a `rentals` route.
 
 Opening the template for this route reveals an outlet underneath the route's general page information.
 At the bottom of the template, you'll notice an `{{outlet}}` helper.
@@ -76,7 +76,7 @@ Ember knows that the default action is to take the user to the `index` route.
 However, you can add the `index` route if you want to customize it.
 For example, you can modify the `index` route's path by specifying `this.route('index', { path: '/custom-path'})`.
 
-In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
+In the section on [using Ember Data](ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
 Let's implement our newly generated `rentals/index` route by moving this `findAll` call from the parent `rentals` route to our new sub-route.
 
 ```app/routes/rentals.js{-2,-3,-4}
@@ -147,13 +147,13 @@ export default RentalsController;
 
 Next, we will want to create a sub-route that will list information for a specific rental.
 To do this, we will need to update a couple of files.
-To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../../models/finding-records/).
+To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../models/finding-records/).
 The `findRecord` function requires that we search by a unique key.
 
 While on the `show` route, we will also want to show additional information about our specific rental.
 
 In order to do this, we will need to modify the Mirage `config.js` file that we added
-back in the [Installing Addons section](../installing-addons). We will add a new route
+back in the [Installing Addons section](installing-addons). We will add a new route
 handler to return a specific rental:
 
 ```mirage/config.js{+57,+58,+59,+60}
@@ -288,7 +288,7 @@ export default Ember.Route.extend({
 ```
 
 Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook.
-When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../models/)).
 
 ## Adding the Rental To Our Template
 
@@ -355,7 +355,7 @@ Clicking on the title will load the detail page for that rental.
 ```
 ![Rental Page Nested Index Route](../../images/subroutes/subroutes-super-rentals-index.png)
 
-At this point you can do a [deployment](../deploying/) and share your Super Rentals application to the world
+At this point you can do a [deployment](deploying/) and share your Super Rentals application to the world
 or you can use this as a base to explore other Ember features and addons.
 Regardless, we hope this has helped you get started with creating your own ambitious applications with Ember!
 
@@ -376,6 +376,6 @@ test('should show details for a specific rental', function (assert) {
 });
 ```
 
-At this point all our tests should pass, including the [list of acceptance tests](../acceptance-test) we created as our beginning requirements.
+At this point all our tests should pass, including the [list of acceptance tests](acceptance-test) we created as our beginning requirements.
 
 ![Acceptance Tests Pass](../../images/subroutes/all-acceptance-pass.png)

--- a/guides/v2.15.0/applications/initializers.md
+++ b/guides/v2.15.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.15.0/applications/run-loop.md
+++ b/guides/v2.15.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.15.0/components/block-params.md
+++ b/guides/v2.15.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.15.0/components/defining-a-component.md
+++ b/guides/v2.15.0/components/defining-a-component.md
@@ -46,7 +46,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.15.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.15.0/components/triggering-changes-with-actions.md
@@ -67,7 +67,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -75,7 +75,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -320,7 +320,7 @@ export default Ember.Component.extend({
 In order for `confirmValue` to take on the value of the message text,
 we'll bind the property to the value of a user input field that will appear when the button is clicked.
 To accomplish this,
-we'll first modify the component so that it can be used in block form and we will [yield](../wrapping-content-in-a-component/) `confirmValue` to the block within the `"confirmDialog"` element:
+we'll first modify the component so that it can be used in block form and we will [yield](wrapping-content-in-a-component/) `confirmValue` to the block within the `"confirmDialog"` element:
 
 ```app/templates/components/button-with-confirmation.hbs
 <button {{action "launchConfirmDialog"}}>{{text}}</button>

--- a/guides/v2.15.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.15.0/components/wrapping-content-in-a-component.md
@@ -13,7 +13,7 @@ Now, we can use the `{{blog-post}}` component and pass it properties in another 
 {{blog-post title=title body=body}}
 ```
 
-See [Passing Properties to a Component](../passing-properties-to-a-component/) for more.
+See [Passing Properties to a Component](passing-properties-to-a-component/) for more.
 
 In this case, the content we wanted to display came from the model.
 But what if we want the developer using our component to be able to provide custom HTML content?

--- a/guides/v2.15.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.15.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.15.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.15.0/configuring-ember/disabling-prototype-extensions.md
@@ -107,7 +107,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.15.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.15.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -33,7 +33,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js{-8,+9}

--- a/guides/v2.15.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.15.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.15.0/ember-inspector/object-inspector.md
+++ b/guides/v2.15.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.15.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.15.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.15.0/ember-inspector/view-tree.md
+++ b/guides/v2.15.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.15.0/getting-started/quick-start.md
+++ b/guides/v2.15.0/getting-started/quick-start.md
@@ -24,7 +24,7 @@ npm install -g ember-cli
 
 Don't have npm? [Learn how to install Node.js and npm here](https://docs.npmjs.com/getting-started/installing-node).
 For a full list of dependencies necessary for an Ember CLI project,
-consult our [Installing Ember](../../getting-started/) guide.
+consult our [Installing Ember](../getting-started/) guide.
 
 ## Create a New Application
 

--- a/guides/v2.15.0/models/customizing-adapters.md
+++ b/guides/v2.15.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.15.0/models/defining-models.md
+++ b/guides/v2.15.0/models/defining-models.md
@@ -21,8 +21,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -63,7 +63,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.15.0/routing/defining-your-routes.md
+++ b/guides/v2.15.0/routing/defining-your-routes.md
@@ -245,7 +245,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.15.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.15.0/routing/preventing-and-retrying-transitions.md
@@ -49,7 +49,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.15.0/routing/redirection.md
+++ b/guides/v2.15.0/routing/redirection.md
@@ -10,7 +10,7 @@ Ember allows you to control that access with a combination of hooks and methods 
 One of the methods is [`transitionTo()`](http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo).
 Calling `transitionTo()` from a route or
 [`transitionToRoute()`](http://emberjs.com/api/classes/Ember.Controller.html#method_transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
-`transitionTo()` behaves exactly like the [link-to](../../templates/links) helper.
+`transitionTo()` behaves exactly like the [link-to](../templates/links) helper.
 
 The other one is [`replaceWith()`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
@@ -45,11 +45,11 @@ export default Ember.Route.extend({
 This allows us to return the user back to the original route.
 For example, we might redirect a user to the login page when they try to edit their profile, and immediately redirect
 them back to the edit page once they have successfully logged in.
-See [Storing and Retrying a Transition](../preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
+See [Storing and Retrying a Transition](preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
 for how to do that.
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.15.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.15.0/routing/specifying-a-routes-model.md
@@ -24,7 +24,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember Data records are promises),
 or a plain JavaScript object or array.
 Ember will wait until the data finishes loading (until the promise is resolved) before rendering the template.
@@ -58,7 +58,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -87,7 +87,7 @@ photo's ID (`params.photo_id`) as an argument to Ember Data's `findRecord`
 method.
 
 Note: A route with a dynamic segment will always have its `model` hook called when it is entered via the URL.
-If the route is entered through a transition (e.g. when using the [link-to](../../templates/links) Handlebars helper),
+If the route is entered through a transition (e.g. when using the [link-to](../templates/links) Handlebars helper),
 and a model context is provided (second argument to `link-to`), then the hook is not executed.
 If an identifier (such as an id or slug) is provided instead then the model hook will be executed.
 
@@ -164,7 +164,7 @@ each record in the song model and album model:
 </ul>
 ```
 
-If you use [Ember Data](../../models/) and you are building an `RSVP.hash` with the model's relationship, consider instead properly setting up your [relationships](../../models/relationships) and letting Ember Data take care of loading them.
+If you use [Ember Data](../models/) and you are building an `RSVP.hash` with the model's relationship, consider instead properly setting up your [relationships](../models/relationships) and letting Ember Data take care of loading them.
 
 ## Reusing Route Context
 

--- a/guides/v2.15.0/templates/actions.md
+++ b/guides/v2.15.0/templates/actions.md
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../../components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.15.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.15.0/templates/displaying-a-list-of-items.md
@@ -45,7 +45,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.15.0/templates/handlebars-basics.md
+++ b/guides/v2.15.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.15.0/templates/links.md
+++ b/guides/v2.15.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` component takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the component, you can provide

--- a/guides/v2.15.0/templates/writing-helpers.md
+++ b/guides/v2.15.0/templates/writing-helpers.md
@@ -81,7 +81,7 @@ helper again with the new values and keep the page up-to-date.
 
 ### Helper Names
 
-Unlike [components](/components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
+Unlike [components](../components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
 
 ### Helper Arguments
 

--- a/guides/v2.15.0/testing/testing-controllers.md
+++ b/guides/v2.15.0/testing/testing-controllers.md
@@ -132,5 +132,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.15.0/testing/testing-helpers.md
+++ b/guides/v2.15.0/testing/testing-helpers.md
@@ -85,5 +85,5 @@ test('updates the currency sign when it changes', function(assert) {
 });
 ```
 
-[Testing Components]: ../unit-testing-basics
-[Writing Helpers]: ../../templates/writing-helpers
+[Testing Components]: unit-testing-basics
+[Writing Helpers]: ../templates/writing-helpers

--- a/guides/v2.15.0/testing/testing-models.md
+++ b/guides/v2.15.0/testing/testing-models.md
@@ -102,5 +102,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.15.0/testing/testing-routes.md
+++ b/guides/v2.15.0/testing/testing-routes.md
@@ -84,5 +84,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.15.0/tutorial/acceptance-test.md
+++ b/guides/v2.15.0/tutorial/acceptance-test.md
@@ -15,11 +15,11 @@ Let's work through what we want to do on the home page. We want our application 
 
 For the remainder of this page, we'll give you an introduction to testing in Ember and get you set up to add tests as we implement pieces of our app. On subsequent tutorial pages, the final sections of each page will be devoted to adding a test for the feature you just implemented. These sections aren't required for a working application and you may move on with the tutorial without writing them.
 
-At this point, you can continue to the [next page](../routes-and-templates/) or read more about Ember testing below.
+At this point, you can continue to the [next page](routes-and-templates/) or read more about Ember testing below.
 
 ### Testing Our Application As We Go
 
-We can represent the goals above as [Ember acceptance tests](../../testing/acceptance/). Acceptance tests interact with our app like an actual person would, but are automated, helping ensure that our app doesn't break in the future.
+We can represent the goals above as [Ember acceptance tests](../testing/acceptance/). Acceptance tests interact with our app like an actual person would, but are automated, helping ensure that our app doesn't break in the future.
 
 When we create a new Ember Project using Ember CLI, it uses the [`QUnit`](https://qunitjs.com/) JavaScript test framework to define and run tests.
 

--- a/guides/v2.15.0/tutorial/autocomplete-component.md
+++ b/guides/v2.15.0/tutorial/autocomplete-component.md
@@ -1,5 +1,5 @@
 As they search for a rental, users might also want to narrow their search to a specific city.
-While our [initial](../simple-component/) rental listing component only displayed rental information, this new filter component will also allow the user to provide input in the form of filter criteria.
+While our [initial](simple-component/) rental listing component only displayed rental information, this new filter component will also allow the user to provide input in the form of filter criteria.
 
 To begin, let's generate our new component.
 We'll call this component `list-filter`, since all we want our component to do is filter the list of rentals based on input.
@@ -8,7 +8,7 @@ We'll call this component `list-filter`, since all we want our component to do i
 ember g component list-filter
 ```
 
-As before when we created the [`rental-listing` component](../simple-component), the "generate component" CLI command creates
+As before when we created the [`rental-listing` component](simple-component), the "generate component" CLI command creates
 
 * a Handlebars template (`app/templates/components/list-filter.hbs`),
 * a JavaScript file (`app/components/list-filter.js`),
@@ -19,7 +19,7 @@ As before when we created the [`rental-listing` component](../simple-component),
 In our `app/templates/rentals.hbs` template file, we'll add a reference to our new `list-filter` component.
 
 Notice that below we "wrap" our rentals markup inside the open and closing mentions of `list-filter` on lines 12 and 20.
-This is an example of the [**block form**](../../components/wrapping-content-in-a-component) of a component,
+This is an example of the [**block form**](../components/wrapping-content-in-a-component) of a component,
 which allows a Handlebars template to be rendered _inside_ the component's template wherever the `{{yield}}` expression appears.
 
 In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14).
@@ -62,10 +62,10 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The `value` property of the `input` will be kept in sync with the `value` property in the component.
 
-Another way to say this is that the `value` property of `input` is [**bound**](../../object-model/bindings/) to the `value` property of the component.
+Another way to say this is that the `value` property of `input` is [**bound**](../object-model/bindings/) to the `value` property of the component.
 If the property changes, either by the user typing in the input field, or by assigning a new value to it in our program,
 the new value of the property is present in both the rendered web page and in the code.
 
@@ -101,7 +101,7 @@ export default Ember.Component.extend({
 In the above example we use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls a function called `filter` based on the `value` attribute set by the input helper.
 
-The `filter` function is passed in by the calling object. This is a pattern known as [closure actions](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component).
+The `filter` function is passed in by the calling object. This is a pattern known as [closure actions](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component).
 
 Notice the `then` function called on the result of calling the `filter` function.
 The code expects the `filter` function to return a promise.
@@ -111,7 +111,7 @@ To account for this, it provides functions, like `then` that let you give it cod
 
 
 To implement the `filter` function to do the actual filter of rentals by city, we'll create a `rentals` controller.
-[Controllers](../../controllers/) contain actions and properties available to the template of its corresponding route.
+[Controllers](../controllers/) contain actions and properties available to the template of its corresponding route.
 In our case we want to generate a controller called `rentals`.
 Ember will know that a controller with the name of `rentals` will apply to the route with the same name.
 
@@ -284,15 +284,15 @@ To create effective and robust autocomplete behavior for your applications,
 we recommend considering the [`ember-concurrency`](http://ember-concurrency.com/#/docs/introduction) addon project.
 
 
-You can now proceed on to implement the [next feature](../service/), or continue on to test our newly created filter component.
+You can now proceed on to implement the [next feature](service/), or continue on to test our newly created filter component.
 
 ### An Integration Test
 
 Now that we've created a new component for filtering a list,
 we want to create a test to verify it.
-Let's use a [component integration test](../../testing/testing-components)
+Let's use a [component integration test](../testing/testing-components)
 to verify our component behavior,
-similar to [how we tested our rental listing component earlier](../simple-component/#toc_an-integration-test).
+similar to [how we tested our rental listing component earlier](simple-component/#toc_an-integration-test).
 
 Lets begin by opening the component integration test created when we generated our `list-filter` component, `tests/integration/components/list-filter-test.js`.
 Remove the default test, and create a new test that verifies that by default, the component will list all items.
@@ -383,7 +383,7 @@ test('should initially load all listings', function (assert) {
 
 Finally we add a `wait` call at the end of our test to assert the results.
 
-Ember's [wait helper](../../testing/testing-components/#toc_waiting-on-asynchronous-behavior)
+Ember's [wait helper](../testing/testing-components/#toc_waiting-on-asynchronous-behavior)
 waits for all asynchronous tasks to complete before running the given function callback.
 It returns a promise that we also return from the test.
 
@@ -510,7 +510,7 @@ Our test fills out "Seattle" as the search criteria in the search field,
 and then sends a `keyup` event to the same field with a code of `69` (the `e` key) to simulate a user typing.
 
 The test locates the results of the search by finding elements with a class of `listing`,
-which we gave to our `rental-listing` component in the ["Building a Simple Component"](../simple-component) section of the tutorial.
+which we gave to our `rental-listing` component in the ["Building a Simple Component"](simple-component) section of the tutorial.
 
 Since our data is hard-coded in Mirage, we know that there is only one rental with a city name of "Seattle",
 so we assert that the number of listings is one and that the location it displays is named, "Seattle".

--- a/guides/v2.15.0/tutorial/ember-cli.md
+++ b/guides/v2.15.0/tutorial/ember-cli.md
@@ -2,7 +2,7 @@ Welcome to the Ember Tutorial!
 This tutorial is meant to introduce basic Ember concepts while creating a professional looking application.
 If you get stuck at any point during the tutorial, feel free to download [https://github.com/ember-learn/super-rentals](https://github.com/ember-learn/super-rentals) for a working example of the completed app.
 
-You can install the latest version of `ember-cli` by following the [Quick Start](../../getting-started/quick-start/#toc_install-ember) guide "Installing Ember" section.
+You can install the latest version of `ember-cli` by following the [Quick Start](../getting-started/quick-start/#toc_install-ember) guide "Installing Ember" section.
 
 Ember CLI, Ember's command line interface, provides a standard project
 structure, a set of development tools, and an addon system.

--- a/guides/v2.15.0/tutorial/ember-data.md
+++ b/guides/v2.15.0/tutorial/ember-data.md
@@ -31,10 +31,10 @@ export default DS.Model.extend({
 });
 ```
 
-Let's define the structure of a rental object using the same attributes for our rental that we [previously used](../model-hook/) in our hard-coded array of JavaScript objects -
+Let's define the structure of a rental object using the same attributes for our rental that we [previously used](model-hook/) in our hard-coded array of JavaScript objects -
 _title_, _owner_, _city_, _property type_, _image_, _bedrooms_ and _description_.
 Define attributes by giving them the result of the function [`DS.attr()`](http://emberjs.com/api/data/classes/DS.html#method_attr).
-For more information on Ember Data Attributes, read the section called [Defining Attributes](../../models/defining-models/#toc_defining-attributes) in the guides.
+For more information on Ember Data Attributes, read the section called [Defining Attributes](../models/defining-models/#toc_defining-attributes) in the guides.
 
 ```app/models/rental.js
 import DS from 'ember-data';
@@ -54,8 +54,8 @@ We now have a model object that we can use for our Ember Data implementation.
 
 ### Updating the Model Hook
 
-To use our new Ember Data Model object, we need to update the `model` function we [previously defined](../model-hook/) in our route handler.
-Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../../models/#toc_the-store-and-a-single-source-of-truth).
+To use our new Ember Data Model object, we need to update the `model` function we [previously defined](model-hook/) in our route handler.
+Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../models/#toc_the-store-and-a-single-source-of-truth).
 The [store service](http://emberjs.com/api/data/classes/DS.Store.html) is injected into all routes and components in Ember.
 It is the main interface you use to interact with Ember Data.
 In this case, call the [`findAll`](http://emberjs.com/api/data/classes/DS.Store.html#method_findAll) function on the store and provide it with the name of your newly created rental model class.
@@ -99,9 +99,9 @@ export default Ember.Route.extend({
 ```
 
 When we call `findAll`, Ember Data will attempt to fetch rentals from `/api/rentals`.
-If you recall, in the section titled [Installing Addons](../installing-addons/) we set up an adapter to route data requests through `/api`.
+If you recall, in the section titled [Installing Addons](installing-addons/) we set up an adapter to route data requests through `/api`.
 
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we have already set up Ember Mirage in our development environment, Mirage will return the data we requested without actually making a network request.
 

--- a/guides/v2.15.0/tutorial/installing-addons.md
+++ b/guides/v2.15.0/tutorial/installing-addons.md
@@ -10,7 +10,7 @@ For Super Rentals, we'll take advantage of two addons: [ember-cli-tutorial-style
 Instead of having you copy/paste in CSS to style Super Rentals, we've created an addon called [ember-cli-tutorial-style](https://github.com/ember-learn/ember-cli-tutorial-style) that instantly adds CSS to the tutorial.
 The addon works by generating a file called `ember-tutorial.css` and putting that file in the super-rentals `vendor` directory.
 
-The [`vendor` directory](../../addons-and-dependencies/managing-dependencies/#toc_other-assets) in Ember is a special directory where you can include content that gets compiled into your application.
+The [`vendor` directory](../addons-and-dependencies/managing-dependencies/#toc_other-assets) in Ember is a special directory where you can include content that gets compiled into your application.
 When Ember CLI builds our app from our source code, it copies `ember-tutorial.css` into a file called `vendor.css`.
 
 As Ember CLI runs, it takes the `ember-tutorial` CSS file and puts it in a file called `vendor.css`.
@@ -125,7 +125,7 @@ Without this change, navigation to `/rentals` in our application would conflict 
 
 In order for this to work, we need our application to default to making requests to the namespace of `/api`.
 To do this, we want to generate an application adapter.
-An [Adapter](../../models/customizing-adapters) is an object that [Ember Data](../../models) uses to determine how we communicate with our backend.
+An [Adapter](../models/customizing-adapters) is an object that [Ember Data](../models) uses to determine how we communicate with our backend.
 We will cover Ember Data in more detail later in this tutorial.
 For now, let's generate an adapter for our application:
 
@@ -148,4 +148,4 @@ export default DS.JSONAPIAdapter.extend({
 
 If you were running `ember serve` in another shell, restart the server to include Mirage in your build.
 
-Note that at this point of the tutorial, the data is still provided by the `app/routes/rentals.js` file. We will make use of the mirage data we set up here in the upcoming section called [Using Ember Data](../ember-data/).
+Note that at this point of the tutorial, the data is still provided by the `app/routes/rentals.js` file. We will make use of the mirage data we set up here in the upcoming section called [Using Ember Data](ember-data/).

--- a/guides/v2.15.0/tutorial/model-hook.md
+++ b/guides/v2.15.0/tutorial/model-hook.md
@@ -59,11 +59,11 @@ export default Ember.Route.extend({
 Note that here, we are using the ES6 shorthand method definition syntax: `model()` is the same as writing `model: function()`.
 
 Ember will use the model object returned above and save it as an attribute called `model`,
-available to the rentals template we generated with our route in [Routes and Templates](../routes-and-templates/#toc_a-rentals-route).
+available to the rentals template we generated with our route in [Routes and Templates](routes-and-templates/#toc_a-rentals-route).
 
 Now, let's switch over to our rentals page template.
 We can use the model attribute to display our list of rentals.
-Here, we'll use another common Handlebars helper called [`{{each}}`](../../templates/displaying-a-list-of-items/).
+Here, we'll use another common Handlebars helper called [`{{each}}`](../templates/displaying-a-list-of-items/).
 This helper will let us loop through each of the rental objects in our model:
 
 ```app/templates/rentals.hbs{+12,+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,+26,+27,+28,+29}
@@ -101,7 +101,7 @@ In this template, we loop through each object.
 On each iteration, the current object gets stored in a variable called `rental`.
 From the rental variable in each step, we create a listing with information about the property.
 
-You may move onto the [next page](../installing-addons/) to keep implementing new features, or continue reading on testing the app you've created.
+You may move onto the [next page](installing-addons/) to keep implementing new features, or continue reading on testing the app you've created.
 
 ### Acceptance Testing the Rental List
 

--- a/guides/v2.15.0/tutorial/routes-and-templates.md
+++ b/guides/v2.15.0/tutorial/routes-and-templates.md
@@ -7,7 +7,7 @@ Let's start by building our "about" page.
 
 In Ember, when we want to make a new page that can be visited using a URL,
 we need to generate a "route" using Ember CLI. For a quick overview of how
-Ember structures things, see [our diagram on the Core Concepts page](../../getting-started/core-concepts/).
+Ember structures things, see [our diagram on the Core Concepts page](../getting-started/core-concepts/).
 
 Let's use Ember's route generator to start our `about` route.
 
@@ -120,7 +120,7 @@ Moving around our site is a bit of a pain right now, so let's make that easier.
 We'll put a link to the contact page on the about page, and a corresponding link to the about
 page on the contact page.
 
-To do that, we'll use a [`{{link-to}}`](../../templates/links/) helper that Ember provides
+To do that, we'll use a [`{{link-to}}`](../templates/links/) helper that Ember provides
 that makes it easy to link between our routes.  Let's adjust our `about.hbs` file:
 
 ```app/templates/about.hbs{+9,+10,+11}
@@ -213,7 +213,7 @@ installing route-test
 
 Unlike the other route handlers we've made so far, the `index` route is special:
 it does NOT require an entry in the router's mapping.
-We'll learn more about why the entry isn't required later on when we look at [nested routes](../subroutes) in Ember.
+We'll learn more about why the entry isn't required later on when we look at [nested routes](subroutes) in Ember.
 
 All we want to do when a user visits the root (`/`) URL is transition to `/rentals`.
 To do this we will add code to our index route handler by implementing a route lifecycle hook,
@@ -222,7 +222,7 @@ called `beforeModel`.
 Each route handler has a set of "lifecycle hooks", which are functions that are invoked at specific times during the loading of a page.
 The [`beforeModel`](http://emberjs.com/api/classes/Ember.Route.html#method_beforeModel)
 hook gets executed before the data gets fetched from the model hook, and before the page is rendered.
-See [the next section](../model-hook) for an explanation of the model hook.
+See [the next section](model-hook) for an explanation of the model hook.
 
 In our index route handler, we'll call the [`replaceWith`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) function.
 The `replaceWith` function is similar to the route's `transitionTo` function,
@@ -281,13 +281,13 @@ or `contact`) should be shown.
 
 At this point, we should be able to navigate between our `about`, `contact`, and `rentals` pages.
 
-From here you can move on to the [next page](../model-hook/) or dive into testing the new functionality we just added.
+From here you can move on to the [next page](model-hook/) or dive into testing the new functionality we just added.
 
 ## Implementing Acceptance Tests
 
 Now that we have various pages in our application, let's walk through how to build tests for them.
 
-As mentioned earlier on the [Planning the Application page](../acceptance-test/),
+As mentioned earlier on the [Planning the Application page](acceptance-test/),
 an Ember acceptance test automates interacting with our app in a similar way to a visitor.
 
 If you open the acceptance test we created (`/tests/acceptance/list-rentals-test.js`), you'll see our
@@ -325,7 +325,7 @@ Some of the helpers we'll use commonly are:
 
 * [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) - loads a given URL
 * [`click`](http://emberjs.com/api/classes/Ember.Test.html#method_click) - pretends to be a user clicking on a specific part of the screen
-* [`andThen`](../../testing/acceptance/#toc_wait-helpers) - waits for our previous commands to run before executing our function.
+* [`andThen`](../testing/acceptance/#toc_wait-helpers) - waits for our previous commands to run before executing our function.
   In our test below, we want to wait for our page to load after `click` is called so that we can double-check that the new page has loaded
 * [`currentURL`](http://emberjs.com/api/classes/Ember.Test.html#method_currentURL) - returns the URL of the page we're currently on
 
@@ -355,7 +355,7 @@ to see if two items (our first and second arguments) equal each other.  If they 
 The third optional argument allows us to provide a nicer message which we'll be shown if this test fails.
 
 In our tests, we also call two helpers (`visit` and `click`) one after another. Although Ember does a number
-of things when we make those calls, Ember hides those complexities by giving us these [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers).
+of things when we make those calls, Ember hides those complexities by giving us these [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers).
 
 If you left `ember test` running, it should have automatically updated to show the three tests related to
 navigating have now passed.

--- a/guides/v2.15.0/tutorial/service.md
+++ b/guides/v2.15.0/tutorial/service.md
@@ -9,7 +9,7 @@ To implement this feature, we will take advantage of several Ember concepts:
 
 Before implementing a map, we need to make a 3rd party map API available to our Ember app.
 There are several ways to include 3rd party libraries in Ember.
-See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/)
+See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/)
 as a starting point when you need to add one.
 
 
@@ -90,7 +90,7 @@ Now that we are able to generate a map element,
 we will implement a maps service that will keep a reference to the Map object we create,
 and attach the map to an element in our application
 
-Accessing our maps API through a [service](../../applications/services) will give us several benefits
+Accessing our maps API through a [service](../applications/services) will give us several benefits
 
 * It is injected with a [service locator](https://en.wikipedia.org/wiki/Service_locator_pattern),
   meaning it will abstract the maps API from the code that uses it,
@@ -170,13 +170,13 @@ This `div` will act as a place for the 3rd party map API to render the map to.
 Next, update the component to append the map output to the `div` element we created.
 
 We provide the maps service into our component by initializing a property of our component, called `maps`.
-Services are commonly made available in components and other Ember objects by ["service injection"](../../applications/services/#toc_accessing-services).
+Services are commonly made available in components and other Ember objects by ["service injection"](../applications/services/#toc_accessing-services).
 When you initialize a property with `Ember.inject.service()`,
 Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```app/components/location-map.js
@@ -227,7 +227,7 @@ After starting the server we should now see some end to end maps functionality s
 
 ![super rentals homepage with maps](../../images/service/style-super-rentals-maps.png)
 
-You may now either move onto the [next feature](../subroutes/), or continue here to test the maps feature we just added.
+You may now either move onto the [next feature](subroutes/), or continue here to test the maps feature we just added.
 
 ###  Unit testing a Service
 
@@ -329,10 +329,10 @@ test('should append map element to container element', function(assert) {
 });
 ```
 
-In the `beforeEach` function that runs before each test, we use the built-in function `this.register` to [register](../../applications/dependency-injection/#toc_factory-registrations) our stub service in place of the maps service.
+In the `beforeEach` function that runs before each test, we use the built-in function `this.register` to [register](../applications/dependency-injection/#toc_factory-registrations) our stub service in place of the maps service.
 Registration makes an object available to your Ember application for things like loading components from templates and injecting services in this case.
 
-The call to the function `this.inject.service` [injects](../../applications/dependency-injection/#toc_ad-hoc-injections) the service we just registered into the context of the tests, so each test may access it through `this.get('mapsService')`.
+The call to the function `this.inject.service` [injects](../applications/dependency-injection/#toc_ad-hoc-injections) the service we just registered into the context of the tests, so each test may access it through `this.get('mapsService')`.
 In the example we assert that `calledWithLocation` in our stub is set to the location we passed to the component.
 
 
@@ -369,7 +369,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.15.0/tutorial/simple-component.md
+++ b/guides/v2.15.0/tutorial/simple-component.md
@@ -161,7 +161,7 @@ Let's call this action `toggleImageSize`
 Clicking the anchor element will send the action to the component.
 Ember will then go into the `actions` hash and call the `toggleImageSize` function.
 
-An [actions hash](../../templates/actions/) is an object in the component that contains functions.
+An [actions hash](../templates/actions/) is an object in the component that contains functions.
 These functions are called when the user interacts with the UI, such as clicking.
 
 Let's create the `toggleImageSize` function and toggle the `isWide` property on our component:
@@ -186,13 +186,13 @@ When we click the enlarged image again, we see it smaller.
 
 ![rental listing with expand](../../images/simple-component/styled-rental-listings.png)
 
-Move on to the [next page](../hbs-helper/) for the next feature, or continue on here to test what you just wrote.
+Move on to the [next page](hbs-helper/) for the next feature, or continue on here to test what you just wrote.
 
 ### An Integration Test
 
-Ember components are commonly tested with [component integration tests](../../testing/testing-components/).
+Ember components are commonly tested with [component integration tests](../testing/testing-components/).
 Component integration tests verify the behavior of a component within the context of Ember's rendering engine.
-When running in an integration test, the component goes through its regular [render lifecycle](../../components/the-component-lifecycle/),
+When running in an integration test, the component goes through its regular [render lifecycle](../components/the-component-lifecycle/),
 and has access to dependent objects, loaded through Ember's resolver.
 
 Our component integration test will test two different behaviors:

--- a/guides/v2.15.0/tutorial/subroutes.md
+++ b/guides/v2.15.0/tutorial/subroutes.md
@@ -6,8 +6,8 @@ Up to this point, we've generated four top level routes.
 * The `index` route, which we've set up to redirect to the `rentals` route.
 
 Our `rentals` route is going to serve multiple functions.
-From our [acceptance tests](../acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
-To satisfy that requirement, we are going to make use of Ember's [nested route capability](../../routing/defining-your-routes/#toc_nested-routes).
+From our [acceptance tests](acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
+To satisfy that requirement, we are going to make use of Ember's [nested route capability](../routing/defining-your-routes/#toc_nested-routes).
 
 By the end of this section we want to have created the following new routes:
 
@@ -18,7 +18,7 @@ The `show` route will get substituted with the id of the rental being shown (for
 
 ## The Parent Route
 
-Previously, in the [Routes and Templates tutorial](../routes-and-templates), we set up a `rentals` route.
+Previously, in the [Routes and Templates tutorial](routes-and-templates), we set up a `rentals` route.
 
 Opening the template for this route reveals an outlet underneath the route's general page information.
 At the bottom of the template, you'll notice an `{{outlet}}` helper.
@@ -76,7 +76,7 @@ Ember knows that the default action is to take the user to the `index` route.
 However, you can add the `index` route if you want to customize it.
 For example, you can modify the `index` route's path by specifying `this.route('index', { path: '/custom-path'})`.
 
-In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
+In the section on [using Ember Data](ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
 Let's implement our newly generated `rentals/index` route by moving this `findAll` call from the parent `rentals` route to our new sub-route.
 
 ```app/routes/rentals.js{-2,-3,-4}
@@ -147,13 +147,13 @@ export default RentalsController;
 
 Next, we will want to create a sub-route that will list information for a specific rental.
 To do this, we will need to update a couple of files.
-To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../../models/finding-records/).
+To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../models/finding-records/).
 The `findRecord` function requires that we search by a unique key.
 
 While on the `show` route, we will also want to show additional information about our specific rental.
 
 In order to do this, we will need to modify the Mirage `config.js` file that we added
-back in the [Installing Addons section](../installing-addons). We will add a new route
+back in the [Installing Addons section](installing-addons). We will add a new route
 handler to return a specific rental:
 
 ```mirage/config.js{+57,+58,+59,+60}
@@ -288,7 +288,7 @@ export default Ember.Route.extend({
 ```
 
 Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook.
-When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../models/)).
 
 ## Adding the Rental To Our Template
 
@@ -355,7 +355,7 @@ Clicking on the title will load the detail page for that rental.
 ```
 ![Rental Page Nested Index Route](../../images/subroutes/subroutes-super-rentals-index.png)
 
-At this point you can do a [deployment](../deploying/) and share your Super Rentals application to the world
+At this point you can do a [deployment](deploying/) and share your Super Rentals application to the world
 or you can use this as a base to explore other Ember features and addons.
 Regardless, we hope this has helped you get started with creating your own ambitious applications with Ember!
 
@@ -376,6 +376,6 @@ test('should show details for a specific rental', function (assert) {
 });
 ```
 
-At this point all our tests should pass, including the [list of acceptance tests](../acceptance-test) we created as our beginning requirements.
+At this point all our tests should pass, including the [list of acceptance tests](acceptance-test) we created as our beginning requirements.
 
 ![Acceptance Tests Pass](../../images/subroutes/all-acceptance-pass.png)

--- a/guides/v2.16.0/applications/initializers.md
+++ b/guides/v2.16.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.16.0/components/block-params.md
+++ b/guides/v2.16.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.16.0/components/defining-a-component.md
+++ b/guides/v2.16.0/components/defining-a-component.md
@@ -46,7 +46,7 @@ Each component is backed by an element under the hood. By default,
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.16.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.16.0/components/triggering-changes-with-actions.md
@@ -67,7 +67,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -75,7 +75,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -328,7 +328,7 @@ export default Component.extend({
 In order for `confirmValue` to take on the value of the message text,
 we'll bind the property to the value of a user input field that will appear when the button is clicked.
 To accomplish this,
-we'll first modify the component so that it can be used in block form and we will [yield](../wrapping-content-in-a-component/) `confirmValue` to the block within the `"confirmDialog"` element:
+we'll first modify the component so that it can be used in block form and we will [yield](wrapping-content-in-a-component/) `confirmValue` to the block within the `"confirmDialog"` element:
 
 ```app/templates/components/button-with-confirmation.hbs
 <button {{action "launchConfirmDialog"}}>{{text}}</button>

--- a/guides/v2.16.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.16.0/components/wrapping-content-in-a-component.md
@@ -13,7 +13,7 @@ Now, we can use the `{{blog-post}}` component and pass it properties in another 
 {{blog-post title=title body=body}}
 ```
 
-See [Passing Properties to a Component](../passing-properties-to-a-component/) for more.
+See [Passing Properties to a Component](passing-properties-to-a-component/) for more.
 
 In this case, the content we wanted to display came from the model.
 But what if we want the developer using our component to be able to provide custom HTML content?

--- a/guides/v2.16.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.16.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.16.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.16.0/configuring-ember/disabling-prototype-extensions.md
@@ -111,7 +111,7 @@ camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.16.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.16.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -33,7 +33,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js{-8,+9}

--- a/guides/v2.16.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.16.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.16.0/ember-inspector/object-inspector.md
+++ b/guides/v2.16.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.16.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.16.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.16.0/ember-inspector/view-tree.md
+++ b/guides/v2.16.0/ember-inspector/view-tree.md
@@ -3,7 +3,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
-Use the tips described in [Object Inspector](../object-inspector) to inspect models and controllers. See below for templates and components.
+Use the tips described in [Object Inspector](object-inspector) to inspect models and controllers. See below for templates and components.
 
 ### Inspecting Templates
 

--- a/guides/v2.16.0/getting-started/quick-start.md
+++ b/guides/v2.16.0/getting-started/quick-start.md
@@ -20,7 +20,7 @@ npm install -g ember-cli
 
 Don't have npm? [Learn how to install Node.js and npm here](https://docs.npmjs.com/getting-started/installing-node).
 For a full list of dependencies necessary for an Ember CLI project,
-consult our [Installing Ember](../../getting-started/) guide.
+consult our [Installing Ember](../getting-started/) guide.
 
 ## Create a New Application
 

--- a/guides/v2.16.0/models/customizing-adapters.md
+++ b/guides/v2.16.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.16.0/models/defining-models.md
+++ b/guides/v2.16.0/models/defining-models.md
@@ -21,8 +21,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -63,7 +63,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.16.0/routing/defining-your-routes.md
+++ b/guides/v2.16.0/routing/defining-your-routes.md
@@ -243,7 +243,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.16.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.16.0/routing/preventing-and-retrying-transitions.md
@@ -49,7 +49,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.16.0/routing/redirection.md
+++ b/guides/v2.16.0/routing/redirection.md
@@ -10,7 +10,7 @@ Ember allows you to control that access with a combination of hooks and methods 
 One of the methods is [`transitionTo()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://www.emberjs.com/api/ember/2.16/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
-`transitionTo()` behaves exactly like the [link-to](../../templates/links) helper.
+`transitionTo()` behaves exactly like the [link-to](../templates/links) helper.
 
 The other one is [`replaceWith()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/transitionTo?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
@@ -45,11 +45,11 @@ export default Route.extend({
 This allows us to return the user back to the original route.
 For example, we might redirect a user to the login page when they try to edit their profile, and immediately redirect
 them back to the edit page once they have successfully logged in.
-See [Storing and Retrying a Transition](../preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
+See [Storing and Retrying a Transition](preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
 for how to do that.
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.16.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.16.0/routing/specifying-a-routes-model.md
@@ -22,7 +22,7 @@ export default Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember Data records are promises),
 or a plain JavaScript object or array.
 Ember will wait until the data finishes loading (until the promise is resolved) before rendering the template.
@@ -56,7 +56,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -85,7 +85,7 @@ photo's ID (`params.photo_id`) as an argument to Ember Data's `findRecord`
 method.
 
 Note: A route with a dynamic segment will always have its `model` hook called when it is entered via the URL.
-If the route is entered through a transition (e.g. when using the [link-to](../../templates/links) Handlebars helper),
+If the route is entered through a transition (e.g. when using the [link-to](../templates/links) Handlebars helper),
 and a model context is provided (second argument to `link-to`), then the hook is not executed.
 If an identifier (such as an id or slug) is provided instead then the model hook will be executed.
 
@@ -162,7 +162,7 @@ each record in the song model and album model:
 </ul>
 ```
 
-If you use [Ember Data](../../models/) and you are building an `RSVP.hash` with the model's relationship, consider instead properly setting up your [relationships](../../models/relationships) and letting Ember Data take care of loading them.
+If you use [Ember Data](../models/) and you are building an `RSVP.hash` with the model's relationship, consider instead properly setting up your [relationships](../models/relationships) and letting Ember Data take care of loading them.
 
 ## Reusing Route Context
 

--- a/guides/v2.16.0/templates/actions.md
+++ b/guides/v2.16.0/templates/actions.md
@@ -29,7 +29,7 @@ export default Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../../components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.16.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.16.0/templates/displaying-a-list-of-items.md
@@ -45,7 +45,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.16.0/templates/handlebars-basics.md
+++ b/guides/v2.16.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.16.0/templates/links.md
+++ b/guides/v2.16.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` component takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the component, you can provide

--- a/guides/v2.16.0/templates/writing-helpers.md
+++ b/guides/v2.16.0/templates/writing-helpers.md
@@ -79,7 +79,7 @@ helper again with the new values and keep the page up-to-date.
 
 ### Helper Names
 
-Unlike [components](../../components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
+Unlike [components](../components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
 
 ### Helper Arguments
 

--- a/guides/v2.16.0/testing/testing-controllers.md
+++ b/guides/v2.16.0/testing/testing-controllers.md
@@ -151,5 +151,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.16.0/testing/testing-helpers.md
+++ b/guides/v2.16.0/testing/testing-helpers.md
@@ -92,5 +92,5 @@ test('updates the currency sign when it changes', function(assert) {
 });
 ```
 
-[Testing Components]: ../unit-testing-basics
-[Writing Helpers]: ../../templates/writing-helpers
+[Testing Components]: unit-testing-basics
+[Writing Helpers]: ../templates/writing-helpers

--- a/guides/v2.16.0/testing/testing-models.md
+++ b/guides/v2.16.0/testing/testing-models.md
@@ -104,5 +104,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.16.0/testing/testing-routes.md
+++ b/guides/v2.16.0/testing/testing-routes.md
@@ -84,5 +84,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.16.0/tutorial/acceptance-test.md
+++ b/guides/v2.16.0/tutorial/acceptance-test.md
@@ -15,11 +15,11 @@ Let's work through what we want to do on the home page. We want our application 
 
 For the remainder of this page, we'll give you an introduction to testing in Ember and get you set up to add tests as we implement pieces of our app. On subsequent tutorial pages, the final sections of each page will be devoted to adding a test for the feature you just implemented. These sections aren't required for a working application and you may move on with the tutorial without writing them.
 
-At this point, you can continue to the [next page](../routes-and-templates/) or read more about Ember testing below.
+At this point, you can continue to the [next page](routes-and-templates/) or read more about Ember testing below.
 
 ### Testing Our Application As We Go
 
-We can represent the goals above as [Ember acceptance tests](../../testing/acceptance/). Acceptance tests interact with our app like an actual person would, but are automated, helping ensure that our app doesn't break in the future.
+We can represent the goals above as [Ember acceptance tests](../testing/acceptance/). Acceptance tests interact with our app like an actual person would, but are automated, helping ensure that our app doesn't break in the future.
 
 When we create a new Ember Project using Ember CLI, it uses the [`QUnit`](https://qunitjs.com/) JavaScript test framework to define and run tests.
 

--- a/guides/v2.16.0/tutorial/autocomplete-component.md
+++ b/guides/v2.16.0/tutorial/autocomplete-component.md
@@ -1,5 +1,5 @@
 As they search for a rental, users might also want to narrow their search to a specific city.
-While our [initial](../simple-component/) rental listing component only displayed rental information, this new filter component will also allow the user to provide input in the form of filter criteria.
+While our [initial](simple-component/) rental listing component only displayed rental information, this new filter component will also allow the user to provide input in the form of filter criteria.
 
 To begin, let's generate our new component.
 We'll call this component `list-filter`, since all we want our component to do is filter the list of rentals based on input.
@@ -8,7 +8,7 @@ We'll call this component `list-filter`, since all we want our component to do i
 ember g component list-filter
 ```
 
-As before when we created the [`rental-listing` component](../simple-component), the "generate component" CLI command creates
+As before when we created the [`rental-listing` component](simple-component), the "generate component" CLI command creates
 
 * a Handlebars template (`app/templates/components/list-filter.hbs`),
 * a JavaScript file (`app/components/list-filter.js`),
@@ -19,7 +19,7 @@ As before when we created the [`rental-listing` component](../simple-component),
 In our `app/templates/rentals.hbs` template file, we'll add a reference to our new `list-filter` component.
 
 Notice that below we "wrap" our rentals markup inside the open and closing mentions of `list-filter` on lines 12 and 20.
-This is an example of the [**block form**](../../components/wrapping-content-in-a-component) of a component,
+This is an example of the [**block form**](../components/wrapping-content-in-a-component) of a component,
 which allows a Handlebars template to be rendered _inside_ the component's template wherever the `{{yield}}` expression appears.
 
 In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14).
@@ -62,10 +62,10 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The `value` property of the `input` will be kept in sync with the `value` property in the component.
 
-Another way to say this is that the `value` property of `input` is [**bound**](../../object-model/bindings/) to the `value` property of the component.
+Another way to say this is that the `value` property of `input` is [**bound**](../object-model/bindings/) to the `value` property of the component.
 If the property changes, either by the user typing in the input field, or by assigning a new value to it in our program,
 the new value of the property is present in both the rendered web page and in the code.
 
@@ -101,7 +101,7 @@ export default Component.extend({
 In the above example we use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls a function called `filter` based on the `value` attribute set by the input helper.
 
-The `filter` function is passed in by the calling object. This is a pattern known as [closure actions](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component).
+The `filter` function is passed in by the calling object. This is a pattern known as [closure actions](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component).
 
 Notice the `then` function called on the result of calling the `filter` function.
 The code expects the `filter` function to return a promise.
@@ -111,7 +111,7 @@ To account for this, it provides functions, like `then` that let you give it cod
 
 
 To implement the `filter` function to do the actual filter of rentals by city, we'll create a `rentals` controller.
-[Controllers](../../controllers/) contain actions and properties available to the template of its corresponding route.
+[Controllers](../controllers/) contain actions and properties available to the template of its corresponding route.
 In our case we want to generate a controller called `rentals`.
 Ember will know that a controller with the name of `rentals` will apply to the route with the same name.
 
@@ -284,15 +284,15 @@ To create effective and robust autocomplete behavior for your applications,
 we recommend considering the [`ember-concurrency`](http://ember-concurrency.com/#/docs/introduction) addon project.
 
 
-You can now proceed on to implement the [next feature](../service/), or continue on to test our newly created filter component.
+You can now proceed on to implement the [next feature](service/), or continue on to test our newly created filter component.
 
 ### An Integration Test
 
 Now that we've created a new component for filtering a list,
 we want to create a test to verify it.
-Let's use a [component integration test](../../testing/testing-components)
+Let's use a [component integration test](../testing/testing-components)
 to verify our component behavior,
-similar to [how we tested our rental listing component earlier](../simple-component/#toc_an-integration-test).
+similar to [how we tested our rental listing component earlier](simple-component/#toc_an-integration-test).
 
 Lets begin by opening the component integration test created when we generated our `list-filter` component, `tests/integration/components/list-filter-test.js`.
 Remove the default test, and create a new test that verifies that by default, the component will list all items.
@@ -383,7 +383,7 @@ test('should initially load all listings', function (assert) {
 
 Finally we add a `wait` call at the end of our test to assert the results.
 
-Ember's [wait helper](../../testing/testing-components/#toc_waiting-on-asynchronous-behavior)
+Ember's [wait helper](../testing/testing-components/#toc_waiting-on-asynchronous-behavior)
 waits for all asynchronous tasks to complete before running the given function callback.
 It returns a promise that we also return from the test.
 
@@ -510,7 +510,7 @@ Our test fills out "Seattle" as the search criteria in the search field,
 and then sends a `keyup` event to the same field with a code of `69` (the `e` key) to simulate a user typing.
 
 The test locates the results of the search by finding elements with a class of `listing`,
-which we gave to our `rental-listing` component in the ["Building a Simple Component"](../simple-component) section of the tutorial.
+which we gave to our `rental-listing` component in the ["Building a Simple Component"](simple-component) section of the tutorial.
 
 Since our data is hard-coded in Mirage, we know that there is only one rental with a city name of "Seattle",
 so we assert that the number of listings is one and that the location it displays is named, "Seattle".

--- a/guides/v2.16.0/tutorial/ember-cli.md
+++ b/guides/v2.16.0/tutorial/ember-cli.md
@@ -2,7 +2,7 @@ Welcome to the Ember Tutorial!
 This tutorial is meant to introduce basic Ember concepts while creating a professional looking application.
 If you get stuck at any point during the tutorial, feel free to download [https://github.com/ember-learn/super-rentals](https://github.com/ember-learn/super-rentals) for a working example of the completed app.
 
-You can install the latest version of `ember-cli` by following the [Quick Start](../../getting-started/quick-start/#toc_install-ember) guide "Installing Ember" section.
+You can install the latest version of `ember-cli` by following the [Quick Start](../getting-started/quick-start/#toc_install-ember) guide "Installing Ember" section.
 
 Ember CLI, Ember's command line interface, provides a standard project
 structure, a set of development tools, and an addon system.

--- a/guides/v2.16.0/tutorial/ember-data.md
+++ b/guides/v2.16.0/tutorial/ember-data.md
@@ -31,10 +31,10 @@ export default DS.Model.extend({
 });
 ```
 
-Let's define the structure of a rental object using the same attributes for our rental that we [previously used](../model-hook/) in our hard-coded array of JavaScript objects -
+Let's define the structure of a rental object using the same attributes for our rental that we [previously used](model-hook/) in our hard-coded array of JavaScript objects -
 _title_, _owner_, _city_, _property type_, _image_, _bedrooms_ and _description_.
 Define attributes by giving them the result of the function [`DS.attr()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS/methods/attr?anchor=attr).
-For more information on Ember Data Attributes, read the section called [Defining Attributes](../../models/defining-models/#toc_defining-attributes) in the guides.
+For more information on Ember Data Attributes, read the section called [Defining Attributes](../models/defining-models/#toc_defining-attributes) in the guides.
 
 ```app/models/rental.js{+4,+5,+6,+7,+8,+9,+10}
 import DS from 'ember-data';
@@ -54,8 +54,8 @@ We now have a model object that we can use for our Ember Data implementation.
 
 ### Updating the Model Hook
 
-To use our new Ember Data Model object, we need to update the `model` function we [previously defined](../model-hook/) in our route handler.
-Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../../models/#toc_the-store-and-a-single-source-of-truth).
+To use our new Ember Data Model object, we need to update the `model` function we [previously defined](model-hook/) in our route handler.
+Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../models/#toc_the-store-and-a-single-source-of-truth).
 The [store service](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store) is injected into all routes and components in Ember.
 It is the main interface you use to interact with Ember Data.
 In this case, call the [`findAll`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/findAll?anchor=findAll) function on the store and provide it with the name of your newly created rental model class.
@@ -99,9 +99,9 @@ export default Route.extend({
 ```
 
 When we call `findAll`, Ember Data will attempt to fetch rentals from `/api/rentals`.
-If you recall, in the section titled [Installing Addons](../installing-addons/) we set up an adapter to route data requests through `/api`.
+If you recall, in the section titled [Installing Addons](installing-addons/) we set up an adapter to route data requests through `/api`.
 
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we have already set up Ember Mirage in our development environment, Mirage will return the data we requested without actually making a network request.
 

--- a/guides/v2.16.0/tutorial/installing-addons.md
+++ b/guides/v2.16.0/tutorial/installing-addons.md
@@ -10,7 +10,7 @@ For Super Rentals, we'll take advantage of two addons: [ember-cli-tutorial-style
 Instead of having you copy/paste in CSS to style Super Rentals, we've created an addon called [ember-cli-tutorial-style](https://github.com/ember-learn/ember-cli-tutorial-style) that instantly adds CSS to the tutorial.
 The addon works by generating a file called `ember-tutorial.css` and putting that file in the super-rentals `vendor` directory.
 
-The [`vendor` directory](../../addons-and-dependencies/managing-dependencies/#toc_other-assets) in Ember is a special directory where you can include content that gets compiled into your application.
+The [`vendor` directory](../addons-and-dependencies/managing-dependencies/#toc_other-assets) in Ember is a special directory where you can include content that gets compiled into your application.
 When Ember CLI builds our app from our source code, it copies `ember-tutorial.css` into a file called `vendor.css`.
 
 As Ember CLI runs, it takes the `ember-tutorial` CSS file and puts it in a file called `vendor.css`.
@@ -135,7 +135,7 @@ Without this change, navigation to `/rentals` in our application would conflict 
 
 In order for this to work, we need our application to default to making requests to the namespace of `/api`.
 To do this, we want to generate an application adapter.
-An [Adapter](../../models/customizing-adapters) is an object that [Ember Data](../../models) uses to determine how we communicate with our backend.
+An [Adapter](../models/customizing-adapters) is an object that [Ember Data](../models) uses to determine how we communicate with our backend.
 We will cover Ember Data in more detail later in this tutorial.
 For now, let's generate an adapter for our application:
 
@@ -155,4 +155,4 @@ export default DS.JSONAPIAdapter.extend({
 
 If you were running `ember serve` in another shell, restart the server to include Mirage in your build.
 
-Note that at this point of the tutorial, the data is still provided by the `app/routes/rentals.js` file. We will make use of the mirage data we set up here in the upcoming section called [Using Ember Data](../ember-data/).
+Note that at this point of the tutorial, the data is still provided by the `app/routes/rentals.js` file. We will make use of the mirage data we set up here in the upcoming section called [Using Ember Data](ember-data/).

--- a/guides/v2.16.0/tutorial/model-hook.md
+++ b/guides/v2.16.0/tutorial/model-hook.md
@@ -57,11 +57,11 @@ export default Route.extend({
 Note that here, we are using the ES6 shorthand method definition syntax: `model()` is the same as writing `model: function()`.
 
 Ember will use the model object returned above and save it as an attribute called `model`,
-available to the rentals template we generated with our route in [Routes and Templates](../routes-and-templates/#toc_a-rentals-route).
+available to the rentals template we generated with our route in [Routes and Templates](routes-and-templates/#toc_a-rentals-route).
 
 Now, let's switch over to our rentals page template.
 We can use the model attribute to display our list of rentals.
-Here, we'll use another common Handlebars helper called [`{{each}}`](../../templates/displaying-a-list-of-items/).
+Here, we'll use another common Handlebars helper called [`{{each}}`](../templates/displaying-a-list-of-items/).
 This helper will let us loop through each of the rental objects in our model:
 
 ```app/templates/rentals.hbs{+12,+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,+26,+27,+28,+29}
@@ -99,7 +99,7 @@ In this template, we loop through each object.
 On each iteration, the current object gets stored in a variable called `rental`.
 From the rental variable in each step, we create a listing with information about the property.
 
-You may move onto the [next page](../installing-addons/) to keep implementing new features, or continue reading on testing the app you've created.
+You may move onto the [next page](installing-addons/) to keep implementing new features, or continue reading on testing the app you've created.
 
 ### Acceptance Testing the Rental List
 

--- a/guides/v2.16.0/tutorial/routes-and-templates.md
+++ b/guides/v2.16.0/tutorial/routes-and-templates.md
@@ -7,7 +7,7 @@ Let's start by building our "about" page.
 
 In Ember, when we want to make a new page that can be visited using a URL,
 we need to generate a "route" using Ember CLI. For a quick overview of how
-Ember structures things, see [our diagram on the Core Concepts page](../../getting-started/core-concepts/).
+Ember structures things, see [our diagram on the Core Concepts page](../getting-started/core-concepts/).
 
 Let's use Ember's route generator to start our `about` route.
 
@@ -120,7 +120,7 @@ Moving around our site is a bit of a pain right now, so let's make that easier.
 We'll put a link to the contact page on the about page, and a corresponding link to the about
 page on the contact page.
 
-To do that, we'll use a [`{{link-to}}`](../../templates/links/) helper that Ember provides
+To do that, we'll use a [`{{link-to}}`](../templates/links/) helper that Ember provides
 that makes it easy to link between our routes.  Let's adjust our `about.hbs` file:
 
 ```app/templates/about.hbs{+9,+10,+11}
@@ -213,7 +213,7 @@ installing route-test
 
 Unlike the other route handlers we've made so far, the `index` route is special:
 it does NOT require an entry in the router's mapping.
-We'll learn more about why the entry isn't required later on when we look at [nested routes](../subroutes) in Ember.
+We'll learn more about why the entry isn't required later on when we look at [nested routes](subroutes) in Ember.
 
 All we want to do when a user visits the root (`/`) URL is transition to `/rentals`.
 To do this we will add code to our index route handler by implementing a route lifecycle hook,
@@ -222,7 +222,7 @@ called `beforeModel`.
 Each route handler has a set of "lifecycle hooks", which are functions that are invoked at specific times during the loading of a page.
 The [`beforeModel`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/beforeModel?anchor=beforeModel)
 hook gets executed before the data gets fetched from the model hook, and before the page is rendered.
-See [the next section](../model-hook) for an explanation of the model hook.
+See [the next section](model-hook) for an explanation of the model hook.
 
 In our index route handler, we'll call the [`replaceWith`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/beforeModel?anchor=replaceWith) function.
 The `replaceWith` function is similar to the route's [`transitionTo()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/transitionTo?anchor=transitionTo) function,
@@ -281,13 +281,13 @@ or `contact`) should be shown.
 
 At this point, we should be able to navigate between our `about`, `contact`, and `rentals` pages.
 
-From here you can move on to the [next page](../model-hook/) or dive into testing the new functionality we just added.
+From here you can move on to the [next page](model-hook/) or dive into testing the new functionality we just added.
 
 ## Implementing Acceptance Tests
 
 Now that we have various pages in our application, let's walk through how to build tests for them.
 
-As mentioned earlier on the [Planning the Application page](../acceptance-test/),
+As mentioned earlier on the [Planning the Application page](acceptance-test/),
 an Ember acceptance test automates interacting with our app in a similar way to a visitor.
 
 If you open the acceptance test we created (`/tests/acceptance/list-rentals-test.js`), you'll see our
@@ -325,7 +325,7 @@ Some of the helpers we'll use commonly are:
 
 * [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) - loads a given URL
 * [`click`](http://emberjs.com/api/classes/Ember.Test.html#method_click) - pretends to be a user clicking on a specific part of the screen
-* [`andThen`](../../testing/acceptance/#toc_wait-helpers) - waits for our previous commands to run before executing our function.
+* [`andThen`](../testing/acceptance/#toc_wait-helpers) - waits for our previous commands to run before executing our function.
   In our test below, we want to wait for our page to load after `click` is called so that we can double-check that the new page has loaded
 * [`currentURL`](http://emberjs.com/api/classes/Ember.Test.html#method_currentURL) - returns the URL of the page we're currently on
 
@@ -355,7 +355,7 @@ to see if two items (our first and second arguments) equal each other.  If they 
 The third optional argument allows us to provide a nicer message which we'll be shown if this test fails.
 
 In our tests, we also call two helpers (`visit` and `click`) one after another. Although Ember does a number
-of things when we make those calls, Ember hides those complexities by giving us these [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers).
+of things when we make those calls, Ember hides those complexities by giving us these [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers).
 
 If you left `ember test` running, it should have automatically updated to show the three tests related to
 navigating have now passed.

--- a/guides/v2.16.0/tutorial/service.md
+++ b/guides/v2.16.0/tutorial/service.md
@@ -9,7 +9,7 @@ To implement this feature, we will take advantage of several Ember concepts:
 
 Before implementing a map, we need to make a 3rd party map API available to our Ember app.
 There are several ways to include 3rd party libraries in Ember.
-See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/)
+See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/)
 as a starting point when you need to add one.
 
 
@@ -90,7 +90,7 @@ Now that we are able to generate a map element,
 we will implement a maps service that will keep a reference to the Map object we create,
 and attach the map to an element in our application
 
-Accessing our maps API through a [service](../../applications/services) will give us several benefits
+Accessing our maps API through a [service](../applications/services) will give us several benefits
 
 * It is injected with a [service locator](https://en.wikipedia.org/wiki/Service_locator_pattern),
   meaning it will abstract the maps API from the code that uses it,
@@ -173,13 +173,13 @@ This `div` will act as a place for the 3rd party map API to render the map to.
 Next, update the component to append the map output to the `div` element we created.
 
 We provide the maps service into our component by initializing a property of our component, called `maps`.
-Services are commonly made available in components and other Ember objects by ["service injection"](../../applications/services/#toc_accessing-services).
+Services are commonly made available in components and other Ember objects by ["service injection"](../applications/services/#toc_accessing-services).
 When you initialize a property with `import { inject } from '@ember/service';`,
 Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```app/components/location-map.js
@@ -231,7 +231,7 @@ After starting the server we should now see some end to end maps functionality s
 
 ![super rentals homepage with maps](../../images/service/style-super-rentals-maps.png)
 
-You may now either move onto the [next feature](../subroutes/), or continue here to test the maps feature we just added.
+You may now either move onto the [next feature](subroutes/), or continue here to test the maps feature we just added.
 
 ###  Unit testing a Service
 
@@ -333,10 +333,10 @@ test('should append map element to container element', function(assert) {
 });
 ```
 
-In the `beforeEach` function that runs before each test, we use the built-in function `this.register` to [register](../../applications/dependency-injection/#toc_factory-registrations) our stub service in place of the maps service.
+In the `beforeEach` function that runs before each test, we use the built-in function `this.register` to [register](../applications/dependency-injection/#toc_factory-registrations) our stub service in place of the maps service.
 Registration makes an object available to your Ember application for things like loading components from templates and injecting services in this case.
 
-The call to the function `this.inject.service` [injects](../../applications/dependency-injection/#toc_ad-hoc-injections) the service we just registered into the context of the tests, so each test may access it through `this.get('mapsService')`.
+The call to the function `this.inject.service` [injects](../applications/dependency-injection/#toc_ad-hoc-injections) the service we just registered into the context of the tests, so each test may access it through `this.get('mapsService')`.
 In the example we assert that `calledWithLocation` in our stub is set to the location we passed to the component.
 
 
@@ -373,7 +373,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.16.0/tutorial/simple-component.md
+++ b/guides/v2.16.0/tutorial/simple-component.md
@@ -161,7 +161,7 @@ Let's call this action `toggleImageSize`
 Clicking the anchor element will send the action to the component.
 Ember will then go into the `actions` hash and call the `toggleImageSize` function.
 
-An [actions hash](../../templates/actions/) is an object in the component that contains functions.
+An [actions hash](../templates/actions/) is an object in the component that contains functions.
 These functions are called when the user interacts with the UI, such as clicking.
 
 Let's create the `toggleImageSize` function and toggle the `isWide` property on our component:
@@ -186,13 +186,13 @@ When we click the enlarged image again, we see it smaller.
 
 ![rental listing with expand](../../images/simple-component/styled-rental-listings.png)
 
-Move on to the [next page](../hbs-helper/) for the next feature, or continue on here to test what you just wrote.
+Move on to the [next page](hbs-helper/) for the next feature, or continue on here to test what you just wrote.
 
 ### An Integration Test
 
-Ember components are commonly tested with [component integration tests](../../testing/testing-components/).
+Ember components are commonly tested with [component integration tests](../testing/testing-components/).
 Component integration tests verify the behavior of a component within the context of Ember's rendering engine.
-When running in an integration test, the component goes through its regular [render lifecycle](../../components/the-component-lifecycle/),
+When running in an integration test, the component goes through its regular [render lifecycle](../components/the-component-lifecycle/),
 and has access to dependent objects, loaded through Ember's resolver.
 
 Our component integration test will test two different behaviors:

--- a/guides/v2.16.0/tutorial/subroutes.md
+++ b/guides/v2.16.0/tutorial/subroutes.md
@@ -6,8 +6,8 @@ Up to this point, we've generated four top level routes.
 * The `index` route, which we've set up to redirect to the `rentals` route.
 
 Our `rentals` route is going to serve multiple functions.
-From our [acceptance tests](../acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
-To satisfy that requirement, we are going to make use of Ember's [nested route capability](../../routing/defining-your-routes/#toc_nested-routes).
+From our [acceptance tests](acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
+To satisfy that requirement, we are going to make use of Ember's [nested route capability](../routing/defining-your-routes/#toc_nested-routes).
 
 By the end of this section we want to have created the following new routes:
 
@@ -18,7 +18,7 @@ The `show` route will get substituted with the id of the rental being shown (for
 
 ## The Parent Route
 
-Previously, in the [Routes and Templates tutorial](../routes-and-templates), we set up a `rentals` route.
+Previously, in the [Routes and Templates tutorial](routes-and-templates), we set up a `rentals` route.
 
 Opening the template for this route reveals an outlet underneath the route's general page information.
 At the bottom of the template, you'll notice an `{{outlet}}` helper.
@@ -76,7 +76,7 @@ Ember knows that the default action is to take the user to the `index` route.
 However, you can add the `index` route if you want to customize it.
 For example, you can modify the `index` route's path by specifying `this.route('index', { path: '/custom-path'})`.
 
-In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
+In the section on [using Ember Data](ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
 Let's implement our newly generated `rentals/index` route by moving this `findAll` call from the parent `rentals` route to our new sub-route.
 
 ```app/routes/rentals.js{-4,-5,-6}
@@ -158,13 +158,13 @@ export default RentalsController;
 
 Next, we will want to create a sub-route that will list information for a specific rental.
 To do this, we will need to update a couple of files.
-To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../../models/finding-records/).
+To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../models/finding-records/).
 The `findRecord` function requires that we search by a unique key.
 
 While on the `show` route, we will also want to show additional information about our specific rental.
 
 In order to do this, we will need to modify the Mirage `config.js` file that we added
-back in the [Installing Addons section](../installing-addons). We will add a new route
+back in the [Installing Addons section](installing-addons). We will add a new route
 handler to return a specific rental:
 
 ```mirage/config.js{+57,+58,+59,+60}
@@ -302,7 +302,7 @@ export default Route.extend({
 ```
 
 Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook.
-When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../models/)).
 
 ## Adding the Rental To Our Template
 
@@ -370,7 +370,7 @@ Clicking on the title will load the detail page for that rental.
 ```
 ![Rental Page Nested Index Route](../../images/subroutes/subroutes-super-rentals-index.png)
 
-At this point you can do a [deployment](../deploying/) and share your Super Rentals application to the world
+At this point you can do a [deployment](deploying/) and share your Super Rentals application to the world
 or you can use this as a base to explore other Ember features and addons.
 Regardless, we hope this has helped you get started with creating your own ambitious applications with Ember!
 
@@ -391,6 +391,6 @@ test('should show details for a specific rental', function (assert) {
 });
 ```
 
-At this point all our tests should pass, including the [list of acceptance tests](../acceptance-test) we created as our beginning requirements.
+At this point all our tests should pass, including the [list of acceptance tests](acceptance-test) we created as our beginning requirements.
 
 ![Acceptance Tests Pass](../../images/subroutes/all-acceptance-pass.png)

--- a/guides/v2.17.0/applications/initializers.md
+++ b/guides/v2.17.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](./dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.17.0/applications/run-loop.md
+++ b/guides/v2.17.0/applications/run-loop.md
@@ -168,8 +168,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.17.0/components/block-params.md
+++ b/guides/v2.17.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.17.0/components/defining-a-component.md
+++ b/guides/v2.17.0/components/defining-a-component.md
@@ -46,7 +46,7 @@ Each component is backed by an element under the hood. By default,
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.17.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.17.0/components/triggering-changes-with-actions.md
@@ -67,7 +67,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -75,7 +75,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -328,7 +328,7 @@ export default Component.extend({
 In order for `confirmValue` to take on the value of the message text,
 we'll bind the property to the value of a user input field that will appear when the button is clicked.
 To accomplish this,
-we'll first modify the component so that it can be used in block form and we will [yield](../wrapping-content-in-a-component/) `confirmValue` to the block within the `"confirmDialog"` element:
+we'll first modify the component so that it can be used in block form and we will [yield](wrapping-content-in-a-component/) `confirmValue` to the block within the `"confirmDialog"` element:
 
 ```app/templates/components/button-with-confirmation.hbs
 <button {{action "launchConfirmDialog"}}>{{text}}</button>

--- a/guides/v2.17.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.17.0/components/wrapping-content-in-a-component.md
@@ -13,7 +13,7 @@ Now, we can use the `{{blog-post}}` component and pass it properties in another 
 {{blog-post title=title body=body}}
 ```
 
-See [Passing Properties to a Component](../passing-properties-to-a-component/) for more.
+See [Passing Properties to a Component](passing-properties-to-a-component/) for more.
 
 In this case, the content we wanted to display came from the model.
 But what if we want the developer using our component to be able to provide custom HTML content?

--- a/guides/v2.17.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.17.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.17.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.17.0/configuring-ember/disabling-prototype-extensions.md
@@ -111,7 +111,7 @@ camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.17.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.17.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -33,7 +33,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js{-8,+9}

--- a/guides/v2.17.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.17.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.17.0/ember-inspector/object-inspector.md
+++ b/guides/v2.17.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.17.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.17.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.17.0/ember-inspector/view-tree.md
+++ b/guides/v2.17.0/ember-inspector/view-tree.md
@@ -3,7 +3,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
-Use the tips described in [Object Inspector](../object-inspector) to inspect models and controllers. See below for templates and components.
+Use the tips described in [Object Inspector](object-inspector) to inspect models and controllers. See below for templates and components.
 
 ### Inspecting Templates
 

--- a/guides/v2.17.0/getting-started/quick-start.md
+++ b/guides/v2.17.0/getting-started/quick-start.md
@@ -20,7 +20,7 @@ npm install -g ember-cli
 
 Don't have npm? [Learn how to install Node.js and npm here](https://docs.npmjs.com/getting-started/installing-node).
 For a full list of dependencies necessary for an Ember CLI project,
-consult our [Installing Ember](../../getting-started/) guide.
+consult our [Installing Ember](../getting-started/) guide.
 
 ## Create a New Application
 

--- a/guides/v2.17.0/index.md
+++ b/guides/v2.17.0/index.md
@@ -13,7 +13,7 @@ Some of these features that you'll learn about in the guides are:
 * [Routing](./routing) - The central part of an Ember application. Enables developers to drive the application state from the URL.
 * [Templating engine](./templates/handlebars-basics/) - Use Handlebars syntax to write your application's templates
 * [Data layer](./models/) - Ember Data provides a consistent way to communicate with external APIs and manage application state
-* [Ember Inspector](./ember-inspector/) - A browser extension, or bookmarklet, to inspect your application live. It's also useful for spotting Ember applications in the wild, try to install it and open up the [NASA website](https://www.nasa.gov/)!
+* [Ember Inspector](ember-inspector) - A browser extension, or bookmarklet, to inspect your application live. It's also useful for spotting Ember applications in the wild, try to install it and open up the [NASA website](https://www.nasa.gov/)!
 
 ## Organization
 

--- a/guides/v2.17.0/models/customizing-adapters.md
+++ b/guides/v2.17.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.17.0/models/defining-models.md
+++ b/guides/v2.17.0/models/defining-models.md
@@ -21,8 +21,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -63,7 +63,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.17.0/routing/defining-your-routes.md
+++ b/guides/v2.17.0/routing/defining-your-routes.md
@@ -243,7 +243,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.17.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.17.0/routing/preventing-and-retrying-transitions.md
@@ -49,7 +49,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.17.0/routing/redirection.md
+++ b/guides/v2.17.0/routing/redirection.md
@@ -10,7 +10,7 @@ Ember allows you to control that access with a combination of hooks and methods 
 One of the methods is [`transitionTo()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://www.emberjs.com/api/ember/2.16/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
-`transitionTo()` behaves exactly like the [link-to](../../templates/links) helper.
+`transitionTo()` behaves exactly like the [link-to](../templates/links) helper.
 
 The other one is [`replaceWith()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/transitionTo?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
@@ -45,11 +45,11 @@ export default Route.extend({
 This allows us to return the user back to the original route.
 For example, we might redirect a user to the login page when they try to edit their profile, and immediately redirect
 them back to the edit page once they have successfully logged in.
-See [Storing and Retrying a Transition](../preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
+See [Storing and Retrying a Transition](preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
 for how to do that.
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.17.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.17.0/routing/specifying-a-routes-model.md
@@ -22,7 +22,7 @@ export default Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember Data records are promises),
 or a plain JavaScript object or array.
 Ember will wait until the data finishes loading (until the promise is resolved) before rendering the template.
@@ -56,7 +56,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -85,7 +85,7 @@ photo's ID (`params.photo_id`) as an argument to Ember Data's `findRecord`
 method.
 
 Note: A route with a dynamic segment will always have its `model` hook called when it is entered via the URL.
-If the route is entered through a transition (e.g. when using the [link-to](../../templates/links) Handlebars helper),
+If the route is entered through a transition (e.g. when using the [link-to](../templates/links) Handlebars helper),
 and a model context is provided (second argument to `link-to`), then the hook is not executed.
 If an identifier (such as an id or slug) is provided instead then the model hook will be executed.
 
@@ -162,7 +162,7 @@ each record in the song model and album model:
 </ul>
 ```
 
-If you use [Ember Data](../../models/) and you are building an `RSVP.hash` with the model's relationship, consider instead properly setting up your [relationships](../../models/relationships) and letting Ember Data take care of loading them.
+If you use [Ember Data](../models/) and you are building an `RSVP.hash` with the model's relationship, consider instead properly setting up your [relationships](../models/relationships) and letting Ember Data take care of loading them.
 
 ## Reusing Route Context
 

--- a/guides/v2.17.0/templates/actions.md
+++ b/guides/v2.17.0/templates/actions.md
@@ -29,7 +29,7 @@ export default Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../../components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.17.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.17.0/templates/displaying-a-list-of-items.md
@@ -45,7 +45,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](https://www.emberjs.com/api/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.17.0/templates/handlebars-basics.md
+++ b/guides/v2.17.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.17.0/templates/links.md
+++ b/guides/v2.17.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` component takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the component, you can provide

--- a/guides/v2.17.0/templates/writing-helpers.md
+++ b/guides/v2.17.0/templates/writing-helpers.md
@@ -79,7 +79,7 @@ helper again with the new values and keep the page up-to-date.
 
 ### Helper Names
 
-Unlike [components](../../components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
+Unlike [components](../components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
 
 ### Helper Arguments
 

--- a/guides/v2.17.0/testing/testing-controllers.md
+++ b/guides/v2.17.0/testing/testing-controllers.md
@@ -151,5 +151,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.17.0/testing/testing-helpers.md
+++ b/guides/v2.17.0/testing/testing-helpers.md
@@ -92,5 +92,5 @@ test('updates the currency sign when it changes', function(assert) {
 });
 ```
 
-[Testing Components]: ../unit-testing-basics
-[Writing Helpers]: ../../templates/writing-helpers
+[Testing Components]: unit-testing-basics
+[Writing Helpers]: ../templates/writing-helpers

--- a/guides/v2.17.0/testing/testing-models.md
+++ b/guides/v2.17.0/testing/testing-models.md
@@ -104,5 +104,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.17.0/testing/testing-routes.md
+++ b/guides/v2.17.0/testing/testing-routes.md
@@ -84,5 +84,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.17.0/tutorial/acceptance-test.md
+++ b/guides/v2.17.0/tutorial/acceptance-test.md
@@ -15,11 +15,11 @@ Let's work through what we want to do on the home page. We want our application 
 
 For the remainder of this page, we'll give you an introduction to testing in Ember and get you set up to add tests as we implement pieces of our app. On subsequent tutorial pages, the final sections of each page will be devoted to adding a test for the feature you just implemented. These sections aren't required for a working application and you may move on with the tutorial without writing them.
 
-At this point, you can continue to the [next page](../routes-and-templates/) or read more about Ember testing below.
+At this point, you can continue to the [next page](routes-and-templates/) or read more about Ember testing below.
 
 ### Testing Our Application As We Go
 
-We can represent the goals above as [Ember acceptance tests](../../testing/acceptance/). Acceptance tests interact with our app like an actual person would, but are automated, helping ensure that our app doesn't break in the future.
+We can represent the goals above as [Ember acceptance tests](../testing/acceptance/). Acceptance tests interact with our app like an actual person would, but are automated, helping ensure that our app doesn't break in the future.
 
 When we create a new Ember Project using Ember CLI, it uses the [`QUnit`](https://qunitjs.com/) JavaScript test framework to define and run tests.
 

--- a/guides/v2.17.0/tutorial/autocomplete-component.md
+++ b/guides/v2.17.0/tutorial/autocomplete-component.md
@@ -1,5 +1,5 @@
 As they search for a rental, users might also want to narrow their search to a specific city.
-While our [initial](../simple-component/) rental listing component only displayed rental information, this new filter component will also allow the user to provide input in the form of filter criteria.
+While our [initial](simple-component/) rental listing component only displayed rental information, this new filter component will also allow the user to provide input in the form of filter criteria.
 
 To begin, let's generate our new component.
 We'll call this component `list-filter`, since all we want our component to do is filter the list of rentals based on input.
@@ -8,7 +8,7 @@ We'll call this component `list-filter`, since all we want our component to do i
 ember g component list-filter
 ```
 
-As before when we created the [`rental-listing` component](../simple-component), the "generate component" CLI command creates
+As before when we created the [`rental-listing` component](simple-component), the "generate component" CLI command creates
 
 * a Handlebars template (`app/templates/components/list-filter.hbs`),
 * a JavaScript file (`app/components/list-filter.js`),
@@ -19,7 +19,7 @@ As before when we created the [`rental-listing` component](../simple-component),
 In our `app/templates/rentals.hbs` template file, we'll add a reference to our new `list-filter` component.
 
 Notice that below we "wrap" our rentals markup inside the open and closing mentions of `list-filter` on lines 12 and 20.
-This is an example of the [**block form**](../../components/wrapping-content-in-a-component) of a component,
+This is an example of the [**block form**](../components/wrapping-content-in-a-component) of a component,
 which allows a Handlebars template to be rendered _inside_ the component's template wherever the `{{yield}}` expression appears.
 
 In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14).
@@ -62,10 +62,10 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The `value` property of the `input` will be kept in sync with the `value` property in the component.
 
-Another way to say this is that the `value` property of `input` is [**bound**](../../object-model/bindings/) to the `value` property of the component.
+Another way to say this is that the `value` property of `input` is [**bound**](../object-model/bindings/) to the `value` property of the component.
 If the property changes, either by the user typing in the input field, or by assigning a new value to it in our program,
 the new value of the property is present in both the rendered web page and in the code.
 
@@ -101,7 +101,7 @@ export default Component.extend({
 In the above example we use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls a function called `filter` based on the `value` attribute set by the input helper.
 
-The `filter` function is passed in by the calling object. This is a pattern known as [closure actions](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component).
+The `filter` function is passed in by the calling object. This is a pattern known as [closure actions](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component).
 
 Notice the `then` function called on the result of calling the `filter` function.
 The code expects the `filter` function to return a promise.
@@ -111,7 +111,7 @@ To account for this, it provides functions, like `then` that let you give it cod
 
 
 To implement the `filter` function to do the actual filter of rentals by city, we'll create a `rentals` controller.
-[Controllers](../../controllers/) contain actions and properties available to the template of its corresponding route.
+[Controllers](../controllers/) contain actions and properties available to the template of its corresponding route.
 In our case we want to generate a controller called `rentals`.
 Ember will know that a controller with the name of `rentals` will apply to the route with the same name.
 
@@ -284,15 +284,15 @@ To create effective and robust autocomplete behavior for your applications,
 we recommend considering the [`ember-concurrency`](http://ember-concurrency.com/#/docs/introduction) addon project.
 
 
-You can now proceed on to implement the [next feature](../service/), or continue on to test our newly created filter component.
+You can now proceed on to implement the [next feature](service/), or continue on to test our newly created filter component.
 
 ### An Integration Test
 
 Now that we've created a new component for filtering a list,
 we want to create a test to verify it.
-Let's use a [component integration test](../../testing/testing-components)
+Let's use a [component integration test](../testing/testing-components)
 to verify our component behavior,
-similar to [how we tested our rental listing component earlier](../simple-component/#toc_an-integration-test).
+similar to [how we tested our rental listing component earlier](simple-component/#toc_an-integration-test).
 
 Lets begin by opening the component integration test created when we generated our `list-filter` component, `tests/integration/components/list-filter-test.js`.
 Remove the default test, and create a new test that verifies that by default, the component will list all items.
@@ -383,7 +383,7 @@ test('should initially load all listings', function (assert) {
 
 Finally we add a `wait` call at the end of our test to assert the results.
 
-Ember's [wait helper](../../testing/testing-components/#toc_waiting-on-asynchronous-behavior)
+Ember's [wait helper](../testing/testing-components/#toc_waiting-on-asynchronous-behavior)
 waits for all asynchronous tasks to complete before running the given function callback.
 It returns a promise that we also return from the test.
 
@@ -510,7 +510,7 @@ Our test fills out "Seattle" as the search criteria in the search field,
 and then sends a `keyup` event to the same field with a code of `69` (the `e` key) to simulate a user typing.
 
 The test locates the results of the search by finding elements with a class of `listing`,
-which we gave to our `rental-listing` component in the ["Building a Simple Component"](../simple-component) section of the tutorial.
+which we gave to our `rental-listing` component in the ["Building a Simple Component"](simple-component) section of the tutorial.
 
 Since our data is hard-coded in Mirage, we know that there is only one rental with a city name of "Seattle",
 so we assert that the number of listings is one and that the location it displays is named, "Seattle".

--- a/guides/v2.17.0/tutorial/ember-cli.md
+++ b/guides/v2.17.0/tutorial/ember-cli.md
@@ -2,7 +2,7 @@ Welcome to the Ember Tutorial!
 This tutorial is meant to introduce basic Ember concepts while creating a professional looking application.
 If you get stuck at any point during the tutorial, feel free to download [https://github.com/ember-learn/super-rentals](https://github.com/ember-learn/super-rentals) for a working example of the completed app.
 
-You can install the latest version of `ember-cli` by following the [Quick Start](../../getting-started/quick-start/#toc_install-ember) guide "Installing Ember" section.
+You can install the latest version of `ember-cli` by following the [Quick Start](../getting-started/quick-start/#toc_install-ember) guide "Installing Ember" section.
 
 Ember CLI, Ember's command line interface, provides a standard project
 structure, a set of development tools, and an addon system.

--- a/guides/v2.17.0/tutorial/ember-data.md
+++ b/guides/v2.17.0/tutorial/ember-data.md
@@ -31,10 +31,10 @@ export default DS.Model.extend({
 });
 ```
 
-Let's define the structure of a rental object using the same attributes for our rental that we [previously used](../model-hook/) in our hard-coded array of JavaScript objects -
+Let's define the structure of a rental object using the same attributes for our rental that we [previously used](model-hook/) in our hard-coded array of JavaScript objects -
 _title_, _owner_, _city_, _property type_, _image_, _bedrooms_ and _description_.
 Define attributes by giving them the result of the function [`DS.attr()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS/methods/attr?anchor=attr).
-For more information on Ember Data Attributes, read the section called [Defining Attributes](../../models/defining-models/#toc_defining-attributes) in the guides.
+For more information on Ember Data Attributes, read the section called [Defining Attributes](../models/defining-models/#toc_defining-attributes) in the guides.
 
 ```app/models/rental.js{+4,+5,+6,+7,+8,+9,+10}
 import DS from 'ember-data';
@@ -54,8 +54,8 @@ We now have a model object that we can use for our Ember Data implementation.
 
 ### Updating the Model Hook
 
-To use our new Ember Data Model object, we need to update the `model` function we [previously defined](../model-hook/) in our route handler.
-Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../../models/#toc_the-store-and-a-single-source-of-truth).
+To use our new Ember Data Model object, we need to update the `model` function we [previously defined](model-hook/) in our route handler.
+Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../models/#toc_the-store-and-a-single-source-of-truth).
 The [store service](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store) is injected into all routes and components in Ember.
 It is the main interface you use to interact with Ember Data.
 In this case, call the [`findAll`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/findAll?anchor=findAll) function on the store and provide it with the name of your newly created rental model class.
@@ -99,9 +99,9 @@ export default Route.extend({
 ```
 
 When we call `findAll`, Ember Data will attempt to fetch rentals from `/api/rentals`.
-If you recall, in the section titled [Installing Addons](../installing-addons/) we set up an adapter to route data requests through `/api`.
+If you recall, in the section titled [Installing Addons](installing-addons/) we set up an adapter to route data requests through `/api`.
 
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we have already set up Ember Mirage in our development environment, Mirage will return the data we requested without actually making a network request.
 

--- a/guides/v2.17.0/tutorial/installing-addons.md
+++ b/guides/v2.17.0/tutorial/installing-addons.md
@@ -10,7 +10,7 @@ For Super Rentals, we'll take advantage of two addons: [ember-cli-tutorial-style
 Instead of having you copy/paste in CSS to style Super Rentals, we've created an addon called [ember-cli-tutorial-style](https://github.com/ember-learn/ember-cli-tutorial-style) that instantly adds CSS to the tutorial.
 The addon works by generating a file called `ember-tutorial.css` and putting that file in the super-rentals `vendor` directory.
 
-The [`vendor` directory](../../addons-and-dependencies/managing-dependencies/#toc_other-assets) in Ember is a special directory where you can include content that gets compiled into your application.
+The [`vendor` directory](../addons-and-dependencies/managing-dependencies/#toc_other-assets) in Ember is a special directory where you can include content that gets compiled into your application.
 When Ember CLI builds our app from our source code, it copies `ember-tutorial.css` into a file called `vendor.css`.
 
 As Ember CLI runs, it takes the `ember-tutorial` CSS file and puts it in a file called `vendor.css`.
@@ -135,7 +135,7 @@ Without this change, navigation to `/rentals` in our application would conflict 
 
 In order for this to work, we need our application to default to making requests to the namespace of `/api`.
 To do this, we want to generate an application adapter.
-An [Adapter](../../models/customizing-adapters) is an object that [Ember Data](../../models) uses to determine how we communicate with our backend.
+An [Adapter](../models/customizing-adapters) is an object that [Ember Data](../models) uses to determine how we communicate with our backend.
 We will cover Ember Data in more detail later in this tutorial.
 For now, let's generate an adapter for our application:
 
@@ -155,4 +155,4 @@ export default DS.JSONAPIAdapter.extend({
 
 If you were running `ember serve` in another shell, restart the server to include Mirage in your build.
 
-Note that at this point of the tutorial, the data is still provided by the `app/routes/rentals.js` file. We will make use of the mirage data we set up here in the upcoming section called [Using Ember Data](../ember-data/).
+Note that at this point of the tutorial, the data is still provided by the `app/routes/rentals.js` file. We will make use of the mirage data we set up here in the upcoming section called [Using Ember Data](ember-data/).

--- a/guides/v2.17.0/tutorial/model-hook.md
+++ b/guides/v2.17.0/tutorial/model-hook.md
@@ -57,11 +57,11 @@ export default Route.extend({
 Note that here, we are using the ES6 shorthand method definition syntax: `model()` is the same as writing `model: function()`.
 
 Ember will use the model object returned above and save it as an attribute called `model`,
-available to the rentals template we generated with our route in [Routes and Templates](../routes-and-templates/#toc_a-rentals-route).
+available to the rentals template we generated with our route in [Routes and Templates](routes-and-templates/#toc_a-rentals-route).
 
 Now, let's switch over to our rentals page template.
 We can use the model attribute to display our list of rentals.
-Here, we'll use another common Handlebars helper called [`{{each}}`](../../templates/displaying-a-list-of-items/).
+Here, we'll use another common Handlebars helper called [`{{each}}`](../templates/displaying-a-list-of-items/).
 This helper will let us loop through each of the rental objects in our model:
 
 ```app/templates/rentals.hbs{+12,+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,+26,+27,+28,+29}
@@ -99,7 +99,7 @@ In this template, we loop through each object.
 On each iteration, the current object gets stored in a variable called `rental`.
 From the rental variable in each step, we create a listing with information about the property.
 
-You may move onto the [next page](../installing-addons/) to keep implementing new features, or continue reading on testing the app you've created.
+You may move onto the [next page](installing-addons/) to keep implementing new features, or continue reading on testing the app you've created.
 
 ### Acceptance Testing the Rental List
 

--- a/guides/v2.17.0/tutorial/routes-and-templates.md
+++ b/guides/v2.17.0/tutorial/routes-and-templates.md
@@ -7,7 +7,7 @@ Let's start by building our "about" page.
 
 In Ember, when we want to make a new page that can be visited using a URL,
 we need to generate a "route" using Ember CLI. For a quick overview of how
-Ember structures things, see [our diagram on the Core Concepts page](../../getting-started/core-concepts/).
+Ember structures things, see [our diagram on the Core Concepts page](../getting-started/core-concepts/).
 
 Let's use Ember's route generator to start our `about` route.
 
@@ -120,7 +120,7 @@ Moving around our site is a bit of a pain right now, so let's make that easier.
 We'll put a link to the contact page on the about page, and a corresponding link to the about
 page on the contact page.
 
-To do that, we'll use a [`{{link-to}}`](../../templates/links/) helper that Ember provides
+To do that, we'll use a [`{{link-to}}`](../templates/links/) helper that Ember provides
 that makes it easy to link between our routes.  Let's adjust our `about.hbs` file:
 
 ```app/templates/about.hbs{+9,+10,+11}
@@ -213,7 +213,7 @@ installing route-test
 
 Unlike the other route handlers we've made so far, the `index` route is special:
 it does NOT require an entry in the router's mapping.
-We'll learn more about why the entry isn't required later on when we look at [nested routes](../subroutes) in Ember.
+We'll learn more about why the entry isn't required later on when we look at [nested routes](subroutes) in Ember.
 
 All we want to do when a user visits the root (`/`) URL is transition to `/rentals`.
 To do this we will add code to our index route handler by implementing a route lifecycle hook,
@@ -222,7 +222,7 @@ called `beforeModel`.
 Each route handler has a set of "lifecycle hooks", which are functions that are invoked at specific times during the loading of a page.
 The [`beforeModel`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/beforeModel?anchor=beforeModel)
 hook gets executed before the data gets fetched from the model hook, and before the page is rendered.
-See [the next section](../model-hook) for an explanation of the model hook.
+See [the next section](model-hook) for an explanation of the model hook.
 
 In our index route handler, we'll call the [`replaceWith`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/beforeModel?anchor=replaceWith) function.
 The `replaceWith` function is similar to the route's [`transitionTo()`](https://www.emberjs.com/api/ember/2.16/classes/Route/methods/transitionTo?anchor=transitionTo) function,
@@ -281,13 +281,13 @@ or `contact`) should be shown.
 
 At this point, we should be able to navigate between our `about`, `contact`, and `rentals` pages.
 
-From here you can move on to the [next page](../model-hook/) or dive into testing the new functionality we just added.
+From here you can move on to the [next page](model-hook/) or dive into testing the new functionality we just added.
 
 ## Implementing Acceptance Tests
 
 Now that we have various pages in our application, let's walk through how to build tests for them.
 
-As mentioned earlier on the [Planning the Application page](../acceptance-test/),
+As mentioned earlier on the [Planning the Application page](acceptance-test/),
 an Ember acceptance test automates interacting with our app in a similar way to a visitor.
 
 If you open the acceptance test we created (`/tests/acceptance/list-rentals-test.js`), you'll see our
@@ -325,7 +325,7 @@ Some of the helpers we'll use commonly are:
 
 * [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) - loads a given URL
 * [`click`](http://emberjs.com/api/classes/Ember.Test.html#method_click) - pretends to be a user clicking on a specific part of the screen
-* [`andThen`](../../testing/acceptance/#toc_wait-helpers) - waits for our previous commands to run before executing our function.
+* [`andThen`](../testing/acceptance/#toc_wait-helpers) - waits for our previous commands to run before executing our function.
   In our test below, we want to wait for our page to load after `click` is called so that we can double-check that the new page has loaded
 * [`currentURL`](http://emberjs.com/api/classes/Ember.Test.html#method_currentURL) - returns the URL of the page we're currently on
 
@@ -355,7 +355,7 @@ to see if two items (our first and second arguments) equal each other.  If they 
 The third optional argument allows us to provide a nicer message which we'll be shown if this test fails.
 
 In our tests, we also call two helpers (`visit` and `click`) one after another. Although Ember does a number
-of things when we make those calls, Ember hides those complexities by giving us these [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers).
+of things when we make those calls, Ember hides those complexities by giving us these [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers).
 
 If you left `ember test` running, it should have automatically updated to show the three tests related to
 navigating have now passed.

--- a/guides/v2.17.0/tutorial/service.md
+++ b/guides/v2.17.0/tutorial/service.md
@@ -9,7 +9,7 @@ To implement this feature, we will take advantage of several Ember concepts:
 
 Before implementing a map, we need to make a 3rd party map API available to our Ember app.
 There are several ways to include 3rd party libraries in Ember.
-See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/)
+See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/)
 as a starting point when you need to add one.
 
 
@@ -90,7 +90,7 @@ Now that we are able to generate a map element,
 we will implement a maps service that will keep a reference to the Map object we create,
 and attach the map to an element in our application
 
-Accessing our maps API through a [service](../../applications/services) will give us several benefits
+Accessing our maps API through a [service](../applications/services) will give us several benefits
 
 * It is injected with a [service locator](https://en.wikipedia.org/wiki/Service_locator_pattern),
   meaning it will abstract the maps API from the code that uses it,
@@ -173,13 +173,13 @@ This `div` will act as a place for the 3rd party map API to render the map to.
 Next, update the component to append the map output to the `div` element we created.
 
 We provide the maps service into our component by initializing a property of our component, called `maps`.
-Services are commonly made available in components and other Ember objects by ["service injection"](../../applications/services/#toc_accessing-services).
+Services are commonly made available in components and other Ember objects by ["service injection"](../applications/services/#toc_accessing-services).
 When you initialize a property with `import { inject } from '@ember/service';`,
 Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```app/components/location-map.js
@@ -231,7 +231,7 @@ After starting the server we should now see some end to end maps functionality s
 
 ![super rentals homepage with maps](../../images/service/style-super-rentals-maps.png)
 
-You may now either move onto the [next feature](../subroutes/), or continue here to test the maps feature we just added.
+You may now either move onto the [next feature](subroutes/), or continue here to test the maps feature we just added.
 
 ###  Unit testing a Service
 
@@ -333,10 +333,10 @@ test('should append map element to container element', function(assert) {
 });
 ```
 
-In the `beforeEach` function that runs before each test, we use the built-in function `this.register` to [register](../../applications/dependency-injection/#toc_factory-registrations) our stub service in place of the maps service.
+In the `beforeEach` function that runs before each test, we use the built-in function `this.register` to [register](../applications/dependency-injection/#toc_factory-registrations) our stub service in place of the maps service.
 Registration makes an object available to your Ember application for things like loading components from templates and injecting services in this case.
 
-The call to the function `this.inject.service` [injects](../../applications/dependency-injection/#toc_ad-hoc-injections) the service we just registered into the context of the tests, so each test may access it through `this.get('mapsService')`.
+The call to the function `this.inject.service` [injects](../applications/dependency-injection/#toc_ad-hoc-injections) the service we just registered into the context of the tests, so each test may access it through `this.get('mapsService')`.
 In the example we assert that `calledWithLocation` in our stub is set to the location we passed to the component.
 
 
@@ -373,7 +373,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.17.0/tutorial/simple-component.md
+++ b/guides/v2.17.0/tutorial/simple-component.md
@@ -161,7 +161,7 @@ Let's call this action `toggleImageSize`
 Clicking the anchor element will send the action to the component.
 Ember will then go into the `actions` hash and call the `toggleImageSize` function.
 
-An [actions hash](../../templates/actions/) is an object in the component that contains functions.
+An [actions hash](../templates/actions/) is an object in the component that contains functions.
 These functions are called when the user interacts with the UI, such as clicking.
 
 Let's create the `toggleImageSize` function and toggle the `isWide` property on our component:
@@ -186,13 +186,13 @@ When we click the enlarged image again, we see it smaller.
 
 ![rental listing with expand](../../images/simple-component/styled-rental-listings.png)
 
-Move on to the [next page](../hbs-helper/) for the next feature, or continue on here to test what you just wrote.
+Move on to the [next page](hbs-helper/) for the next feature, or continue on here to test what you just wrote.
 
 ### An Integration Test
 
-Ember components are commonly tested with [component integration tests](../../testing/testing-components/).
+Ember components are commonly tested with [component integration tests](../testing/testing-components/).
 Component integration tests verify the behavior of a component within the context of Ember's rendering engine.
-When running in an integration test, the component goes through its regular [render lifecycle](../../components/the-component-lifecycle/),
+When running in an integration test, the component goes through its regular [render lifecycle](../components/the-component-lifecycle/),
 and has access to dependent objects, loaded through Ember's resolver.
 
 Our component integration test will test two different behaviors:

--- a/guides/v2.17.0/tutorial/subroutes.md
+++ b/guides/v2.17.0/tutorial/subroutes.md
@@ -6,8 +6,8 @@ Up to this point, we've generated four top level routes.
 * The `index` route, which we've set up to redirect to the `rentals` route.
 
 Our `rentals` route is going to serve multiple functions.
-From our [acceptance tests](../acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
-To satisfy that requirement, we are going to make use of Ember's [nested route capability](../../routing/defining-your-routes/#toc_nested-routes).
+From our [acceptance tests](acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
+To satisfy that requirement, we are going to make use of Ember's [nested route capability](../routing/defining-your-routes/#toc_nested-routes).
 
 By the end of this section we want to have created the following new routes:
 
@@ -18,7 +18,7 @@ The `show` route will get substituted with the id of the rental being shown (for
 
 ## The Parent Route
 
-Previously, in the [Routes and Templates tutorial](../routes-and-templates), we set up a `rentals` route.
+Previously, in the [Routes and Templates tutorial](routes-and-templates), we set up a `rentals` route.
 
 Opening the template for this route reveals an outlet underneath the route's general page information.
 At the bottom of the template, you'll notice an `{{outlet}}` helper.
@@ -76,7 +76,7 @@ Ember knows that the default action is to take the user to the `index` route.
 However, you can add the `index` route if you want to customize it.
 For example, you can modify the `index` route's path by specifying `this.route('index', { path: '/custom-path'})`.
 
-In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
+In the section on [using Ember Data](ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
 Let's implement our newly generated `rentals/index` route by moving this `findAll` call from the parent `rentals` route to our new sub-route.
 
 ```app/routes/rentals.js{-4,-5,-6}
@@ -158,13 +158,13 @@ export default RentalsController;
 
 Next, we will want to create a sub-route that will list information for a specific rental.
 To do this, we will need to update a couple of files.
-To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../../models/finding-records/).
+To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../models/finding-records/).
 The `findRecord` function requires that we search by a unique key.
 
 While on the `show` route, we will also want to show additional information about our specific rental.
 
 In order to do this, we will need to modify the Mirage `config.js` file that we added
-back in the [Installing Addons section](../installing-addons). We will add a new route
+back in the [Installing Addons section](installing-addons). We will add a new route
 handler to return a specific rental:
 
 ```mirage/config.js{+57,+58,+59,+60}
@@ -302,7 +302,7 @@ export default Route.extend({
 ```
 
 Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook.
-When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../models/)).
 
 ## Adding the Rental To Our Template
 
@@ -370,7 +370,7 @@ Clicking on the title will load the detail page for that rental.
 ```
 ![Rental Page Nested Index Route](../../images/subroutes/subroutes-super-rentals-index.png)
 
-At this point you can do a [deployment](../deploying/) and share your Super Rentals application to the world
+At this point you can do a [deployment](deploying/) and share your Super Rentals application to the world
 or you can use this as a base to explore other Ember features and addons.
 Regardless, we hope this has helped you get started with creating your own ambitious applications with Ember!
 
@@ -391,6 +391,6 @@ test('should show details for a specific rental', function (assert) {
 });
 ```
 
-At this point all our tests should pass, including the [list of acceptance tests](../acceptance-test) we created as our beginning requirements.
+At this point all our tests should pass, including the [list of acceptance tests](acceptance-test) we created as our beginning requirements.
 
 ![Acceptance Tests Pass](../../images/subroutes/all-acceptance-pass.png)

--- a/guides/v2.2.0/applications/initializers.md
+++ b/guides/v2.2.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.2.0/applications/run-loop.md
+++ b/guides/v2.2.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a runloop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.2.0/components/defining-a-component.md
+++ b/guides/v2.2.0/components/defining-a-component.md
@@ -44,7 +44,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.2.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.2.0/components/triggering-changes-with-actions.md
@@ -63,7 +63,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -71,7 +71,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js

--- a/guides/v2.2.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.2.0/components/wrapping-content-in-a-component.md
@@ -17,7 +17,7 @@ in another template:
 ```
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v2.2.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.2.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.2.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.2.0/configuring-ember/disabling-prototype-extensions.md
@@ -106,7 +106,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.2.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.2.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -26,7 +26,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js

--- a/guides/v2.2.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.2.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.2.0/controllers/dependencies-between-controllers.md
+++ b/guides/v2.2.0/controllers/dependencies-between-controllers.md
@@ -46,4 +46,4 @@ export default Ember.Controller.extend({
 ```
 
 For more information about aliases, see the API docs for
-[aliased properties](http://emberjs.com/api/#method_computed_alias). If you have more extensive "data sharing" needs across your app, see the [services page](../../applications/services/), which largely replaces injected controllers.
+[aliased properties](http://emberjs.com/api/#method_computed_alias). If you have more extensive "data sharing" needs across your app, see the [services page](../applications/services/), which largely replaces injected controllers.

--- a/guides/v2.2.0/ember-inspector/object-inspector.md
+++ b/guides/v2.2.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.2.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.2.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.2.0/ember-inspector/view-tree.md
+++ b/guides/v2.2.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.2.0/models/customizing-adapters.md
+++ b/guides/v2.2.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.2.0/models/defining-models.md
+++ b/guides/v2.2.0/models/defining-models.md
@@ -19,8 +19,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -56,7 +56,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.2.0/routing/defining-your-routes.md
+++ b/guides/v2.2.0/routing/defining-your-routes.md
@@ -181,7 +181,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post. See [Specifying a Route's
-Model](../specifying-a-routes-model) for
+Model](specifying-a-routes-model) for
 more about how to load a model.
 
 ## Wildcard / globbing routes

--- a/guides/v2.2.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.2.0/routing/preventing-and-retrying-transitions.md
@@ -47,7 +47,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.2.0/routing/redirection.md
+++ b/guides/v2.2.0/routing/redirection.md
@@ -1,7 +1,7 @@
 Calling [`transitionTo()`][1] from a route or [`transitionToRoute()`][2] from a 
 controller will stop any transition currently in progress and start a new 
 one, functioning as a redirect. `transitionTo()` behaves exactly like the 
-[link-to](../../templates/links) helper.
+[link-to](../templates/links) helper.
 
 [1]: http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo
 [2]: http://emberjs.com/api/classes/Ember.Route.html#method_transitionToRoute
@@ -32,7 +32,7 @@ export default Ember.Route.extend({
 ```
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.2.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.2.0/routing/specifying-a-routes-model.md
@@ -22,7 +22,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember
 Data records are promises), or a plain JavaScript object or array. Ember will
 wait until the data finishes loading (until the promise is resolved) before
@@ -57,7 +57,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -85,7 +85,7 @@ method.
 
 Note: A route with a dynamic segment will only have its `model` hook called
 when it is entered via the URL. If the route is entered through a transition
-(e.g. when using the [link-to](../../templates/links) Handlebars helper), then a model context is
+(e.g. when using the [link-to](../templates/links) Handlebars helper), then a model context is
 already provided and the hook is not executed. Routes without dynamic segments
 will always execute the model hook.
 

--- a/guides/v2.2.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.2.0/templates/displaying-a-list-of-items.md
@@ -43,7 +43,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays.
 
 ### Accessing an item's `index`

--- a/guides/v2.2.0/templates/handlebars-basics.md
+++ b/guides/v2.2.0/templates/handlebars-basics.md
@@ -54,4 +54,4 @@ controllers and components.
 
 Helpers bring a minimum of logic into Ember templating. Ember ships with several
 built-in helpers, which are explained in the following guides, and also allows
-you to [write your own helpers](../writing-helpers/).
+you to [write your own helpers](writing-helpers/).

--- a/guides/v2.2.0/templates/links.md
+++ b/guides/v2.2.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` helper takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the helper, you can provide

--- a/guides/v2.2.0/testing/testing-controllers.md
+++ b/guides/v2.2.0/testing/testing-controllers.md
@@ -126,5 +126,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.2.0/testing/testing-models.md
+++ b/guides/v2.2.0/testing/testing-models.md
@@ -96,5 +96,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.2.0/testing/testing-routes.md
+++ b/guides/v2.2.0/testing/testing-routes.md
@@ -82,5 +82,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.3.0/applications/initializers.md
+++ b/guides/v2.3.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.3.0/applications/run-loop.md
+++ b/guides/v2.3.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.3.0/components/block-params.md
+++ b/guides/v2.3.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.3.0/components/defining-a-component.md
+++ b/guides/v2.3.0/components/defining-a-component.md
@@ -44,7 +44,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.3.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.3.0/components/triggering-changes-with-actions.md
@@ -63,7 +63,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -71,7 +71,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -242,7 +242,7 @@ The action helper will add the arguments provided in the template to the call.
 
 Action arguments curry, meaning that you can provide partial arguments to the action helper and provide the rest of the
 arguments when you call the function within the component javascript file.
-For example, our `button-with-confirmation` component will now [yield](../wrapping-content-in-a-component/) the content
+For example, our `button-with-confirmation` component will now [yield](wrapping-content-in-a-component/) the content
 of the confirmation dialog to collect extra information to be sent along with the `onConfirm` action:
 
 ```app/templates/components/button-with-confirmation.hbs

--- a/guides/v2.3.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.3.0/components/wrapping-content-in-a-component.md
@@ -17,7 +17,7 @@ in another template:
 ```
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v2.3.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.3.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.3.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.3.0/configuring-ember/disabling-prototype-extensions.md
@@ -106,7 +106,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.3.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.3.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -26,7 +26,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js

--- a/guides/v2.3.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.3.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.3.0/ember-inspector/object-inspector.md
+++ b/guides/v2.3.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.3.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.3.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.3.0/ember-inspector/view-tree.md
+++ b/guides/v2.3.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.3.0/models/customizing-adapters.md
+++ b/guides/v2.3.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.3.0/models/defining-models.md
+++ b/guides/v2.3.0/models/defining-models.md
@@ -21,8 +21,8 @@ export default Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -64,7 +64,7 @@ export default Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.3.0/routing/defining-your-routes.md
+++ b/guides/v2.3.0/routing/defining-your-routes.md
@@ -230,7 +230,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.3.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.3.0/routing/preventing-and-retrying-transitions.md
@@ -47,7 +47,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.3.0/routing/redirection.md
+++ b/guides/v2.3.0/routing/redirection.md
@@ -1,7 +1,7 @@
 Calling [`transitionTo()`][1] from a route or [`transitionToRoute()`][2] from a 
 controller will stop any transition currently in progress and start a new 
 one, functioning as a redirect. `transitionTo()` behaves exactly like the 
-[link-to](../../templates/links) helper.
+[link-to](../templates/links) helper.
 
 [1]: http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo
 [2]: http://emberjs.com/api/classes/Ember.Controller.html#method_transitionToRoute
@@ -32,7 +32,7 @@ export default Ember.Route.extend({
 ```
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.3.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.3.0/routing/specifying-a-routes-model.md
@@ -22,7 +22,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember
 Data records are promises), or a plain JavaScript object or array. Ember will
 wait until the data finishes loading (until the promise is resolved) before
@@ -57,7 +57,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -85,7 +85,7 @@ method.
 
 Note: A route with a dynamic segment will only have its `model` hook called
 when it is entered via the URL. If the route is entered through a transition
-(e.g. when using the [link-to](../../templates/links) Handlebars helper), then a model context is
+(e.g. when using the [link-to](../templates/links) Handlebars helper), then a model context is
 already provided and the hook is not executed. Routes without dynamic segments
 will always execute the model hook.
 

--- a/guides/v2.3.0/templates/actions.md
+++ b/guides/v2.3.0/templates/actions.md
@@ -27,7 +27,7 @@ export default Ember.Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](/components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.3.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.3.0/templates/displaying-a-list-of-items.md
@@ -43,7 +43,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.3.0/templates/handlebars-basics.md
+++ b/guides/v2.3.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.3.0/templates/links.md
+++ b/guides/v2.3.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` helper takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the helper, you can provide

--- a/guides/v2.3.0/testing/testing-controllers.md
+++ b/guides/v2.3.0/testing/testing-controllers.md
@@ -126,5 +126,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.3.0/testing/testing-models.md
+++ b/guides/v2.3.0/testing/testing-models.md
@@ -104,5 +104,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.3.0/testing/testing-routes.md
+++ b/guides/v2.3.0/testing/testing-routes.md
@@ -82,5 +82,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.3.0/tutorial/acceptance-test.md
+++ b/guides/v2.3.0/tutorial/acceptance-test.md
@@ -7,7 +7,7 @@ We want our application to:
 * Link to contact information.
 * Filter the list of rentals by city.
 
-We can represent these goals as [Ember acceptance tests](../../testing/acceptance/).
+We can represent these goals as [Ember acceptance tests](../testing/acceptance/).
 Acceptance tests interact with our app like an actual person would, but can be automated, ensuring that our app doesn't break in the future.
 
 We'll start by using Ember CLI to generate a new acceptance test:
@@ -90,7 +90,7 @@ The test assumes that each rental element will have a class called `listing`.
 
 The [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) helper loads the route specified for the given URL.
 
-The [`andThen`](../../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
+The [`andThen`](../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
 In this case, we need to wait for the page to load after `visit`, so that we can assert that the listings are displayed.
 
 For the next two tests, we want to verify that clicking the about and contact page links successfully load the proper URLs.
@@ -114,7 +114,7 @@ test('should link to contact information', function (assert) {
   });
 });
 ```
-Note that we can call two [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
+Note that we can call two [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
 This is because each asynchronous test helper is made to wait until other test helpers are complete.
 
 Finally, we'll test that we can filter the list down according to a city search criteria.

--- a/guides/v2.3.0/tutorial/autocomplete-component.md
+++ b/guides/v2.3.0/tutorial/autocomplete-component.md
@@ -137,7 +137,7 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search. 
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search. 
 The `value` property of the `input` will be bound to the `value` property in our component.
 The `key-up` property will be bound to the `handleFilterEntry` action.
 
@@ -169,7 +169,7 @@ export default Ember.Component.extend({
 We use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls our filter action based on the `value` attribute set by our input helper.
 
-Both the `filter` action is [passed](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
+Both the `filter` action is [passed](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
 
 To implement these actions, we'll create the index controller for the application.  The index controller is executed when the user goes to the base (index) route for the application.
 

--- a/guides/v2.3.0/tutorial/ember-data.md
+++ b/guides/v2.3.0/tutorial/ember-data.md
@@ -62,7 +62,7 @@ export default Ember.Route.extend({
 ```
 
 When we call `this.store.findAll('rental')`, Ember Data will make a GET request to `/rentals`.
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we're using Mirage in our development environment, Mirage will return the data we've provided.
 When we deploy our app to a production server, we will need to provide a backend for Ember Data to communicate with.

--- a/guides/v2.3.0/tutorial/service.md
+++ b/guides/v2.3.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`, 
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```app/components/location-map.js
@@ -219,7 +219,7 @@ export default Ember.Service.extend({
 ### Making Google Maps Available
 
 Before implementing the map utility, we need to make the 3rd party map API available to our Ember app.
-There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
+There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
 
 Since Google provides its map API as a remote script, we'll use curl to download it into our project's vendor directory.
 
@@ -337,7 +337,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.4.0/applications/initializers.md
+++ b/guides/v2.4.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.4.0/applications/run-loop.md
+++ b/guides/v2.4.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.4.0/components/block-params.md
+++ b/guides/v2.4.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.4.0/components/defining-a-component.md
+++ b/guides/v2.4.0/components/defining-a-component.md
@@ -44,7 +44,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.4.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.4.0/components/triggering-changes-with-actions.md
@@ -63,7 +63,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -71,7 +71,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -242,7 +242,7 @@ The action helper will add the arguments provided in the template to the call.
 
 Action arguments curry, meaning that you can provide partial arguments to the action helper and provide the rest of the
 arguments when you call the function within the component javascript file.
-For example, our `button-with-confirmation` component will now [yield](../wrapping-content-in-a-component/) the content
+For example, our `button-with-confirmation` component will now [yield](wrapping-content-in-a-component/) the content
 of the confirmation dialog to collect extra information to be sent along with the `onConfirm` action:
 
 ```app/templates/components/button-with-confirmation.hbs

--- a/guides/v2.4.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.4.0/components/wrapping-content-in-a-component.md
@@ -17,7 +17,7 @@ in another template:
 ```
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v2.4.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.4.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.4.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.4.0/configuring-ember/disabling-prototype-extensions.md
@@ -106,7 +106,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.4.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.4.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -26,7 +26,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js

--- a/guides/v2.4.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.4.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.4.0/ember-inspector/object-inspector.md
+++ b/guides/v2.4.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.4.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.4.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.4.0/ember-inspector/view-tree.md
+++ b/guides/v2.4.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.4.0/models/customizing-adapters.md
+++ b/guides/v2.4.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.4.0/models/defining-models.md
+++ b/guides/v2.4.0/models/defining-models.md
@@ -19,8 +19,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -56,7 +56,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.4.0/routing/defining-your-routes.md
+++ b/guides/v2.4.0/routing/defining-your-routes.md
@@ -230,7 +230,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.4.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.4.0/routing/preventing-and-retrying-transitions.md
@@ -47,7 +47,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.4.0/routing/redirection.md
+++ b/guides/v2.4.0/routing/redirection.md
@@ -1,7 +1,7 @@
 Calling [`transitionTo()`][1] from a route or [`transitionToRoute()`][2] from a 
 controller will stop any transition currently in progress and start a new 
 one, functioning as a redirect. `transitionTo()` behaves exactly like the 
-[link-to](../../templates/links) helper.
+[link-to](../templates/links) helper.
 
 [1]: http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo
 [2]: http://emberjs.com/api/classes/Ember.Controller.html#method_transitionToRoute
@@ -32,7 +32,7 @@ export default Ember.Route.extend({
 ```
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.4.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.4.0/routing/specifying-a-routes-model.md
@@ -22,7 +22,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember
 Data records are promises), or a plain JavaScript object or array. Ember will
 wait until the data finishes loading (until the promise is resolved) before
@@ -57,7 +57,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -85,7 +85,7 @@ method.
 
 Note: A route with a dynamic segment will only have its `model` hook called
 when it is entered via the URL. If the route is entered through a transition
-(e.g. when using the [link-to](../../templates/links) Handlebars helper), then a model context is
+(e.g. when using the [link-to](../templates/links) Handlebars helper), then a model context is
 already provided and the hook is not executed. Routes without dynamic segments
 will always execute the model hook.
 

--- a/guides/v2.4.0/templates/actions.md
+++ b/guides/v2.4.0/templates/actions.md
@@ -27,7 +27,7 @@ export default Ember.Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](/components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.4.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.4.0/templates/displaying-a-list-of-items.md
@@ -43,7 +43,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.4.0/templates/handlebars-basics.md
+++ b/guides/v2.4.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.4.0/templates/links.md
+++ b/guides/v2.4.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` helper takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the helper, you can provide

--- a/guides/v2.4.0/testing/testing-controllers.md
+++ b/guides/v2.4.0/testing/testing-controllers.md
@@ -126,5 +126,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.4.0/testing/testing-models.md
+++ b/guides/v2.4.0/testing/testing-models.md
@@ -96,5 +96,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.4.0/testing/testing-routes.md
+++ b/guides/v2.4.0/testing/testing-routes.md
@@ -82,5 +82,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.4.0/tutorial/acceptance-test.md
+++ b/guides/v2.4.0/tutorial/acceptance-test.md
@@ -7,7 +7,7 @@ We want our application to:
 * Link to contact information.
 * Filter the list of rentals by city.
 
-We can represent these goals as [Ember acceptance tests](../../testing/acceptance/).
+We can represent these goals as [Ember acceptance tests](../testing/acceptance/).
 Acceptance tests interact with our app like an actual person would, but can be automated, ensuring that our app doesn't break in the future.
 
 We'll start by using Ember CLI to generate a new acceptance test:
@@ -90,7 +90,7 @@ The test assumes that each rental element will have a class called `listing`.
 
 The [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) helper loads the route specified for the given URL.
 
-The [`andThen`](../../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
+The [`andThen`](../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
 In this case, we need to wait for the page to load after `visit`, so that we can assert that the listings are displayed.
 
 For the next two tests, we want to verify that clicking the about and contact page links successfully load the proper URLs.
@@ -114,7 +114,7 @@ test('should link to contact information', function (assert) {
   });
 });
 ```
-Note that we can call two [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
+Note that we can call two [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
 This is because each asynchronous test helper is made to wait until other test helpers are complete.
 
 Finally, we'll test that we can filter the list down according to a city search criteria.

--- a/guides/v2.4.0/tutorial/autocomplete-component.md
+++ b/guides/v2.4.0/tutorial/autocomplete-component.md
@@ -137,7 +137,7 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search. 
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search. 
 The `value` property of the `input` will be bound to the `value` property in our component.
 The `key-up` property will be bound to the `handleFilterEntry` action.
 
@@ -169,7 +169,7 @@ export default Ember.Component.extend({
 We use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls our filter action based on the `value` attribute set by our input helper.
 
-Both the `filter` action is [passed](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
+Both the `filter` action is [passed](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
 
 To implement these actions, we'll create the index controller for the application.  The index controller is executed when the user goes to the base (index) route for the application.
 

--- a/guides/v2.4.0/tutorial/ember-data.md
+++ b/guides/v2.4.0/tutorial/ember-data.md
@@ -61,7 +61,7 @@ export default Ember.Route.extend({
 ```
 
 When we call `this.store.findAll('rental')`, Ember Data will make a GET request to `/rentals`.
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we're using Mirage in our development environment, Mirage will return the data we've provided.
 When we deploy our app to a production server, we will need to provide a backend for Ember Data to communicate with.

--- a/guides/v2.4.0/tutorial/service.md
+++ b/guides/v2.4.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`, 
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```app/components/location-map.js
@@ -219,7 +219,7 @@ export default Ember.Service.extend({
 ### Making Google Maps Available
 
 Before implementing the map utility, we need to make the 3rd party map API available to our Ember app.
-There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
+There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
 
 Since Google provides its map API as a remote script, we'll use curl to download it into our project's vendor directory.
 
@@ -337,7 +337,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.5.0/applications/initializers.md
+++ b/guides/v2.5.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.5.0/applications/run-loop.md
+++ b/guides/v2.5.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.5.0/components/block-params.md
+++ b/guides/v2.5.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.5.0/components/defining-a-component.md
+++ b/guides/v2.5.0/components/defining-a-component.md
@@ -44,7 +44,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.5.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.5.0/components/triggering-changes-with-actions.md
@@ -63,7 +63,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -71,7 +71,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -242,7 +242,7 @@ The action helper will add the arguments provided in the template to the call.
 
 Action arguments curry, meaning that you can provide partial arguments to the action helper and provide the rest of the
 arguments when you call the function within the component javascript file.
-For example, our `button-with-confirmation` component will now [yield](../wrapping-content-in-a-component/) the content
+For example, our `button-with-confirmation` component will now [yield](wrapping-content-in-a-component/) the content
 of the confirmation dialog to collect extra information to be sent along with the `onConfirm` action:
 
 ```app/templates/components/button-with-confirmation.hbs

--- a/guides/v2.5.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.5.0/components/wrapping-content-in-a-component.md
@@ -17,7 +17,7 @@ in another template:
 ```
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v2.5.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.5.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.5.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.5.0/configuring-ember/disabling-prototype-extensions.md
@@ -106,7 +106,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.5.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.5.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -26,7 +26,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js

--- a/guides/v2.5.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.5.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.5.0/ember-inspector/object-inspector.md
+++ b/guides/v2.5.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.5.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.5.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.5.0/ember-inspector/view-tree.md
+++ b/guides/v2.5.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.5.0/models/customizing-adapters.md
+++ b/guides/v2.5.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.5.0/models/defining-models.md
+++ b/guides/v2.5.0/models/defining-models.md
@@ -19,8 +19,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -56,7 +56,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.5.0/routing/defining-your-routes.md
+++ b/guides/v2.5.0/routing/defining-your-routes.md
@@ -230,7 +230,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.5.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.5.0/routing/preventing-and-retrying-transitions.md
@@ -47,7 +47,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.5.0/routing/redirection.md
+++ b/guides/v2.5.0/routing/redirection.md
@@ -1,7 +1,7 @@
 Calling [`transitionTo()`][1] from a route or [`transitionToRoute()`][2] from a 
 controller will stop any transition currently in progress and start a new 
 one, functioning as a redirect. `transitionTo()` behaves exactly like the 
-[link-to](../../templates/links) helper.
+[link-to](../templates/links) helper.
 
 [1]: http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo
 [2]: http://emberjs.com/api/classes/Ember.Controller.html#method_transitionToRoute
@@ -32,7 +32,7 @@ export default Ember.Route.extend({
 ```
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.5.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.5.0/routing/specifying-a-routes-model.md
@@ -22,7 +22,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember
 Data records are promises), or a plain JavaScript object or array. Ember will
 wait until the data finishes loading (until the promise is resolved) before
@@ -57,7 +57,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -85,7 +85,7 @@ method.
 
 Note: A route with a dynamic segment will only have its `model` hook called
 when it is entered via the URL. If the route is entered through a transition
-(e.g. when using the [link-to](../../templates/links) Handlebars helper), then a model context is
+(e.g. when using the [link-to](../templates/links) Handlebars helper), then a model context is
 already provided and the hook is not executed. Routes without dynamic segments
 will always execute the model hook.
 

--- a/guides/v2.5.0/templates/actions.md
+++ b/guides/v2.5.0/templates/actions.md
@@ -27,7 +27,7 @@ export default Ember.Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](/components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.5.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.5.0/templates/displaying-a-list-of-items.md
@@ -43,7 +43,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.5.0/templates/handlebars-basics.md
+++ b/guides/v2.5.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.5.0/templates/links.md
+++ b/guides/v2.5.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` helper takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the helper, you can provide

--- a/guides/v2.5.0/testing/testing-controllers.md
+++ b/guides/v2.5.0/testing/testing-controllers.md
@@ -126,5 +126,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.5.0/testing/testing-models.md
+++ b/guides/v2.5.0/testing/testing-models.md
@@ -96,5 +96,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.5.0/testing/testing-routes.md
+++ b/guides/v2.5.0/testing/testing-routes.md
@@ -82,5 +82,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.5.0/tutorial/acceptance-test.md
+++ b/guides/v2.5.0/tutorial/acceptance-test.md
@@ -7,7 +7,7 @@ We want our application to:
 * Link to contact information.
 * Filter the list of rentals by city.
 
-We can represent these goals as [Ember acceptance tests](../../testing/acceptance/).
+We can represent these goals as [Ember acceptance tests](../testing/acceptance/).
 Acceptance tests interact with our app like an actual person would, but can be automated, ensuring that our app doesn't break in the future.
 
 We'll start by using Ember CLI to generate a new acceptance test:
@@ -90,7 +90,7 @@ The test assumes that each rental element will have a class called `listing`.
 
 The [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) helper loads the route specified for the given URL.
 
-The [`andThen`](../../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
+The [`andThen`](../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
 In this case, we need to wait for the page to load after `visit`, so that we can assert that the listings are displayed.
 
 For the next two tests, we want to verify that clicking the about and contact page links successfully load the proper URLs.
@@ -114,7 +114,7 @@ test('should link to contact information', function (assert) {
   });
 });
 ```
-Note that we can call two [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
+Note that we can call two [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
 This is because each asynchronous test helper is made to wait until other test helpers are complete.
 
 Finally, we'll test that we can filter the list down according to a city search criteria.

--- a/guides/v2.5.0/tutorial/autocomplete-component.md
+++ b/guides/v2.5.0/tutorial/autocomplete-component.md
@@ -137,7 +137,7 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search. 
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search. 
 The `value` property of the `input` will be bound to the `value` property in our component.
 The `key-up` property will be bound to the `handleFilterEntry` action.
 
@@ -169,7 +169,7 @@ export default Ember.Component.extend({
 We use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls our filter action based on the `value` attribute set by our input helper.
 
-Both the `filter` action is [passed](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
+Both the `filter` action is [passed](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
 
 To implement these actions, we'll create the index controller for the application.  The index controller is executed when the user goes to the base (index) route for the application.
 

--- a/guides/v2.5.0/tutorial/ember-data.md
+++ b/guides/v2.5.0/tutorial/ember-data.md
@@ -61,7 +61,7 @@ export default Ember.Route.extend({
 ```
 
 When we call `this.store.findAll('rental')`, Ember Data will make a GET request to `/rentals`.
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we're using Mirage in our development environment, Mirage will return the data we've provided.
 When we deploy our app to a production server, we will need to provide a backend for Ember Data to communicate with.

--- a/guides/v2.5.0/tutorial/service.md
+++ b/guides/v2.5.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`, 
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```app/components/location-map.js
@@ -219,7 +219,7 @@ export default Ember.Service.extend({
 ### Making Google Maps Available
 
 Before implementing the map utility, we need to make the 3rd party map API available to our Ember app.
-There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
+There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
 
 Since Google provides its map API as a remote script, we'll use curl to download it into our project's vendor directory.
 
@@ -337,7 +337,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.6.0/applications/initializers.md
+++ b/guides/v2.6.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.6.0/applications/run-loop.md
+++ b/guides/v2.6.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.6.0/components/block-params.md
+++ b/guides/v2.6.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.6.0/components/defining-a-component.md
+++ b/guides/v2.6.0/components/defining-a-component.md
@@ -44,7 +44,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.6.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.6.0/components/triggering-changes-with-actions.md
@@ -63,7 +63,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -71,7 +71,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -242,7 +242,7 @@ The action helper will add the arguments provided in the template to the call.
 
 Action arguments curry, meaning that you can provide partial arguments to the action helper and provide the rest of the
 arguments when you call the function within the component javascript file.
-For example, our `button-with-confirmation` component will now [yield](../wrapping-content-in-a-component/) the content
+For example, our `button-with-confirmation` component will now [yield](wrapping-content-in-a-component/) the content
 of the confirmation dialog to collect extra information to be sent along with the `onConfirm` action:
 
 ```app/templates/components/button-with-confirmation.hbs

--- a/guides/v2.6.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.6.0/components/wrapping-content-in-a-component.md
@@ -17,7 +17,7 @@ in another template:
 ```
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v2.6.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.6.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.6.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.6.0/configuring-ember/disabling-prototype-extensions.md
@@ -106,7 +106,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.6.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.6.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -26,7 +26,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js

--- a/guides/v2.6.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.6.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.6.0/ember-inspector/object-inspector.md
+++ b/guides/v2.6.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.6.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.6.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.6.0/ember-inspector/view-tree.md
+++ b/guides/v2.6.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.6.0/models/customizing-adapters.md
+++ b/guides/v2.6.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.6.0/models/defining-models.md
+++ b/guides/v2.6.0/models/defining-models.md
@@ -19,8 +19,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -56,7 +56,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.6.0/routing/defining-your-routes.md
+++ b/guides/v2.6.0/routing/defining-your-routes.md
@@ -246,7 +246,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.6.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.6.0/routing/preventing-and-retrying-transitions.md
@@ -47,7 +47,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.6.0/routing/redirection.md
+++ b/guides/v2.6.0/routing/redirection.md
@@ -1,7 +1,7 @@
 Calling [`transitionTo()`][1] from a route or [`transitionToRoute()`][2] from a 
 controller will stop any transition currently in progress and start a new 
 one, functioning as a redirect. `transitionTo()` behaves exactly like the 
-[link-to](../../templates/links) helper.
+[link-to](../templates/links) helper.
 
 [1]: http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo
 [2]: http://emberjs.com/api/classes/Ember.Controller.html#method_transitionToRoute
@@ -32,7 +32,7 @@ export default Ember.Route.extend({
 ```
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.6.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.6.0/routing/specifying-a-routes-model.md
@@ -22,7 +22,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember
 Data records are promises), or a plain JavaScript object or array. Ember will
 wait until the data finishes loading (until the promise is resolved) before
@@ -57,7 +57,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -85,7 +85,7 @@ method.
 
 Note: A route with a dynamic segment will only have its `model` hook called
 when it is entered via the URL. If the route is entered through a transition
-(e.g. when using the [link-to](../../templates/links) Handlebars helper), then a model context is
+(e.g. when using the [link-to](../templates/links) Handlebars helper), then a model context is
 already provided and the hook is not executed. Routes without dynamic segments
 will always execute the model hook.
 

--- a/guides/v2.6.0/templates/actions.md
+++ b/guides/v2.6.0/templates/actions.md
@@ -27,7 +27,7 @@ export default Ember.Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../../components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.6.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.6.0/templates/displaying-a-list-of-items.md
@@ -43,7 +43,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.6.0/templates/handlebars-basics.md
+++ b/guides/v2.6.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.6.0/templates/links.md
+++ b/guides/v2.6.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` helper takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the helper, you can provide

--- a/guides/v2.6.0/templates/writing-helpers.md
+++ b/guides/v2.6.0/templates/writing-helpers.md
@@ -79,7 +79,7 @@ helper again with the new values and keep the page up-to-date.
 
 ### Helper Names
 
-Unlike [components](/components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples in this page.
+Unlike [components](../components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples in this page.
 
 ### Helper Arguments
 

--- a/guides/v2.6.0/testing/testing-controllers.md
+++ b/guides/v2.6.0/testing/testing-controllers.md
@@ -126,5 +126,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.6.0/testing/testing-models.md
+++ b/guides/v2.6.0/testing/testing-models.md
@@ -96,5 +96,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.6.0/testing/testing-routes.md
+++ b/guides/v2.6.0/testing/testing-routes.md
@@ -82,5 +82,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.6.0/tutorial/acceptance-test.md
+++ b/guides/v2.6.0/tutorial/acceptance-test.md
@@ -7,7 +7,7 @@ We want our application to:
 * Link to contact information.
 * Filter the list of rentals by city.
 
-We can represent these goals as [Ember acceptance tests](../../testing/acceptance/).
+We can represent these goals as [Ember acceptance tests](../testing/acceptance/).
 Acceptance tests interact with our app like an actual person would, but can be automated, ensuring that our app doesn't break in the future.
 
 We'll start by using Ember CLI to generate a new acceptance test:
@@ -90,7 +90,7 @@ The test assumes that each rental element will have a class called `listing`.
 
 The [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) helper loads the route specified for the given URL.
 
-The [`andThen`](../../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
+The [`andThen`](../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
 In this case, we need to wait for the page to load after `visit`, so that we can assert that the listings are displayed.
 
 For the next two tests, we want to verify that clicking the about and contact page links successfully load the proper URLs.
@@ -114,7 +114,7 @@ test('should link to contact information', function (assert) {
   });
 });
 ```
-Note that we can call two [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
+Note that we can call two [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
 This is because each asynchronous test helper is made to wait until other test helpers are complete.
 
 Finally, we'll test that we can filter the list down according to a city search criteria.

--- a/guides/v2.6.0/tutorial/autocomplete-component.md
+++ b/guides/v2.6.0/tutorial/autocomplete-component.md
@@ -137,7 +137,7 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search. 
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search. 
 The `value` property of the `input` will be bound to the `value` property in our component.
 The `key-up` property will be bound to the `handleFilterEntry` action.
 
@@ -169,7 +169,7 @@ export default Ember.Component.extend({
 We use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls our filter action based on the `value` attribute set by our input helper.
 
-The `filter` action is [passed](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
+The `filter` action is [passed](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
 
 To implement these actions, we'll create the index controller for the application.  The index controller is executed when the user goes to the base (index) route for the application.
 

--- a/guides/v2.6.0/tutorial/ember-data.md
+++ b/guides/v2.6.0/tutorial/ember-data.md
@@ -61,7 +61,7 @@ export default Ember.Route.extend({
 ```
 
 When we call `this.get('store').findAll('rental')`, Ember Data will make a GET request to `/rentals`.
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we're using Mirage in our development environment, Mirage will return the data we've provided.
 When we deploy our app to a production server, we will need to provide a backend for Ember Data to communicate with.

--- a/guides/v2.6.0/tutorial/service.md
+++ b/guides/v2.6.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```app/components/location-map.js
@@ -118,7 +118,7 @@ export default Ember.Component.extend({
 At this point we should have a passing component integration test, but our acceptance test should now fail, unable to find our maps service.  In addition to our acceptance test failing, no maps show up when we view our web page.
 To actually generate the maps, we'll implement the maps service.
 
-Accessing our maps API through a [service](../../applications/services) will give us several benefits
+Accessing our maps API through a [service](../applications/services) will give us several benefits
 
 * It is injected with a [service locator](https://en.wikipedia.org/wiki/Service_locator_pattern), meaning it will abstract the maps API from the code that uses it, allowing for easier refactoring and maintenance.
 * It is lazy-loaded, meaning it won't be initialized until it is called the first time.
@@ -219,7 +219,7 @@ export default Ember.Service.extend({
 ### Making Google Maps Available
 
 Before implementing the map utility, we need to make the 3rd party map API available to our Ember app.
-There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
+There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
 
 Since Google provides its map API as a remote script, we'll use curl to download it into our project's vendor directory.
 
@@ -339,7 +339,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.7.0/applications/initializers.md
+++ b/guides/v2.7.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.7.0/applications/run-loop.md
+++ b/guides/v2.7.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.7.0/components/block-params.md
+++ b/guides/v2.7.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.7.0/components/defining-a-component.md
+++ b/guides/v2.7.0/components/defining-a-component.md
@@ -46,7 +46,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.7.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.7.0/components/triggering-changes-with-actions.md
@@ -63,7 +63,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -71,7 +71,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -250,7 +250,7 @@ The action helper will add the arguments provided in the template to the call.
 
 Action arguments curry, meaning that you can provide partial arguments to the action helper and provide the rest of the
 arguments when you call the function within the component javascript file.
-For example, our `button-with-confirmation` component will now [yield](../wrapping-content-in-a-component/) the content
+For example, our `button-with-confirmation` component will now [yield](wrapping-content-in-a-component/) the content
 of the confirmation dialog to collect extra information to be sent along with the `onConfirm` action:
 
 ```app/templates/components/button-with-confirmation.hbs

--- a/guides/v2.7.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.7.0/components/wrapping-content-in-a-component.md
@@ -17,7 +17,7 @@ in another template:
 ```
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v2.7.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.7.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.7.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.7.0/configuring-ember/disabling-prototype-extensions.md
@@ -106,7 +106,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.7.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.7.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -28,7 +28,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js

--- a/guides/v2.7.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.7.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.7.0/ember-inspector/object-inspector.md
+++ b/guides/v2.7.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.7.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.7.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.7.0/ember-inspector/view-tree.md
+++ b/guides/v2.7.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.7.0/models/customizing-adapters.md
+++ b/guides/v2.7.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.7.0/models/defining-models.md
+++ b/guides/v2.7.0/models/defining-models.md
@@ -21,8 +21,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -62,7 +62,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.7.0/routing/defining-your-routes.md
+++ b/guides/v2.7.0/routing/defining-your-routes.md
@@ -246,7 +246,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.7.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.7.0/routing/preventing-and-retrying-transitions.md
@@ -49,7 +49,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.7.0/routing/redirection.md
+++ b/guides/v2.7.0/routing/redirection.md
@@ -1,7 +1,7 @@
 Calling [`transitionTo()`][1] from a route or [`transitionToRoute()`][2] from a 
 controller will stop any transition currently in progress and start a new 
 one, functioning as a redirect. `transitionTo()` behaves exactly like the 
-[link-to](../../templates/links) helper.
+[link-to](../templates/links) helper.
 
 [1]: http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo
 [2]: http://emberjs.com/api/classes/Ember.Controller.html#method_transitionToRoute
@@ -34,7 +34,7 @@ export default Ember.Route.extend({
 ```
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.7.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.7.0/routing/specifying-a-routes-model.md
@@ -24,7 +24,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember Data records are promises),
 or a plain JavaScript object or array.
 Ember will wait until the data finishes loading (until the promise is resolved) before rendering the template.
@@ -58,7 +58,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -87,7 +87,7 @@ photo's ID (`params.photo_id`) as an argument to Ember Data's `findRecord`
 method.
 
 Note: A route with a dynamic segment will always have its `model` hook called when it is entered via the URL.
-If the route is entered through a transition (e.g. when using the [link-to](../../templates/links) Handlebars helper),
+If the route is entered through a transition (e.g. when using the [link-to](../templates/links) Handlebars helper),
 and a model context is provided (second argument to `link-to`), then the hook is not executed.
 If an identifier (such as an id or slug) is provided instead then the model hook will be executed.
 

--- a/guides/v2.7.0/templates/actions.md
+++ b/guides/v2.7.0/templates/actions.md
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../../components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.7.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.7.0/templates/displaying-a-list-of-items.md
@@ -43,7 +43,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.7.0/templates/handlebars-basics.md
+++ b/guides/v2.7.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.7.0/templates/links.md
+++ b/guides/v2.7.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` helper takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the helper, you can provide

--- a/guides/v2.7.0/templates/writing-helpers.md
+++ b/guides/v2.7.0/templates/writing-helpers.md
@@ -81,7 +81,7 @@ helper again with the new values and keep the page up-to-date.
 
 ### Helper Names
 
-Unlike [components](/components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples in this page.
+Unlike [components](../components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples in this page.
 
 ### Helper Arguments
 

--- a/guides/v2.7.0/testing/testing-controllers.md
+++ b/guides/v2.7.0/testing/testing-controllers.md
@@ -132,5 +132,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.7.0/testing/testing-models.md
+++ b/guides/v2.7.0/testing/testing-models.md
@@ -102,5 +102,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.7.0/testing/testing-routes.md
+++ b/guides/v2.7.0/testing/testing-routes.md
@@ -84,5 +84,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.7.0/tutorial/acceptance-test.md
+++ b/guides/v2.7.0/tutorial/acceptance-test.md
@@ -7,7 +7,7 @@ We want our application to:
 * Link to contact information.
 * Filter the list of rentals by city.
 
-We can represent these goals as [Ember acceptance tests](../../testing/acceptance/).
+We can represent these goals as [Ember acceptance tests](../testing/acceptance/).
 Acceptance tests interact with our app like an actual person would, but can be automated, ensuring that our app doesn't break in the future.
 
 We'll start by using Ember CLI to generate a new acceptance test:
@@ -96,7 +96,7 @@ test('should redirect to rentals route', function (assert) {
 A few helpers are in play in this test: 
 
 * The [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) helper loads the route specified for the given URL.
-* The [`andThen`](../../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
+* The [`andThen`](../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
 In this case, we need to wait for the page to load after `visit`, so that we can assert that the listings are displayed.
 * [`currentUrl`](http://emberjs.com/api/classes/Ember.Test.html#method_currentURL) returns the URL that test application is currently visiting.
 
@@ -133,7 +133,7 @@ test('should link to contact information', function (assert) {
   });
 });
 ```
-Note that we can call two [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
+Note that we can call two [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
 This is because each asynchronous test helper is made to wait until other test helpers are complete.
 
 After testing URLs, we'll drill down on our main rental page to test that we can filter the list down according to a city search criteria.

--- a/guides/v2.7.0/tutorial/autocomplete-component.md
+++ b/guides/v2.7.0/tutorial/autocomplete-component.md
@@ -136,7 +136,7 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The `value` property of the `input` will be bound to the `value` property in our component.
 The `key-up` property will be bound to the `handleFilterEntry` action.
 
@@ -168,7 +168,7 @@ export default Ember.Component.extend({
 We use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls our filter action based on the `value` attribute set by our input helper.
 
-The `filter` action is [passed](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
+The `filter` action is [passed](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
 
 To implement these actions, we'll create the index controller for the application.  The index controller is executed when the user goes to the base (index) route for the application.
 

--- a/guides/v2.7.0/tutorial/ember-data.md
+++ b/guides/v2.7.0/tutorial/ember-data.md
@@ -61,7 +61,7 @@ export default Ember.Route.extend({
 ```
 
 When we call `this.get('store').findAll('rental')`, Ember Data will make a GET request to `/rentals`.
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we're using Mirage in our development environment, Mirage will return the data we've provided.
 When we deploy our app to a production server, we will need to provide a backend for Ember Data to communicate with.

--- a/guides/v2.7.0/tutorial/routes-and-templates.md
+++ b/guides/v2.7.0/tutorial/routes-and-templates.md
@@ -217,7 +217,7 @@ installing route-test
 
 Unlike the other route handlers we've made so far, the `index` route is special:
 it does NOT require an entry in the router's mapping.
-We'll learn more about why the entry isn't required when we look at [nested routes](../subroutes) in Ember.
+We'll learn more about why the entry isn't required when we look at [nested routes](subroutes) in Ember.
 
 We can start by implementing the unit test for index.
 Since all we want to do is transition to `rentals`, our unit test will make sure that the route's [`replaceWith`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) method is called with the desired route.

--- a/guides/v2.7.0/tutorial/service.md
+++ b/guides/v2.7.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```app/components/location-map.js
@@ -118,7 +118,7 @@ export default Ember.Component.extend({
 At this point we should have a passing component integration test, but our acceptance test should now fail, unable to find our maps service.  In addition to our acceptance test failing, no maps show up when we view our web page.
 To actually generate the maps, we'll implement the maps service.
 
-Accessing our maps API through a [service](../../applications/services) will give us several benefits
+Accessing our maps API through a [service](../applications/services) will give us several benefits
 
 * It is injected with a [service locator](https://en.wikipedia.org/wiki/Service_locator_pattern), meaning it will abstract the maps API from the code that uses it, allowing for easier refactoring and maintenance.
 * It is lazy-loaded, meaning it won't be initialized until it is called the first time.
@@ -219,7 +219,7 @@ export default Ember.Service.extend({
 ### Making Google Maps Available
 
 Before implementing the map utility, we need to make the 3rd party map API available to our Ember app.
-There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
+There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
 
 Since Google provides its map API as a remote script, we'll use curl to download it into our project's vendor directory.
 
@@ -338,7 +338,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.7.0/tutorial/subroutes.md
+++ b/guides/v2.7.0/tutorial/subroutes.md
@@ -6,8 +6,8 @@ Up to this point, we've generated four top level routes.
 * The `index` route, which we've set up to redirect to the `rentals` route.
 
 Our `rentals` route is going to serve multiple functions.
-From our [acceptance tests](../acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
-To satisfy that requirement, we are going to make use of Ember's [nested route capability](../../routing/defining-your-routes/#toc_nested-routes).
+From our [acceptance tests](acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
+To satisfy that requirement, we are going to make use of Ember's [nested route capability](../routing/defining-your-routes/#toc_nested-routes).
 
 By the end of this section we want to have created the following new routes:
 
@@ -18,7 +18,7 @@ The `show` route will get substituted with the id of the rental being shown (for
 
 ## The Parent Route
 
-Previously, in the [Routes and Templates tutorial](../routes-and-templates), we set up a `rentals` route.
+Previously, in the [Routes and Templates tutorial](routes-and-templates), we set up a `rentals` route.
 
 Opening the template for this route reveals an outlet underneath the route's general page information.
 At the bottom of the template, you'll notice an `{{outlet}}` helper.
@@ -75,7 +75,7 @@ Ember knows that the default action is to take the user to the `index` route.
 However, you can add the `index` route if you want to customize it.
 For example, you can modify the `index` route's path by specifying `this.route('index', { path: '/custom-path'})`.
 
-In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
+In the section on [using Ember Data](ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
 Let's implement our newly generated `rentals/index` route by moving this `findAll` call from the parent `rentals` route to our new sub-route.
 
 ```app/routes/rentals.hbs{-2,-3,-4}
@@ -146,13 +146,13 @@ export default RentalsController;
 
 Next, we will want to create a sub-route that will list information for a specific rental.
 To do this, we will need to update a couple of files.
-To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../../models/finding-records/).
+To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../models/finding-records/).
 The `findRecord` function requires that we search by a unique key.
 
 While on the `show` route, we will also want to show additional information about our specific rental.
 
 In order to do this, we will need to modify the Mirage `config.js` file that we added
-back in the [Installing Addons section](../installing-addons). We will add a new route
+back in the [Installing Addons section](installing-addons). We will add a new route
 handler to return a specific rental:
 
 ```mirage/config.js{+57,+58,+59,+60}
@@ -288,7 +288,7 @@ export default Ember.Route.extend({
 ```
 
 Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook.
-When we call `this.store.findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+When we call `this.store.findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../models/)).
 
 ## Adding the Rental To Our Template
 
@@ -355,10 +355,10 @@ Clicking on the title will load the detail page for that rental.
 
 ## Final Check
 
-At this point all our tests should pass, including the [list of acceptance tests](../acceptance-test) we created as our beginning requirements.
+At this point all our tests should pass, including the [list of acceptance tests](acceptance-test) we created as our beginning requirements.
 
 ![Acceptance Tests Pass](../../images/subroutes/all-acceptance-pass.png)
 
-At this point you can do a [deployment](../deploying) and share your Super Rentals application to the world
+At this point you can do a [deployment](deploying) and share your Super Rentals application to the world
 or you can use this as a base to explore other Ember features and addons.
 Regardless, we hope this has helped you get started with creating your own ambitious applications with Ember!

--- a/guides/v2.8.0/applications/initializers.md
+++ b/guides/v2.8.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.8.0/applications/run-loop.md
+++ b/guides/v2.8.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.8.0/components/block-params.md
+++ b/guides/v2.8.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.8.0/components/defining-a-component.md
+++ b/guides/v2.8.0/components/defining-a-component.md
@@ -46,7 +46,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.8.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.8.0/components/triggering-changes-with-actions.md
@@ -63,7 +63,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -71,7 +71,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -247,7 +247,7 @@ The action helper will add the arguments provided in the template to the call.
 
 Action arguments curry, meaning that you can provide partial arguments to the action helper and provide the rest of the
 arguments when you call the function within the component javascript file.
-For example, our `button-with-confirmation` component will now [yield](../wrapping-content-in-a-component/) the content
+For example, our `button-with-confirmation` component will now [yield](wrapping-content-in-a-component/) the content
 of the confirmation dialog to collect extra information to be sent along with the `onConfirm` action:
 
 ```app/templates/components/button-with-confirmation.hbs

--- a/guides/v2.8.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.8.0/components/wrapping-content-in-a-component.md
@@ -17,7 +17,7 @@ in another template:
 ```
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v2.8.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.8.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.8.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.8.0/configuring-ember/disabling-prototype-extensions.md
@@ -107,7 +107,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.8.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.8.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -28,7 +28,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js

--- a/guides/v2.8.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.8.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.8.0/ember-inspector/object-inspector.md
+++ b/guides/v2.8.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.8.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.8.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.8.0/ember-inspector/view-tree.md
+++ b/guides/v2.8.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.8.0/getting-started/quick-start.md
+++ b/guides/v2.8.0/getting-started/quick-start.md
@@ -19,7 +19,7 @@ npm install -g ember-cli
 ```
 
 Don't have npm? [Learn how to install Node.js and npm here][npm].
-For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../../getting-started/) guide.
+For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../getting-started/) guide.
 
 [npm]: https://docs.npmjs.com/getting-started/installing-node
 

--- a/guides/v2.8.0/models/customizing-adapters.md
+++ b/guides/v2.8.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.8.0/models/defining-models.md
+++ b/guides/v2.8.0/models/defining-models.md
@@ -21,8 +21,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -62,7 +62,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.8.0/routing/defining-your-routes.md
+++ b/guides/v2.8.0/routing/defining-your-routes.md
@@ -246,7 +246,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.8.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.8.0/routing/preventing-and-retrying-transitions.md
@@ -49,7 +49,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.8.0/routing/redirection.md
+++ b/guides/v2.8.0/routing/redirection.md
@@ -1,7 +1,7 @@
 Calling [`transitionTo()`][1] from a route or [`transitionToRoute()`][2] from a 
 controller will stop any transition currently in progress and start a new 
 one, functioning as a redirect. `transitionTo()` behaves exactly like the 
-[link-to](../../templates/links) helper.
+[link-to](../templates/links) helper.
 
 [1]: http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo
 [2]: http://emberjs.com/api/classes/Ember.Controller.html#method_transitionToRoute
@@ -34,7 +34,7 @@ export default Ember.Route.extend({
 ```
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.8.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.8.0/routing/specifying-a-routes-model.md
@@ -24,7 +24,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember Data records are promises),
 or a plain JavaScript object or array.
 Ember will wait until the data finishes loading (until the promise is resolved) before rendering the template.
@@ -58,7 +58,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -87,7 +87,7 @@ photo's ID (`params.photo_id`) as an argument to Ember Data's `findRecord`
 method.
 
 Note: A route with a dynamic segment will always have its `model` hook called when it is entered via the URL.
-If the route is entered through a transition (e.g. when using the [link-to](../../templates/links) Handlebars helper),
+If the route is entered through a transition (e.g. when using the [link-to](../templates/links) Handlebars helper),
 and a model context is provided (second argument to `link-to`), then the hook is not executed.
 If an identifier (such as an id or slug) is provided instead then the model hook will be executed.
 

--- a/guides/v2.8.0/templates/actions.md
+++ b/guides/v2.8.0/templates/actions.md
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../../components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.8.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.8.0/templates/displaying-a-list-of-items.md
@@ -43,7 +43,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.8.0/templates/handlebars-basics.md
+++ b/guides/v2.8.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.8.0/templates/links.md
+++ b/guides/v2.8.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` helper takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the helper, you can provide

--- a/guides/v2.8.0/templates/writing-helpers.md
+++ b/guides/v2.8.0/templates/writing-helpers.md
@@ -81,7 +81,7 @@ helper again with the new values and keep the page up-to-date.
 
 ### Helper Names
 
-Unlike [components](/components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
+Unlike [components](../components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
 
 ### Helper Arguments
 

--- a/guides/v2.8.0/testing/testing-controllers.md
+++ b/guides/v2.8.0/testing/testing-controllers.md
@@ -132,5 +132,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.8.0/testing/testing-models.md
+++ b/guides/v2.8.0/testing/testing-models.md
@@ -102,5 +102,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.8.0/testing/testing-routes.md
+++ b/guides/v2.8.0/testing/testing-routes.md
@@ -84,5 +84,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.8.0/tutorial/acceptance-test.md
+++ b/guides/v2.8.0/tutorial/acceptance-test.md
@@ -14,7 +14,7 @@ We want our application to:
 * Link to contact information.
 * Filter the list of rentals by city.
 
-We can represent these goals as [Ember acceptance tests](../../testing/acceptance/).
+We can represent these goals as [Ember acceptance tests](../testing/acceptance/).
 Acceptance tests interact with our app like an actual person would, but can be automated, ensuring that our app doesn't break in the future.
 
 We'll start by using Ember CLI to generate a new acceptance test:
@@ -103,7 +103,7 @@ test('should redirect to rentals route', function (assert) {
 A few helpers are in play in this test:
 
 * The [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) helper loads the route specified for the given URL.
-* The [`andThen`](../../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
+* The [`andThen`](../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
 In this case, we need to wait for the page to load after `visit`, so that we can assert that the listings are displayed.
 * [`currentURL`](http://emberjs.com/api/classes/Ember.Test.html#method_currentURL) returns the URL that test application is currently visiting.
 
@@ -140,7 +140,7 @@ test('should link to contact information', function (assert) {
   });
 });
 ```
-Note that we can call two [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
+Note that we can call two [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
 This is because each asynchronous test helper is made to wait until other test helpers are complete.
 
 After testing URLs, we'll drill down on our main rental page to test that we can filter the list down according to a city search criteria.

--- a/guides/v2.8.0/tutorial/autocomplete-component.md
+++ b/guides/v2.8.0/tutorial/autocomplete-component.md
@@ -19,9 +19,9 @@ We want our component to call out to two actions: one action to provide a list o
 For our initial test, we will check that all the cities we provide are rendered and that the listing object is accessible from the template.
 
 Our action call to filter by city will be made asynchronously and we will have to accommodate for this in our test.
-We will leverage [actions](../../components/triggering-changes-with-actions/#toc_handling-action-completion) here to handle asynchronous action completion from our `filterByCity` call by returning a promise from our stubbed action.
+We will leverage [actions](../components/triggering-changes-with-actions/#toc_handling-action-completion) here to handle asynchronous action completion from our `filterByCity` call by returning a promise from our stubbed action.
 
-Note that we also need to add a `wait` call at the end of our test to assert the results. Ember's [`wait` helper](../../testing/testing-components/#toc_waiting-on-asynchronous-behavior) waits for all promises to resolve before running the given function callback and finishing the test.
+Note that we also need to add a `wait` call at the end of our test to assert the results. Ember's [`wait` helper](../testing/testing-components/#toc_waiting-on-asynchronous-behavior) waits for all promises to resolve before running the given function callback and finishing the test.
 
 ```tests/integration/components/list-filter-test.js
 import { moduleForComponent, test } from 'ember-qunit';
@@ -138,7 +138,7 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The `value` property of the `input` will be bound to the `value` property in our component.
 The `key-up` property will be bound to the `handleFilterEntry` action.
 
@@ -170,7 +170,7 @@ export default Ember.Component.extend({
 We use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls our filter action based on the `value` attribute set by our input helper.
 
-The `filter` action is [passed](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
+The `filter` action is [passed](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
 
 To implement these actions, we'll create a `rentals` controller.
 Controllers can contain actions and properties available to the template of its corresponding route.

--- a/guides/v2.8.0/tutorial/ember-data.md
+++ b/guides/v2.8.0/tutorial/ember-data.md
@@ -62,7 +62,7 @@ export default Ember.Route.extend({
 ```
 
 When we call `this.get('store').findAll('rental')`, Ember Data will make a GET request to `/rentals`.
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we're using Mirage in our development environment, Mirage will return the data we've provided.
 When we deploy our app to a production server, we will need to provide a backend for Ember Data to communicate with.

--- a/guides/v2.8.0/tutorial/routes-and-templates.md
+++ b/guides/v2.8.0/tutorial/routes-and-templates.md
@@ -213,7 +213,7 @@ installing route-test
 
 Unlike the other route handlers we've made so far, the `index` route is special:
 it does NOT require an entry in the router's mapping.
-We'll learn more about why the entry isn't required when we look at [nested routes](../subroutes) in Ember.
+We'll learn more about why the entry isn't required when we look at [nested routes](subroutes) in Ember.
 
 We can start by implementing the unit test for index.
 Since all we want to do is transition to `rentals`, our unit test will make sure that the route's [`replaceWith`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) method is called with the desired route.

--- a/guides/v2.8.0/tutorial/service.md
+++ b/guides/v2.8.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```app/components/location-map.js
@@ -118,7 +118,7 @@ export default Ember.Component.extend({
 At this point we should have a passing component integration test, but our acceptance test should now fail, unable to find our maps service.  In addition to our acceptance test failing, no maps show up when we view our web page.
 To actually generate the maps, we'll implement the maps service.
 
-Accessing our maps API through a [service](../../applications/services) will give us several benefits
+Accessing our maps API through a [service](../applications/services) will give us several benefits
 
 * It is injected with a [service locator](https://en.wikipedia.org/wiki/Service_locator_pattern), meaning it will abstract the maps API from the code that uses it, allowing for easier refactoring and maintenance.
 * It is lazy-loaded, meaning it won't be initialized until it is called the first time.
@@ -219,7 +219,7 @@ export default Ember.Service.extend({
 ### Making Google Maps Available
 
 Before implementing the map utility, we need to make the 3rd party map API available to our Ember app.
-There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
+There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
 
 Since Google provides its map API as a remote script, we'll use curl to download it into our project's vendor directory.
 
@@ -338,7 +338,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.8.0/tutorial/subroutes.md
+++ b/guides/v2.8.0/tutorial/subroutes.md
@@ -6,8 +6,8 @@ Up to this point, we've generated four top level routes.
 * The `index` route, which we've set up to redirect to the `rentals` route.
 
 Our `rentals` route is going to serve multiple functions.
-From our [acceptance tests](../acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
-To satisfy that requirement, we are going to make use of Ember's [nested route capability](../../routing/defining-your-routes/#toc_nested-routes).
+From our [acceptance tests](acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
+To satisfy that requirement, we are going to make use of Ember's [nested route capability](../routing/defining-your-routes/#toc_nested-routes).
 
 By the end of this section we want to have created the following new routes:
 
@@ -18,7 +18,7 @@ The `show` route will get substituted with the id of the rental being shown (for
 
 ## The Parent Route
 
-Previously, in the [Routes and Templates tutorial](../routes-and-templates), we set up a `rentals` route.
+Previously, in the [Routes and Templates tutorial](routes-and-templates), we set up a `rentals` route.
 
 Opening the template for this route reveals an outlet underneath the route's general page information.
 At the bottom of the template, you'll notice an `{{outlet}}` helper.
@@ -75,7 +75,7 @@ Ember knows that the default action is to take the user to the `index` route.
 However, you can add the `index` route if you want to customize it.
 For example, you can modify the `index` route's path by specifying `this.route('index', { path: '/custom-path'})`.
 
-In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
+In the section on [using Ember Data](ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
 Let's implement our newly generated `rentals/index` route by moving this `findAll` call from the parent `rentals` route to our new sub-route.
 
 ```app/routes/rentals.js{-2,-3,-4}
@@ -146,13 +146,13 @@ export default RentalsController;
 
 Next, we will want to create a sub-route that will list information for a specific rental.
 To do this, we will need to update a couple of files.
-To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../../models/finding-records/).
+To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../models/finding-records/).
 The `findRecord` function requires that we search by a unique key.
 
 While on the `show` route, we will also want to show additional information about our specific rental.
 
 In order to do this, we will need to modify the Mirage `config.js` file that we added
-back in the [Installing Addons section](../installing-addons). We will add a new route
+back in the [Installing Addons section](installing-addons). We will add a new route
 handler to return a specific rental:
 
 ```mirage/config.js{+57,+58,+59,+60}
@@ -288,7 +288,7 @@ export default Ember.Route.extend({
 ```
 
 Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook.
-When we call `this.store.findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+When we call `this.store.findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../models/)).
 
 ## Adding the Rental To Our Template
 
@@ -355,10 +355,10 @@ Clicking on the title will load the detail page for that rental.
 
 ## Final Check
 
-At this point all our tests should pass, including the [list of acceptance tests](../acceptance-test) we created as our beginning requirements.
+At this point all our tests should pass, including the [list of acceptance tests](acceptance-test) we created as our beginning requirements.
 
 ![Acceptance Tests Pass](../../images/subroutes/all-acceptance-pass.png)
 
-At this point you can do a [deployment](../deploying) and share your Super Rentals application to the world
+At this point you can do a [deployment](deploying) and share your Super Rentals application to the world
 or you can use this as a base to explore other Ember features and addons.
 Regardless, we hope this has helped you get started with creating your own ambitious applications with Ember!

--- a/guides/v2.9.0/applications/initializers.md
+++ b/guides/v2.9.0/applications/initializers.md
@@ -3,7 +3,7 @@ Initializers provide an opportunity to configure your application as it boots.
 There are two types of initializers: application initializers and application instance initializers.
 
 Application initializers are run as your application boots,
-and provide the primary means to configure [dependency injections](../dependency-injection) in your application.
+and provide the primary means to configure [dependency injections](dependency-injection) in your application.
 
 Application instance initializers are run as an application instance is loaded.
 They provide a way to configure the initial state of your application,

--- a/guides/v2.9.0/applications/run-loop.md
+++ b/guides/v2.9.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.9.0/components/block-params.md
+++ b/guides/v2.9.0/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](passing-properties-to-a-component/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/v2.9.0/components/defining-a-component.md
+++ b/guides/v2.9.0/components/defining-a-component.md
@@ -46,7 +46,7 @@ Each component, under the hood, is backed by an element. By default
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](../customizing-a-components-element).
+Element](customizing-a-components-element).
 
 
 ## Defining a Component Subclass

--- a/guides/v2.9.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.9.0/components/triggering-changes-with-actions.md
@@ -63,7 +63,7 @@ account and delete it.
 In Ember, each component can
 have a property called `actions`, where you put functions that can be
 [invoked by the user interacting with the component
-itself](../../templates/actions/), or by child components.
+itself](../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
 imagine we have a parent component called `user-profile` that shows the
@@ -71,7 +71,7 @@ user's profile to them.
 
 We'll implement an action on the parent component called
 `userDidDeleteAccount()` that, when called, gets a hypothetical `login`
-[service](../../applications/services/) and calls the service's
+[service](../applications/services/) and calls the service's
 `deleteUser()` method.
 
 ```app/components/user-profile.js
@@ -245,7 +245,7 @@ The action helper will add the arguments provided in the template to the call.
 
 Action arguments curry, meaning that you can provide partial arguments to the action helper and provide the rest of the
 arguments when you call the function within the component javascript file.
-For example, our `button-with-confirmation` component will now [yield](../wrapping-content-in-a-component/) the content
+For example, our `button-with-confirmation` component will now [yield](wrapping-content-in-a-component/) the content
 of the confirmation dialog to collect extra information to be sent along with the `onConfirm` action:
 
 ```app/templates/components/button-with-confirmation.hbs

--- a/guides/v2.9.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.9.0/components/wrapping-content-in-a-component.md
@@ -17,7 +17,7 @@ in another template:
 ```
 
 (See [Passing Properties to a
-Component](../passing-properties-to-a-component/) for
+Component](passing-properties-to-a-component/) for
 more.)
 
 In this case, the content we wanted to display came from the model. But

--- a/guides/v2.9.0/configuring-ember/configuring-your-app.md
+++ b/guides/v2.9.0/configuring-ember/configuring-your-app.md
@@ -2,7 +2,7 @@ Ember CLI ships with support for managing your application's environment. Ember 
 
 The ENV object contains three important keys:
 
-  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](../feature-flags/)).
+  - `EmberENV` can be used to define Ember feature flags (see the [Feature Flags guide](feature-flags/)).
   - `APP` can be used to pass flags/options to your application instance.
   - `environment` contains the name of the current environment (`development`,`production` or `test`).
 

--- a/guides/v2.9.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.9.0/configuring-ember/disabling-prototype-extensions.md
@@ -107,7 +107,7 @@ Ember.String.camelize("my_cool_class");
 
 ### Functions
 
-The [Object Model](../../object-model/) section of the Guides describes
+The [Object Model](../object-model/) section of the Guides describes
 how to write computed properties, observers, and bindings without
 prototype extensions. Below you can learn about how to convert existing
 code to the format now encouraged.

--- a/guides/v2.9.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.9.0/configuring-ember/embedding-applications.md
@@ -7,7 +7,7 @@ same domain as another app?
 
 ### Changing the Root Element
 
-By default, your application will render the [application template](../../routing/defining-your-routes/#toc_the-application-route)
+By default, your application will render the [application template](../routing/defining-your-routes/#toc_the-application-route)
 and attach it to the document's `body` element.
 
 You can tell the application to append the application template to a
@@ -28,7 +28,7 @@ string](http://api.jquery.com/category/selectors/).
 ### Disabling URL Management
 
 You can prevent Ember from making changes to the URL by [changing the
-router's `location`](../specifying-url-type) to
+router's `location`](specifying-url-type) to
 `none`:
 
 ```config/environment.js

--- a/guides/v2.9.0/configuring-ember/handling-deprecations.md
+++ b/guides/v2.9.0/configuring-ember/handling-deprecations.md
@@ -135,4 +135,4 @@ template deprecation warnings during compile in favor of showing them in the bro
 
 Ember Inspector also provides deprecation handling capability.  It can work complimentary to ember-cli-deprecation-workflow.  As you unsilence deprecations to
 fix them, the inspector can allow you to more quickly find where in your code a deprecation occurs when you run into it at runtime, reducing the amount of
-stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../../ember-inspector/deprecations/).
+stack trace browsing you have to do.  For more information on using deprecation handling in Ember Inspector, see its [guides section](../ember-inspector/deprecations/).

--- a/guides/v2.9.0/ember-inspector/object-inspector.md
+++ b/guides/v2.9.0/ember-inspector/object-inspector.md
@@ -17,7 +17,7 @@ property updates in your app, it will be reflected in the Inspector.
 
 If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]:../../object-model/computed-properties
+[computed-property]:../object-model/computed-properties
 
 ### Exposing Objects to the Console
 

--- a/guides/v2.9.0/ember-inspector/troubleshooting.md
+++ b/guides/v2.9.0/ember-inspector/troubleshooting.md
@@ -15,7 +15,7 @@ Some of the reasons this may happen:
 - This is not an Ember application
 - You are using an old Ember version ( < 1.0 ).
 - You are using a protocol other than http or https. For file:// protocol,
-follow [these steps](../installation/#toc_file-protocol).
+follow [these steps](installation/#toc_file-protocol).
 - The Ember application is inside a sandboxed iframe with no url (if you
   are using JS Bin, follow [these steps](#toc_using-the-inspector-with-js-bin).
 
@@ -40,7 +40,7 @@ When you click on the Data tab, and see this message:
 <img src="/images/guides/ember-inspector/troubleshooting-data-adapter.png" width="350">
 
 It means that the data persistence library you're using does not support the Inspector.
-If you are the library's author, [see this section](../data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
+If you are the library's author, [see this section](data/#toc_building-a-data-custom-adapter) on how to add Inspector support to your library.
 
 ### Promises Not Detected
 

--- a/guides/v2.9.0/ember-inspector/view-tree.md
+++ b/guides/v2.9.0/ember-inspector/view-tree.md
@@ -4,7 +4,7 @@ The View Tree shows you the currently rendered templates, models, controllers, a
 <img src="/images/guides/ember-inspector/view-tree-screenshot.png" width="680">
 
 Use the tips described in [Object Inspector][object-inspector] to inspect models and controllers. See below for templates and components.
-[object-inspector]:../object-inspector
+[object-inspector]:object-inspector
 
 ### Inspecting Templates
 

--- a/guides/v2.9.0/getting-started/quick-start.md
+++ b/guides/v2.9.0/getting-started/quick-start.md
@@ -19,7 +19,7 @@ npm install -g ember-cli
 ```
 
 Don't have npm? [Learn how to install Node.js and npm here][npm].
-For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../../getting-started/) guide.
+For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../getting-started/) guide.
 
 [npm]: https://docs.npmjs.com/getting-started/installing-node
 

--- a/guides/v2.9.0/models/customizing-adapters.md
+++ b/guides/v2.9.0/models/customizing-adapters.md
@@ -1,7 +1,7 @@
 In Ember Data, the Adapter determines how data is persisted to a
 backend data store, such as the URL format and headers for a REST API.
 (The format of the data itself is determined by the
-[serializer](../customizing-serializers/).)
+[serializer](customizing-serializers/).)
 Ember Data's default Adapter has some built-in
 assumptions of how a [REST API should look](http://jsonapi.org/). If
 your backend conventions differ from these assumptions Ember Data

--- a/guides/v2.9.0/models/defining-models.md
+++ b/guides/v2.9.0/models/defining-models.md
@@ -21,8 +21,8 @@ export default DS.Model.extend({
 });
 ```
 
-After you have defined a model class, you can start [finding](../finding-records)
-and [working with records](../creating-updating-and-deleting-records) of that type.
+After you have defined a model class, you can start [finding](finding-records)
+and [working with records](creating-updating-and-deleting-records) of that type.
 
 
 ## Defining Attributes
@@ -62,7 +62,7 @@ export default DS.Model.extend({
 ```
 
 For more about adding computed properties to your classes, see [Computed
-Properties](../../object-model/computed-properties).
+Properties](../object-model/computed-properties).
 
 ### Transforms
 

--- a/guides/v2.9.0/routing/defining-your-routes.md
+++ b/guides/v2.9.0/routing/defining-your-routes.md
@@ -246,7 +246,7 @@ Router.map(function() {
 });
 ```
 
-In the next section, [Specifying a Route's Model](../specifying-a-routes-model), you will learn more about how to load a model.
+In the next section, [Specifying a Route's Model](specifying-a-routes-model), you will learn more about how to load a model.
 
 ## Wildcard / globbing routes
 

--- a/guides/v2.9.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.9.0/routing/preventing-and-retrying-transitions.md
@@ -49,7 +49,7 @@ called. This will result in the browser displaying the new URL, even if
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in
-[Asynchronous Routing](../asynchronous-routing)
+[Asynchronous Routing](asynchronous-routing)
 each get called with a transition object. This makes it possible for
 destination routes to abort attempted transitions.
 

--- a/guides/v2.9.0/routing/redirection.md
+++ b/guides/v2.9.0/routing/redirection.md
@@ -10,7 +10,7 @@ Whatever the reason, Ember allows you that control with a combination of hooks a
 One of the methods is [`transitionTo()`](http://emberjs.com/api/classes/Ember.Route.html#method_transitionTo).
 Calling `transitionTo()` from a route or
 [`transitionToRoute()`](http://emberjs.com/api/classes/Ember.Controller.html#method_transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
-`transitionTo()` behaves exactly like the [link-to](../../templates/links) helper.
+`transitionTo()` behaves exactly like the [link-to](../templates/links) helper.
 
 The other one is [`replaceWith()`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
@@ -45,11 +45,11 @@ export default Ember.Route.extend({
 This allows us to return the user back to the original route.
 For example, we might redirect a user to the login page when they try to edit their profile, and immediately redirect
 them back to the edit page once they have successfully logged in.
-See [Storing and Retrying a Transition](../preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
+See [Storing and Retrying a Transition](preventing-and-retrying-transitions/#toc_storing-and-retrying-a-transition)
 for how to do that.
 
 If you need to examine some application state to figure out where to redirect,
-you might use a [service](../../applications/services).
+you might use a [service](../applications/services).
 
 ## Transitioning After the Model is Known
 

--- a/guides/v2.9.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.9.0/routing/specifying-a-routes-model.md
@@ -24,7 +24,7 @@ export default Ember.Route.extend({
 });
 ```
 
-Typically, the `model` hook should return an [Ember Data](../../models/) record,
+Typically, the `model` hook should return an [Ember Data](../models/) record,
 but it can also return any [promise](https://www.promisejs.org/) object (Ember Data records are promises),
 or a plain JavaScript object or array.
 Ember will wait until the data finishes loading (until the promise is resolved) before rendering the template.
@@ -58,7 +58,7 @@ In cases like this, it's important that we include some information in
 the URL about not only which template to display, but also which model.
 
 In Ember, this is accomplished by defining routes with [dynamic
-segments](../defining-your-routes/#toc_dynamic-segments).
+segments](defining-your-routes/#toc_dynamic-segments).
 
 Once you have defined a route with a dynamic segment,
 Ember will extract the value of the dynamic segment from the URL for
@@ -87,7 +87,7 @@ photo's ID (`params.photo_id`) as an argument to Ember Data's `findRecord`
 method.
 
 Note: A route with a dynamic segment will always have its `model` hook called when it is entered via the URL.
-If the route is entered through a transition (e.g. when using the [link-to](../../templates/links) Handlebars helper),
+If the route is entered through a transition (e.g. when using the [link-to](../templates/links) Handlebars helper),
 and a model context is provided (second argument to `link-to`), then the hook is not executed.
 If an identifier (such as an id or slug) is provided instead then the model hook will be executed.
 

--- a/guides/v2.9.0/templates/actions.md
+++ b/guides/v2.9.0/templates/actions.md
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
 });
 ```
 
-You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../../components/triggering-changes-with-actions/) guide,
+You will learn about more advanced usages in the Component's [Triggering Changes With Actions](../components/triggering-changes-with-actions/) guide,
 but you should familiarize yourself with the following basics first.
 
 ## Action Parameters

--- a/guides/v2.9.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.9.0/templates/displaying-a-list-of-items.md
@@ -43,7 +43,7 @@ The above template will render HTML like this:
 Like other helpers, the `{{#each}}` helper is bound.  If a new item is added to
 or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
-methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
+methods](../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
 helper](http://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
 can improve re-render performance when an array is replaced with another

--- a/guides/v2.9.0/templates/handlebars-basics.md
+++ b/guides/v2.9.0/templates/handlebars-basics.md
@@ -46,7 +46,7 @@ controllers and components.
 
 ### Helpers
 
-Ember gives you the ability to [write your own helpers](../writing-helpers/), to bring a minimum of logic into Ember templating.
+Ember gives you the ability to [write your own helpers](writing-helpers/), to bring a minimum of logic into Ember templating.
 
 For example, let's say you would like the ability to add a few numbers together, without needing to define a computed property everywhere you would like to do so.
 

--- a/guides/v2.9.0/templates/links.md
+++ b/guides/v2.9.0/templates/links.md
@@ -35,7 +35,7 @@ The `{{link-to}}` helper takes one or two arguments:
 
 * The name of a route. In this example, it would be `index`, `photos`, or
   `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+* At most one model for each [dynamic segment](../routing/defining-your-routes/#toc_dynamic-segments).
   By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
   In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
   the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the helper, you can provide

--- a/guides/v2.9.0/templates/writing-helpers.md
+++ b/guides/v2.9.0/templates/writing-helpers.md
@@ -81,7 +81,7 @@ helper again with the new values and keep the page up-to-date.
 
 ### Helper Names
 
-Unlike [components](/components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
+Unlike [components](../components/defining-a-component/), which require a dash in the name to follow the Custom Element spec, helper names can be single or multi-word. If your helper's name is multi-word, it should be dasherized as the examples on this page.
 
 ### Helper Arguments
 

--- a/guides/v2.9.0/testing/testing-controllers.md
+++ b/guides/v2.9.0/testing/testing-controllers.md
@@ -132,5 +132,5 @@ test('should modify the post model', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
-[needs]: ../../controllers/dependencies-between-controllers
+[Unit Testing Basics]: unit-testing-basics
+[needs]: ../controllers/dependencies-between-controllers

--- a/guides/v2.9.0/testing/testing-models.md
+++ b/guides/v2.9.0/testing/testing-models.md
@@ -102,5 +102,5 @@ look at the [Ember Data tests] for examples of deeper relationship testing if yo
 feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v2.9.0/testing/testing-routes.md
+++ b/guides/v2.9.0/testing/testing-routes.md
@@ -84,5 +84,5 @@ test('should display an alert', function(assert) {
 });
 ```
 
-[Unit Testing Basics]: ../unit-testing-basics
+[Unit Testing Basics]: unit-testing-basics
 [separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v2.9.0/tutorial/acceptance-test.md
+++ b/guides/v2.9.0/tutorial/acceptance-test.md
@@ -14,7 +14,7 @@ We want our application to:
 * Link to contact information.
 * Filter the list of rentals by city.
 
-We can represent these goals as [Ember acceptance tests](../../testing/acceptance/).
+We can represent these goals as [Ember acceptance tests](../testing/acceptance/).
 Acceptance tests interact with our app like an actual person would, but can be automated, ensuring that our app doesn't break in the future.
 
 We'll start by using Ember CLI to generate a new acceptance test:
@@ -103,7 +103,7 @@ test('should redirect to rentals route', function (assert) {
 A few helpers are in play in this test:
 
 * The [`visit`](http://emberjs.com/api/classes/Ember.Test.html#method_visit) helper loads the route specified for the given URL.
-* The [`andThen`](../../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
+* The [`andThen`](../testing/acceptance/#toc_wait-helpers) helper waits for all previously called test helpers to complete before executing the function you provide it.
 In this case, we need to wait for the page to load after `visit`, so that we can assert that the listings are displayed.
 * [`currentURL`](http://emberjs.com/api/classes/Ember.Test.html#method_currentURL) returns the URL that test application is currently visiting.
 
@@ -140,7 +140,7 @@ test('should link to contact information', function (assert) {
   });
 });
 ```
-Note that we can call two [asynchronous test helpers](../../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
+Note that we can call two [asynchronous test helpers](../testing/acceptance/#toc_asynchronous-helpers) in a row without needing to use `andThen` or a promise.
 This is because each asynchronous test helper is made to wait until other test helpers are complete.
 
 After testing URLs, we'll drill down on our main rental page to test that we can filter the list down according to a city search criteria.

--- a/guides/v2.9.0/tutorial/autocomplete-component.md
+++ b/guides/v2.9.0/tutorial/autocomplete-component.md
@@ -19,9 +19,9 @@ We want our component to call out to two actions: one action to provide a list o
 For our initial test, we will check that all the cities we provide are rendered and that the listing object is accessible from the template.
 
 Our action call to filter by city will be made asynchronously and we will have to accommodate for this in our test.
-We will leverage [actions](../../components/triggering-changes-with-actions/#toc_handling-action-completion) here to handle asynchronous action completion from our `filterByCity` call by returning a promise from our stubbed action.
+We will leverage [actions](../components/triggering-changes-with-actions/#toc_handling-action-completion) here to handle asynchronous action completion from our `filterByCity` call by returning a promise from our stubbed action.
 
-Note that we also need to add a `wait` call at the end of our test to assert the results. Ember's [`wait` helper](../../testing/testing-components/#toc_waiting-on-asynchronous-behavior) waits for all promises to resolve before running the given function callback and finishing the test.
+Note that we also need to add a `wait` call at the end of our test to assert the results. Ember's [`wait` helper](../testing/testing-components/#toc_waiting-on-asynchronous-behavior) waits for all promises to resolve before running the given function callback and finishing the test.
 
 ```tests/integration/components/list-filter-test.js
 import { moduleForComponent, test } from 'ember-qunit';
@@ -138,7 +138,7 @@ We want the component to simply provide an input field and yield the results lis
 {{yield results}}
 ```
 
-The template contains an [`{{input}}`](../../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
+The template contains an [`{{input}}`](../templates/input-helpers) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The `value` property of the `input` will be bound to the `value` property in our component.
 The `key-up` property will be bound to the `handleFilterEntry` action.
 
@@ -170,7 +170,7 @@ export default Ember.Component.extend({
 We use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls our filter action based on the `value` attribute set by our input helper.
 
-The `filter` action is [passed](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
+The `filter` action is [passed](../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component) in by the calling object. This is a pattern known as _closure actions_.
 
 To implement these actions, we'll create a `rentals` controller.
 Controllers can contain actions and properties available to the template of its corresponding route.

--- a/guides/v2.9.0/tutorial/ember-data.md
+++ b/guides/v2.9.0/tutorial/ember-data.md
@@ -62,7 +62,7 @@ export default Ember.Route.extend({
 ```
 
 When we call `this.get('store').findAll('rental')`, Ember Data will make a GET request to `/rentals`.
-You can read more about Ember Data in the [Models section](../../models/).
+You can read more about Ember Data in the [Models section](../models/).
 
 Since we're using Mirage in our development environment, Mirage will return the data we've provided.
 When we deploy our app to a production server, we will need to provide a backend for Ember Data to communicate with.

--- a/guides/v2.9.0/tutorial/routes-and-templates.md
+++ b/guides/v2.9.0/tutorial/routes-and-templates.md
@@ -213,7 +213,7 @@ installing route-test
 
 Unlike the other route handlers we've made so far, the `index` route is special:
 it does NOT require an entry in the router's mapping.
-We'll learn more about why the entry isn't required when we look at [nested routes](../subroutes) in Ember.
+We'll learn more about why the entry isn't required when we look at [nested routes](subroutes) in Ember.
 
 We can start by implementing the unit test for index.
 Since all we want to do is transition to `rentals`, our unit test will make sure that the route's [`replaceWith`](http://emberjs.com/api/classes/Ember.Route.html#method_replaceWith) method is called with the desired route.

--- a/guides/v2.9.0/tutorial/service.md
+++ b/guides/v2.9.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```app/components/location-map.js
@@ -118,7 +118,7 @@ export default Ember.Component.extend({
 At this point we should have a passing component integration test, but our acceptance test should now fail, unable to find our maps service.  In addition to our acceptance test failing, no maps show up when we view our web page.
 To actually generate the maps, we'll implement the maps service.
 
-Accessing our maps API through a [service](../../applications/services) will give us several benefits
+Accessing our maps API through a [service](../applications/services) will give us several benefits
 
 * It is injected with a [service locator](https://en.wikipedia.org/wiki/Service_locator_pattern), meaning it will abstract the maps API from the code that uses it, allowing for easier refactoring and maintenance.
 * It is lazy-loaded, meaning it won't be initialized until it is called the first time.
@@ -219,7 +219,7 @@ export default Ember.Service.extend({
 ### Making Google Maps Available
 
 Before implementing the map utility, we need to make the 3rd party map API available to our Ember app.
-There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
+There are several ways to include 3rd party libraries in Ember. See the guides section on [managing dependencies](../addons-and-dependencies/managing-dependencies/) as a starting point when you need to add one.
 
 Since Google provides its map API as a remote script, we'll use curl to download it into our project's vendor directory.
 
@@ -338,7 +338,7 @@ moduleForAcceptance('Acceptance | list rentals', {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
+Then we are putting it in Ember's [registry](../applications/dependency-injection#toc_factory-registrations), and injecting it into the `location-map` component that uses it.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our acceptance tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v2.9.0/tutorial/subroutes.md
+++ b/guides/v2.9.0/tutorial/subroutes.md
@@ -6,8 +6,8 @@ Up to this point, we've generated four top level routes.
 * The `index` route, which we've set up to redirect to the `rentals` route.
 
 Our `rentals` route is going to serve multiple functions.
-From our [acceptance tests](../acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
-To satisfy that requirement, we are going to make use of Ember's [nested route capability](../../routing/defining-your-routes/#toc_nested-routes).
+From our [acceptance tests](acceptance-test), we've shown that we want our users to be able to browse and search rentals, as well as see detailed information for individual rentals.
+To satisfy that requirement, we are going to make use of Ember's [nested route capability](../routing/defining-your-routes/#toc_nested-routes).
 
 By the end of this section we want to have created the following new routes:
 
@@ -18,7 +18,7 @@ The `show` route will get substituted with the id of the rental being shown (for
 
 ## The Parent Route
 
-Previously, in the [Routes and Templates tutorial](../routes-and-templates), we set up a `rentals` route.
+Previously, in the [Routes and Templates tutorial](routes-and-templates), we set up a `rentals` route.
 
 Opening the template for this route reveals an outlet underneath the route's general page information.
 At the bottom of the template, you'll notice an `{{outlet}}` helper.
@@ -75,7 +75,7 @@ Ember knows that the default action is to take the user to the `index` route.
 However, you can add the `index` route if you want to customize it.
 For example, you can modify the `index` route's path by specifying `this.route('index', { path: '/custom-path'})`.
 
-In the section on [using Ember Data](../ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
+In the section on [using Ember Data](ember-data#toc_updating-the-model-hook), we added a call to fetch all rentals.
 Let's implement our newly generated `rentals/index` route by moving this `findAll` call from the parent `rentals` route to our new sub-route.
 
 ```app/routes/rentals.js{-2,-3,-4}
@@ -146,13 +146,13 @@ export default RentalsController;
 
 Next, we will want to create a sub-route that will list information for a specific rental.
 To do this, we will need to update a couple of files.
-To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../../models/finding-records/).
+To find a specific rental, we will want to use Ember Data's `findRecord` function [(see "Finding Records" for more details)](../models/finding-records/).
 The `findRecord` function requires that we search by a unique key.
 
 While on the `show` route, we will also want to show additional information about our specific rental.
 
 In order to do this, we will need to modify the Mirage `config.js` file that we added
-back in the [Installing Addons section](../installing-addons). We will add a new route
+back in the [Installing Addons section](installing-addons). We will add a new route
 handler to return a specific rental:
 
 ```mirage/config.js{+57,+58,+59,+60}
@@ -288,7 +288,7 @@ export default Ember.Route.extend({
 ```
 
 Since we added `:rental_id` to the `show` path in our router, `rental_id` is now available in our `model` hook.
-When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../../models/)).
+When we call `this.get('store').findRecord('rental', params.rental_id)`, Ember Data queries `/rentals/our-id` using a HTTP GET request ([learn more about that here](../models/)).
 
 ## Adding the Rental To Our Template
 
@@ -355,10 +355,10 @@ Clicking on the title will load the detail page for that rental.
 
 ## Final Check
 
-At this point all our tests should pass, including the [list of acceptance tests](../acceptance-test) we created as our beginning requirements.
+At this point all our tests should pass, including the [list of acceptance tests](acceptance-test) we created as our beginning requirements.
 
 ![Acceptance Tests Pass](../../images/subroutes/all-acceptance-pass.png)
 
-At this point you can do a [deployment](../deploying) and share your Super Rentals application to the world
+At this point you can do a [deployment](deploying) and share your Super Rentals application to the world
 or you can use this as a base to explore other Ember features and addons.
 Regardless, we hope this has helped you get started with creating your own ambitious applications with Ember!

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "bugs": {
     "url": "https://github.com/ember-learn/guides-source/issues"
   },
-  "homepage": "https://github.com/ember-learn/guides-source#readme"
+  "homepage": "https://github.com/ember-learn/guides-source#readme",
+  "devDependencies": {
+    "markdown-link-extractor": "^1.1.1"
+  }
 }

--- a/utils/link-checker.js
+++ b/utils/link-checker.js
@@ -1,0 +1,72 @@
+const readline = require('readline-promise')
+const path = require('path')
+const fs =require('fs');
+var markdownLinkExtractor = require('markdown-link-extractor');
+
+let allMdFilepaths = []
+// https://stackoverflow.com/questions/25460574/find-files-by-extension-html-under-a-folder-in-nodejs
+const walkFileTree = function(startPath,filter){
+    if (!fs.existsSync(startPath)){
+        console.log("no dir ",startPath);
+        return;
+    }
+
+    var files=fs.readdirSync(startPath);
+    for(var i=0;i<files.length;i++){
+        var filename=path.join(startPath,files[i]);
+        var stat = fs.lstatSync(filename);
+        if (stat.isDirectory()){
+            walkFileTree(filename,filter); //recurse
+        }
+        else if (filename.indexOf(filter)>=0) {
+            allMdFilepaths.push( {filepath: filename, links: findMarkdownLinks(filename)})
+        };
+    };
+    return allMdFilepaths
+};
+
+const findMarkdownLinks = function(filepath) {
+  var markdown = fs.readFileSync(filepath).toString();
+  return links = markdownLinkExtractor(markdown);
+}
+
+const getBadRelativeUrls = function(fileObjs) {
+  let results = []
+  fileObjs.forEach(function(fileObj) {
+    fileObj.links.forEach(function(link) {
+      if (link.includes("http")) {
+        // skip it
+        return
+      } else if (pathIsValid(fileObj.filepath, link)) {
+        // console.log('valid')
+        return
+      } else {
+        // console.log()
+        results.push({fileToFix: fileObj.filepath, badLink: link})
+      }
+    })
+  })
+  return results
+}
+
+const pathIsValid = function(filepath, link) {
+  let cleanedLink = link.includes('#') ? link.substring(0, link.lastIndexOf("#")) : link // remove anchor tags
+  cleanedLink = cleanedLink.replace(/\/$/, "") // strip trailing slash
+  let cleanedFilepath = filepath.substring(0, filepath.lastIndexOf("/"))
+  let normalized = (path.normalize(cleanedFilepath + '/' + cleanedLink)).replace(/\/$/, "") // join root and relative path to create absolute path, and strip trailing slash
+  normalized = normalized.includes('images') ? "public/" + link.substring(link.indexOf("images")) : normalized
+  let exists = checkIfPathExists(normalized) || link[0] === "#" || checkIfPathExists(normalized + '.md')
+  if (!exists && normalized.includes('image')) {
+    // console.log(normalized)
+  }
+  return exists
+}
+
+checkIfPathExists = function getFileRealPath(s){
+    try {return fs.realpathSync(s);} catch(e){return false;}
+}
+
+let filesAndLinks = walkFileTree('guides','.md');
+let badUrls = getBadRelativeUrls(filesAndLinks)
+console.log(badUrls)
+console.log("how many to fix?", badUrls.length)

--- a/utils/link-checker.js
+++ b/utils/link-checker.js
@@ -1,20 +1,34 @@
-const readline = require('readline-promise')
-const path = require('path')
-const fs =require('fs');
-var markdownLinkExtractor = require('markdown-link-extractor');
+/*
+  This script can be run from the command line to check the validity of
+  relative links in the markdown. Run with `node utils/link-checker.js`.
+  It prints an array of objects to the console that show you which markdown
+  file has a faulty link plus the link itself. It also reports the total incorrect
+  links.
+*/
 
-let allMdFilepaths = []
-// https://stackoverflow.com/questions/25460574/find-files-by-extension-html-under-a-folder-in-nodejs
+const path = require('path')
+const fs = require('fs');
+const markdownLinkExtractor = require('markdown-link-extractor');
+const dirToSearch = 'guides' // the path of the directory that has md files in it, relative to the working directory you are running the script from
+
+let allMdFilepaths = [] // will be set to an array of objects like [{filepath: 'something/like/this.md', links: ['../a', '../b/c', 'd']}, ...]
+
+/*
+  walkFileTree is a recursive function that outputs an array of objects that
+  look like {filepath: 'something/like/this.md', links: ['../a', '../b/c', 'd']}
+  where filepath is a markdown file and links are an array of all links found
+  in the file (relative and http). Uses synchronous file operations.
+  Initial code from https://stackoverflow.com/questions/25460574/find-files-by-extension-html-under-a-folder-in-nodejs
+*/
 const walkFileTree = function(startPath,filter){
     if (!fs.existsSync(startPath)){
-        console.log("no dir ",startPath);
+        console.log("not a valid directory path: ",startPath);
         return;
     }
-
-    var files=fs.readdirSync(startPath);
-    for(var i=0;i<files.length;i++){
-        var filename=path.join(startPath,files[i]);
-        var stat = fs.lstatSync(filename);
+    let files=fs.readdirSync(startPath);
+    for(let i=0;i<files.length;i++){
+        let filename=path.join(startPath,files[i]);
+        let stat = fs.lstatSync(filename);
         if (stat.isDirectory()){
             walkFileTree(filename,filter); //recurse
         }
@@ -25,48 +39,110 @@ const walkFileTree = function(startPath,filter){
     return allMdFilepaths
 };
 
+/*
+  findMarkdownLinks takes a string filepath to a markdown file, relative to the
+  working directory the script was run from. It returns an array of link strings
+  found in the markdown.
+*/
 const findMarkdownLinks = function(filepath) {
-  var markdown = fs.readFileSync(filepath).toString();
+  let markdown = fs.readFileSync(filepath).toString();
   return links = markdownLinkExtractor(markdown);
 }
 
-const getBadRelativeUrls = function(fileObjs) {
+/*
+  getBadRelativeUrls takes an array of file objects like
+  [{filepath: 'something/like/this.md', links: ['../a', '../b/c', 'd']}, ...]
+  and returns an array of objects containing a "bad" link and the path to the markdown file
+  that contains it, like [{fileToFix: 'path/to/file.md', badLink: '../something'}, ...]
+  The function iterates over each object and its links array. For each link, it
+  ignores any that are http, since the script only tests relative links.
+  If the path to the link is incorrect relative to the working directory the
+  script was run from, it is returned in the results.
+*/
+const getBadRelativeUrls = function(mdFiles) {
   let results = []
-  fileObjs.forEach(function(fileObj) {
-    fileObj.links.forEach(function(link) {
-      if (link.includes("http")) {
-        // skip it
+  mdFiles.forEach(function(mdFile) {
+    mdFile.links.forEach(function(link) {
+      if (link.includes("http" || link[0] === "#")) {
+        // skip it if it's a url or just an anchor tag
         return
-      } else if (pathIsValid(fileObj.filepath, link)) {
-        // console.log('valid')
-        return
-      } else {
-        // console.log()
-        results.push({fileToFix: fileObj.filepath, badLink: link})
+      } else if (!pathIsValid(mdFile.filepath, link)) {
+        results.push({fileToFix: mdFile.filepath, badLink: link})
       }
     })
   })
   return results
 }
 
+/*
+  pathIsValid takes in a path to a markdown file and a link contained in that file.
+  It checks to see if the link is correct relative to the markdown file's path.
+  Returns true if the link is an existing directory or markdown file.
+*/
+
 const pathIsValid = function(filepath, link) {
-  let cleanedLink = link.includes('#') ? link.substring(0, link.lastIndexOf("#")) : link // remove anchor tags
-  cleanedLink = cleanedLink.replace(/\/$/, "") // strip trailing slash
-  let cleanedFilepath = filepath.substring(0, filepath.lastIndexOf("/"))
-  let normalized = (path.normalize(cleanedFilepath + '/' + cleanedLink)).replace(/\/$/, "") // join root and relative path to create absolute path, and strip trailing slash
-  normalized = normalized.includes('images') ? "public/" + link.substring(link.indexOf("images")) : normalized
-  let exists = checkIfPathExists(normalized) || link[0] === "#" || checkIfPathExists(normalized + '.md')
-  if (!exists && normalized.includes('image')) {
-    // console.log(normalized)
+  let cleanedLink = stripOffAnchorTags(link)
+  cleanedLink = removeTrailingSlash(cleanedLink)
+  let cleanedFilepath = removeMarkdownFileFromFilepath(filepath)
+  let normalized =  computeLinkRelativeToWorkingDir(cleanedFilepath, cleanedLink)
+  normalized = handleImageEdgeCases(normalized, link)
+  // return true if it is a valid path to a directory OR markdown file. No easy way to tell which is which, so try both
+  return checkIfPathExists(normalized) || checkIfPathExists(normalized + '.md')
+}
+
+const stripOffAnchorTags = function(link) {
+  return link.includes('#') ? link.substring(0, link.lastIndexOf("#")) : link
+}
+
+const removeTrailingSlash = function(cleanedLink) {
+  return cleanedLink.replace(/\/$/, "") // strip trailing slash. $ is regex for "last"
+}
+
+const removeMarkdownFileFromFilepath = function(filepath) {
+  return filepath.substring(0, filepath.lastIndexOf("/")) // chops off whatever is after the final slash
+}
+
+/*
+  In order to know if a link in a markdown file is correct relative to the
+  markdown file's location, you have to combine the path of the md file
+  with the path of the link it contains.
+  This function takes a markdown file path like guides/v1.13.0/components/blah,
+  relative to the working directory where the script was run, and adds it together
+  with the relative link contained in the file, like ../templates/foo. path.normalize
+  is a Node method that takes a filepath like
+  guides/v1.13.0/components/blah/../templates/foo. path.normalize and resolves it
+  into guides/v1.13.0/templates/foo. The result is an absolute path with the
+  root of the working directory the script is running in. Finally, the trailing
+  slash is removed.
+*/
+const computeLinkRelativeToWorkingDir = function(cleanedFilepath, cleanedLink) {
+  return (path.normalize(cleanedFilepath + '/' + cleanedLink)).replace(/\/$/, "")
+}
+
+/*
+  Since these files are consumed by an ember app, the path to images doesn't
+  need to be relative to the markdown file. The filepath should be relative to
+  the public folder. But our link checker doesn't know that, so we have to correct
+  for it by stripping away punctuation in front of "images" and replacing it
+  with public. So, ../../images/whatever.png becomes public/images/whatever.png
+*/
+const handleImageEdgeCases = function(normalized, link) {
+  if (normalized.includes('images')) {
+    return "public/" + link.substring(link.indexOf("images"))
+  } else {
+    return normalized
   }
-  return exists
 }
 
-checkIfPathExists = function getFileRealPath(s){
-    try {return fs.realpathSync(s);} catch(e){return false;}
+const checkIfPathExists = function getFileRealPath(s){
+  try {
+    return fs.realpathSync(s);
+  } catch(e) {
+    return false
+  }
 }
 
-let filesAndLinks = walkFileTree('guides','.md');
-let badUrls = getBadRelativeUrls(filesAndLinks)
-console.log(badUrls)
-console.log("how many to fix?", badUrls.length)
+walkFileTree(dirToSearch, '.md');
+let badRelativePaths = getBadRelativeUrls(allMdFilepaths)
+console.log(badRelativePaths)
+console.log("how many are left to fix?", badRelativePaths.length)


### PR DESCRIPTION
Warning, trying to view the diff on GitHub might crash your browser.

I only found one type of url that had a line break between the markdown for `]` and `(`

I did a crazy find/replace to move the url nesting up a level. I expect some links to be broken because a few were working earlier, but I'll find them and fix them before removing the WIP label. Edit: I wrote a script to find the broken links and there were a gazillion. They are fixed.