### PR TITLE
Remove undefined Diff from articles each loop 

### DIFF
--- a/guides/v3.2.0/tutorial/model-hook.md
+++ b/guides/v3.2.0/tutorial/model-hook.md
@@ -64,7 +64,7 @@ We can use the model attribute to display our list of rentals.
 Here, we'll use another common Handlebars helper called [`{{each}}`](../../templates/displaying-a-list-of-items/).
 This helper will let us loop through each of the rental objects in our model:
 
-```handlebars {data-filename="app/templates/rentals.hbs" data-diff="+12,+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,+26,+27,+28,+29"}
+```handlebars {data-filename="app/templates/rentals.hbs" data-diff="+12,+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,+26,+27,+28"}
 <div class="jumbo">
   <div class="right tomster"></div>
   <h2>Welcome!</h2>


### PR DESCRIPTION
While working through the tutorial, I noticed that there exists a diff for a line that doesn't exist, causing `undefined` to be displayed.

<img width="636" alt="screen shot 2018-05-23 at 11 25 27 am" src="https://user-images.githubusercontent.com/1660286/40440734-1b1620e4-5e7c-11e8-89ad-b90953a5eaa8.png">

Found on Safari 11.1.1 
Confirmed on Chrome  66.0.3359.181