### PR TITLE
Fixed component lifecycle anchor links

### DIFF
--- a/guides/v2.10.0/components/the-component-lifecycle.md
+++ b/guides/v2.10.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render 
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.10.0/tutorial/service.md
+++ b/guides/v2.10.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v2.11.0/components/the-component-lifecycle.md
+++ b/guides/v2.11.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render 
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.11.0/tutorial/service.md
+++ b/guides/v2.11.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v2.12.0/components/the-component-lifecycle.md
+++ b/guides/v2.12.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render 
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.12.0/tutorial/service.md
+++ b/guides/v2.12.0/tutorial/service.md
@@ -192,7 +192,7 @@ Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v2.13.0/components/the-component-lifecycle.md
+++ b/guides/v2.13.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render 
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.13.0/tutorial/service.md
+++ b/guides/v2.13.0/tutorial/service.md
@@ -192,7 +192,7 @@ Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v2.14.0/components/the-component-lifecycle.md
+++ b/guides/v2.14.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render 
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.14.0/tutorial/service.md
+++ b/guides/v2.14.0/tutorial/service.md
@@ -176,7 +176,7 @@ Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v2.15.0/components/the-component-lifecycle.md
+++ b/guides/v2.15.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.15.0/tutorial/service.md
+++ b/guides/v2.15.0/tutorial/service.md
@@ -176,7 +176,7 @@ Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v2.16.0/components/the-component-lifecycle.md
+++ b/guides/v2.16.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.16.0/tutorial/service.md
+++ b/guides/v2.16.0/tutorial/service.md
@@ -179,7 +179,7 @@ Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v2.17.0/components/the-component-lifecycle.md
+++ b/guides/v2.17.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.17.0/tutorial/service.md
+++ b/guides/v2.17.0/tutorial/service.md
@@ -179,7 +179,7 @@ Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v2.18.0/components/the-component-lifecycle.md
+++ b/guides/v2.18.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.18.0/tutorial/service.md
+++ b/guides/v2.18.0/tutorial/service.md
@@ -183,7 +183,7 @@ Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```javascript {data-filename="app/components/location-map.js" data-diff="+2,+5,+7,+8,+9,+10,+11,+12"}

--- a/guides/v2.3.0/components/the-component-lifecycle.md
+++ b/guides/v2.3.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render 
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.3.0/tutorial/service.md
+++ b/guides/v2.3.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`, 
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v2.4.0/components/the-component-lifecycle.md
+++ b/guides/v2.4.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render 
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.4.0/tutorial/service.md
+++ b/guides/v2.4.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`, 
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v2.5.0/components/the-component-lifecycle.md
+++ b/guides/v2.5.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render 
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.5.0/tutorial/service.md
+++ b/guides/v2.5.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`, 
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v2.6.0/components/the-component-lifecycle.md
+++ b/guides/v2.6.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render 
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.6.0/tutorial/service.md
+++ b/guides/v2.6.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v2.7.0/components/the-component-lifecycle.md
+++ b/guides/v2.7.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render 
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.7.0/tutorial/service.md
+++ b/guides/v2.7.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v2.8.0/components/the-component-lifecycle.md
+++ b/guides/v2.8.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render 
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.8.0/tutorial/service.md
+++ b/guides/v2.8.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v2.9.0/components/the-component-lifecycle.md
+++ b/guides/v2.9.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render 
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v2.9.0/tutorial/service.md
+++ b/guides/v2.9.0/tutorial/service.md
@@ -95,7 +95,7 @@ Then update the component to append the map output to its inner container elemen
 We'll add a maps service injection, and call the `getMapElement` function with the provided location.
 
 We then append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function gets executed at render time after the component's markup gets inserted into the DOM.
 
 ```javascript {data-filename=app/components/location-map.js}

--- a/guides/v3.0.0/components/the-component-lifecycle.md
+++ b/guides/v3.0.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle hooks in order of execution according t
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v3.0.0/tutorial/service.md
+++ b/guides/v3.0.0/tutorial/service.md
@@ -183,7 +183,7 @@ Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```javascript {data-filename="app/components/location-map.js" data-diff="+2,+5,+7,+8,+9,+10,+11,+12"}

--- a/guides/v3.1.0/components/the-component-lifecycle.md
+++ b/guides/v3.1.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle [hooks](../../getting-started/core-conc
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v3.1.0/tutorial/service.md
+++ b/guides/v3.1.0/tutorial/service.md
@@ -184,7 +184,7 @@ Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```javascript {data-filename="app/components/location-map.js" data-diff="+2,+5,+7,+8,+9,+10,+11,+12"}

--- a/guides/v3.2.0/components/the-component-lifecycle.md
+++ b/guides/v3.2.0/components/the-component-lifecycle.md
@@ -11,23 +11,23 @@ Listed below are the component lifecycle [hooks](../../getting-started/core-conc
 ### On Initial Render
 
 1. `init`
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willRender`
-4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code)
-5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+4. [`didInsertElement`](#toc_integrating-with-third-party-libraries-with-didinsertelement)
+5. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Re-Render
 
-1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)
-2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+1. [`didUpdateAttrs`](#toc_resetting-presentation-state-on-attribute-change-with-didupdateattrs)
+2. [`didReceiveAttrs`](#toc_formatting-component-attributes-with-didreceiveattrs)
 3. `willUpdate`
 4. `willRender`
 5. `didUpdate`
-6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-code-didrender-code)
+6. [`didRender`](#toc_making-updates-to-the-rendered-dom-with-didrender)
 
 ### On Component Destroy
 
-1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-code-willdestroyelement-code)
+1. [`willDestroyElement`](#toc_detaching-and-tearing-down-component-elements-with-willdestroyelement)
 2. `willClearRender`
 3. `didDestroyElement`
 

--- a/guides/v3.2.0/tutorial/service.md
+++ b/guides/v3.2.0/tutorial/service.md
@@ -184,7 +184,7 @@ Ember tries to set that property with a service matching its name.
 
 With our `maps` service, our component will call the `getMapElement` function with the provided location.
 We append the map element we get back from the service by implementing `didInsertElement`,
-which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code).
+which is a [component lifecycle hook](../../components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-didinsertelement).
 This function runs during the component render, after the component's markup gets inserted into the page.
 
 ```javascript {data-filename="app/components/location-map.js" data-diff="+2,+5,+7,+8,+9,+10,+11,+12"}


### PR DESCRIPTION
Anchor links to methods within the component lifecycle pages all contained an unneeded `-code` in the url

I'd guess from the consistently wrong urls that they were auto-generated from the anchor titles, which contained a word surrounded by backticks that looks to have been converted to the word `code`.

Fixed and tested from 2.30 through to 3.2.0