### PR TITLE
Where to add attribute bindings

### DIFF
--- a/guides/v3.1.0/templates/binding-element-attributes.md
+++ b/guides/v3.1.0/templates/binding-element-attributes.md
@@ -40,46 +40,37 @@ If `isAdministrator` is `false`, Handlebars will produce the following:
 
 ### Adding Other Attributes (Including Data Attributes)
 
-By default, helpers and components only accept a limited number of HTML attributes.
+By default, components only accept a limited number of HTML attributes.
 This means that some uncommon but perfectly valid attributes, such as `lang` or
 custom `data-*` attributes must be specifically enabled. For example, this template:
 
 ```handlebars
 {{#link-to "photos" data-toggle="dropdown" lang="es"}}Fotos{{/link-to}}
-
-{{input type="text" data-toggle="tooltip" data-placement="bottom" title="Name"}}
 ```
 
-renders the following HTML:
+Will render the following HTML:
 
 ```html
 <a id="ember239" class="ember-view" href="#/photos">Fotos</a>
-
-<input id="ember257" class="ember-view ember-text-field" type="text"
-       title="Name">
 ```
 
-To enable support for these attributes an attribute binding must be
-added to the component, e.g.
+To enable support for these attributes, an attribute binding must be
+added for each specific attribute on the component.
+To do this, you can extend the appropriate components
+in your application. For example, for `link-to` you would create your own version
+of this component by extending
 [`Ember.LinkComponent`](https://www.emberjs.com/api/ember/release/classes/LinkComponent)
-or [`Ember.TextField`](https://www.emberjs.com/api/ember/release/classes/TextField)
-for the specific attribute:
 
-```javascript
-Ember.LinkComponent.reopen({
+```javascript {data-filename="app/components/link-to/component.js"}
+import LinkComponent from '@ember/routing/link-component';
+
+export default LinkComponent.extend({
   attributeBindings: ['data-toggle', 'lang']
-});
-
-Ember.TextField.reopen({
-  attributeBindings: ['data-toggle', 'data-placement']
 });
 ```
 
 Now the same template above renders the following HTML:
 
 ```html
-<a id="ember240" class="ember-view" href="#/photos" data-toggle="dropdown" lang="es">Fotos</a>
-
-<input id="ember259" class="ember-view ember-text-field"
-       type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
+<a id="ember239" class="ember-view" href="#/photos" data-toggle="dropdown" lang="es">Fotos</a>
 ```


### PR DESCRIPTION
Previously submitted as https://github.com/emberjs/guides/pull/2132

The Guides currently advise to use `Component.reopen` to add attribute bindings to bundled components, such as `LinkComponent` and `TextField`. However this practise is now discouraged.

This PR updates this advice to recommend that users override these components instead.

Note that I have had to remove the text field example, as it requires overriding the undocumented `-text-field` component.

Here's a Twiddle with an example: https://ember-twiddle.com/0feff0577066c1414747aef04202aa9d?openFiles=templates.application.hbs%2C