### PR TITLE
incorrect apostrophe removal

### DIFF
--- a/guides/v2.18.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v2.18.0/object-model/computed-properties-and-aggregate-data.md
@@ -1,6 +1,6 @@
 Sometimes you have a computed property whose value depends on the properties of
 items in an array. For example, you may have an array of todo items, and want
-to calculate the incomplete todo's based on their `isDone` property.
+to calculate the incomplete todos based on their `isDone` property.
 
 ## `@each`
 


### PR DESCRIPTION
todo's -> todos, '...the incomplete todos...' is plural