### PR TITLE
Removing unwanted trailing slashes on sample code

### DIFF
--- a/guides/v3.1.0/tutorial/service.md
+++ b/guides/v3.1.0/tutorial/service.md
@@ -135,12 +135,12 @@ export default Service.extend({
   },
 
   getMapElement(location) {
-    let camelizedLocation = camelize(location/);
+    let camelizedLocation = camelize(location);
     let element = this.get(`cachedMaps.${camelizedLocation}`);
-    if (!element/) {
+    if (!element) {
       element = this.createMapElement();
-      this.get('mapUtil').createMap(element, location/);
-      this.set(`cachedMaps.${camelizedLocation}`, element/);
+      this.get('mapUtil').createMap(element, location);
+      this.set(`cachedMaps.${camelizedLocation}`, element);
     }
     return element;
   },


### PR DESCRIPTION
Using that part of the code by just copying and pasting would cause an error because of some unwanted trailing slashes. Someone learning Ember would think that those are necessary and could take some time to realize it should not be there.