### PR TITLE
Repair bad line breaks for Markdown links

### DIFF
--- a/guides/v2.10.0/applications/run-loop.md
+++ b/guides/v2.10.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.11.0/applications/run-loop.md
+++ b/guides/v2.11.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.12.0/applications/run-loop.md
+++ b/guides/v2.12.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.13.0/applications/run-loop.md
+++ b/guides/v2.13.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.14.0/applications/run-loop.md
+++ b/guides/v2.14.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.15.0/applications/run-loop.md
+++ b/guides/v2.15.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.17.0/applications/run-loop.md
+++ b/guides/v2.17.0/applications/run-loop.md
@@ -168,8 +168,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.18.0/applications/run-loop.md
+++ b/guides/v2.18.0/applications/run-loop.md
@@ -168,8 +168,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.2.0/applications/run-loop.md
+++ b/guides/v2.2.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a runloop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.3.0/applications/run-loop.md
+++ b/guides/v2.3.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.4.0/applications/run-loop.md
+++ b/guides/v2.4.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.5.0/applications/run-loop.md
+++ b/guides/v2.5.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.6.0/applications/run-loop.md
+++ b/guides/v2.6.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.7.0/applications/run-loop.md
+++ b/guides/v2.7.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.8.0/applications/run-loop.md
+++ b/guides/v2.8.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v2.9.0/applications/run-loop.md
+++ b/guides/v2.9.0/applications/run-loop.md
@@ -163,8 +163,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v3.0.0/applications/run-loop.md
+++ b/guides/v3.0.0/applications/run-loop.md
@@ -168,8 +168,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v3.1.0/applications/run-loop.md
+++ b/guides/v3.1.0/applications/run-loop.md
@@ -167,8 +167,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v3.2.0/applications/run-loop.md
+++ b/guides/v3.2.0/applications/run-loop.md
@@ -167,8 +167,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/guides/v3.3.0/applications/run-loop.md
+++ b/guides/v3.3.0/applications/run-loop.md
@@ -167,8 +167,7 @@ You should begin a run loop when the callback fires.
 The `Ember.run` method can be used to create a run loop.
 In this example, jQuery and `Ember.run` are used to handle a click event and run some Ember code.
 
-This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions]
-(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+This example uses the `=>` function syntax, which is a [new ES2015 syntax for callback functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 that provides a lexical `this`.
 If this syntax is new,
 think of it as a function that has the same `this` as the context it is defined in.

--- a/test/helpers/getBadLineBreaks.js
+++ b/test/helpers/getBadLineBreaks.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+
+module.exports = function findBadLineBreaks(filepath) {
+  const markdown = fs.readFileSync(filepath).toString();
+
+  return [
+    // urls that have a newline between the ] and (
+    /\]\n\(/.test(markdown),
+
+    // to be safe, also search where \s is a whitespace
+    /\]\n\s\(/.test(markdown),
+    /\]\s\n\s\(/.test(markdown),
+  ].filter(Boolean);
+};

--- a/test/link-checker.js
+++ b/test/link-checker.js
@@ -1,6 +1,11 @@
 const { expect } = require('chai');
 
-const { getBadRelativeUrlsForFile, findMarkdownLinks, getBadImageUrls } = require('./helpers');
+const {
+  findMarkdownLinks,
+  getBadRelativeUrlsForFile,
+  getBadLineBreaks,
+  getBadImageUrls,
+} = require('./helpers');
 
 /**
  * Autogenerate some mocha tests
@@ -28,6 +33,9 @@ describe('check all links in markdown files', function () {
       });
 
       expect(badLinks, printBadLinks(badLinks)).to.be.empty;
+
+      const badLineBreaks = getBadLineBreaks(filepath);
+      expect(badLineBreaks, printBadLinks(badLineBreaks)).to.be.empty;
 
       const badImageLinks = getBadImageUrls({
         filepath,


### PR DESCRIPTION
It looks like #15 didn't _quite_ cover @jenweber's work outlined in #12. Specifically, detecting bad line breaks in the Markdown docs (see link to MDN docs Arrow function):

<img width="1281" alt="screen shot 2018-06-12 at 9 08 06 pm" src="https://user-images.githubusercontent.com/423755/41614164-9547ab40-73ac-11e8-8504-f304284d1ba5.png">

This PR adds a failing test with a helper that detects those bad line breaks using the RegExp recommendations from https://github.com/ember-learn/guides-source/issues/12#issuecomment-357822393, and fixes the affected run-loop docs.