### PR TITLE
Typo in guides/v3.2.0/tutorial/subroutes.md line 229

### DIFF
--- a/guides/v3.2.0/tutorial/subroutes.md
+++ b/guides/v3.2.0/tutorial/subroutes.md
@@ -226,7 +226,7 @@ export default function() {
 
   // Find and return the provided rental from our rental list above
   this.get('/rentals/:id', function (db, request) {
-    return { data: rentals.find((rental) => request.params.id === rental.id/) };
+    return { data: rentals.find((rental) => request.params.id === rental.id) };
   });
 
 }


### PR DESCRIPTION
A random "/" on line 229 of `guides/v3.2.0/tutorial/subroutes.md`. Not sure if it was on purpose but I am going to think its just a syntax error because of a typo!