### PR TITLE
Fix 'display rental details' test

### DIFF
--- a/guides/v3.2.0/tutorial/simple-component.md
+++ b/guides/v3.2.0/tutorial/simple-component.md
@@ -374,8 +374,8 @@ module('Integration | Component | rental listing', function (hooks) {
 
   test('should display rental details', async function(assert) {
     await render(hbs`{{rental-listing rental=rental}}`);
-    assert.equal(this.element.querySelector('.listing h3').textContent, 'test-title', 'Title: test-title');
-    assert.equal(this.element.querySelector('.listing .owner').textContent.trim(), 'Owner: test-owner', 'Owner: test-owner');
+    assert.equal(this.element.querySelector('.listing h3').text(), 'test-title', 'Title: test-title');
+    assert.equal(this.element.querySelector('.listing .owner').text().trim(), 'Owner: test-owner', 'Owner: test-owner');
   });
 
   test('should toggle wide class on click', async function(assert) {


### PR DESCRIPTION
In recap of the final test file, .`textContent` should be `.text()` to correctly run the test