### PR TITLE
Differentiate when a promise/record is returned

### DIFF
--- a/guides/v3.2.0/models/finding-records.md
+++ b/guides/v3.2.0/models/finding-records.md
@@ -6,14 +6,19 @@ Use [`store.findRecord()`](https://www.emberjs.com/api/ember-data/release/classe
 This will return a promise that fulfills with the requested record:
 
 ```javascript
-let blogPost = this.get('store').findRecord('blog-post', 1); // => GET /blog-posts/1
+// GET /blog-posts/1
+this.get('store').findRecord('blog-post', 1)
+  .then(function(blogPost) {
+    // Do something with `blogPost`
+  });
 ```
 
 Use [`store.peekRecord()`](https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
-let blogPost = this.get('store').peekRecord('blog-post', 1); // => no network request
+// no network request
+let blogPost = this.get('store').peekRecord('blog-post', 1);
 ```
 
 ### Retrieving Multiple Records
@@ -21,13 +26,18 @@ let blogPost = this.get('store').peekRecord('blog-post', 1); // => no network re
 Use [`store.findAll()`](https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findAll?anchor=findAll) to retrieve all of the records for a given type:
 
 ```javascript
-let blogPosts = this.get('store').findAll('blog-post'); // => GET /blog-posts
+// GET /blog-posts
+this.get('store').findAll('blog-post')
+  .then(function(blogPosts) {
+    // Do something with `blogPosts`
+  });
 ```
 
 Use [`store.peekAll()`](http://emberjs.com/api/data/classes/DS.Store.html#method_peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
 
 ```javascript
-let blogPosts = this.get('store').peekAll('blog-post'); // => no network request
+// no network request
+let blogPosts = this.get('store').peekAll('blog-post');
 ```
 
 `store.findAll()` returns a `DS.PromiseArray` that fulfills to a `DS.RecordArray` and `store.peekAll` directly returns a `DS.RecordArray`.


### PR DESCRIPTION
This change adds `.then()` to `findRecord` and `findAll` examples and moves the comment on the end of the line to the previous line which should also help by removing the need to scroll towards the right to see that lil tidbit.

![screenshot](https://user-images.githubusercontent.com/83319/42294860-a38365c0-7fb2-11e8-9515-c6344dd6dbcb.png)
