### PR TITLE
The `context` parameter is no more (+formatting)

### DIFF
--- a/guides/v3.3.0/testing/acceptance.md
+++ b/guides/v3.3.0/testing/acceptance.md
@@ -134,15 +134,14 @@ Synchronous helpers are performed immediately when triggered.
   - Returns the currently active route name.
 * [`currentURL()`][7]
   - Returns the current URL.
-* [`find(selector, context)`][8]
-  - Finds an element within the app's root element and within the context
-    (optional). Scoping to the root element is especially useful to avoid
-    conflicts with the test framework's reporter, and this is done by default
-    if the context is not specified.
+* [`find(selector)`][8]
+  - Finds one element within the app's root element that matches the given
+    selector. Scoping to the root element is useful to avoid
+    conflicts with the test framework's reporter.
 * [`findAll(selector)`][9]
-  - Find all elements matched by the given selector. Equivalent to calling
-    querySelectorAll() on the test root element.  Returns an array of matched
-    elements.
+  - Like `find(selector)`, but finds all elements that match the given selector.
+    Equivalent to calling querySelectorAll() on the test root element.
+    Returns an array of matched elements.
 
 
 [1]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click

--- a/guides/v3.3.0/testing/acceptance.md
+++ b/guides/v3.3.0/testing/acceptance.md
@@ -130,18 +130,14 @@ previous steps in the test have completed.
 
 Synchronous helpers are performed immediately when triggered.
 
-* [`currentRouteName()`][6]
-  - Returns the currently active route name.
-* [`currentURL()`][7]
-  - Returns the current URL.
-* [`find(selector)`][8]
-  - Finds one element within the app's root element that matches the given
-    selector. Scoping to the root element is useful to avoid
-    conflicts with the test framework's reporter.
-* [`findAll(selector)`][9]
-  - Like `find(selector)`, but finds all elements that match the given selector.
-    Equivalent to calling querySelectorAll() on the test root element.
-    Returns an array of matched elements.
+* [`currentRouteName()`][6]: returns the currently active route name.
+* [`currentURL()`][7]: returns the current URL.
+* [`find(selector)`][8]: finds one element within the app's root element
+  that matches the given selector. Scoping to the root element is useful
+  to avoid conflicts with the test framework's reporter.
+* [`findAll(selector)`][9]: like `find(selector)`, but finds all elements
+  that match the given selector. Equivalent to calling querySelectorAll()
+  on the test root element. Returns an array of matched elements.
 
 
 [1]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click


### PR DESCRIPTION
The `context` parameter was removed from `find` and `findAll` in `ember-test-helpers`. Currently, trying to use it will get you an exception, as can be seen in this PR: https://github.com/emberjs/ember-test-helpers/pull/358 That's the first of these two commits.

Since I was at it, I added a second commit to try make the formatting less awkward. Currently it tries to be a definition list formatted as nested lists, but doesn't really achieve that. From the Showdown documentation[1], I see that the correct way to do that would be with 4 spaces, rather than the current 2. However I went to see what this would look like if instead I put both term+definition in a single list item:

![alternative-formatting](https://user-images.githubusercontent.com/36066/44311434-51c99500-a3df-11e8-8f1a-113797794836.png)

Thoughts?

[1] Nested lists with Showdown: https://github.com/showdownjs/showdown/wiki/Showdown's-Markdown-syntax#nested-lists