### PR TITLE
Adding note for transitionning to a wildcard route

### DIFF
--- a/guides/v3.4.0/routing/defining-your-routes.md
+++ b/guides/v3.4.0/routing/defining-your-routes.md
@@ -267,7 +267,7 @@ so that when a user navigates to `/a/non-existent/path` they will be shown a mes
 
 Note that if you want to manually transition to this wildcard route, you need to pass an arbitrary (not empty) argument. For example:
 
-```javascript {data-filename=app/route/some-route.js}
+```javascript {data-filename=app/routes/some-route.js}
 this.transitionTo('not-found', 404);
 ```
 

--- a/guides/v3.4.0/routing/defining-your-routes.md
+++ b/guides/v3.4.0/routing/defining-your-routes.md
@@ -265,6 +265,11 @@ Router.map(function() {
 In the above example we have successfully used a wildcard route to handle all routes not managed by our application
 so that when a user navigates to `/a/non-existent/path` they will be shown a message that says the page they're looking for wasn't found.
 
+Note that if you want to manually transition to this wildcard route, you need to pass an arbitrary (not empty) argument, ie
+```javascript {data-filename=app/route/some-route.js}
+this.transitionTo('not-found', 404);
+```
+
 ## Route Handlers
 
 To have your route do something beyond render a template with the same name, you'll

--- a/guides/v3.4.0/routing/defining-your-routes.md
+++ b/guides/v3.4.0/routing/defining-your-routes.md
@@ -265,7 +265,8 @@ Router.map(function() {
 In the above example we have successfully used a wildcard route to handle all routes not managed by our application
 so that when a user navigates to `/a/non-existent/path` they will be shown a message that says the page they're looking for wasn't found.
 
-Note that if you want to manually transition to this wildcard route, you need to pass an arbitrary (not empty) argument, ie
+Note that if you want to manually transition to this wildcard route, you need to pass an arbitrary (not empty) argument. For example:
+
 ```javascript {data-filename=app/route/some-route.js}
 this.transitionTo('not-found', 404);
 ```


### PR DESCRIPTION
I just found myself stuck because I forgot this empty argument (seems like the router interprets the path as a dynamic segment). The error seems intentionnally not thrown, and hard to track down: https://github.com/tildeio/router.js/blob/73d6a7f5ca6fba3cfff8460245fb5a3ceef8a2b5/lib/router/transition-intent/named-transition-intent.ts#L214)