### PR TITLE
use ES5 getters in the 3.1+ docs ?

### DIFF
--- a/guides/v3.1.0/object-model/computed-properties.md
+++ b/guides/v3.1.0/object-model/computed-properties.md
@@ -32,7 +32,7 @@ let ironMan = Person.create({
   lastName:  'Stark'
 });
 
-ironMan.get('fullName'); // "Tony Stark"
+ironMan.fullName; // "Tony Stark"
 ```
 
 This declares `fullName` to be a computed property, with `firstName` and `lastName` as the properties it depends on.


### PR DESCRIPTION
in the 3.3+ docs, `.get` is not used anymore since to reflect the changes brought by Ember 3.1.
But why only in the 3.3+ docs? Shouldn't we update the 3.1+ docs ?