### PR TITLE
Update computed-properties.md

### DIFF
--- a/guides/v3.4.0/object-model/computed-properties.md
+++ b/guides/v3.4.0/object-model/computed-properties.md
@@ -90,7 +90,7 @@ let home = EmberObject.extend({
   location: {
     streetName: 'Evergreen Terrace',
     streetNumber: 742
-  }
+  },
 
   address: computed('location.streetName', 'location.streetNumber', function() {
     return `${this.location.streetNumber} ${this.location.streetName}`;
@@ -111,7 +111,7 @@ let home = EmberObject.extend({
   location: {
     streetName: 'Evergreen Terrace',
     streetNumber: 742
-  }
+  },
 
   address: computed('location', function() {
     return `${this.location.streetNumber} ${this.location.streetName}`;
@@ -138,7 +138,7 @@ let home = EmberObject.extend({
   location: {
     streetName: 'Evergreen Terrace',
     streetNumber: 742
-  }
+  },
 
   address: computed('location.{streetName,streetNumber}', function() {
     return `${this.location.streetNumber} ${this.location.streetName}`;


### PR DESCRIPTION
Missing commas between fields in `EmberObject.extend({})` examples.