### PR TITLE
Fix formatting errors

### DIFF
--- a/guides/v2.0.0/components/defining-a-component.md
+++ b/guides/v2.0.0/components/defining-a-component.md
@@ -28,6 +28,7 @@ Given the above template, you can now use the `{{blog-post}}` component:
     {{post.body}}
   {{/blog-post}}
 {{/each}}
+```
 
 ```javascript {data-filename=app/routes/index.js}
 export default Ember.Route.extend({


### PR DESCRIPTION
One code block was unclosed, so it was messing up the rendering for the rest of the page on your docs site.