### PR TITLE
autocomplete-component.md: Fix test module string description.

### DIFF
--- a/guides/v3.4.0/tutorial/autocomplete-component.md
+++ b/guides/v3.4.0/tutorial/autocomplete-component.md
@@ -310,7 +310,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | rental-listing', function(hooks) {
+module('Integration | Component | list-filter', function(hooks) {
   setupRenderingTest(hooks);
 
   test('should initially load all listings', async function (assert) {
@@ -349,7 +349,7 @@ import { resolve } from 'rsvp';
 const ITEMS = [{city: 'San Francisco'}, {city: 'Portland'}, {city: 'Seattle'}];
 const FILTERED_ITEMS = [{city: 'San Francisco'}];
 
-module('Integration | Component | rental-listing', function(hooks) {
+module('Integration | Component | list-filter', function(hooks) {
   setupRenderingTest(hooks);
 
   test('should initially load all listings', async function (assert) {
@@ -382,7 +382,7 @@ import { resolve } from 'rsvp';
 const ITEMS = [{city: 'San Francisco'}, {city: 'Portland'}, {city: 'Seattle'}];
 const FILTERED_ITEMS = [{city: 'San Francisco'}];
 
-module('Integration | Component | rental-listing', function(hooks) {
+module('Integration | Component | list-filter', function(hooks) {
   setupRenderingTest(hooks);
 
   test('should initially load all listings', async function (assert) {
@@ -430,7 +430,7 @@ import { resolve } from 'rsvp';
 const ITEMS = [{city: 'San Francisco'}, {city: 'Portland'}, {city: 'Seattle'}];
 const FILTERED_ITEMS = [{city: 'San Francisco'}];
 
-module('Integration | Component | rental-listing', function(hooks) {
+module('Integration | Component | list-filter', function(hooks) {
   setupRenderingTest(hooks);
 
   test('should initially load all listings', async function (assert) {


### PR DESCRIPTION
The tutorial mistakenly uses 'rental-listing' in the 'list-filter-test.js'
test module description string. Correct it, to match what the end user
would see after generating the test for this component.