### PR TITLE
Fixed a typo for the handle bars template

### DIFF
--- a/guides/v3.5.0/templates/actions.md
+++ b/guides/v3.5.0/templates/actions.md
@@ -10,7 +10,7 @@ will be sent to the template's corresponding component or controller.
 ```handlebars {data-filename=app/templates/components/single-post.hbs}
 <h3><button {{action "toggleBody"}}>{{title}}</button></h3>
 {{#if isShowingBody}}
-  <p>{{{body}}}</p>
+  <p>{{body}}</p>
 {{/if}}
 ```
 


### PR DESCRIPTION
Fixed a typo for the handle bars template. It should be {{body}} instead of {{{body}}}