### PR TITLE
Updated documentation for query-param scope

### DIFF
--- a/guides/v3.5.0/routing/query-params.md
+++ b/guides/v3.5.0/routing/query-params.md
@@ -255,6 +255,13 @@ This affects query param behavior in two ways:
    will become `/articles?page=2`.
 
 ### Sticky Query Param Values
+The query params are defined per route/controller. They are not global to the app. 
+For example, if a route `first-route` has a query param `firstParam` associated with it and we try to navigate to `first-route` by using `link-to` helper from a different route `second-route`, like in the following handlebar template, the `firstParam` will be omitted. 
+
+```handlebars
+{{#link-to "first-route" (query-params secondParam="asc")}}Sort{{/link-to}}
+```
+
 
 By default, query param values in Ember are "sticky",
 in that if you make changes to a query param and then leave and re-enter the route,


### PR DESCRIPTION
While working with {{link-to}} helper and query param today, I hit issue https://github.com/emberjs/ember.js/issues/16867.
I couldn't find a sample example to see why query param was getting set as undefined. Looks like that is the expected behavior based on the comment in the thread.
Hence updated the documentation to make it more clearer.