### PR TITLE
fixed referencing old Ember.Enumerable

### DIFF
--- a/guides/v3.5.0/models/finding-records.md
+++ b/guides/v3.5.0/models/finding-records.md
@@ -40,7 +40,7 @@ let blogPosts = this.store.peekAll('blog-post'); // => no network request
 
 `store.findAll()` returns a `DS.PromiseArray` that fulfills to a `DS.RecordArray` and `store.peekAll` directly returns a `DS.RecordArray`.
 
-It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`Ember.Enumerable`](https://emberjs.com/api/ember/release/classes/Ember.Enumerable).
+It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`MutableArray`](https://emberjs.com/api/ember/release/classes/MutableArray).
 This is important because, for example, if you want to retrieve records by index,
 the `[]` notation will not work--you'll have to use `objectAt(index)` instead.
 


### PR DESCRIPTION
It seems for me that Ember.Enumerable was used in older releases of Ember. Currently link to https://emberjs.com/api/ember/release/classes/Ember.Enumerable just returns 404.