### PR TITLE
fix: wrong slash before closing bracket

### DIFF
--- a/guides/v1.10.0/routing/specifying-a-routes-model.md
+++ b/guides/v1.10.0/routing/specifying-a-routes-model.md
@@ -178,7 +178,7 @@ App.Router.map(function() {
 });
 
 App.PhotoRoute = Ember.Route.extend({
-  model: function(params/) {
+  model: function(params) {
     return Ember.$.getJSON('/photos/'+params.photo_id/);
   }
 });

--- a/guides/v1.11.0/routing/specifying-a-routes-model.md
+++ b/guides/v1.11.0/routing/specifying-a-routes-model.md
@@ -180,7 +180,7 @@ Router.map(function() {
 
 ```javascript {data-filename=app/routes/photo.js}
 export default Ember.Route.extend({
-  model: function(params/) {
+  model: function(params) {
     return Ember.$.getJSON('/photos/'+params.photo_id/);
   }
 });

--- a/guides/v1.12.0/routing/specifying-a-routes-model.md
+++ b/guides/v1.12.0/routing/specifying-a-routes-model.md
@@ -180,7 +180,7 @@ Router.map(function() {
 
 ```javascript {data-filename=app/routes/photo.js}
 export default Ember.Route.extend({
-  model: function(params/) {
+  model: function(params) {
     return Ember.$.getJSON('/photos/'+params.photo_id/);
   }
 });

--- a/guides/v1.13.0/routing/specifying-a-routes-model.md
+++ b/guides/v1.13.0/routing/specifying-a-routes-model.md
@@ -180,7 +180,7 @@ Router.map(function() {
 
 ```javascript {data-filename=app/routes/photo.js}
 export default Ember.Route.extend({
-  model(params/) {
+  model(params) {
     return Ember.$.getJSON('/photos/'+params.photo_id/);
   }
 });

--- a/guides/v2.10.0/tutorial/autocomplete-component.md
+++ b/guides/v2.10.0/tutorial/autocomplete-component.md
@@ -152,15 +152,15 @@ export default Ember.Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 

--- a/guides/v2.10.0/tutorial/service.md
+++ b/guides/v2.10.0/tutorial/service.md
@@ -144,7 +144,7 @@ import Ember from 'ember';
 const DUMMY_ELEMENT = {};
 
 let MapUtilStub = Ember.Object.extend({
-  createMap(element, location/) {
+  createMap(element, location) {
     this.assert.ok(element, 'createMap called with element');
     this.assert.ok(location, 'createMap called with location');
     return DUMMY_ELEMENT;
@@ -155,7 +155,7 @@ moduleFor('service:maps', 'Unit | Service | maps', {
   needs: ['util:google-maps']
 });
 
-test('should create a new map if one isnt cached for location', function (assert/) {
+test('should create a new map if one isnt cached for location', function (assert) {
   assert.expect(4/);
   let stubMapUtil = MapUtilStub.create({ assert });
   let mapService = this.subject({ mapUtil: stubMapUtil });
@@ -164,7 +164,7 @@ test('should create a new map if one isnt cached for location', function (assert
   assert.equal(element.className, 'map', 'element has class name of map');
 });
 
-test('should use existing map if one is cached for location', function (assert/) {
+test('should use existing map if one is cached for location', function (assert) {
   assert.expect(1/);
   let stubCachedMaps = Ember.Object.create({
     sanFrancisco: DUMMY_ELEMENT
@@ -196,10 +196,10 @@ export default Ember.Service.extend({
     }
   },
 
-  getMapElement(location/) {
+  getMapElement(location) {
     let camelizedLocation = location.camelize();
     let element = this.get(`cachedMaps.${camelizedLocation}`);
-    if (!element/) {
+    if (!element) {
       element = this.createMapElement();
       this.get('mapUtil').createMap(element, location/);
       this.set(`cachedMaps.${camelizedLocation}`, element/);

--- a/guides/v2.11.0/tutorial/autocomplete-component.md
+++ b/guides/v2.11.0/tutorial/autocomplete-component.md
@@ -152,15 +152,15 @@ export default Ember.Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 

--- a/guides/v2.11.0/tutorial/service.md
+++ b/guides/v2.11.0/tutorial/service.md
@@ -144,7 +144,7 @@ import Ember from 'ember';
 const DUMMY_ELEMENT = {};
 
 let MapUtilStub = Ember.Object.extend({
-  createMap(element, location/) {
+  createMap(element, location) {
     this.assert.ok(element, 'createMap called with element');
     this.assert.ok(location, 'createMap called with location');
     return DUMMY_ELEMENT;
@@ -155,7 +155,7 @@ moduleFor('service:maps', 'Unit | Service | maps', {
   needs: ['util:google-maps']
 });
 
-test('should create a new map if one isnt cached for location', function (assert/) {
+test('should create a new map if one isnt cached for location', function (assert) {
   assert.expect(4/);
   let stubMapUtil = MapUtilStub.create({ assert });
   let mapService = this.subject({ mapUtil: stubMapUtil });
@@ -164,7 +164,7 @@ test('should create a new map if one isnt cached for location', function (assert
   assert.equal(element.className, 'map', 'element has class name of map');
 });
 
-test('should use existing map if one is cached for location', function (assert/) {
+test('should use existing map if one is cached for location', function (assert) {
   assert.expect(1/);
   let stubCachedMaps = Ember.Object.create({
     sanFrancisco: DUMMY_ELEMENT
@@ -196,10 +196,10 @@ export default Ember.Service.extend({
     }
   },
 
-  getMapElement(location/) {
+  getMapElement(location) {
     let camelizedLocation = location.camelize();
     let element = this.get(`cachedMaps.${camelizedLocation}`);
-    if (!element/) {
+    if (!element) {
       element = this.createMapElement();
       this.get('mapUtil').createMap(element, location/);
       this.set(`cachedMaps.${camelizedLocation}`, element/);

--- a/guides/v2.12.0/tutorial/autocomplete-component.md
+++ b/guides/v2.12.0/tutorial/autocomplete-component.md
@@ -20,7 +20,7 @@ Notice that below we "wrap" our rentals markup inside the open and closing menti
 This is an example of the [**block form**](../../components/wrapping-content-in-a-component/) of a component,
 which allows a Handlebars template to be rendered _inside_ the component's template wherever the `{{yield}}` expression appears.
 
-In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14/).
+In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14).
 
 ```handlebars {data-filename=app/templates/rentals.hbs}
 <div class="jumbo">
@@ -75,15 +75,15 @@ export default Ember.Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 
@@ -120,7 +120,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   actions: {
-    filterByCity(param/) {
+    filterByCity(param) {
       if (param !== '') {
         return this.get('store').query('rental', { city: param });
       } else {
@@ -151,7 +151,7 @@ export default function() {
         city: 'San Francisco',
         type: 'Estate',
         bedrooms: 15,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5/).jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg',
         description: "This grand old mansion sits on over 100 acres of rolling hills and dense redwood forests."
       }
     }, {
@@ -180,9 +180,9 @@ export default function() {
       }
     }];
 
-  this.get('/rentals', function(db, request/) {
-    if(request.queryParams.city !== undefined/) {
-      let filteredRentals = rentals.filter(function(i/) {
+  this.get('/rentals', function(db, request) {
+    if(request.queryParams.city !== undefined) {
+      let filteredRentals = rentals.filter(function(i) {
         return i.attributes.city.toLowerCase().indexOf(request.queryParams.city.toLowerCase()) !== -1;
       });
       return { data: filteredRentals };

--- a/guides/v2.12.0/tutorial/service.md
+++ b/guides/v2.12.0/tutorial/service.md
@@ -143,10 +143,10 @@ export default Ember.Service.extend({
     }
   },
 
-  getMapElement(location/) {
+  getMapElement(location) {
     let camelizedLocation = location.camelize();
     let element = this.get(`cachedMaps.${camelizedLocation}`);
-    if (!element/) {
+    if (!element) {
       element = this.createMapElement();
       this.get('mapUtil').createMap(element, location/);
       this.set(`cachedMaps.${camelizedLocation}`, element/);

--- a/guides/v2.13.0/tutorial/autocomplete-component.md
+++ b/guides/v2.13.0/tutorial/autocomplete-component.md
@@ -20,7 +20,7 @@ Notice that below we "wrap" our rentals markup inside the open and closing menti
 This is an example of the [**block form**](../../components/wrapping-content-in-a-component/) of a component,
 which allows a Handlebars template to be rendered _inside_ the component's template wherever the `{{yield}}` expression appears.
 
-In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14/).
+In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14).
 
 ```handlebars {data-filename=app/templates/rentals.hbs data-diff="+35,+36,+37,+38,+39,+40,+41,+42,+43,+44,+45,-46,-47,-48"}
 <div class="jumbo">
@@ -78,15 +78,15 @@ export default Ember.Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 
@@ -123,7 +123,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   actions: {
-    filterByCity(param/) {
+    filterByCity(param) {
       if (param !== '') {
         return this.get('store').query('rental', { city: param });
       } else {
@@ -154,7 +154,7 @@ export default function() {
         city: 'San Francisco',
         "property-type": 'Estate',
         bedrooms: 15,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5/).jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg',
         description: "This grand old mansion sits on over 100 acres of rolling hills and dense redwood forests."
       }
     }, {
@@ -183,9 +183,9 @@ export default function() {
       }
     }];
 
-  this.get('/rentals', function(db, request/) {
-    if(request.queryParams.city !== undefined/) {
-      let filteredRentals = rentals.filter(function(i/) {
+  this.get('/rentals', function(db, request) {
+    if(request.queryParams.city !== undefined) {
+      let filteredRentals = rentals.filter(function(i) {
         return i.attributes.city.toLowerCase().indexOf(request.queryParams.city.toLowerCase()) !== -1;
       });
       return { data: filteredRentals };

--- a/guides/v2.13.0/tutorial/service.md
+++ b/guides/v2.13.0/tutorial/service.md
@@ -143,10 +143,10 @@ export default Ember.Service.extend({
     }
   },
 
-  getMapElement(location/) {
+  getMapElement(location) {
     let camelizedLocation = location.camelize();
     let element = this.get(`cachedMaps.${camelizedLocation}`);
-    if (!element/) {
+    if (!element) {
       element = this.createMapElement();
       this.get('mapUtil').createMap(element, location/);
       this.set(`cachedMaps.${camelizedLocation}`, element/);

--- a/guides/v2.14.0/tutorial/autocomplete-component.md
+++ b/guides/v2.14.0/tutorial/autocomplete-component.md
@@ -20,7 +20,7 @@ Notice that below we "wrap" our rentals markup inside the open and closing menti
 This is an example of the [**block form**](../../components/wrapping-content-in-a-component/) of a component,
 which allows a Handlebars template to be rendered _inside_ the component's template wherever the `{{yield}}` expression appears.
 
-In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14/).
+In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14).
 
 ```handlebars {data-filename=app/templates/rentals.hbs data-diff="+12,+13,+14,+15,+16,+17,+18,+19,+20,-21,-22,-23"}
 <div class="jumbo">
@@ -78,15 +78,15 @@ export default Ember.Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 
@@ -123,7 +123,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   actions: {
-    filterByCity(param/) {
+    filterByCity(param) {
       if (param !== '') {
         return this.get('store').query('rental', { city: param });
       } else {
@@ -154,7 +154,7 @@ export default function() {
         city: 'San Francisco',
         "property-type": 'Estate',
         bedrooms: 15,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5/).jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg',
         description: "This grand old mansion sits on over 100 acres of rolling hills and dense redwood forests."
       }
     }, {
@@ -183,9 +183,9 @@ export default function() {
       }
     }];
 
-  this.get('/rentals', function(db, request/) {
-    if(request.queryParams.city !== undefined/) {
-      let filteredRentals = rentals.filter(function(i/) {
+  this.get('/rentals', function(db, request) {
+    if(request.queryParams.city !== undefined) {
+      let filteredRentals = rentals.filter(function(i) {
         return i.attributes.city.toLowerCase().indexOf(request.queryParams.city.toLowerCase()) !== -1;
       });
       return { data: filteredRentals };

--- a/guides/v2.14.0/tutorial/service.md
+++ b/guides/v2.14.0/tutorial/service.md
@@ -127,10 +127,10 @@ export default Ember.Service.extend({
     }
   },
 
-  getMapElement(location/) {
+  getMapElement(location) {
     let camelizedLocation = location.camelize();
     let element = this.get(`cachedMaps.${camelizedLocation}`);
-    if (!element/) {
+    if (!element) {
       element = this.createMapElement();
       this.get('mapUtil').createMap(element, location/);
       this.set(`cachedMaps.${camelizedLocation}`, element/);

--- a/guides/v2.15.0/tutorial/autocomplete-component.md
+++ b/guides/v2.15.0/tutorial/autocomplete-component.md
@@ -22,7 +22,7 @@ Notice that below we "wrap" our rentals markup inside the open and closing menti
 This is an example of the [**block form**](../../components/wrapping-content-in-a-component/) of a component,
 which allows a Handlebars template to be rendered _inside_ the component's template wherever the `{{yield}}` expression appears.
 
-In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14/).
+In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14).
 
 ```handlebars {data-filename=app/templates/rentals.hbs data-diff="+12,+13,+14,+15,+16,+17,+18,+19,+20,-21,-22,-23"}
 <div class="jumbo">
@@ -81,15 +81,15 @@ export default Ember.Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 
@@ -128,7 +128,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   actions: {
-    filterByCity(param/) {
+    filterByCity(param) {
       if (param !== '') {
         return this.get('store').query('rental', { city: param });
       } else {

--- a/guides/v2.15.0/tutorial/service.md
+++ b/guides/v2.15.0/tutorial/service.md
@@ -127,10 +127,10 @@ export default Ember.Service.extend({
     }
   },
 
-  getMapElement(location/) {
+  getMapElement(location) {
     let camelizedLocation = Ember.String.camelize(location/);
     let element = this.get(`cachedMaps.${camelizedLocation}`);
-    if (!element/) {
+    if (!element) {
       element = this.createMapElement();
       this.get('mapUtil').createMap(element, location/);
       this.set(`cachedMaps.${camelizedLocation}`, element/);

--- a/guides/v2.16.0/tutorial/autocomplete-component.md
+++ b/guides/v2.16.0/tutorial/autocomplete-component.md
@@ -22,7 +22,7 @@ Notice that below we "wrap" our rentals markup inside the open and closing menti
 This is an example of the [**block form**](../../components/wrapping-content-in-a-component/) of a component,
 which allows a Handlebars template to be rendered _inside_ the component's template wherever the `{{yield}}` expression appears.
 
-In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14/).
+In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14).
 
 ```handlebars {data-filename=app/templates/rentals.hbs data-diff="+12,+13,+14,+15,+16,+17,+18,+19,+20,-21,-22,-23"}
 <div class="jumbo">
@@ -81,15 +81,15 @@ export default Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 
@@ -128,7 +128,7 @@ import Controller from '@ember/controller';
 
 export default Controller.extend({
   actions: {
-    filterByCity(param/) {
+    filterByCity(param) {
       if (param !== '') {
         return this.get('store').query('rental', { city: param });
       } else {

--- a/guides/v2.16.0/tutorial/service.md
+++ b/guides/v2.16.0/tutorial/service.md
@@ -130,10 +130,10 @@ export default Service.extend({
     }
   },
 
-  getMapElement(location/) {
+  getMapElement(location) {
     let camelizedLocation = camelize(location/);
     let element = this.get(`cachedMaps.${camelizedLocation}`);
-    if (!element/) {
+    if (!element) {
       element = this.createMapElement();
       this.get('mapUtil').createMap(element, location/);
       this.set(`cachedMaps.${camelizedLocation}`, element/);

--- a/guides/v2.17.0/tutorial/autocomplete-component.md
+++ b/guides/v2.17.0/tutorial/autocomplete-component.md
@@ -22,7 +22,7 @@ Notice that below we "wrap" our rentals markup inside the open and closing menti
 This is an example of the [**block form**](../../components/wrapping-content-in-a-component/) of a component,
 which allows a Handlebars template to be rendered _inside_ the component's template wherever the `{{yield}}` expression appears.
 
-In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14/).
+In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `rentals` (line 14).
 
 ```handlebars {data-filename=app/templates/rentals.hbs data-diff="+12,+13,+14,+15,+16,+17,+18,+19,+20,-21,-22,-23"}
 <div class="jumbo">
@@ -81,15 +81,15 @@ export default Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 
@@ -128,7 +128,7 @@ import Controller from '@ember/controller';
 
 export default Controller.extend({
   actions: {
-    filterByCity(param/) {
+    filterByCity(param) {
       if (param !== '') {
         return this.get('store').query('rental', { city: param });
       } else {

--- a/guides/v2.17.0/tutorial/service.md
+++ b/guides/v2.17.0/tutorial/service.md
@@ -130,10 +130,10 @@ export default Service.extend({
     }
   },
 
-  getMapElement(location/) {
+  getMapElement(location) {
     let camelizedLocation = camelize(location/);
     let element = this.get(`cachedMaps.${camelizedLocation}`);
-    if (!element/) {
+    if (!element) {
       element = this.createMapElement();
       this.get('mapUtil').createMap(element, location/);
       this.set(`cachedMaps.${camelizedLocation}`, element/);

--- a/guides/v2.18.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.18.0/routing/preventing-and-retrying-transitions.md
@@ -57,7 +57,7 @@ destination routes to abort attempted transitions.
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-  beforeModel(transition/) {
+  beforeModel(transition) {
     if (new Date() > new Date('January 1, 1980')) {
       alert('Sorry, you need a time machine to enter this route.');
       transition.abort();

--- a/guides/v2.18.0/tutorial/autocomplete-component.md
+++ b/guides/v2.18.0/tutorial/autocomplete-component.md
@@ -128,7 +128,7 @@ import Controller from '@ember/controller';
 
 export default Controller.extend({
   actions: {
-    filterByCity(param/) {
+    filterByCity(param) {
       if (param !== '') {
         return this.get('store').query('rental', { city: param });
       } else {

--- a/guides/v2.18.0/tutorial/model-hook.md
+++ b/guides/v2.18.0/tutorial/model-hook.md
@@ -29,7 +29,7 @@ export default Route.extend({
       city: 'San Francisco',
       category: 'Estate',
       bedrooms: 15,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5/).jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg',
       description: 'This grand old mansion sits on over 100 acres of rolling hills and dense redwood forests.'
     }, {
       id: 'urban-living',

--- a/guides/v2.18.0/tutorial/simple-component.md
+++ b/guides/v2.18.0/tutorial/simple-component.md
@@ -222,7 +222,7 @@ test('should toggle wide class on click', function(assert) {
 test('it renders', function(assert) {
 
   // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val/) { ... });
+  // Handle any actions with this.on('myAction', function(val) { ... });
 
   this.render(hbs`{{rental-listing}}`);
 

--- a/guides/v2.3.0/tutorial/autocomplete-component.md
+++ b/guides/v2.3.0/tutorial/autocomplete-component.md
@@ -151,15 +151,15 @@ export default Ember.Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 

--- a/guides/v2.4.0/tutorial/autocomplete-component.md
+++ b/guides/v2.4.0/tutorial/autocomplete-component.md
@@ -151,15 +151,15 @@ export default Ember.Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 

--- a/guides/v2.5.0/tutorial/autocomplete-component.md
+++ b/guides/v2.5.0/tutorial/autocomplete-component.md
@@ -151,15 +151,15 @@ export default Ember.Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 

--- a/guides/v2.6.0/tutorial/autocomplete-component.md
+++ b/guides/v2.6.0/tutorial/autocomplete-component.md
@@ -151,15 +151,15 @@ export default Ember.Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 

--- a/guides/v2.6.0/tutorial/service.md
+++ b/guides/v2.6.0/tutorial/service.md
@@ -144,7 +144,7 @@ import Ember from 'ember';
 const DUMMY_ELEMENT = {};
 
 let MapUtilStub = Ember.Object.extend({
-  createMap(element, location/) {
+  createMap(element, location) {
     this.assert.ok(element, 'createMap called with element');
     this.assert.ok(location, 'createMap called with location');
     return DUMMY_ELEMENT;
@@ -155,7 +155,7 @@ moduleFor('service:maps', 'Unit | Service | maps', {
   needs: ['util:google-maps']
 });
 
-test('should create a new map if one isnt cached for location', function (assert/) {
+test('should create a new map if one isnt cached for location', function (assert) {
   assert.expect(4/);
   let stubMapUtil = MapUtilStub.create({ assert });
   let mapService = this.subject({ mapUtil: stubMapUtil });
@@ -164,7 +164,7 @@ test('should create a new map if one isnt cached for location', function (assert
   assert.equal(element.className, 'map', 'element has class name of map');
 });
 
-test('should use existing map if one is cached for location', function (assert/) {
+test('should use existing map if one is cached for location', function (assert) {
   assert.expect(1/);
   let stubCachedMaps = Ember.Object.create({
     sanFrancisco: DUMMY_ELEMENT
@@ -196,10 +196,10 @@ export default Ember.Service.extend({
     }
   },
 
-  getMapElement(location/) {
+  getMapElement(location) {
     let camelizedLocation = location.camelize();
     let element = this.get(`cachedMaps.${camelizedLocation}`);
-    if (!element/) {
+    if (!element) {
       element = this.createMapElement();
       this.get('mapUtil').createMap(element, location/);
       this.set(`cachedMaps.${camelizedLocation}`, element/);

--- a/guides/v2.7.0/tutorial/autocomplete-component.md
+++ b/guides/v2.7.0/tutorial/autocomplete-component.md
@@ -150,15 +150,15 @@ export default Ember.Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 

--- a/guides/v2.7.0/tutorial/service.md
+++ b/guides/v2.7.0/tutorial/service.md
@@ -144,7 +144,7 @@ import Ember from 'ember';
 const DUMMY_ELEMENT = {};
 
 let MapUtilStub = Ember.Object.extend({
-  createMap(element, location/) {
+  createMap(element, location) {
     this.assert.ok(element, 'createMap called with element');
     this.assert.ok(location, 'createMap called with location');
     return DUMMY_ELEMENT;
@@ -155,7 +155,7 @@ moduleFor('service:maps', 'Unit | Service | maps', {
   needs: ['util:google-maps']
 });
 
-test('should create a new map if one isnt cached for location', function (assert/) {
+test('should create a new map if one isnt cached for location', function (assert) {
   assert.expect(4/);
   let stubMapUtil = MapUtilStub.create({ assert });
   let mapService = this.subject({ mapUtil: stubMapUtil });
@@ -164,7 +164,7 @@ test('should create a new map if one isnt cached for location', function (assert
   assert.equal(element.className, 'map', 'element has class name of map');
 });
 
-test('should use existing map if one is cached for location', function (assert/) {
+test('should use existing map if one is cached for location', function (assert) {
   assert.expect(1/);
   let stubCachedMaps = Ember.Object.create({
     sanFrancisco: DUMMY_ELEMENT
@@ -196,10 +196,10 @@ export default Ember.Service.extend({
     }
   },
 
-  getMapElement(location/) {
+  getMapElement(location) {
     let camelizedLocation = location.camelize();
     let element = this.get(`cachedMaps.${camelizedLocation}`);
-    if (!element/) {
+    if (!element) {
       element = this.createMapElement();
       this.get('mapUtil').createMap(element, location/);
       this.set(`cachedMaps.${camelizedLocation}`, element/);

--- a/guides/v2.8.0/tutorial/autocomplete-component.md
+++ b/guides/v2.8.0/tutorial/autocomplete-component.md
@@ -152,15 +152,15 @@ export default Ember.Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 

--- a/guides/v2.8.0/tutorial/service.md
+++ b/guides/v2.8.0/tutorial/service.md
@@ -144,7 +144,7 @@ import Ember from 'ember';
 const DUMMY_ELEMENT = {};
 
 let MapUtilStub = Ember.Object.extend({
-  createMap(element, location/) {
+  createMap(element, location) {
     this.assert.ok(element, 'createMap called with element');
     this.assert.ok(location, 'createMap called with location');
     return DUMMY_ELEMENT;
@@ -155,7 +155,7 @@ moduleFor('service:maps', 'Unit | Service | maps', {
   needs: ['util:google-maps']
 });
 
-test('should create a new map if one isnt cached for location', function (assert/) {
+test('should create a new map if one isnt cached for location', function (assert) {
   assert.expect(4/);
   let stubMapUtil = MapUtilStub.create({ assert });
   let mapService = this.subject({ mapUtil: stubMapUtil });
@@ -164,7 +164,7 @@ test('should create a new map if one isnt cached for location', function (assert
   assert.equal(element.className, 'map', 'element has class name of map');
 });
 
-test('should use existing map if one is cached for location', function (assert/) {
+test('should use existing map if one is cached for location', function (assert) {
   assert.expect(1/);
   let stubCachedMaps = Ember.Object.create({
     sanFrancisco: DUMMY_ELEMENT
@@ -196,10 +196,10 @@ export default Ember.Service.extend({
     }
   },
 
-  getMapElement(location/) {
+  getMapElement(location) {
     let camelizedLocation = location.camelize();
     let element = this.get(`cachedMaps.${camelizedLocation}`);
-    if (!element/) {
+    if (!element) {
       element = this.createMapElement();
       this.get('mapUtil').createMap(element, location/);
       this.set(`cachedMaps.${camelizedLocation}`, element/);

--- a/guides/v2.9.0/tutorial/autocomplete-component.md
+++ b/guides/v2.9.0/tutorial/autocomplete-component.md
@@ -152,15 +152,15 @@ export default Ember.Component.extend({
   value: '',
 
   init() {
-    this._super(...arguments/);
-    this.get('filter')('').then((results/) => this.set('results', results/));
+    this._super(...arguments);
+    this.get('filter')('').then((results) => this.set('results', results));
   },
 
   actions: {
     handleFilterEntry() {
       let filterInputValue = this.get('value');
       let filterAction = this.get('filter');
-      filterAction(filterInputValue/).then((filterResults/) => this.set('results', filterResults/));
+      filterAction(filterInputValue).then((filterResults) => this.set('results', filterResults));
     }
   }
 

--- a/guides/v2.9.0/tutorial/service.md
+++ b/guides/v2.9.0/tutorial/service.md
@@ -144,7 +144,7 @@ import Ember from 'ember';
 const DUMMY_ELEMENT = {};
 
 let MapUtilStub = Ember.Object.extend({
-  createMap(element, location/) {
+  createMap(element, location) {
     this.assert.ok(element, 'createMap called with element');
     this.assert.ok(location, 'createMap called with location');
     return DUMMY_ELEMENT;
@@ -155,7 +155,7 @@ moduleFor('service:maps', 'Unit | Service | maps', {
   needs: ['util:google-maps']
 });
 
-test('should create a new map if one isnt cached for location', function (assert/) {
+test('should create a new map if one isnt cached for location', function (assert) {
   assert.expect(4/);
   let stubMapUtil = MapUtilStub.create({ assert });
   let mapService = this.subject({ mapUtil: stubMapUtil });
@@ -164,7 +164,7 @@ test('should create a new map if one isnt cached for location', function (assert
   assert.equal(element.className, 'map', 'element has class name of map');
 });
 
-test('should use existing map if one is cached for location', function (assert/) {
+test('should use existing map if one is cached for location', function (assert) {
   assert.expect(1/);
   let stubCachedMaps = Ember.Object.create({
     sanFrancisco: DUMMY_ELEMENT
@@ -196,10 +196,10 @@ export default Ember.Service.extend({
     }
   },
 
-  getMapElement(location/) {
+  getMapElement(location) {
     let camelizedLocation = location.camelize();
     let element = this.get(`cachedMaps.${camelizedLocation}`);
-    if (!element/) {
+    if (!element) {
       element = this.createMapElement();
       this.get('mapUtil').createMap(element, location/);
       this.set(`cachedMaps.${camelizedLocation}`, element/);

--- a/guides/v3.0.0/tutorial/model-hook.md
+++ b/guides/v3.0.0/tutorial/model-hook.md
@@ -29,7 +29,7 @@ export default Route.extend({
       city: 'San Francisco',
       category: 'Estate',
       bedrooms: 15,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5/).jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/c/cb/Crane_estate_(5).jpg',
       description: 'This grand old mansion sits on over 100 acres of rolling hills and dense redwood forests.'
     }, {
       id: 'urban-living',

--- a/guides/v3.0.0/tutorial/service.md
+++ b/guides/v3.0.0/tutorial/service.md
@@ -137,7 +137,7 @@ export default Service.extend({
   getMapElement(location) {
     let camelizedLocation = camelize(location/);
     let element = this.get(`cachedMaps.${camelizedLocation}`);
-    if (!element/) {
+    if (!element) {
       element = this.createMapElement();
       this.get('mapUtil').createMap(element, location/);
       this.set(`cachedMaps.${camelizedLocation}`, element/);

--- a/guides/v3.0.0/tutorial/simple-component.md
+++ b/guides/v3.0.0/tutorial/simple-component.md
@@ -222,7 +222,7 @@ test('should toggle wide class on click', function(assert) {
 test('it renders', function(assert) {
 
   // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val/) { ... });
+  // Handle any actions with this.on('myAction', function(val) { ... });
 
   this.render(hbs`{{rental-listing}}`);
 

--- a/guides/v3.1.0/tutorial/simple-component.md
+++ b/guides/v3.1.0/tutorial/simple-component.md
@@ -223,7 +223,7 @@ module('Integration | Component | rental listing', function (hooks) {
 });
   test('it renders', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val/) { ... });
+    // Handle any actions with this.set('myAction', function(val) { ... });
 
     await render(hbs`{{rental-listing}}`);
 

--- a/guides/v3.2.0/tutorial/simple-component.md
+++ b/guides/v3.2.0/tutorial/simple-component.md
@@ -223,7 +223,7 @@ module('Integration | Component | rental listing', function (hooks) {
 });
   test('it renders', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val/) { ... });
+    // Handle any actions with this.set('myAction', function(val) { ... });
 
     await render(hbs`{{rental-listing}}`);
 

--- a/guides/v3.3.0/tutorial/simple-component.md
+++ b/guides/v3.3.0/tutorial/simple-component.md
@@ -223,7 +223,7 @@ module('Integration | Component | rental listing', function (hooks) {
 });
   test('it renders', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val/) { ... });
+    // Handle any actions with this.set('myAction', function(val) { ... });
 
     await render(hbs`{{rental-listing}}`);
 

--- a/guides/v3.4.0/tutorial/simple-component.md
+++ b/guides/v3.4.0/tutorial/simple-component.md
@@ -223,7 +223,7 @@ module('Integration | Component | rental listing', function (hooks) {
 });
   test('it renders', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val/) { ... });
+    // Handle any actions with this.set('myAction', function(val) { ... });
 
     await render(hbs`{{rental-listing}}`);
 

--- a/guides/v3.5.0/tutorial/simple-component.md
+++ b/guides/v3.5.0/tutorial/simple-component.md
@@ -223,7 +223,7 @@ module('Integration | Component | rental listing', function (hooks) {
 });
   test('it renders', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val/) { ... });
+    // Handle any actions with this.set('myAction', function(val) { ... });
 
     await render(hbs`{{rental-listing}}`);
 


### PR DESCRIPTION
Some of the code examples were broken by a slash before closing bracket.
I guess this was introduced by migration.

This commit removes all slashes before a closing bracket followed by an
opening curly bracket if they are not preceeded by an asterisk. Slashes
preceeded by an asterisk should belong to an inline comment.

Evenso this was already fixed for recent versions it has caused confusion:
https://stackoverflow.com/questions/52955179/what-does-the-slash-at-the-end-of-the-parameter-in-javascript-mean