### PR TITLE
Test for (and correct) non-relative guides links

### DIFF
--- a/guides/v2.10.0/components/the-component-lifecycle.md
+++ b/guides/v2.10.0/components/the-component-lifecycle.md
@@ -188,7 +188,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
 [dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 [on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ### Making Updates to the Rendered DOM with `didRender`

--- a/guides/v2.11.0/components/the-component-lifecycle.md
+++ b/guides/v2.11.0/components/the-component-lifecycle.md
@@ -188,7 +188,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
 [dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 [on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ### Making Updates to the Rendered DOM with `didRender`

--- a/guides/v2.12.0/components/the-component-lifecycle.md
+++ b/guides/v2.12.0/components/the-component-lifecycle.md
@@ -188,7 +188,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
 [dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 [on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ### Making Updates to the Rendered DOM with `didRender`

--- a/guides/v2.12.0/tutorial/hbs-helper.md
+++ b/guides/v2.12.0/tutorial/hbs-helper.md
@@ -80,7 +80,7 @@ export function rentalPropertyType([type]) {
 export default Ember.Helper.helper(rentalPropertyType);
 ```
 
-Each [argument](https://guides.emberjs.com/v2.12.0/templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `type`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
+Each [argument](../../templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `type`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
 
 Now in our browser we should see that the first rental property is listed as "Standalone",
 while the other two are listed as "Community".

--- a/guides/v2.12.0/tutorial/installing-addons.md
+++ b/guides/v2.12.0/tutorial/installing-addons.md
@@ -114,4 +114,4 @@ export default DS.JSONAPIAdapter.extend({
 
 If you were running `ember serve` in another shell, restart the server to include Mirage in your build.
 
-Note that at this point of the tutorial, the data is still provided by the `app/routes/rentals.js` file. We will make use of the mirage data we set up here in the upcoming section called [Using Ember Data](https://guides.emberjs.com/v2.12.0/tutorial/ember-data/).
+Note that at this point of the tutorial, the data is still provided by the `app/routes/rentals.js` file. We will make use of the mirage data we set up here in the upcoming section called [Using Ember Data](../ember-data/).

--- a/guides/v2.13.0/components/the-component-lifecycle.md
+++ b/guides/v2.13.0/components/the-component-lifecycle.md
@@ -188,7 +188,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
 [dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 [on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ### Making Updates to the Rendered DOM with `didRender`

--- a/guides/v2.13.0/tutorial/hbs-helper.md
+++ b/guides/v2.13.0/tutorial/hbs-helper.md
@@ -81,7 +81,7 @@ export function rentalPropertyType([propertyType]) {
 export default Ember.Helper.helper(rentalPropertyType);
 ```
 
-Each [argument](https://guides.emberjs.com/v2.12.0/templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
+Each [argument](../../templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
 
 Now in our browser we should see that the first rental property is listed as "Standalone",
 while the other two are listed as "Community".

--- a/guides/v2.14.0/components/the-component-lifecycle.md
+++ b/guides/v2.14.0/components/the-component-lifecycle.md
@@ -188,7 +188,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
 [dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 [on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ### Making Updates to the Rendered DOM with `didRender`

--- a/guides/v2.14.0/tutorial/hbs-helper.md
+++ b/guides/v2.14.0/tutorial/hbs-helper.md
@@ -81,7 +81,7 @@ export function rentalPropertyType([propertyType]) {
 export default Ember.Helper.helper(rentalPropertyType);
 ```
 
-Each [argument](https://guides.emberjs.com/v2.12.0/templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
+Each [argument](../../templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
 
 Now in our browser we should see that the first rental property is listed as "Standalone",
 while the other two are listed as "Community".

--- a/guides/v2.15.0/components/the-component-lifecycle.md
+++ b/guides/v2.15.0/components/the-component-lifecycle.md
@@ -200,7 +200,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
 [dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 [on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ### Making Updates to the Rendered DOM with `didRender`

--- a/guides/v2.15.0/tutorial/hbs-helper.md
+++ b/guides/v2.15.0/tutorial/hbs-helper.md
@@ -85,7 +85,7 @@ export function rentalPropertyType([propertyType]) {
 export default Ember.Helper.helper(rentalPropertyType);
 ```
 
-Each [argument](https://guides.emberjs.com/v2.12.0/templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
+Each [argument](../../templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
 
 Now in our browser we should see that the first rental property is listed as "Standalone",
 while the other two are listed as "Community".

--- a/guides/v2.16.0/components/the-component-lifecycle.md
+++ b/guides/v2.16.0/components/the-component-lifecycle.md
@@ -200,7 +200,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: https://www.emberjs.com/api/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement
 [dollar]: https://www.emberjs.com/api/ember/2.16/classes/Component/methods/$?anchor=%24
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 
 ### Making Updates to the Rendered DOM with `didRender`
 

--- a/guides/v2.16.0/tutorial/hbs-helper.md
+++ b/guides/v2.16.0/tutorial/hbs-helper.md
@@ -85,7 +85,7 @@ export function rentalPropertyType([propertyType]) {
 export default helper(rentalPropertyType);
 ```
 
-Each [argument](https://guides.emberjs.com/v2.12.0/templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
+Each [argument](../../templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
 
 Now in our browser we should see that the first rental property is listed as "Standalone",
 while the other two are listed as "Community".

--- a/guides/v2.17.0/components/the-component-lifecycle.md
+++ b/guides/v2.17.0/components/the-component-lifecycle.md
@@ -200,7 +200,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: https://www.emberjs.com/api/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement
 [dollar]: https://www.emberjs.com/api/ember/2.16/classes/Component/methods/$?anchor=%24
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 
 ### Making Updates to the Rendered DOM with `didRender`
 

--- a/guides/v2.17.0/tutorial/hbs-helper.md
+++ b/guides/v2.17.0/tutorial/hbs-helper.md
@@ -85,7 +85,7 @@ export function rentalPropertyType([propertyType]) {
 export default helper(rentalPropertyType);
 ```
 
-Each [argument](https://guides.emberjs.com/v2.12.0/templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
+Each [argument](../../templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
 
 Now in our browser we should see that the first rental property is listed as "Standalone",
 while the other two are listed as "Community".

--- a/guides/v2.18.0/components/the-component-lifecycle.md
+++ b/guides/v2.18.0/components/the-component-lifecycle.md
@@ -200,7 +200,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: https://www.emberjs.com/api/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement
 [dollar]: https://www.emberjs.com/api/ember/2.16/classes/Component/methods/$?anchor=%24
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 
 ### Making Updates to the Rendered DOM with `didRender`
 

--- a/guides/v2.18.0/tutorial/hbs-helper.md
+++ b/guides/v2.18.0/tutorial/hbs-helper.md
@@ -85,7 +85,7 @@ export function rentalPropertyType([propertyType]) {
 export default helper(rentalPropertyType);
 ```
 
-Each [argument](https://guides.emberjs.com/v2.12.0/templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
+Each [argument](../../templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
 
 Now in our browser we should see that the first rental property is listed as "Standalone",
 while the other two are listed as "Community".

--- a/guides/v2.2.0/components/the-component-lifecycle.md
+++ b/guides/v2.2.0/components/the-component-lifecycle.md
@@ -93,7 +93,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
 [dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 [on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ## Detaching and Tearing Down Component Elements

--- a/guides/v2.3.0/components/the-component-lifecycle.md
+++ b/guides/v2.3.0/components/the-component-lifecycle.md
@@ -188,7 +188,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
 [dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 [on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ### Making Updates to the Rendered DOM with `didRender`

--- a/guides/v2.4.0/components/the-component-lifecycle.md
+++ b/guides/v2.4.0/components/the-component-lifecycle.md
@@ -188,7 +188,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
 [dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 [on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ### Making Updates to the Rendered DOM with `didRender`

--- a/guides/v2.5.0/components/the-component-lifecycle.md
+++ b/guides/v2.5.0/components/the-component-lifecycle.md
@@ -188,7 +188,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
 [dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 [on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ### Making Updates to the Rendered DOM with `didRender`

--- a/guides/v2.6.0/components/the-component-lifecycle.md
+++ b/guides/v2.6.0/components/the-component-lifecycle.md
@@ -188,7 +188,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
 [dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 [on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ### Making Updates to the Rendered DOM with `didRender`

--- a/guides/v2.7.0/components/the-component-lifecycle.md
+++ b/guides/v2.7.0/components/the-component-lifecycle.md
@@ -188,7 +188,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
 [dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 [on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ### Making Updates to the Rendered DOM with `didRender`

--- a/guides/v2.7.0/getting-started/quick-start.md
+++ b/guides/v2.7.0/getting-started/quick-start.md
@@ -19,7 +19,7 @@ npm install -g ember-cli
 ```
 
 Don't have npm? [Learn how to install Node.js and npm here][npm].
-For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](https://guides.emberjs.com/v2.7.0/getting-started/) guide.
+For a full list of dependencies necessary for an Ember CLI project, consult our [Installing Ember](../../getting-started/) guide.
 
 [npm]: https://docs.npmjs.com/getting-started/installing-node
 

--- a/guides/v2.8.0/components/the-component-lifecycle.md
+++ b/guides/v2.8.0/components/the-component-lifecycle.md
@@ -188,7 +188,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
 [dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 [on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ### Making Updates to the Rendered DOM with `didRender`

--- a/guides/v2.9.0/components/the-component-lifecycle.md
+++ b/guides/v2.9.0/components/the-component-lifecycle.md
@@ -188,7 +188,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: http://emberjs.com/api/classes/Ember.Component.html#event_didInsertElement
 [dollar]: http://emberjs.com/api/classes/Ember.Component.html#method__
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 [on]: http://emberjs.com/api/classes/Ember.Component.html#method_on
 
 ### Making Updates to the Rendered DOM with `didRender`

--- a/guides/v3.0.0/components/the-component-lifecycle.md
+++ b/guides/v3.0.0/components/the-component-lifecycle.md
@@ -200,7 +200,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 [did-insert-element]: https://www.emberjs.com/api/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement
 [dollar]: https://www.emberjs.com/api/ember/2.16/classes/Component/methods/$?anchor=%24
-[event-names]: http://guides.emberjs.com/v2.1.0/components/handling-events/#toc_event-names
+[event-names]: ../handling-events/#toc_event-names
 
 ### Making Updates to the Rendered DOM with `didRender`
 

--- a/guides/v3.0.0/testing/testing-models.md
+++ b/guides/v3.0.0/testing/testing-models.md
@@ -50,7 +50,7 @@ module('Unit | Model | player', function(hooks) {
 ```
 
 Also note, how both creating a record and updating properties on the record through the `levelUp` method requires
-us to wrap these operations into a `run` function. You can read more the Ember run loop [over here](https://guides.emberjs.com/v2.18.0/applications/run-loop/).
+us to wrap these operations into a `run` function. You can read more the Ember run loop [over here](../../applications/run-loop/).
 
 ## Testing Relationships
 

--- a/guides/v3.0.0/tutorial/hbs-helper.md
+++ b/guides/v3.0.0/tutorial/hbs-helper.md
@@ -85,7 +85,7 @@ export function rentalPropertyType([propertyType]) {
 export default helper(rentalPropertyType);
 ```
 
-Each [argument](https://guides.emberjs.com/v2.12.0/templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
+Each [argument](../../templates/writing-helpers/#toc_helper-arguments) in the helper will be added to an array and passed to our helper. For example, `{{my-helper "foo" "bar"}}` would result in `myHelper(["foo", "bar"])`. Using array [ES2015 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) assignment, we can name expected parameters within the array. In the example above, the first argument in the template will be assigned to `propertyType`. This provides a flexible, expressive interface for your helpers, including optional arguments and default values.
 
 Now in our browser we should see that the first rental property is listed as "Standalone",
 while the other two are listed as "Community".

--- a/test/helpers/getNonRelativeGuidesLinks.js
+++ b/test/helpers/getNonRelativeGuidesLinks.js
@@ -1,0 +1,9 @@
+module.exports = function findBadLineBreaks(filepath, links) {
+  let results = [];
+  links.forEach(function (link) {
+    if (link.includes('guides.emberjs.com/')) {
+      results.push({ fileToFix: filepath, makeThisARelativePath: link });
+    }
+  });
+  return results;
+};

--- a/test/link-checker.js
+++ b/test/link-checker.js
@@ -1,11 +1,5 @@
 const { expect } = require('chai');
 
-const {
-  findMarkdownLinks,
-  getBadRelativeUrlsForFile,
-  getBadLineBreaks,
-  getBadImageUrls,
-} = require('./helpers');
 
 /**
  * Autogenerate some mocha tests
@@ -14,6 +8,13 @@ const {
 const walkSync = require('walk-sync');
 const { extname } = require('path');
 const { inspect } = require('util');
+const {
+  findMarkdownLinks,
+  getBadRelativeUrlsForFile,
+  getBadLineBreaks,
+  getBadImageUrls,
+  getNonRelativeGuidesLinks,
+} = require('./helpers');
 
 const paths = walkSync('guides')
   .filter(filePath => extname(filePath) === '.md')
@@ -31,6 +32,8 @@ describe('check all links in markdown files', function () {
         filepath,
         links,
       });
+      const nonRelativeGuidesLinks = getNonRelativeGuidesLinks(filepath, links);
+      expect(nonRelativeGuidesLinks, printBadLinks(nonRelativeGuidesLinks)).to.be.empty;
 
       expect(badLinks, printBadLinks(badLinks)).to.be.empty;
 
@@ -46,3 +49,4 @@ describe('check all links in markdown files', function () {
     });
   });
 });
+


### PR DESCRIPTION
Guides links should be relative, not `https://guides.emberjs.com/something`.

This PR adds a test for non-relative links and corrects existing non-relative links.