### PR TITLE
fixed broken link from Ember.Enumerable to MutableArray

### DIFF
--- a/guides/v3.0.0/models/finding-records.md
+++ b/guides/v3.0.0/models/finding-records.md
@@ -32,7 +32,7 @@ let blogPosts = this.get('store').peekAll('blog-post'); // => no network request
 
 `store.findAll()` returns a `DS.PromiseArray` that fulfills to a `DS.RecordArray` and `store.peekAll` directly returns a `DS.RecordArray`.
 
-It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`Ember.Enumerable`](http://emberjs.com/api/classes/Ember.Enumerable.html).
+It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`MutableArray`](https://emberjs.com/api/ember/release/classes/MutableArray).
 This is important because, for example, if you want to retrieve records by index,
 the `[]` notation will not work--you'll have to use `objectAt(index)` instead.
 

--- a/guides/v3.1.0/models/finding-records.md
+++ b/guides/v3.1.0/models/finding-records.md
@@ -32,7 +32,7 @@ let blogPosts = this.get('store').peekAll('blog-post'); // => no network request
 
 `store.findAll()` returns a `DS.PromiseArray` that fulfills to a `DS.RecordArray` and `store.peekAll` directly returns a `DS.RecordArray`.
 
-It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`Ember.Enumerable`](https://emberjs.com/api/ember/release/classes/Ember.Enumerable).
+It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`MutableArray`](https://emberjs.com/api/ember/release/classes/MutableArray).
 This is important because, for example, if you want to retrieve records by index,
 the `[]` notation will not work--you'll have to use `objectAt(index)` instead.
 

--- a/guides/v3.2.0/models/finding-records.md
+++ b/guides/v3.2.0/models/finding-records.md
@@ -32,7 +32,7 @@ let blogPosts = this.store.peekAll('blog-post'); // => no network request
 
 `store.findAll()` returns a `DS.PromiseArray` that fulfills to a `DS.RecordArray` and `store.peekAll` directly returns a `DS.RecordArray`.
 
-It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`Ember.Enumerable`](https://emberjs.com/api/ember/release/classes/Ember.Enumerable).
+It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`MutableArray`](https://emberjs.com/api/ember/release/classes/MutableArray).
 This is important because, for example, if you want to retrieve records by index,
 the `[]` notation will not work--you'll have to use `objectAt(index)` instead.
 

--- a/guides/v3.3.0/models/finding-records.md
+++ b/guides/v3.3.0/models/finding-records.md
@@ -40,7 +40,7 @@ let blogPosts = this.store.peekAll('blog-post'); // => no network request
 
 `store.findAll()` returns a `DS.PromiseArray` that fulfills to a `DS.RecordArray` and `store.peekAll` directly returns a `DS.RecordArray`.
 
-It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`Ember.Enumerable`](https://emberjs.com/api/ember/release/classes/Ember.Enumerable).
+It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`MutableArray`](https://emberjs.com/api/ember/release/classes/MutableArray).
 This is important because, for example, if you want to retrieve records by index,
 the `[]` notation will not work--you'll have to use `objectAt(index)` instead.
 

--- a/guides/v3.4.0/models/finding-records.md
+++ b/guides/v3.4.0/models/finding-records.md
@@ -40,7 +40,7 @@ let blogPosts = this.store.peekAll('blog-post'); // => no network request
 
 `store.findAll()` returns a `DS.PromiseArray` that fulfills to a `DS.RecordArray` and `store.peekAll` directly returns a `DS.RecordArray`.
 
-It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`Ember.Enumerable`](https://emberjs.com/api/ember/release/classes/Ember.Enumerable).
+It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`MutableArray`](https://emberjs.com/api/ember/release/classes/MutableArray).
 This is important because, for example, if you want to retrieve records by index,
 the `[]` notation will not work--you'll have to use `objectAt(index)` instead.
 


### PR DESCRIPTION
additionally to https://github.com/ember-learn/guides-source/pull/221 I've updated guides back to 3.0.0 when MutableArray arrived. 