### PR TITLE
Replaced Slack links with Discord in old guides and Contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ First-time contributors are encouraged to choose issues that are labeled
 "help wanted" or "good for new contributors." If you have questions, want a
 suggestion of what to work on, or would like a buddy to pair with, you can 
 join the #-team-learning channel in the 
-[Ember Community Slack](https://ember-community-slackin.herokuapp.com/).
+[Ember Community Discord](https://discordapp.com/invite/zT3asNS).
 
 Fork this repository (click "fork" on the repository's home page in GitHub)
 

--- a/guides/v2.10.0/index.md
+++ b/guides/v2.10.0/index.md
@@ -58,8 +58,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -75,4 +74,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.11.0/index.md
+++ b/guides/v2.11.0/index.md
@@ -84,8 +84,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -101,4 +100,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.12.0/index.md
+++ b/guides/v2.12.0/index.md
@@ -98,8 +98,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -115,4 +114,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.13.0/index.md
+++ b/guides/v2.13.0/index.md
@@ -98,8 +98,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -115,4 +114,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.14.0/index.md
+++ b/guides/v2.14.0/index.md
@@ -98,8 +98,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -115,4 +114,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.15.0/index.md
+++ b/guides/v2.15.0/index.md
@@ -101,8 +101,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -118,4 +117,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.16.0/index.md
+++ b/guides/v2.16.0/index.md
@@ -98,8 +98,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -115,4 +114,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.17.0/index.md
+++ b/guides/v2.17.0/index.md
@@ -98,8 +98,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -115,4 +114,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.18.0/index.md
+++ b/guides/v2.18.0/index.md
@@ -98,8 +98,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -115,4 +114,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.2.0/index.md
+++ b/guides/v2.2.0/index.md
@@ -58,8 +58,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any styling questions, or about the contributing process you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#documentation` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -73,4 +72,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.3.0/index.md
+++ b/guides/v2.3.0/index.md
@@ -58,8 +58,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any styling questions, or about the contributing process you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -73,4 +72,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.4.0/index.md
+++ b/guides/v2.4.0/index.md
@@ -58,8 +58,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any styling questions, or about the contributing process you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -73,4 +72,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.5.0/index.md
+++ b/guides/v2.5.0/index.md
@@ -58,8 +58,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any styling questions, or about the contributing process you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -73,4 +72,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.6.0/index.md
+++ b/guides/v2.6.0/index.md
@@ -58,8 +58,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any styling questions, or about the contributing process you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -73,4 +72,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.7.0/index.md
+++ b/guides/v2.7.0/index.md
@@ -58,8 +58,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -75,4 +74,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.8.0/index.md
+++ b/guides/v2.8.0/index.md
@@ -58,8 +58,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -75,4 +74,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v2.9.0/index.md
+++ b/guides/v2.9.0/index.md
@@ -58,8 +58,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -75,4 +74,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v3.0.0/index.md
+++ b/guides/v3.0.0/index.md
@@ -98,8 +98,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -115,4 +114,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v3.1.0/index.md
+++ b/guides/v3.1.0/index.md
@@ -98,8 +98,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -115,4 +114,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v3.2.0/index.md
+++ b/guides/v3.2.0/index.md
@@ -98,8 +98,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -115,4 +114,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v3.3.0/index.md
+++ b/guides/v3.3.0/index.md
@@ -98,8 +98,7 @@ addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
 can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us at `#-team-learning` on the [Slack
-group][slackin].
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
 
 Good luck!
 
@@ -115,4 +114,4 @@ Good luck!
 [gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
 [gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
 
-[slackin]: https://ember-community-slackin.herokuapp.com/
+[discord]: https://discordapp.com/invite/zT3asNS


### PR DESCRIPTION
As mentioned a week ago on Discord, now I finally came around to fixing all the slack links to discord

I hope this is still needed.