### PR TITLE
remove backburner link from header

### DIFF
--- a/guides/v3.5.0/configuring-ember/debugging.md
+++ b/guides/v3.5.0/configuring-ember/debugging.md
@@ -127,9 +127,9 @@ RSVP.on('error', function(error) {
 });
 ```
 
-#### Errors within `Ember.run.later` ([Backburner.js](https://github.com/ebryn/backburner.js))
+#### Errors within `Ember.run.later` Backburner
 
-Backburner has support for stitching the stacktraces together so that you can
+[Backburner.js](https://github.com/ebryn/backburner.js) has support for stitching the stacktraces together so that you can
 track down where an error thrown by `Ember.run.later` is being initiated from. Unfortunately,
 this is quite slow and is not appropriate for production or even normal development.
 


### PR DESCRIPTION
The link being in the header caused the entire section to become a link, so you couldn't even copy the text inside it. It also partially duplicated the header. I suspect this is some post-processing thing we do that making an error here (the markdown directly would probably be fine), but I don't think that's worth investigating/debugging - the link being below is good enough.

Moving the link out of the header should fix the issue :)