### PR TITLE
Add `Ember Data flexibility` section

### DIFF
--- a/guides/v3.5.0/models/index.md
+++ b/guides/v3.5.0/models/index.md
@@ -54,9 +54,25 @@ more information about how components get model data, see the
 [Specifying a Route's Model](../routing/specifying-a-routes-model/)
 guide.
 
+At first, using Ember Data may feel different than the way you're used
+to writing JavaScript applications. Many developers are familiar with
+using AJAX to fetch raw JSON data from an endpoint, which may appear
+easy at first. Over time, however, complexity leaks out into your
+application code, making it hard to maintain.
+
+With Ember Data, managing models as your application grows becomes both
+simple _and_ easy.
+
+Once you have an understanding of Ember Data, you will have a much
+better way to manage the complexity of data loading in your application.
+This will allow your code to evolve without becoming a mess.
+
+## Ember Data flexibility
+
 Thanks to its use of the _adapter pattern_, Ember Data can be configured
-to work with many different kinds of backends. There is [an entire
-ecosystem of adapters][adapters] that allow your Ember app to talk to different
+to work with many different kinds of backends. There is [an entire ecosystem of adapters][adapters]
+and several [built-in adapters](./customizing-adapters/)
+that allow your Ember app to talk to different
 types of servers without you writing any networking code.
 
 [adapters]: http://emberobserver.com/categories/ember-data-adapters
@@ -71,18 +87,6 @@ powered by WebSockets. You can open a socket to your server and push
 changes into Ember Data whenever they occur, giving your app a real-time
 user interface that is always up-to-date.
 
-At first, using Ember Data may feel different than the way you're used
-to writing JavaScript applications. Many developers are familiar with
-using AJAX to fetch raw JSON data from an endpoint, which may appear
-easy at first. Over time, however, complexity leaks out into your
-application code, making it hard to maintain.
-
-With Ember Data, managing models as your application grows becomes both
-simple _and_ easy.
-
-Once you have an understanding of Ember Data, you will have a much
-better way to manage the complexity of data loading in your application.
-This will allow your code to evolve without becoming a mess.
 
 ## The Store and a Single Source of Truth
 

--- a/guides/v3.5.0/models/index.md
+++ b/guides/v3.5.0/models/index.md
@@ -61,7 +61,7 @@ easy at first. Over time, however, complexity leaks out into your
 application code, making it hard to maintain.
 
 With Ember Data, managing models as your application grows becomes both
-simple _and_ easy.
+simpler _and_ easier.
 
 Once you have an understanding of Ember Data, you will have a much
 better way to manage the complexity of data loading in your application.

--- a/guides/v3.5.0/models/index.md
+++ b/guides/v3.5.0/models/index.md
@@ -65,7 +65,7 @@ simpler _and_ easier.
 
 Once you have an understanding of Ember Data, you will have a much
 better way to manage the complexity of data loading in your application.
-This will allow your code to evolve without becoming a mess.
+This will allow your code to evolve and grow, with better maintainability.
 
 ## Ember Data flexibility
 


### PR DESCRIPTION
The change splits the section `What are Ember Data models?`  in two parts:

- `What are Ember Data models?`
- `Ember Data flexibility`


I described the reasons for this change on the [`When to add Ember Data` discussion](https://discuss.emberjs.com/t/when-to-add-ember-data/15050/14).

> Some folks decided to provide a JSON-API backend because Ember Data uses it as a default format, and this added more work for them. I think extending the REST adapter and use a conventional REST backend would have been a better choice for them. 

This made me think how the documentation of the default format of Ember Data  is communicated or may be interpreted. 


@jenweber suggested creating small incremental PRs, so this is a small change to highlight more the existing content around the "Flexibility" capabilities that was included in the `What are Ember Data models?`.

Additionally, I also thought about:

1) extend a little more the `Ember Data flexibility` section.

2) Tweak the content of the `Convention Over Configuration with JSON API` section.

But I didn't want to include more changes without validating if there is a shared opinion on the topic. 

Relates to #20 




