### PR TITLE
Fix lint errors for rental-listing.hbs

### DIFF
--- a/guides/v3.5.0/tutorial/simple-component.md
+++ b/guides/v3.5.0/tutorial/simple-component.md
@@ -138,7 +138,7 @@ Let's call this action `toggleImageSize`
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-2,+3"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-  <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
+  <a href="#" {{action "toggleImageSize"}} class="image {{if isWide "wide"}}">
     <img src="{{rental.image}}" alt="">
     <small>View Larger</small>
   </a>


### PR DESCRIPTION
I was going through this tutorial today, and found 2 lint errors for the `rental-listing.hbs` file:

![screen shot 2018-11-02 at 15 47 43](https://user-images.githubusercontent.com/190129/47944221-6209f000-deb7-11e8-9d2f-98e994e76f73.png)

Not sure if this is the best way to fix the no-invalid-interactive error, but hope this is helpful.