### PR TITLE
Defines what a component is and is used for

### DIFF
--- a/guides/v3.5.0/tutorial/simple-component.md
+++ b/guides/v3.5.0/tutorial/simple-component.md
@@ -3,7 +3,7 @@ interactive options to help them make a decision. Let's add the ability to
 toggle the size of the image for each rental. To do this, we'll use a component.
 
 Ember components are used to turn markup text and styles into reusable content.
-Components can be included in any routes' template, even multiple times, saving
+Components can be included in any route's template, even multiple times, saving
 you from copy-and-pasting the same code around your application.
 
 Let's generate a `rental-listing` component that will manage the behavior for

--- a/guides/v3.5.0/tutorial/simple-component.md
+++ b/guides/v3.5.0/tutorial/simple-component.md
@@ -1,10 +1,15 @@
-As a user looks through our list of rentals, they may want to have some interactive options to help them make a decision.
-Let's add the ability to toggle the size of the image for each rental.
-To do this, we'll use a component.
+As a user looks through our list of rentals, they may want to have some
+interactive options to help them make a decision. Let's add the ability to
+toggle the size of the image for each rental. To do this, we'll use a component.
 
-Let's generate a `rental-listing` component that will manage the behavior for each of our rentals.
-A dash is required in every component name to avoid conflicting with a possible HTML element,
-so `rental-listing` is acceptable but `rental` isn't.
+Ember components are used to turn markup text and styles into reusable content.
+Components can be included in any routes' template, even multiple times, saving
+you from copy-and-pasting the same code around your application.
+
+Let's generate a `rental-listing` component that will manage the behavior for
+each of our rentals. A dash is required in every component name to avoid
+conflicting with a possible HTML element, so `rental-listing` is acceptable but
+`rental` isn't.
 
 ```bash
 ember g component rental-listing


### PR DESCRIPTION
On the Building a Simple Component page, we jump right into building a
component without defining what a component is or what they are use for.
This change adds a brief definition (the same one used in
https://guides.emberjs.com/v3.5.0/components/defining-a-component/) and
a reason why the user might want to use them.

This addresses one of the "tiny tutorial fixes" @jenweber listed
in #245.