### PR TITLE
Uses plainer wording to describe calling a component

### DIFF
--- a/guides/v3.5.0/tutorial/simple-component.md
+++ b/guides/v3.5.0/tutorial/simple-component.md
@@ -84,7 +84,10 @@ with our new `rental-listing` component:
   </article>
 {{/each}}
 ```
-Here we invoke the `rental-listing` component by name, and assign each `rentalUnit` as the `rental` attribute of the component.
+
+For each `rentalUnit` in the `model` list, we are creating a new instance of our
+`rental-listing` component and passing in the `rentalUnit` by assigning it to
+the component's `rental` attribute.
 
 Our app should behave now as before, with the addition of an image for each rental item.
 


### PR DESCRIPTION
On the Building a Simple Component page, we use jargon to describe
calling a component. This change attempts to use plainer wording
instead.

This addresses one of the "tiny tutorial fixes" @jenweber listed
in #245.