### PR TITLE
[Docs] Replace `non-block` with `inline`

### DIFF
--- a/guides/v3.5.0/components/block-params.md
+++ b/guides/v3.5.0/components/block-params.md
@@ -33,9 +33,9 @@ but any event handling behavior implemented in the component is retained such as
 
 The names are bound in the order that they are passed to `yield` in the component template.
 
-### Supporting both block and non-block component usage in one template
+### Supporting both block and inline component usage in one template
 
-It is possible to support both block and non-block usage of a component from a single component template
+It is possible to support both block and inline usage of a component from a single component template
 using the `has-block` helper.
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}
@@ -48,5 +48,5 @@ using the `has-block` helper.
 {{/if}}
 ```
 
-This has the effect of providing a default template when using a component in the non-block form
+This has the effect of providing a default template when using a component in the inline form
 but providing yielded values for use with block params when using a block expression.


### PR DESCRIPTION
This seems to be the only place where we talk of using components in `non-block` form. From my experience, and looking at other pages, `inline` seems to be the most prevalent term used to describe this.

I'm updating this here for consistency.

Some examples from the docs:
- [link-to docs](https://guides.emberjs.com/release/templates/links/#toc_using-link-to-as-an-inline-component)
- [`component` helper docs](https://emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods?anchor=component)