### PR TITLE
Adds Handlebars explainer paragraph

### DIFF
--- a/guides/v2.10.0/tutorial/simple-component.md
+++ b/guides/v2.10.0/tutorial/simple-component.md
@@ -61,6 +61,13 @@ A component consists of two parts:
 * A template that defines how it will look (`app/templates/components/rental-listing.hbs`)
 * A JavaScript source file (`app/components/rental-listing.js`) that defines how it will behave.
 
+Our template files (with the `.hbs` file extension) are written using the
+[Handlebars](../../templates/handlebars-basics) syntax, which consists of
+regular HTML elements mixed with dynamic content in double curly braces:
+`{{ }}`. The variables inside the curly braces represent properties from our
+Javascript source file. If the value of a property in our source file changes,
+the corresponding value in the template will change, as well.
+
 Our new `rental-listing` component will manage how a user sees and interacts with a rental.
 To start, let's move the rental display details for a single rental from the `rentals.hbs` template into `rental-listing.hbs` and add the image field:
 

--- a/guides/v2.10.0/tutorial/simple-component.md
+++ b/guides/v2.10.0/tutorial/simple-component.md
@@ -66,7 +66,7 @@ Our template files (with the `.hbs` file extension) are written using the
 regular HTML elements mixed with dynamic content in double curly braces:
 `{{ }}`. The variables inside the curly braces represent properties from our
 Javascript source file. If the value of a property in our source file changes,
-the corresponding value in the template will change, as well.
+the corresponding value in the template will change as well.
 
 Our new `rental-listing` component will manage how a user sees and interacts with a rental.
 To start, let's move the rental display details for a single rental from the `rentals.hbs` template into `rental-listing.hbs` and add the image field:


### PR DESCRIPTION
In Building a Simple Component, we mention Handlebars templates but
never state what Handlebars is. This change adds a brief paragraph to
describe Handlebars, link to a more robust explanation ([Handlebars
Basics](https://guides.emberjs.com/release/tutorial/simple-component/)), and explain the relationship between templates and component
source files.

This addresses one of the "tiny tutorial fixes" @jenweber listed
in #245.