### PR TITLE
Remove no-unnecessary-concat jslint violation

### DIFF
--- a/guides/v2.10.0/tutorial/simple-component.md
+++ b/guides/v2.10.0/tutorial/simple-component.md
@@ -73,7 +73,7 @@ To start, let's move the rental display details for a single rental from the `re
 
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -136,7 +136,7 @@ Let's use the `{{#if}}` helper to show our current rental image larger only when
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -173,7 +173,7 @@ Let's call this action `toggleImageSize`
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.11.0/tutorial/simple-component.md
+++ b/guides/v2.11.0/tutorial/simple-component.md
@@ -66,7 +66,7 @@ To start, let's move the rental display details for a single rental from the `re
 
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -129,7 +129,7 @@ Let's use the `{{if}}` helper to show our current rental image larger only when 
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -165,7 +165,7 @@ Let's call this action `toggleImageSize`
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.12.0/tutorial/simple-component.md
+++ b/guides/v2.12.0/tutorial/simple-component.md
@@ -31,7 +31,7 @@ To start, let's move the rental display details for a single rental from the `re
 
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -101,7 +101,7 @@ giving it the `image` class name so that our test can find it.
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -137,7 +137,7 @@ Let's call this action `toggleImageSize`
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.13.0/tutorial/simple-component.md
+++ b/guides/v2.13.0/tutorial/simple-component.md
@@ -31,7 +31,7 @@ To start, let's move the rental display details for a single rental from the `re
 
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -101,7 +101,7 @@ giving it the `image` class name so that our test can find it.
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -137,7 +137,7 @@ Let's call this action `toggleImageSize`
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.14.0/tutorial/simple-component.md
+++ b/guides/v2.14.0/tutorial/simple-component.md
@@ -32,7 +32,7 @@ To start, let's move the rental display details for a single rental from the `re
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="-1,+2,+3,+4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17"}
 {{yield}}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -102,7 +102,7 @@ giving it the `image` class name so that our test can find it.
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -139,7 +139,7 @@ Let's call this action `toggleImageSize`
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.15.0/tutorial/simple-component.md
+++ b/guides/v2.15.0/tutorial/simple-component.md
@@ -32,7 +32,7 @@ To start, let's move the rental display details for a single rental from the `re
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="-1,+2,+3,+4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17"}
 {{yield}}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -102,7 +102,7 @@ giving it the `image` class name so that our test can find it.
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -139,7 +139,7 @@ Let's call this action `toggleImageSize`
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.16.0/tutorial/simple-component.md
+++ b/guides/v2.16.0/tutorial/simple-component.md
@@ -32,7 +32,7 @@ To start, let's move the rental display details for a single rental from the `re
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="-1,+2,+3,+4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17"}
 {{yield}}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -102,7 +102,7 @@ giving it the `image` class name so that our test can find it.
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -139,7 +139,7 @@ Let's call this action `toggleImageSize`
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.17.0/tutorial/simple-component.md
+++ b/guides/v2.17.0/tutorial/simple-component.md
@@ -32,7 +32,7 @@ To start, let's move the rental display details for a single rental from the `re
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="-1,+2,+3,+4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17"}
 {{yield}}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -102,7 +102,7 @@ giving it the `image` class name so that our test can find it.
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -139,7 +139,7 @@ Let's call this action `toggleImageSize`
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.18.0/tutorial/simple-component.md
+++ b/guides/v2.18.0/tutorial/simple-component.md
@@ -32,7 +32,7 @@ To start, let's move the rental display details for a single rental from the `re
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-1,+2,+3,+4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17"}
 {{yield}}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -102,7 +102,7 @@ giving it the `image` class name so that our test can find it.
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -139,7 +139,7 @@ Let's call this action `toggleImageSize`
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.3.0/tutorial/simple-component.md
+++ b/guides/v2.3.0/tutorial/simple-component.md
@@ -66,7 +66,7 @@ To start, let's move the rental display details for a single rental from the `in
 
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
-  <img src="{{rental.image}}" class="image" alt="">
+  <img src={{rental.image}} class="image" alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -129,7 +129,7 @@ Let's use the `{{#if}}` helper to show our current rental image larger only when
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -165,7 +165,7 @@ Let's call this action `toggleImageSize`
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.4.0/tutorial/simple-component.md
+++ b/guides/v2.4.0/tutorial/simple-component.md
@@ -66,7 +66,7 @@ To start, let's move the rental display details for a single rental from the `in
 
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
-  <img src="{{rental.image}}" class="image" alt="">
+  <img src={{rental.image}} class="image" alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -129,7 +129,7 @@ Let's use the `{{#if}}` helper to show our current rental image larger only when
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -165,7 +165,7 @@ Let's call this action `toggleImageSize`
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.5.0/tutorial/simple-component.md
+++ b/guides/v2.5.0/tutorial/simple-component.md
@@ -66,7 +66,7 @@ To start, let's move the rental display details for a single rental from the `in
 
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
-  <img src="{{rental.image}}" class="image" alt="">
+  <img src={{rental.image}} class="image" alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -129,7 +129,7 @@ Let's use the `{{#if}}` helper to show our current rental image larger only when
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -165,7 +165,7 @@ Let's call this action `toggleImageSize`
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.6.0/tutorial/simple-component.md
+++ b/guides/v2.6.0/tutorial/simple-component.md
@@ -66,7 +66,7 @@ To start, let's move the rental display details for a single rental from the `in
 
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
-  <img src="{{rental.image}}" class="image" alt="">
+  <img src={{rental.image}} class="image" alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -130,7 +130,7 @@ Let's use the `{{#if}}` helper to show our current rental image larger only when
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -166,7 +166,7 @@ Let's call this action `toggleImageSize`
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.7.0/tutorial/simple-component.md
+++ b/guides/v2.7.0/tutorial/simple-component.md
@@ -66,7 +66,7 @@ To start, let's move the rental display details for a single rental from the `in
 
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -129,7 +129,7 @@ Let's use the `{{#if}}` helper to show our current rental image larger only when
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -165,7 +165,7 @@ Let's call this action `toggleImageSize`
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.8.0/tutorial/simple-component.md
+++ b/guides/v2.8.0/tutorial/simple-component.md
@@ -66,7 +66,7 @@ To start, let's move the rental display details for a single rental from the `re
 
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -129,7 +129,7 @@ Let's use the `{{#if}}` helper to show our current rental image larger only when
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -165,7 +165,7 @@ Let's call this action `toggleImageSize`
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v2.9.0/tutorial/simple-component.md
+++ b/guides/v2.9.0/tutorial/simple-component.md
@@ -66,7 +66,7 @@ To start, let's move the rental display details for a single rental from the `re
 
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -129,7 +129,7 @@ Let's use the `{{#if}}` helper to show our current rental image larger only when
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -165,7 +165,7 @@ Let's call this action `toggleImageSize`
 ```handlebars {data-filename=app/templates/components/rental-listing.hbs data-diff="+2"}
 <article class="listing">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v3.0.0/tutorial/simple-component.md
+++ b/guides/v3.0.0/tutorial/simple-component.md
@@ -32,7 +32,7 @@ To start, let's move the rental display details for a single rental from the `re
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-1,+2,+3,+4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17"}
 {{yield}}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -102,7 +102,7 @@ giving it the `image` class name so that our test can find it.
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -139,7 +139,7 @@ Let's call this action `toggleImageSize`
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v3.1.0/tutorial/simple-component.md
+++ b/guides/v3.1.0/tutorial/simple-component.md
@@ -32,7 +32,7 @@ To start, let's move the rental display details for a single rental from the `re
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-1,+2,+3,+4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17"}
 {{yield}}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -102,7 +102,7 @@ giving it the `image` class name so that our test can find it.
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -139,7 +139,7 @@ Let's call this action `toggleImageSize`
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v3.2.0/tutorial/simple-component.md
+++ b/guides/v3.2.0/tutorial/simple-component.md
@@ -32,7 +32,7 @@ To start, let's move the rental display details for a single rental from the `re
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-1,+2,+3,+4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17"}
 {{yield}}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -102,7 +102,7 @@ giving it the `image` class name so that our test can find it.
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -139,7 +139,7 @@ Let's call this action `toggleImageSize`
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v3.3.0/tutorial/simple-component.md
+++ b/guides/v3.3.0/tutorial/simple-component.md
@@ -32,7 +32,7 @@ To start, let's move the rental display details for a single rental from the `re
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-1,+2,+3,+4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17"}
 {{yield}}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -102,7 +102,7 @@ giving it the `image` class name so that our test can find it.
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -139,7 +139,7 @@ Let's call this action `toggleImageSize`
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v3.4.0/tutorial/simple-component.md
+++ b/guides/v3.4.0/tutorial/simple-component.md
@@ -32,7 +32,7 @@ To start, let's move the rental display details for a single rental from the `re
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-1,+2,+3,+4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17"}
 {{yield}}
 <article class="listing">
-  <img src="{{rental.image}}" alt="">
+  <img src={{rental.image}} alt="">
   <h3>{{rental.title}}</h3>
   <div class="detail owner">
     <span>Owner:</span> {{rental.owner}}
@@ -102,7 +102,7 @@ giving it the `image` class name so that our test can find it.
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="+2,+4,+5"}
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>
@@ -139,7 +139,7 @@ Let's call this action `toggleImageSize`
 <article class="listing">
   <a class="image {{if isWide "wide"}}">
   <a {{action 'toggleImageSize'}} class="image {{if isWide "wide"}}">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <h3>{{rental.title}}</h3>

--- a/guides/v3.5.0/tutorial/simple-component.md
+++ b/guides/v3.5.0/tutorial/simple-component.md
@@ -113,7 +113,7 @@ giving it the `image` class name so that our test can find it.
 <article class="listing">
   <a class="image {{if isWide "wide"}}"
     role="button">
-    <img src="{{rental.image}}" alt="">
+    <img src={{rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <div class="details">


### PR DESCRIPTION
This removes the following JSLint violation `Unnecessary string concatenation. Use {{rental.image}} instead of "{{rental.image}}".  no-unnecessary-concat`. 