### PR TITLE
Update docs to use prefixed `this.` in templates

### DIFF
--- a/guides/v3.6.0/applications/run-loop.md
+++ b/guides/v3.6.0/applications/run-loop.md
@@ -81,8 +81,8 @@ let User = EmberObject.extend({
 and a template to display its attributes:
 
 ```handlebars
-{{firstName}}
-{{fullName}}
+{{this.firstName}}
+{{this.fullName}}
 ```
 
 If we execute the following code without the run loop:

--- a/guides/v3.6.0/applications/services.md
+++ b/guides/v3.6.0/applications/services.md
@@ -132,7 +132,7 @@ Note `cart` being used below to get data from the cart.
 
 ```handlebars {data-filename=app/templates/components/cart-contents.hbs}
 <ul>
-  {{#each cart.items as |item|}}
+  {{#each this.cart.items as |item|}}
     <li>
       {{item.name}}
       <button {{action "remove" item}}>Remove</button>

--- a/guides/v3.6.0/components/block-params.md
+++ b/guides/v3.6.0/components/block-params.md
@@ -4,11 +4,11 @@ but they can also return output to be used in a block expression.
 ### Return values from a component with `yield`
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{blog-post post=model}}
+{{blog-post post=this.model}}
 ```
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}
-{{yield post.title post.body post.author}}
+{{yield this.post.title this.post.body this.post.author}}
 ```
 
 Here an entire blog post model is being passed to the component as a single component property.
@@ -24,7 +24,7 @@ where the markup is provided by the consuming template,
 but any event handling behavior implemented in the component is retained such as `click()` handlers.
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{#blog-post post=model as |title body author|}}
+{{#blog-post post=this.model as |title body author|}}
   <h2>{{title}}</h2>
   <p class="author">by {{author}}</p>
   <p class="post-body">{{body}}</p>
@@ -40,11 +40,11 @@ using the `has-block` helper.
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}
 {{#if (has-block)}}
-  {{yield post.title post.body post.author}}  
+  {{yield this.post.title this.post.body this.post.author}}  
 {{else}}
-  <h1>{{post.title}}</h1>
-  <p class="author">Authored by {{post.author}}</p>
-  <p>{{post.body}}</p>
+  <h1>{{this.post.title}}</h1>
+  <p class="author">Authored by {{this.post.author}}</p>
+  <p>{{this.post.body}}</p>
 {{/if}}
 ```
 

--- a/guides/v3.6.0/components/defining-a-component.md
+++ b/guides/v3.6.0/components/defining-a-component.md
@@ -17,16 +17,16 @@ A sample component template could look like this:
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}
 <article class="blog-post">
-  <h1>{{title}}</h1>
+  <h1>{{this.title}}</h1>
   <p>{{yield}}</p>
-  <p>Edit title: {{input type="text" value=title}}</p>
+  <p>Edit title: {{input type="text" value=this.title}}</p>
 </article>
 ```
 
 Given the above template, you can now use the `{{blog-post}}` component:
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{#each model as |post|}}
+{{#each this.model as |post|}}
   {{#blog-post title=post.title}}
     {{post.body}}
   {{/blog-post}}
@@ -88,12 +88,12 @@ means of choosing different components for displaying different kinds of posts:
 
 ```handlebars {data-filename=app/templates/components/foo-component.hbs}
 <h3>Hello from foo!</h3>
-<p>{{post.body}}</p>
+<p>{{this.post.body}}</p>
 ```
 
 ```handlebars {data-filename=app/templates/components/bar-component.hbs}
 <h3>Hello from bar!</h3>
-<div>{{post.author}}</div>
+<div>{{this.post.author}}</div>
 ```
 
 ```javascript {data-filename=app/routes/index.js}
@@ -107,7 +107,7 @@ export default Route.extend({
 ```
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{#each model as |post|}}
+{{#each this.model as |post|}}
   {{!-- either foo-component or bar-component --}}
   {{component post.componentName post=post}}
 {{/each}}

--- a/guides/v3.6.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.6.0/components/passing-properties-to-a-component.md
@@ -6,8 +6,8 @@ display a blog post:
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}
 <article class="blog-post">
-  <h1>{{title}}</h1>
-  <p>{{body}}</p>
+  <h1>{{this.title}}</h1>
+  <p>{{this.body}}</p>
 </article>
 ```
 
@@ -26,7 +26,7 @@ export default Route.extend({
 If we tried to use the component like this:
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{#each model as |post|}}
+{{#each this.model as |post|}}
   {{blog-post}}
 {{/each}}
 ```
@@ -44,7 +44,7 @@ In order to make a property available to a component, you must pass it
 in like this:
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{#each model as |post|}}
+{{#each this.model as |post|}}
   {{blog-post title=post.title body=post.body}}
 {{/each}}
 ```
@@ -75,7 +75,7 @@ In addition to passing parameters in by name, you can pass them in by position.
 In other words, you can invoke the above component example like this:
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{#each model as |post|}}
+{{#each this.model as |post|}}
   {{blog-post post.title post.body}}
 {{/each}}
 ```

--- a/guides/v3.6.0/components/the-component-lifecycle.md
+++ b/guides/v3.6.0/components/the-component-lifecycle.md
@@ -49,14 +49,14 @@ you can use `didUpdateAttrs` to clear any error state that was built up from edi
 
 ```handlebars {data-filename=app/templates/components/profile-editor.hbs}
 <ul class="errors">
-  {{#each errors as |error|}}
+  {{#each this.errors as |error|}}
     <li>{{error.message}}</li>
   {{/each}}
 </ul>
 <fieldset>
-  {{input name="user.name" value=name change=(action "required")}}
-  {{input name="user.department" value=department change=(action "required")}}
-  {{input name="user.email" value=email change=(action "required")}}
+  {{input name="user.name" value=this.name change=(action "required")}}
+  {{input name="user.department" value=this.department change=(action "required")}}
+  {{input name="user.email" value=this.email change=(action "required")}}
 </fieldset>
 ```
 
@@ -216,7 +216,7 @@ The component below takes a list of items and displays them on the screen.
 Additionally, it takes an object representing which item is selected and will select and set the scroll top to that item.
 
 ```handlebars {data-filename=app/templates/application.hbs}
-{{selected-item-list items=items selectedItem=selection}}
+{{selected-item-list items=this.items selectedItem=this.selection}}
 ```
 
 When rendered the component will iterate through the given list and apply a class to the one that is selected.
@@ -224,7 +224,7 @@ When rendered the component will iterate through the given list and apply a clas
 
 ```handlebars {data-filename=app/templates/components/selected-item-list.hbs}
 <div class="item-list">
-  {{#each items as |item|}}
+  {{#each this.items as |item|}}
     <div class="list-item {{if item.isSelected 'selected-item'}}">{{item.label}}</div>
   {{/each}}
 </div>
@@ -262,7 +262,7 @@ Component teardown can be triggered by a number of different conditions.
 For instance, the user may navigate to a different route, or a conditional Handlebars block surrounding your component may change:
 
 ```handlebars {data-filename=app/templates/application.hbs}
-{{#if falseBool}}
+{{#if this.falseBool}}
   {{my-component}}
 {{/if}}
 ```

--- a/guides/v3.6.0/components/triggering-changes-with-actions.md
+++ b/guides/v3.6.0/components/triggering-changes-with-actions.md
@@ -126,8 +126,8 @@ The component template will have a button and a div that shows the confirmation 
 based on the value of `confirmShown`.
 
 ```handlebars {data-filename=app/templates/components/button-with-confirmation.hbs}
-<button {{action "launchConfirmDialog"}}>{{text}}</button>
-{{#if confirmShown}}
+<button {{action "launchConfirmDialog"}}>{{this.text}}</button>
+{{#if this.confirmShown}}
   <div class="confirm-dialog">
     <button class="confirm-submit" {{action "submitConfirm"}}>OK</button>
     <button class="confirm-cancel" {{action "cancelConfirm"}}>Cancel</button>
@@ -329,10 +329,10 @@ To accomplish this,
 we'll first modify the component so that it can be used in block form and we will [yield](../wrapping-content-in-a-component/) `confirmValue` to the block within the `"confirmDialog"` element:
 
 ```handlebars {data-filename=app/templates/components/button-with-confirmation.hbs}
-<button {{action "launchConfirmDialog"}}>{{text}}</button>
-{{#if confirmShown}}
+<button {{action "launchConfirmDialog"}}>{{this.text}}</button>
+{{#if this.confirmShown}}
   <div class="confirm-dialog">
-    {{yield confirmValue}}
+    {{yield this.confirmValue}}
     <button class="confirm-submit" {{action "submitConfirm"}}>OK</button>
     <button class="confirm-cancel" {{action "cancelConfirm"}}>Cancel</button>
   </div>
@@ -377,7 +377,7 @@ We can tell the action to invoke the `sendMessage` action directly on the messag
 ```handlebars {data-filename=app/templates/components/send-message.hbs}
 {{#button-with-confirmation
     text="Click to send your message."
-    onConfirm=(action "sendMessage" "info" target=messaging)
+    onConfirm=(action "sendMessage" "info" target=this.messaging)
     as |confirmValue| }}
   {{input value=confirmValue}}
 {{/button-with-confirmation}}
@@ -472,7 +472,7 @@ component's `deleteCurrentUser` property.
 
 ```handlebars {data-filename=app/templates/components/system-preferences-editor.hbs}
 {{user-profile
-  deleteCurrentUser=(action 'deleteUser' login.currentUser.id)
+  deleteCurrentUser=(action 'deleteUser' this.login.currentUser.id)
 }}
 ```
 
@@ -482,7 +482,7 @@ In our `user-profile.hbs` template we change our action to call `deleteCurrentUs
 
 ```handlebars {data-filename=app/templates/components/user-profile.hbs}
 {{button-with-confirmation
-  onConfirm=(action deleteCurrentUser)
+  onConfirm=(action this.deleteCurrentUser)
   text="Click OK to delete your account."
 }}
 ```

--- a/guides/v3.6.0/components/wrapping-content-in-a-component.md
+++ b/guides/v3.6.0/components/wrapping-content-in-a-component.md
@@ -3,14 +3,14 @@ Sometimes, you may want to define a component that wraps content provided by oth
 For example, imagine we are building a `blog-post` component that we can use in our application to display a blog post:
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}
-<h1>{{title}}</h1>
-<div class="body">{{body}}</div>
+<h1>{{this.title}}</h1>
+<div class="body">{{this.body}}</div>
 ```
 
 Now, we can use the `{{blog-post}}` component and pass it properties in another template:
 
 ```handlebars
-{{blog-post title=title body=body}}
+{{blog-post title=this.title body=this.body}}
 ```
 
 See [Passing Properties to a Component](../passing-properties-to-a-component/) for more.
@@ -31,19 +31,19 @@ In that case, we can use the `{{blog-post}}` component in **block form** and tel
 To update the example above, we'll first change the component's template:
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}
-<h1>{{title}}</h1>
+<h1>{{this.title}}</h1>
 <div class="body">{{yield}}</div>
 ```
 
-You can see that we've replaced `{{body}}` with `{{yield}}`.
+You can see that we've replaced `{{this.body}}` with `{{yield}}`.
 This tells Ember that this content will be provided when the component is used.
 
 Next, we'll update the template using the component to use the block form:
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{#blog-post title=title}}
-  <p class="author">by {{author}}</p>
-  {{body}}
+{{#blog-post title=this.title}}
+  <p class="author">by {{this.author}}</p>
+  {{this.body}}
 {{/blog-post}}
 ```
 
@@ -58,8 +58,8 @@ We will give them the option to specify either `markdown-style` or `html-style`.
 
 ```handlebars {data-filename=app/templates/index.hbs}
 {{#blog-post editStyle="markdown-style"}}
-  <p class="author">by {{author}}</p>
-  {{body}}
+  <p class="author">by {{this.author}}</p>
+  {{this.body}}
 {{/blog-post}}
 ```
 
@@ -70,16 +70,16 @@ Here, the appropriate component is assigned to a hash using nested helpers and y
 Notice `editStyle` being used as an argument to the component helper.
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}
-<h2>{{title}}</h2>
-<div class="body">{{yield (hash body=(component editStyle))}}</div>
+<h2>{{this.title}}</h2>
+<div class="body">{{yield (hash body=(component this.editStyle))}}</div>
 ```
 
 Once yielded, the data can be accessed by the wrapped content by referencing the `post` variable.
 Now a component called `markdown-style` will be rendered in `{{post.body}}`.
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{#blog-post editStyle="markdown-style" postData=myText as |post|}}
-  <p class="author">by {{author}}</p>
+{{#blog-post editStyle="markdown-style" postData=this.myText as |post|}}
+  <p class="author">by {{this.author}}</p>
   {{post.body}}
 {{/blog-post}}
 ```
@@ -88,10 +88,10 @@ Finally, we need to share `myText` with the body in order to have it display.
 To pass the blog text to the body component, we'll add a `postData` argument to the component helper.
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}
-<h2>{{title}}</h2>
+<h2>{{this.title}}</h2>
 <div class="body">
   {{yield (hash
-    body=(component editStyle postData=postData)
+    body=(component this.editStyle postData=this.postData)
   )}}
 </div>
 ```
@@ -106,8 +106,8 @@ When `{{post.body}}` is instantiated, it will have both the `editStyle` and `pos
 as well as the `bodyStyle` declared in the template.
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{#blog-post editStyle="markdown-style" postData=myText as |post|}}
-  <p class="author">by {{author}}</p>
+{{#blog-post editStyle="markdown-style" postData=this.myText as |post|}}
+  <p class="author">by {{this.author}}</p>
   {{post.body bodyStyle="compact-style"}}
 {{/blog-post}}
 ```

--- a/guides/v3.6.0/controllers/index.md
+++ b/guides/v3.6.0/controllers/index.md
@@ -43,15 +43,15 @@ The `BlogPost` model would have properties like:
 In the example below, we can see how the template is using the model properties to display some data.
 
 ```handlebars {data-filename=app/templates/blog-post.hbs}
-<h1>{{model.title}}</h1>
-<h2>by {{model.author}}</h2>
+<h1>{{this.model.title}}</h1>
+<h2>by {{this.model.author}}</h2>
 
 <div class="intro">
-  {{model.intro}}
+  {{this.model.intro}}
 </div>
 <hr>
 <div class="body">
-  {{model.body}}
+  {{this.model.body}}
 </div>
 ```
 
@@ -74,18 +74,18 @@ export default Controller.extend({
 The property `isExpanded` keeps track if the user has expanded the body or not. The action `toggleBody()` provides a way for the user to provide their setting. Both of the them are used in the updated template below.
 
 ```handlebars {data-filename=app/templates/blog-post.hbs}
-<h1>{{model.title}}</h1>
-<h2>by {{model.author}}</h2>
+<h1>{{this.model.title}}</h1>
+<h2>by {{this.model.author}}</h2>
 
 <div class='intro'>
-  {{model.intro}}
+  {{this.model.intro}}
 </div>
 <hr>
 
-{{#if isExpanded}}
+{{#if this.isExpanded}}
   <button {{action "toggleBody"}}>Hide Body</button>
   <div class="body">
-    {{model.body}}
+    {{this.model.body}}
   </div>
 {{else}}
   <button {{action "toggleBody"}}>Show Body</button>

--- a/guides/v3.6.0/getting-started/core-concepts.md
+++ b/guides/v3.6.0/getting-started/core-concepts.md
@@ -36,10 +36,10 @@ templates. Anything that is valid Handlebars syntax is valid Ember syntax.
 Templates can also display properties provided to them from their context, which is either a component or a route's controller. For example:
 
 ```handlebars
-<div>Hi {{name}}, this is a valid Ember template!</div>
+<div>Hi {{this.name}}, this is a valid Ember template!</div>
 ```
 
-Here, `{{name}}` is a property provided by the template's context.
+Here, `{{this.name}}` is a property provided by the template's context.
 
 Besides properties, double curly braces (`{{}}`) may also contain
 helpers and components, which we'll discuss later.

--- a/guides/v3.6.0/getting-started/quick-start.md
+++ b/guides/v3.6.0/getting-started/quick-start.md
@@ -153,7 +153,7 @@ Open the `scientists` template and add the following code to loop through the ar
 <h2>List of Scientists</h2>
 
 <ul>
-  {{#each model as |scientist|}}
+  {{#each this.model as |scientist|}}
     <li>{{scientist}}</li>
   {{/each}}
 </ul>
@@ -179,10 +179,10 @@ ember generate component people-list
 Copy and paste the `scientists` template into the `people-list` component's template and edit it to look as follows:
 
 ```handlebars {data-filename=app/templates/components/people-list.hbs}
-<h2>{{title}}</h2>
+<h2>{{this.title}}</h2>
 
 <ul>
-  {{#each people as |person|}}
+  {{#each this.people as |person|}}
     <li>{{person}}</li>
   {{/each}}
 </ul>
@@ -206,11 +206,11 @@ We're going to tell our component:
 <h2>List of Scientists</h2>
 
 <ul>
-  {{#each model as |scientist|}}
+  {{#each this.model as |scientist|}}
     <li>{{scientist}}</li>
   {{/each}}
 </ul>
-{{people-list title="List of Scientists" people=model}}
+{{people-list title="List of Scientists" people=this.model}}
 ```
 
 Go back to your browser and you should see that the UI looks identical.
@@ -230,10 +230,10 @@ Ember makes this easy to do.
 First add an `action` helper to the `li` in your `people-list` component.
 
 ```handlebars {data-filename="app/templates/components/people-list.hbs" data-diff="-5,+6"}
-<h2>{{title}}</h2>
+<h2>{{this.title}}</h2>
 
 <ul>
-  {{#each people as |person|}}
+  {{#each this.people as |person|}}
     <li>{{person}}</li>
     <li {{action "showPerson" person}}>{{person}}</li>
   {{/each}}

--- a/guides/v3.6.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.6.0/models/creating-updating-and-deleting-records.md
@@ -107,10 +107,10 @@ be available on the `errors` property of your model. Here's how you might displa
 the errors from saving a blog post in your template:
 
 ```handlebars
-{{#each post.errors.title as |error|}}
+{{#each this.post.errors.title as |error|}}
   <div class="error">{{error.message}}</div>
 {{/each}}
-{{#each post.errors.body as |error|}}
+{{#each this.post.errors.body as |error|}}
   <div class="error">{{error.message}}</div>
 {{/each}}
 ```

--- a/guides/v3.6.0/models/defining-models.md
+++ b/guides/v3.6.0/models/defining-models.md
@@ -176,5 +176,5 @@ tags: DS.attr() // a read-only array
 ```
 
 ```handlebars
-{{model.location.latitude}}
+{{this.model.location.latitude}}
 ```

--- a/guides/v3.6.0/models/index.md
+++ b/guides/v3.6.0/models/index.md
@@ -123,7 +123,7 @@ this:
 
 ```handlebars {data-filename=app/templates/components/list-of-drafts.hbs}
 <ul>
-  {{#each drafts key="id" as |draft|}}
+  {{#each this.drafts key="id" as |draft|}}
     <li>{{draft.title}}</li>
   {{/each}}
 </ul>
@@ -149,7 +149,7 @@ export default Component.extend({
 
 ```handlebars {data-filename=app/templates/components/drafts-button.hbs}
 {{#link-to "drafts" tagName="button"}}
-  Drafts ({{drafts.length}})
+  Drafts ({{this.drafts.length}})
 {{/link-to}}
 ```
 

--- a/guides/v3.6.0/models/relationships.md
+++ b/guides/v3.6.0/models/relationships.md
@@ -473,7 +473,7 @@ Handlebars templates will automatically be updated to reflect a resolved promise
 
 ```handlebars
 <ul>
-  {{#each blogPost.comments as |comment|}}
+  {{#each this.blogPost.comments as |comment|}}
     <li>{{comment.id}}</li>
   {{/each}}
 </ul>

--- a/guides/v3.6.0/routing/query-params.md
+++ b/guides/v3.6.0/routing/query-params.md
@@ -90,7 +90,7 @@ The `link-to` helper supports specifying query params using the
 {{#link-to "posts" (query-params direction="asc")}}Sort{{/link-to}}
 
 // Binding is also supported
-{{#link-to "posts" (query-params direction=otherDirection)}}Sort{{/link-to}}
+{{#link-to "posts" (query-params direction=this.otherDirection)}}Sort{{/link-to}}
 ```
 
 In the above examples, `direction` is presumably a query param property

--- a/guides/v3.6.0/routing/specifying-a-routes-model.md
+++ b/guides/v3.6.0/routing/specifying-a-routes-model.md
@@ -32,7 +32,7 @@ You will then be able to access the controller's `model` property in your templa
 
 ```handlebars {data-filename=app/templates/favorite-posts.hbs}
 <h1>Favorite Posts</h1>
-{{#each model as |post|}}
+{{#each this.model as |post|}}
   <p>{{post.body}}</p>
 {{/each}}
 ```
@@ -94,7 +94,7 @@ was passed a model/):
 
 ```handlebars {data-filename=app/templates/photos.hbs}
 <h1>Photos</h1>
-{{#each model as |photo|}}
+{{#each this.model as |photo|}}
   <p>
     {{#link-to "photo" photo}}
       <img src="{{photo.thumbnailUrl}}" alt="{{photo.title}}" />
@@ -108,7 +108,7 @@ identifier, instead):
 
 ```handlebars {data-filename=app/templates/photos.hbs}
 <h1>Photos</h1>
-{{#each model as |photo|}}
+{{#each this.model as |photo|}}
   <p>
     {{#link-to "photo" photo.id}}
       <img src="{{photo.thumbnailUrl}}" alt="{{photo.title}}" />
@@ -147,7 +147,7 @@ each record in the song model and album model:
 <h1>Playlist</h1>
 
 <ul>
-  {{#each model.songs as |song|}}
+  {{#each this.model.songs as |song|}}
     <li>{{song.name}} by {{song.artist}}</li>
   {{/each}}
 </ul>
@@ -155,7 +155,7 @@ each record in the song model and album model:
 <h1>Albums</h1>
 
 <ul>
-  {{#each model.albums as |album|}}
+  {{#each this.model.albums as |album|}}
     <li>{{album.title}} by {{album.artist}}</li>
   {{/each}}
 </ul>

--- a/guides/v3.6.0/templates/actions.md
+++ b/guides/v3.6.0/templates/actions.md
@@ -8,9 +8,9 @@ helper to any HTML DOM element, when a user clicks the element, the named event
 will be sent to the template's corresponding component or controller.
 
 ```handlebars {data-filename=app/templates/components/single-post.hbs}
-<h3><button {{action "toggleBody"}}>{{title}}</button></h3>
-{{#if isShowingBody}}
-  <p>{{body}}</p>
+<h3><button {{action "toggleBody"}}>{{this.title}}</button></h3>
+{{#if this.isShowingBody}}
+  <p>{{this.body}}</p>
 {{/if}}
 ```
 
@@ -41,7 +41,7 @@ the handler as arguments.
 For example, if the `post` argument was passed:
 
 ```handlebars
-<p><button {{action "select" post}}>✓</button> {{post.title}}</p>
+<p><button {{action "select" this.post}}>✓</button> {{this.post.title}}</p>
 ```
 
 The `select` action handler would be called with a single argument
@@ -70,8 +70,8 @@ You can specify an alternative event by using the `on` option.
 
 ```handlebars
 <p>
-  <button {{action "select" post on="mouseUp"}}>✓</button>
-  {{post.title}}
+  <button {{action "select" this.post on="mouseUp"}}>✓</button>
+  {{this.post.title}}
 </p>
 ```
 
@@ -123,7 +123,7 @@ event listeners and enables to work with one-way bindings.
 
 ```handlebars
 <label>What's your favorite band?</label>
-<input type="text" value={{favoriteBand}} onblur={{action "bandDidChange"}} />
+<input type="text" value={{this.favoriteBand}} onblur={{action "bandDidChange"}} />
 ```
 
 Let's assume we have an action handler that prints its first parameter:
@@ -145,7 +145,7 @@ the event object:
 
 ```handlebars
 <label>What's your favorite band?</label>
-<input type="text" value={{favoriteBand}} onblur={{action "bandDidChange" value="target.value"}} />
+<input type="text" value={{this.favoriteBand}} onblur={{action "bandDidChange" value="target.value"}} />
 ```
 
 The `newValue` parameter thus becomes the `target.value` property of the event

--- a/guides/v3.6.0/templates/binding-element-attributes.md
+++ b/guides/v3.6.0/templates/binding-element-attributes.md
@@ -6,7 +6,7 @@ to an image:
 
 ```handlebars
 <div id="logo">
-  <img src={{logoUrl}} alt="Logo">
+  <img src={{this.logoUrl}} alt="Logo">
 </div>
 ```
 
@@ -22,7 +22,7 @@ If you use data binding with a Boolean value, it will add or remove
 the specified attribute. For example, given this template:
 
 ```handlebars
-<input type="checkbox" disabled={{isAdministrator}}>
+<input type="checkbox" disabled={{this.isAdministrator}}>
 ```
 
 If `isAdministrator` is `true`, Handlebars will produce the following

--- a/guides/v3.6.0/templates/built-in-helpers.md
+++ b/guides/v3.6.0/templates/built-in-helpers.md
@@ -10,7 +10,7 @@ makes it easy to dynamically send the value of a variable to another helper or c
 This can be useful if you want to output one of several values based on the result of a computed property.
 
 ```handlebars
-{{get address part}}
+{{get this.address this.part}}
 ```
 
 if the `part` computed property returns "zip", this will display the result of `this.address.zip`.
@@ -25,7 +25,7 @@ helper makes it easy to dynamically send a number of parameters to a component o
 format of a concatenated string.
 
 ```handlebars
-{{get "foo" (concat "item" index)}}
+{{get "foo" (concat "item" this.index)}}
 ```
 
 This will display the result of `this.foo.item1` when index is 1, and `this.foo.item2` when index is 2, etc.
@@ -39,11 +39,11 @@ The [`{{let}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Template
 Say your template now looks like this:
 
 ```handlebars
-Welcome back {{concat (capitalize person.firstName) ' ' (capitalize person.lastName)}}
+Welcome back {{concat (capitalize this.person.firstName) ' ' (capitalize this.person.lastName)}}
 
 Account Details:
-First Name: {{capitalize person.firstName}}
-Last Name: {{capitalize person.lastName}}
+First Name: {{capitalize this.person.firstName}}
+Last Name: {{capitalize this.person.lastName}}
 ```
 
 As mentioned in the previous section we use the `concat` helper to render both `person.firstName` and `person.lastName` in one go.
@@ -52,7 +52,7 @@ It gets a bit repetitive to keep writing `capitalize` and honestly, we might jus
 Thankfully, we can use the `{{let}}` helper to fix this:
 
 ```handlebars
-{{#let (capitalize person.firstName) (capitalize person.lastName)
+{{#let (capitalize this.person.firstName) (capitalize this.person.lastName)
   as |firstName lastName|
 }}
   Welcome back {{concat firstName ' ' lastName}}
@@ -64,7 +64,7 @@ Thankfully, we can use the `{{let}}` helper to fix this:
 ```
 
 Now, as long as your template is wrapped in the `let` helper you can access the capitalized first name and last name as
-`firstName` and `lastName` instead of `(capitalize person.firstName)`.
+`firstName` and `lastName` instead of `(capitalize this.person.firstName)`.
 
 ### Array helper
 
@@ -75,7 +75,7 @@ you can pass arrays directly from the template as an argument to your components
 {{my-component people=(array
     'Tom Dade'
     'Yehuda Katz'
-    myOtherPerson)
+    this.myOtherPerson)
  }}
 ```
 
@@ -83,7 +83,7 @@ In the component's template, you can then use the `people` argument as an array:
 
 ```handlebars {data-filename=app/templates/components/my-component.hbs}
 <ul>
-  {{#each people as |person|}}
+  {{#each this.people as |person|}}
     <li>{{person}}</li>
   {{/each}}
 </ul>

--- a/guides/v3.6.0/templates/conditionals.md
+++ b/guides/v3.6.0/templates/conditionals.md
@@ -8,7 +8,7 @@ displaying a property, but helpers accept arguments. For example:
 
 ```handlebars
 <div>
-  {{if isFast "zoooom" "putt-putt-putt"}}
+  {{if this.isFast "zoooom" "putt-putt-putt"}}
 </div>
 ```
 
@@ -21,7 +21,7 @@ Inline helpers don't need to be used inside HTML tags. They can also be used
 inside attribute values:
 
 ```handlebars
-<div class="is-car {{if isFast "zoooom" "putt-putt-putt"}}">
+<div class="is-car {{if this.isFast "zoooom" "putt-putt-putt"}}">
 </div>
 ```
 
@@ -31,7 +31,7 @@ only renders `"zoooom"` if both `isFast` and `isFueled` are true:
 
 ```handlebars
 <div>
-  {{if isFast (if isFueled "zoooom")}}
+  {{if isFast (if this.isFueled "zoooom")}}
 </div>
 ```
 
@@ -48,8 +48,8 @@ For example, this template conditionally shows
 properties on `person` only if that it is present:
 
 ```handlebars
-{{#if person}}
-  Welcome back, <b>{{person.firstName}} {{person.lastName}}</b>!
+{{#if this.person}}
+  Welcome back, <b>{{this.person.firstName}} {{this.person.lastName}}</b>!
 {{/if}}
 ```
 
@@ -62,8 +62,8 @@ If a value passed to `{{#if}}` evaluates to falsy, the `{{else}}` block
 of that invocation is rendered:
 
 ```handlebars
-{{#if person}}
-  Welcome back, <b>{{person.firstName}} {{person.lastName}}</b>!
+{{#if this.person}}
+  Welcome back, <b>{{this.person.firstName}} {{this.person.lastName}}</b>!
 {{else}}
   Please log in.
 {{/if}}
@@ -73,9 +73,9 @@ of that invocation is rendered:
 `{{else if}}`:
 
 ```handlebars
-{{#if isAtWork}}
+{{#if this.isAtWork}}
   Ship that code!
-{{else if isReading}}
+{{else if this.isReading}}
   You can finish War and Peace eventually...
 {{/if}}
 ```
@@ -86,7 +86,7 @@ which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 
 ```handlebars
-{{#unless hasPaid}}
-  You owe: ${{total}}
+{{#unless this.hasPaid}}
+  You owe: ${{this.total}}
 {{/unless}}
 ```

--- a/guides/v3.6.0/templates/development-helpers.md
+++ b/guides/v3.6.0/templates/development-helpers.md
@@ -11,7 +11,7 @@ The [`{{log}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Template
 current rendering context into your browser's console:
 
 ```handlebars
-{{log 'Name is:' name}}
+{{log 'Name is:' this.name}}
 ```
 
 The `{{log}}` helper also accepts primitive types such as strings or numbers.
@@ -40,7 +40,7 @@ when the `debugger;` breakpoint is hit, you can attempt to retrieve this value:
 `get` is also aware of keywords. So in this situation:
 
 ```handlebars
-{{#each items as |item|}}
+{{#each this.items as |item|}}
   {{debugger}}
 {{/each}}
 ```
@@ -48,7 +48,7 @@ when the `debugger;` breakpoint is hit, you can attempt to retrieve this value:
 You'll be able to get values from the current item:
 
 ```javascript
-> get('item.name')
+> get('this.item.name')
 ```
 
 You can also access the context of the view to make sure it is the object that

--- a/guides/v3.6.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.6.0/templates/displaying-a-list-of-items.md
@@ -9,7 +9,7 @@ objects. Each item in the array is provided as the block param `person`.
 
 ```handlebars
 <ul>
-  {{#each people as |person|}}
+  {{#each this.people as |person|}}
     <li>Hello, {{person.name}}!</li>
   {{/each}}
 </ul>
@@ -58,7 +58,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ```handlebars
 <ul>
-  {{#each people as |person index|}}
+  {{#each this.people as |person index|}}
     <li>Hello, {{person.name}}! You're number {{index}} in line</li>
   {{/each}}
 </ul>
@@ -71,7 +71,7 @@ helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 
 ```handlebars
-{{#each people as |person|}}
+{{#each this.people as |person|}}
   Hello, {{person.name}}!
 {{else}}
   Sorry, nobody is here.

--- a/guides/v3.6.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.6.0/templates/displaying-the-keys-in-an-object.md
@@ -19,7 +19,7 @@ export default Component.extend({
 
 ```handlebars {data-filename=/app/templates/components/store-categories.hbs}
 <ul>
-  {{#each-in categories as |category products|}}
+  {{#each-in this.categories as |category products|}}
     <li>{{category}}
       <ol>
         {{#each products as |product|}}
@@ -68,7 +68,7 @@ helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 
 ```handlebars
-{{#each-in people as |name person|}}
+{{#each-in this.people as |name person|}}
   Hello, {{name}}! You are {{person.age}} years old.
 {{else}}
   Sorry, nobody is here.

--- a/guides/v3.6.0/templates/handlebars-basics.md
+++ b/guides/v3.6.0/templates/handlebars-basics.md
@@ -11,7 +11,7 @@ Handlebars expressions read their properties. In Ember this is often a component
 For example, this `application.hbs` template will render a first and last name:
 
 ```handlebars {data-filename=app/templates/application.hbs}
-Hello, <strong>{{firstName}} {{lastName}}</strong>!
+Hello, <strong>{{this.firstName}} {{this.lastName}}</strong>!
 ```
 
 The `firstName` and `lastName` properties are read from the
@@ -66,7 +66,7 @@ export default helper(sum);
 
 The above code will allow you invoke the `sum()` function as a `{{sum}}` handlebars "helper" in your templates:
 
-```html
+```handlebars {data-filename=app/templates/application.hbs}
 <p>Total: {{sum 1 2 3}}</p>
 ```
 
@@ -82,7 +82,7 @@ This gives you the flexibility to compute a value _before_ it is passed in as an
 
 It is not possible to nest curly braces `{{}}`, so the correct way to nest a helper is by using parentheses `()`:
 
-```html
+```handlebars {data-filename=app/templates/application.hbs}
 {{sum (multiply 2 4) 2}}
 ```
 

--- a/guides/v3.6.0/templates/input-helpers.md
+++ b/guides/v3.6.0/templates/input-helpers.md
@@ -37,7 +37,7 @@ unquoted, these values will be bound to a property on the template's current
 rendering context. For example:
 
 ```handlebars
-{{input type="text" value=firstName disabled=entryNotAllowed size="50"}}
+{{input type="text" value=this.firstName disabled=this.entryNotAllowed size="50"}}
 ```
 
 Will bind the `disabled` attribute to the value of `entryNotAllowed` in the
@@ -48,7 +48,7 @@ current context.
 To dispatch an action on specific events, such as `enter` or `key-press`, use the following
 
 ```handlebars
-{{input value=firstName key-press=(action "updateFirstName")}}
+{{input value=this.firstName key-press=(action "updateFirstName")}}
 ```
 
 [Event Names](https://www.emberjs.com/api/ember/release/classes/Component) must be dasherized.
@@ -60,7 +60,7 @@ You can also use the
 helper to create a checkbox by setting its `type`:
 
 ```handlebars
-{{input type="checkbox" name="isAdmin" checked=isAdmin}}
+{{input type="checkbox" name="isAdmin" checked=this.isAdmin}}
 ```
 
 Checkboxes support the following properties:
@@ -79,7 +79,7 @@ Which can be bound or set as described in the previous section.
 ## Text Areas
 
 ```handlebars
-{{textarea value=name cols="80" rows="6"}}
+{{textarea value=this.name cols="80" rows="6"}}
 ```
 
 Will bind the value of the text area to `name` on the current context.
@@ -109,7 +109,7 @@ Will bind the value of the text area to `name` on the current context.
 You might need to bind a property dynamically to an input if you're building a flexible form, for example. To achieve this you need to use the [`{{get}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get) and [`{{mut}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/mut?anchor=mut) in conjunction like shown in the following example:
 
 ```handlebars
-{{input value=(mut (get person field))}}
+{{input value=(mut (get this.person this.field))}}
 ```
 
 The `{{get}}` helper allows you to dynamically specify which property to bind, while the `{{mut}}` helper allows the binding to be updated from the input. See the respective helper documentation for more detail.

--- a/guides/v3.6.0/templates/links.md
+++ b/guides/v3.6.0/templates/links.md
@@ -14,7 +14,7 @@ Router.map(function() {
 
 ```handlebars {data-filename=app/templates/photos.hbs}
 <ul>
-  {{#each photos as |photo|}}
+  {{#each this.photos as |photo|}}
     <li>{{#link-to "photos.edit" photo}}{{photo.title}}{{/link-to}}</li>
   {{/each}}
 </ul>
@@ -78,10 +78,10 @@ Router.map(function() {
 
 ```handlebars {data-filename=app/templates/photo/index.hbs}
 <div class="photo">
-  {{body}}
+  {{this.body}}
 </div>
 
-<p>{{#link-to "photos.photo.comment" primaryComment}}Main Comment{{/link-to}}</p>
+<p>{{#link-to "photos.photo.comment" this.primaryComment}}Main Comment{{/link-to}}</p>
 ```
 
 If you specify only one model, it will represent the innermost dynamic segment `:comment_id`.
@@ -91,7 +91,7 @@ Alternatively, you could pass both a photo's ID and a comment to the component:
 
 ```handlebars {data-filename=app/templates/photo/index.hbs}
 <p>
-  {{#link-to 'photo.comment' 5 primaryComment}}
+  {{#link-to 'photo.comment' 5 this.primaryComment}}
     Main Comment for the Next Photo
   {{/link-to}}
 </p>
@@ -110,7 +110,7 @@ The `query-params` helper can be used to set query params on a link:
 {{#link-to "posts" (query-params direction="asc")}}Sort{{/link-to}}
 
 // Binding is also supported
-{{#link-to "posts" (query-params direction=otherDirection)}}Sort{{/link-to}}
+{{#link-to "posts" (query-params direction=this.otherDirection)}}Sort{{/link-to}}
 ```
 
 For more information on how to use query parameters see the [query parameters](../../routing/query-params/) section in Routing.
@@ -141,7 +141,7 @@ arguments to the `link-to` component:
 
 ```handlebars
 <p>
-  {{link-to "Edit this photo" "photo.edit" photo class="btn btn-primary"}}
+  {{link-to "Edit this photo" "photo.edit" this.photo class="btn btn-primary"}}
 </p>
 ```
 
@@ -158,7 +158,7 @@ can use the `replace=true` option:
 
 ```handlebars
 <p>
-  {{#link-to "photo.comment" 5 primaryComment replace=true}}
+  {{#link-to "photo.comment" 5 this.primaryComment replace=true}}
     Main Comment for the Next Photo
   {{/link-to}}
 </p>

--- a/guides/v3.6.0/templates/writing-helpers.md
+++ b/guides/v3.6.0/templates/writing-helpers.md
@@ -22,7 +22,7 @@ To use the `format-currency` helper, you call it using curly braces in
 your template:
 
 ```handlebars
-Your total is {{format-currency model.totalDue}}.
+Your total is {{format-currency this.model.totalDue}}.
 ```
 
 Let's now implement the helper. Helpers are functions that take
@@ -69,7 +69,7 @@ Your total is {{format-currency 250}}.
 
 And Ember makes use of our new helper function to replace the content inside the ```{{ }}``` with the formatted amount.
 
-```handlebars
+```html
 Your total is $2.50.
 ```
 
@@ -150,7 +150,7 @@ helper:
 
 We'd like our helper to print pounds sterling rather than US dollars:
 
-```handlebars
+```html
 £3.50
 ```
 
@@ -210,7 +210,7 @@ export default helper(myHelper);
 In sum, arguments are good for passing values:
 
 ```handlebars
-{{format-date currentDate}}
+{{format-date this.currentDate}}
 ```
 
 Hashes are useful for configuring the behavior of a helper:
@@ -223,7 +223,7 @@ You can have as many of both as you want, so long as the parameters come
 first:
 
 ```handlebars
-{{format-date-and-time date time format="YYYY MM DD h:mm" locale="en"}}
+{{format-date-and-time this.date this.time format="YYYY MM DD h:mm" locale="en"}}
 ```
 
 The above example contains two arguments:
@@ -325,7 +325,7 @@ You can invoke it like this:
 
 Ember will escape the HTML tags, like this:
 
-```handlebars
+```html
 &lt;b&gt;Hello world&lt;/b&gt;
 ```
 
@@ -358,7 +358,7 @@ For example, imagine that we have a chat app  and use our `make-bold`
 helper to welcome the new users into the channel:
 
 ```handlebars
-Welcome back! {{make-bold model.firstName}} has joined the channel.
+Welcome back! {{make-bold this.model.firstName}} has joined the channel.
 ```
 
 Now a malicious user simply needs to set their `firstName` to a string
@@ -390,7 +390,7 @@ Now the value passed into the helper has its HTML escaped, but the trusted
 malicious user setting their `firstName` to something containing HTML
 would see this:
 
-```handlebars
+```html
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```

--- a/guides/v3.6.0/testing/testing-components.md
+++ b/guides/v3.6.0/testing/testing-components.md
@@ -21,7 +21,7 @@ export default Component.extend({
 ```
 
 ```handlebars {data-filename="app/templates/components/pretty-color.hbs"}
-Pretty Color: {{name}}
+Pretty Color: {{this.name}}
 ```
 
 The `module` from QUnit will scope your tests into groups of tests which can be configured and run independently.
@@ -170,7 +170,7 @@ export default Component.extend({
 ```
 
 ```handlebars {data-filename="app/templates/components/magic-title.hbs"}
-<h2>{{title}}</h2>
+<h2>{{this.title}}</h2>
 
 <button class="title-button" {{action "updateTitle"}}>
   Update Title
@@ -234,7 +234,7 @@ export default Component.extend({
 ```handlebars {data-filename="app/templates/components/comment-form.hbs"}
 <form {{action "submitComment" on="submit"}}>
   <label>Comment:</label>
-  {{textarea value=comment}}
+  {{textarea value=this.comment}}
 
   <input class="comment-input" type="submit" value="Submit"/>
 </form>
@@ -304,7 +304,7 @@ export default Component.extend({
 ```
 
 ```handlebars {data-filename="app/templates/components/location-indicator.hbs"}
-You currently are located in {{city}}, {{country}}
+You currently are located in {{this.city}}, {{this.country}}
 ```
 
 To stub the location service in your test, create a local stub object that extends `Ember.Service`,
@@ -479,9 +479,9 @@ export default Component.extend({
 ```
 
 ```handlebars {data-filename="app/templates/components/delayed-typeahead.hbs"}
-{{input value=searchValue key-up=(action 'handleTyping')}}
+{{input value=this.searchValue key-up=(action 'handleTyping')}}
 <ul>
-{{#each results as |result|}}
+{{#each this.results as |result|}}
   <li class="result">{{result.name}}</li>
 {{/each}}
 </ul>

--- a/guides/v3.6.0/tutorial/autocomplete-component.md
+++ b/guides/v3.6.0/tutorial/autocomplete-component.md
@@ -47,7 +47,7 @@ as |filteredResults|
   </ul>
 {{/list-filter}}
 {{outlet}}
-{{#each model as |rentalUnit|}}
+{{#each this.model as |rentalUnit|}}
   {{rental-listing rental=rentalUnit}}
 {{/each}}
 ```
@@ -58,12 +58,12 @@ We want the component to simply provide an input field and yield the results lis
 
 ```handlebars {data-filename=app/templates/components/list-filter.hbs}
 {{input
-  value=value
+  value=this.value
   key-up=(action "handleFilterEntry")
   class="light"
   placeholder="Filter By City"
 }}
-{{yield results}}
+{{yield this.results}}
 ```
 
 The template contains an [`{{input}}`](../../templates/input-helpers/) helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.

--- a/guides/v3.6.0/tutorial/hbs-helper.md
+++ b/guides/v3.6.0/tutorial/hbs-helper.md
@@ -36,25 +36,25 @@ Let's update our `rental-listing` component template to use our new helper and p
 <article class="listing">
   <a
     onclick={{action 'toggleImageSize'}}
-    class="image {{if isWide "wide"}}"
+    class="image {{if this.isWide "wide"}}"
   >
-    <img src={{rental.image}} alt="">
+    <img src={{this.rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <div class="details">
-    <h3>{{rental.title}}</h3>
+    <h3>{{this.rental.title}}</h3>
     <div class="detail owner">
-      <span>Owner:</span> {{rental.owner}}
+      <span>Owner:</span> {{this.rental.owner}}
     </div>
     <div class="detail type">
-      <span>Type:</span> {{rental.category}}
-      <span>Type:</span> {{rental-property-type rental.category}} - {{rental.category}}
+      <span>Type:</span> {{this.rental.category}}
+      <span>Type:</span> {{rental-property-type this.rental.category}} - {{this.rental.category}}
     </div>
     <div class="detail location">
-      <span>Location:</span> {{rental.city}}
+      <span>Location:</span> {{this.rental.city}}
     </div>
     <div class="detail bedrooms">
-      <span>Number of bedrooms:</span> {{rental.bedrooms}}
+      <span>Number of bedrooms:</span> {{this.rental.bedrooms}}
     </div>
   </div>
 </article>

--- a/guides/v3.6.0/tutorial/model-hook.md
+++ b/guides/v3.6.0/tutorial/model-hook.md
@@ -76,7 +76,7 @@ This helper will let us loop through each of the rental objects in our model:
   {{/link-to}}
 </div>
 
-{{#each model as |rental|}}
+{{#each this.model as |rental|}}
   <article class="listing">
     <div class="details">
       <h3>{{rental.title}}</h3>

--- a/guides/v3.6.0/tutorial/service.md
+++ b/guides/v3.6.0/tutorial/service.md
@@ -171,29 +171,29 @@ Finally open the template file for our `rental-listing` component and add the ne
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="+25"}
 <article class="listing">
   <a
-    class="image {{if isWide "wide"}}"
+    class="image {{if this.isWide "wide"}}"
     onclick={{action "toggleImageSize"}}
     role="button"
   >
-    <img src={{rental.image}} alt="">
+    <img src={{this.rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <div class="details">
-    <h3>{{rental.title}}</h3>
+    <h3>{{this.rental.title}}</h3>
     <div class="detail owner">
-      <span>Owner:</span> {{rental.owner}}
+      <span>Owner:</span> {{this.rental.owner}}
     </div>
     <div class="detail type">
-      <span>Type:</span> {{rental-property-type rental.category}} - {{rental.category}}
+      <span>Type:</span> {{rental-property-type this.rental.category}} - {{this.rental.category}}
     </div>
     <div class="detail location">
-      <span>Location:</span> {{rental.city}}
+      <span>Location:</span> {{this.rental.city}}
     </div>
     <div class="detail bedrooms">
-      <span>Number of bedrooms:</span> {{rental.bedrooms}}
+      <span>Number of bedrooms:</span> {{this.rental.bedrooms}}
     </div>
   </div>
-  {{location-map location=rental.city}}
+  {{location-map location=this.rental.city}}
 </article>
 ```
 

--- a/guides/v3.6.0/tutorial/simple-component.md
+++ b/guides/v3.6.0/tutorial/simple-component.md
@@ -37,20 +37,20 @@ To start, let's move the rental display details for a single rental from the `re
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-1,+2,+3,+4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17,+18,+19"}
 {{yield}}
 <article class="listing">
-  <img src={{rental.image}} alt="">
+  <img src={{this.rental.image}} alt="">
   <div class="details">
-    <h3>{{rental.title}}</h3>
+    <h3>{{this.rental.title}}</h3>
     <div class="detail owner">
-      <span>Owner:</span> {{rental.owner}}
+      <span>Owner:</span> {{this.rental.owner}}
     </div>
     <div class="detail type">
-      <span>Type:</span> {{rental.category}}
+      <span>Type:</span> {{this.rental.category}}
     </div>
     <div class="detail location">
-      <span>Location:</span> {{rental.city}}
+      <span>Location:</span> {{this.rental.city}}
     </div>
     <div class="detail bedrooms">
-      <span>Number of bedrooms:</span> {{rental.bedrooms}}
+      <span>Number of bedrooms:</span> {{this.rental.bedrooms}}
     </div>
   </div>
 </article>
@@ -71,9 +71,9 @@ with our new `rental-listing` component:
   {{/link-to}}
 </div>
 
-{{#each model as |rentalUnit|}}
+{{#each this.model as |rentalUnit|}}
   {{rental-listing rental=rentalUnit}}
-{{#each model as |rental|}}
+{{#each this.model as |rental|}}
   <article class="listing">
     <h3>{{rental.title}}</h3>
     <div class="detail owner">
@@ -111,24 +111,24 @@ giving it the `image` class name so that our test can find it.
 
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="+2,+3,+5,+6"}
 <article class="listing">
-  <a class="image {{if isWide "wide"}}"
+  <a class="image {{if this.isWide "wide"}}"
     role="button">
-    <img src={{rental.image}} alt="">
+    <img src={{this.rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <div class="details">
-    <h3>{{rental.title}}</h3>
+    <h3>{{this.rental.title}}</h3>
     <div class="detail owner">
-      <span>Owner:</span> {{rental.owner}}
+      <span>Owner:</span> {{this.rental.owner}}
     </div>
     <div class="detail type">
-      <span>Type:</span> {{rental.category}}
+      <span>Type:</span> {{this.rental.category}}
     </div>
     <div class="detail location">
-      <span>Location:</span> {{rental.city}}
+      <span>Location:</span> {{this.rental.city}}
     </div>
     <div class="detail bedrooms">
-      <span>Number of bedrooms:</span> {{rental.bedrooms}}
+      <span>Number of bedrooms:</span> {{this.rental.bedrooms}}
     </div>
   </div>
 </article>
@@ -168,28 +168,28 @@ template:
 
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-2,+3,+4,+4,+6,+7"}
 <article class="listing">
-  <a class="image {{if isWide "wide"}}">
+  <a class="image {{if this.isWide "wide"}}">
   <a
     onclick={{action "toggleImageSize"}}
-    class="image {{if isWide "wide"}}"
+    class="image {{if this.isWide "wide"}}"
     role="button"
   >
-    <img src={{rental.image}} alt="">
+    <img src={{this.rental.image}} alt="">
     <small>View Larger</small>
   </a>
   <div class="details">
-    <h3>{{rental.title}}</h3>
+    <h3>{{this.rental.title}}</h3>
     <div class="detail owner">
-      <span>Owner:</span> {{rental.owner}}
+      <span>Owner:</span> {{this.rental.owner}}
     </div>
     <div class="detail type">
-      <span>Type:</span> {{rental.category}}
+      <span>Type:</span> {{this.rental.category}}
     </div>
     <div class="detail location">
-      <span>Location:</span> {{rental.city}}
+      <span>Location:</span> {{this.rental.city}}
     </div>
     <div class="detail bedrooms">
-      <span>Number of bedrooms:</span> {{rental.bedrooms}}
+      <span>Number of bedrooms:</span> {{this.rental.bedrooms}}
     </div>
   </div>
 </article>

--- a/guides/v3.6.0/tutorial/subroutes.md
+++ b/guides/v3.6.0/tutorial/subroutes.md
@@ -310,26 +310,26 @@ Next, we can update the template for our show route (`app/templates/rentals/show
 
 ```handlebars {data-filename="app/templates/rentals/show.hbs" data-diff="+1,+2,+3,+4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,-26"}
 <div class="jumbo show-listing">
-  <h2 class="title">{{model.title}}</h2>
+  <h2 class="title">{{this.model.title}}</h2>
   <div class="content">
     <div>
-      <img src={{model.image}} class="rental-pic" alt="Picture of {{model.title}}">
+      <img src={{this.model.image}} class="rental-pic" alt="Picture of {{this.model.title}}">
     </div>
     <div class="detail-section">
       <div class="detail owner">
-        <strong>Owner:</strong> {{model.owner}}
+        <strong>Owner:</strong> {{this.model.owner}}
       </div>
       <div class="detail">
-        <strong>Type:</strong> {{rental-property-type model.category}} - {{model.category}}
+        <strong>Type:</strong> {{rental-property-type this.model.category}} - {{this.model.category}}
       </div>
       <div class="detail">
-        <strong>Location:</strong> {{model.city}}
+        <strong>Location:</strong> {{this.model.city}}
       </div>
       <div class="detail">
-        <strong>Number of bedrooms:</strong> {{model.bedrooms}}
+        <strong>Number of bedrooms:</strong> {{this.model.bedrooms}}
       </div>
       <div class="description">
-        <p>{{model.description}}</p>
+        <p>{{this.model.description}}</p>
       </div>
     </div>
   </div>
@@ -355,30 +355,30 @@ Clicking on the title will load the detail page for that rental.
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-11,+12"}
 <article class="listing">
   <a
-    class="image {{if isWide "wide"}}">
+    class="image {{if this.isWide "wide"}}">
     onclick={{action 'toggleImageSize'}}
     role="button"
   >
-    <img src="{{rental.image}}" alt=""
+    <img src="{{this.rental.image}}" alt=""
     <small>View Larger</small>
   </a>
   <div class="details">
-    <h3>{{rental.title}}</h3>
-    <h3>{{#link-to "rentals.show" rental class=rental.id}}{{rental.title}}{{/link-to}}</h3>
+    <h3>{{this.rental.title}}</h3>
+    <h3>{{#link-to "rentals.show" rental class=rental.id}}{{this.rental.title}}{{/link-to}}</h3>
     <div class="detail owner">
-      <span>Owner:</span> {{rental.owner}}
+      <span>Owner:</span> {{this.rental.owner}}
     </div>
     <div class="detail type">
-      <span>Type:</span> {{rental-property-type rental.category}} - {{rental.category}}
+      <span>Type:</span> {{rental-property-type this.rental.category}} - {{this.rental.category}}
     </div>
     <div class="detail location">
-      <span>Location:</span> {{rental.city}}
+      <span>Location:</span> {{this.rental.city}}
     </div>
     <div class="detail bedrooms">
-      <span>Number of bedrooms:</span> {{rental.bedrooms}}
+      <span>Number of bedrooms:</span> {{this.rental.bedrooms}}
     </div>
   </div>
-  {{location-map location=rental.city}}
+  {{location-map location=this.rental.city}}
 </article>
 ```
 ![Rental Page Nested Index Route](/images/subroutes/subroutes-super-rentals-index.png)


### PR DESCRIPTION
Closes https://github.com/ember-learn/guides-source/pull/149

This is essentially continuing the work that @chadhietala did in #149 but updated to the latest version folder. 

This is a manual PR that used the previous PR as a visual input and a tool to extract handlebars code samples from the markdown files. I'm happy to share that script if anyone is interested in it but I just don't know where it should go 😂 
