### PR TITLE
Fixes 'customize a components element' link

### DIFF
--- a/guides/v3.6.0/components/defining-a-component.md
+++ b/guides/v3.6.0/components/defining-a-component.md
@@ -49,7 +49,7 @@ Each component is backed by an element under the hood. By default,
 Ember will use a `<div>` element to contain your component's template.
 To learn how to change the element Ember uses for your component, see
 [Customizing a Component's
-Element](./customizing-a-components-element/).
+Element](../customizing-a-components-element/).
 
 
 ## Defining a Component Subclass


### PR DESCRIPTION
The previous version linked to `https://guides.emberjs.com/release/components/defining-a-component/customizing-a-components-element/`, which showed a 404 error instead of `https://guides.emberjs.com/release/components/customizing-a-components-element/`, which is the intended page.

I see from the contribution guidelines that links should be in another format, but have retained the current markdown style to be consistent with the current document.