### PR TITLE
Convert to angle bracket notation in version 3.7

### DIFF
--- a/guides/v3.7.0/components/block-params.md
+++ b/guides/v3.7.0/components/block-params.md
@@ -4,7 +4,7 @@ but they can also return output to be used in a block expression.
 ### Return values from a component with `yield`
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{blog-post post=this.model}}
+<BlogPost @post={{this.model}}/>
 ```
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}
@@ -24,11 +24,11 @@ where the markup is provided by the consuming template,
 but any event handling behavior implemented in the component is retained such as `click()` handlers.
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{#blog-post post=this.model as |title body author|}}
+<BlogPost @post={{this.model}} as |title body author|>
   <h2>{{title}}</h2>
   <p class="author">by {{author}}</p>
   <p class="post-body">{{body}}</p>
-{{/blog-post}}
+</BlogPost>
 ```
 
 The names are bound in the order that they are passed to `yield` in the component template.

--- a/guides/v3.7.0/components/block-params.md
+++ b/guides/v3.7.0/components/block-params.md
@@ -4,7 +4,7 @@ but they can also return output to be used in a block expression.
 ### Return values from a component with `yield`
 
 ```handlebars {data-filename=app/templates/index.hbs}
-<BlogPost @post={{this.model}}/>
+<BlogPost @post={{this.model}} />
 ```
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}

--- a/guides/v3.7.0/components/customizing-a-components-element.md
+++ b/guides/v3.7.0/components/customizing-a-components-element.md
@@ -39,7 +39,7 @@ You can specify the class of a component's element at invocation time the same
 way you would for a regular HTML element:
 
 ```handlebars
-{{navigation-bar class="primary"}}
+<NavigationBar class="primary"/>
 ```
 
 You can also specify which class names are applied to the component's

--- a/guides/v3.7.0/components/customizing-a-components-element.md
+++ b/guides/v3.7.0/components/customizing-a-components-element.md
@@ -39,7 +39,7 @@ You can specify the class of a component's element at invocation time the same
 way you would for a regular HTML element:
 
 ```handlebars
-<NavigationBar class="primary"/>
+<NavigationBar class="primary" />
 ```
 
 You can also specify which class names are applied to the component's

--- a/guides/v3.7.0/components/defining-a-component.md
+++ b/guides/v3.7.0/components/defining-a-component.md
@@ -17,7 +17,7 @@ A sample component template could look like this:
 </article>
 ```
 
-Given the above template, you can now use the `<BlogPost/>` component:
+Given the above template, you can now use the `<BlogPost />` component:
 
 ```handlebars {data-filename=app/templates/index.hbs}
 {{#each this.model as |post|}}
@@ -67,14 +67,14 @@ file at `app/components/blog-post.js`. If your component was called
 ## Dynamically rendering a component
 
 The [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component) helper can be used to defer the selection of a component to
-run time. The `<MyComponent/>` syntax always renders the same component,
+run time. The `<MyComponent />` syntax always renders the same component,
 while using the `{{component}}` helper allows choosing a component to render on
 the fly. This is useful in cases where you want to interact with different
 external libraries depending on the data. Using the `{{component}}` helper would
 allow you to keep different logic well separated.
 
 The first parameter of the helper is the name of a component to render, as a
-string. So `{{component 'blog-post'}}` is the same as using `<BlogPost/>`.
+string. So `{{component 'blog-post'}}` is the same as using `<BlogPost />`.
 
 The real value of [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component) comes from being able to dynamically pick
 the component being rendered. Below is an example of using the helper as a

--- a/guides/v3.7.0/components/defining-a-component.md
+++ b/guides/v3.7.0/components/defining-a-component.md
@@ -107,6 +107,17 @@ export default Route.extend({
 {{/each}}
 ```
 
+or 
+
+```handlebars {data-filename=app/templates/index.hbs}
+{{#each this.model as |post|}}
+  {{!-- either foo-component or bar-component --}}
+  {{#let (component (concat this.componentName)) as |Post|}}
+    <Post @post={{post}} />
+  {{/let}}
+{{/each}}
+```
+
 When the parameter passed to `{{component}}` evaluates to `null` or `undefined`,
 the helper renders nothing. When the parameter changes, the currently rendered
 component is destroyed and the new component is created and brought in.

--- a/guides/v3.7.0/components/defining-a-component.md
+++ b/guides/v3.7.0/components/defining-a-component.md
@@ -7,12 +7,6 @@ ember generate component my-component-name
 Ember components are used to turn markup text and styles into reusable content. 
 Components consist of two parts: a JavaScript component file that defines behavior, and its accompanying Handlebars template that defines the markup for the component's UI.
 
-Components must have at least one dash in their name. So `blog-post` is an acceptable
-name, and so is `audio-player-controls`, but `post` is not. This prevents clashes with
-current or future HTML element names, aligns Ember components with the W3C [Custom
-Elements](https://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/custom/index.html)
-spec, and ensures Ember detects the components automatically.
-
 A sample component template could look like this:
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}
@@ -23,13 +17,13 @@ A sample component template could look like this:
 </article>
 ```
 
-Given the above template, you can now use the `{{blog-post}}` component:
+Given the above template, you can now use the `<BlogPost/>` component:
 
 ```handlebars {data-filename=app/templates/index.hbs}
 {{#each this.model as |post|}}
-  {{#blog-post title=post.title}}
+  <BlogPost @title={{post.title}}>
     {{post.body}}
-  {{/blog-post}}
+  </BlogPost>
 {{/each}}
 ```
 
@@ -73,14 +67,14 @@ file at `app/components/blog-post.js`. If your component was called
 ## Dynamically rendering a component
 
 The [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component) helper can be used to defer the selection of a component to
-run time. The `{{my-component}}` syntax always renders the same component,
+run time. The `<MyComponent/>` syntax always renders the same component,
 while using the `{{component}}` helper allows choosing a component to render on
 the fly. This is useful in cases where you want to interact with different
 external libraries depending on the data. Using the `{{component}}` helper would
 allow you to keep different logic well separated.
 
 The first parameter of the helper is the name of a component to render, as a
-string. So `{{component 'blog-post'}}` is the same as using `{{blog-post}}`.
+string. So `{{component 'blog-post'}}` is the same as using `<BlogPost/>`.
 
 The real value of [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component) comes from being able to dynamically pick
 the component being rendered. Below is an example of using the helper as a

--- a/guides/v3.7.0/components/defining-a-component.md
+++ b/guides/v3.7.0/components/defining-a-component.md
@@ -112,7 +112,7 @@ or
 ```handlebars {data-filename=app/templates/index.hbs}
 {{#each this.model as |post|}}
   {{!-- either foo-component or bar-component --}}
-  {{#let (component (concat this.componentName)) as |Post|}}
+  {{#let (component this.componentName) as |Post|}}
     <Post @post={{post}} />
   {{/let}}
 {{/each}}

--- a/guides/v3.7.0/components/handling-events.md
+++ b/guides/v3.7.0/components/handling-events.md
@@ -5,12 +5,12 @@ you want to respond to as a method on your component.
 For example, imagine we have a template like this:
 
 ```handlebars
-{{#double-clickable}}
+<DoubleClickable>
   This is a double clickable area!
-{{/double-clickable}}
+</DoubleClickable>
 ```
 
-Let's implement `double-clickable` such that when it is
+Let's implement `DoubleClickable` such that when it is
 clicked, an alert is displayed:
 
 ```javascript {data-filename=app/components/double-clickable.js}
@@ -49,7 +49,7 @@ various draggable behaviors. For example, a component may need to send an `id`
 when it receives a drop event:
 
 ```handlebars
-{{drop-target dropAction=(action "didDrop")}}
+<DropTarget @dropAction={{action "didDrop"}}/>
 ```
 
 You can define the component's event handlers to manage the drop event.

--- a/guides/v3.7.0/components/handling-events.md
+++ b/guides/v3.7.0/components/handling-events.md
@@ -49,7 +49,7 @@ various draggable behaviors. For example, a component may need to send an `id`
 when it receives a drop event:
 
 ```handlebars
-<DropTarget @dropAction={{action "didDrop"}}/>
+<DropTarget @dropAction={{action "didDrop"}} />
 ```
 
 You can define the component's event handlers to manage the drop event.

--- a/guides/v3.7.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.7.0/components/passing-properties-to-a-component.md
@@ -27,7 +27,7 @@ If we tried to use the component like this:
 
 ```handlebars {data-filename=app/templates/index.hbs}
 {{#each this.model as |post|}}
-  <BlogPost/>
+  <BlogPost />
 {{/each}}
 ```
 
@@ -45,7 +45,7 @@ in like this:
 
 ```handlebars {data-filename=app/templates/index.hbs}
 {{#each this.model as |post|}}
-  <BlogPost @title={{post.title}} @body={{post.body}}/>
+  <BlogPost @title={{post.title}} @body={{post.body}} />
 {{/each}}
 ```
 
@@ -76,7 +76,7 @@ In other words, you can invoke the above component example like this:
 
 ```handlebars {data-filename=app/templates/index.hbs}
 {{#each this.model as |post|}}
-  <BlogPost @post.title @post.body/>
+  {{blog-post post.title post.body}}
 {{/each}}
 ```
 
@@ -92,7 +92,7 @@ export default Component.extend({}).reopenClass({
 ```
 
 Then you can use the attributes in the component exactly as if they had been
-passed in like `<BlogPost @title={{post.title}} @body={{post.body}}/>`.
+passed in like `<BlogPost @title={{post.title}} @body={{post.body}} />`.
 
 Notice that the `positionalParams` property is added to the class as a
 static variable via `reopenClass`. Positional params are always declared on

--- a/guides/v3.7.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.7.0/components/passing-properties-to-a-component.md
@@ -1,7 +1,7 @@
 Components are isolated from their surroundings, so any data that the component
 needs has to be passed in.
 
-For example, imagine you have a `blog-post` component that is used to
+For example, imagine you have a `BlogPost` component that is used to
 display a blog post:
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}
@@ -27,7 +27,7 @@ If we tried to use the component like this:
 
 ```handlebars {data-filename=app/templates/index.hbs}
 {{#each this.model as |post|}}
-  {{blog-post}}
+  <BlogPost/>
 {{/each}}
 ```
 
@@ -45,7 +45,7 @@ in like this:
 
 ```handlebars {data-filename=app/templates/index.hbs}
 {{#each this.model as |post|}}
-  {{blog-post title=post.title body=post.body}}
+  <BlogPost @title={{post.title}} @body={{post.body}}/>
 {{/each}}
 ```
 
@@ -59,10 +59,10 @@ to components. This allows data to flow back up to its parent. You pass actions
 like this.
 
 ```handlebars {data-filename=app/templates/index.hbs}
-  {{button-with-confirmation
-    text="Click here to unsubscribe."
-    onConfirm=(action "unsubscribe")
-  }}
+  <ButtonWithConfirmation
+    @text="Click here to unsubscribe."
+    @onConfirm={{action "unsubscribe"}}
+  />
 ```
 
 It is important to note that actions can only be passed from a controller or another
@@ -76,7 +76,7 @@ In other words, you can invoke the above component example like this:
 
 ```handlebars {data-filename=app/templates/index.hbs}
 {{#each this.model as |post|}}
-  {{blog-post post.title post.body}}
+  <BlogPost @post.title @post.body/>
 {{/each}}
 ```
 
@@ -92,7 +92,7 @@ export default Component.extend({}).reopenClass({
 ```
 
 Then you can use the attributes in the component exactly as if they had been
-passed in like `{{blog-post title=post.title body=post.body}}`.
+passed in like `<BlogPost @title={{post.title}} @body={{post.body}}/>`.
 
 Notice that the `positionalParams` property is added to the class as a
 static variable via `reopenClass`. Positional params are always declared on

--- a/guides/v3.7.0/components/the-component-lifecycle.md
+++ b/guides/v3.7.0/components/the-component-lifecycle.md
@@ -216,7 +216,7 @@ The component below takes a list of items and displays them on the screen.
 Additionally, it takes an object representing which item is selected and will select and set the scroll top to that item.
 
 ```handlebars {data-filename=app/templates/application.hbs}
-{{selected-item-list items=this.items selectedItem=this.selection}}
+<SelectedItemList @items={{this.items}} @selectedItem={{this.selection}}/>
 ```
 
 When rendered the component will iterate through the given list and apply a class to the one that is selected.
@@ -263,7 +263,7 @@ For instance, the user may navigate to a different route, or a conditional Handl
 
 ```handlebars {data-filename=app/templates/application.hbs}
 {{#if this.falseBool}}
-  {{my-component}}
+  <MyComponent/>
 {{/if}}
 ```
 

--- a/guides/v3.7.0/components/the-component-lifecycle.md
+++ b/guides/v3.7.0/components/the-component-lifecycle.md
@@ -216,7 +216,7 @@ The component below takes a list of items and displays them on the screen.
 Additionally, it takes an object representing which item is selected and will select and set the scroll top to that item.
 
 ```handlebars {data-filename=app/templates/application.hbs}
-<SelectedItemList @items={{this.items}} @selectedItem={{this.selection}}/>
+<SelectedItemList @items={{this.items}} @selectedItem={{this.selection}} />
 ```
 
 When rendered the component will iterate through the given list and apply a class to the one that is selected.
@@ -263,7 +263,7 @@ For instance, the user may navigate to a different route, or a conditional Handl
 
 ```handlebars {data-filename=app/templates/application.hbs}
 {{#if this.falseBool}}
-  <MyComponent/>
+  <MyComponent />
 {{/if}}
 ```
 

--- a/guides/v3.7.0/components/triggering-changes-with-actions.md
+++ b/guides/v3.7.0/components/triggering-changes-with-actions.md
@@ -427,7 +427,7 @@ For this case, the action helper provides the `value` attribute to allow a paren
 object to pull out only what it needs.
 
 ```handlebars {data-filename=app/templates/components/system-preferences-editor.hbs}
-<UserProfile @didDelete={{action "userDeleted" value="account.id"}}/>
+<UserProfile @didDelete={{action "userDeleted" value="account.id"}} />
 ```
 
 Now when the `system-preferences-editor` handles the delete action, it receives only the user's account `id` string.

--- a/guides/v3.7.0/components/triggering-changes-with-actions.md
+++ b/guides/v3.7.0/components/triggering-changes-with-actions.md
@@ -21,7 +21,7 @@ component, we want to be able to reuse it all over our application.
 
 ## Creating the Component
 
-Let's call our component `button-with-confirmation`. We can create it by
+Let's call our component `ButtonWithConfirmation`. We can create it by
 typing:
 
 ```bash
@@ -31,17 +31,17 @@ ember generate component button-with-confirmation
 We'll plan to use the component in a template something like this:
 
 ```handlebars {data-filename=app/templates/components/user-profile.hbs}
-{{button-with-confirmation
-  text="Click OK to delete your account."
-}}
+<ButtonWithConfirmation
+  @text="Click OK to delete your account."
+/>
 ```
 
 We'll also want to use the component elsewhere, perhaps like this:
 
 ```handlebars {data-filename=app/templates/components/send-message.hbs}
-{{button-with-confirmation
-  text="Click OK to send your message."
-}}
+<ButtonWithConfirmation
+  @text="Click OK to send your message."
+/>
 ```
 
 ## Designing the Action
@@ -70,7 +70,7 @@ have a property called `actions`, where you put functions that can be
 itself](../../templates/actions/), or by child components.
 
 Let's look at the parent component's JavaScript file. In this example,
-imagine we have a parent component called `user-profile` that shows the
+imagine we have a parent component called `UserProfile` that shows the
 user's profile to them.
 
 We'll implement an action on the parent component called
@@ -137,29 +137,29 @@ based on the value of `confirmShown`.
 
 ## Passing the Action to the Component
 
-Now we need to make it so that the `userDidDeleteAccount()` action defined in the parent component `user-profile` can be triggered from within `button-with-confirmation`.
+Now we need to make it so that the `userDidDeleteAccount()` action defined in the parent component `UserProfile` can be triggered from within `ButtonWithConfirmation`.
 We'll do this by passing the action to the child component in exactly the same way that we pass other properties.
 This is possible since actions are simply functions, just like any other method on a component,
 and they can therefore be passed from one component to another like this:
 
 ```handlebars {data-filename=app/templates/components/user-profile.hbs}
-{{button-with-confirmation
-  text="Click here to delete your account."
-  onConfirm=(action "userDidDeleteAccount")
-}}
+<ButtonWithConfirmation
+  @text="Click here to delete your account."
+  @onConfirm={{action "userDidDeleteAccount"}}
+/>
 ```
 
 This snippet says "take the `userDidDeleteAccount` action from the parent and make it available on the child component as the property `onConfirm`."
 Note the use here of the `action` helper,
 which serves to return the function named `"userDidDeleteAccount"` that we are passing to the component.
 
-We can do a similar thing for our `send-message` component:
+We can do a similar thing for our `SendMessage` component:
 
 ```handlebars {data-filename=app/templates/components/send-message.hbs}
-{{button-with-confirmation
-  text="Click to send your message."
-  onConfirm=(action "sendMessage")
-}}
+<ButtonWithConfirmation
+  @text="Click to send your message."
+  @onConfirm={{action "sendMessage"}}
+/>
 ```
 
 Now, we can use `onConfirm` in the child component to invoke the action on the
@@ -204,7 +204,7 @@ Often actions perform asynchronous tasks, such as making an ajax request to a se
 Since actions are functions that can be passed in by a parent component, they are able to return values when called.
 The most common scenario is for an action to return a promise so that the component can handle the action's completion.
 
-In our user `button-with-confirmation` component we want to leave the confirmation modal open until we know that the
+In our user `ButtonWithConfirmation` component we want to leave the confirmation modal open until we know that the
 operation has completed successfully.
 This is accomplished by expecting a promise to be returned from `onConfirm`.
 Upon resolution of the promise, we set a property used to indicate the visibility of the confirmation modal.
@@ -238,7 +238,7 @@ export default Component.extend({
 Sometimes the parent component invoking an action has some context needed for the action that the child component
 doesn't.
 Consider, for example,
-the case where the `button-with-confirmation` component we've defined is used within `send-message`.
+the case where the `ButtonWithConfirmation` component we've defined is used within `SendMessage`.
 The `sendMessage` action that we pass to the child component may expect a message type parameter to be provided as an argument:
 
 ```javascript {data-filename=app/components/send-message.js}
@@ -254,18 +254,18 @@ export default Component.extend({
 ```
 
 However,
-the `button-with-confirmation` component invoking the action doesn't know or care what type of message it's collecting.
+the `ButtonWithConfirmation` component invoking the action doesn't know or care what type of message it's collecting.
 In cases like this, the parent template can provide the required parameter when the action is passed to the child.
 For example, if we want to use the button to send a message of type `"info"`:
 
 ```handlebars {data-filename=app/templates/components/send-message.hbs}
-{{button-with-confirmation
-  text="Click to send your message."
-  onConfirm=(action "sendMessage" "info")
-}}
+<ButtonWithConfirmation
+  @text="Click to send your message."
+  @onConfirm={{action "sendMessage" "info"}}
+/>
 ```
 
-Within `button-with-confirmation`, the code in the `submitConfirm` action does not change.
+Within `ButtonWithConfirmation`, the code in the `submitConfirm` action does not change.
 It will still invoke `onConfirm` without explicit arguments:
 
 ```javascript {data-filename=app/components/button-with-confirmation.js}
@@ -276,7 +276,7 @@ i.e. an object that binds the parameter we've provided to the function specified
 So now when the action is invoked, that parameter will automatically be passed as its argument, effectively calling `sendMessage("info")`,
 despite the argument not appearing in the calling code.
 
-So far in our example, the action we have passed to `button-with-confirmation` is a function that accepts one argument,
+So far in our example, the action we have passed to `ButtonWithConfirmation` is a function that accepts one argument,
 `messageType`.
 Suppose we want to extend this by allowing `sendMessage` to take a second argument,
 the actual text of the message the user is sending:
@@ -293,15 +293,15 @@ export default Component.extend({
 });
 ```
 
-We want to arrange for the action to be invoked from within `button-with-confirmation` with both arguments.
-We've seen already that if we provide a `messageType` value to the `action` helper when we insert `button-with-confirmation` into its parent `send-message` template,
+We want to arrange for the action to be invoked from within `ButtonWithConfirmation` with both arguments.
+We've seen already that if we provide a `messageType` value to the `action` helper when we insert `ButtonWithConfirmation` into its parent `SendMessage` template,
 that value will be passed to the `sendMessage` action as its first argument automatically when invoked as `onConfirm`.
 If we subsequently pass a single additional argument to `onConfirm` explicitly,
 that argument will be passed to `sendMessage` as its second argument
 (This ability to provide arguments to a function one at a time is known as [currying](https://en.wikipedia.org/wiki/Currying)).
 
 In our case, the explicit argument that we pass to `onConfirm` will be the required `messageText`.
-However, remember that internally our `button-with-confirmation` component does not know or care that it is being used in a messaging application.
+However, remember that internally our `ButtonWithConfirmation` component does not know or care that it is being used in a messaging application.
 Therefore within the component's JavaScript file,
 we will use a property `confirmValue` to represent that argument and pass it to `onConfirm` as shown here:
 
@@ -340,26 +340,26 @@ we'll first modify the component so that it can be used in block form and we wil
 ```
 
 With this modification,
-we can now use the component in `send-message` to wrap a text input element whose `value` attribute is set to `confirmValue`:
+we can now use the component in `SendMessage` to wrap a text input element whose `value` attribute is set to `confirmValue`:
 
 ```handlebars {data-filename=app/templates/components/send-message.hbs}
-{{#button-with-confirmation
-    text="Click to send your message."
-    onConfirm=(action "sendMessage" "info")
-    as |confirmValue|}}
+<ButtonWithConfirmation
+    @text="Click to send your message."
+    @onConfirm={{action "sendMessage" "info"}}
+    as |confirmValue|>
   {{input value=confirmValue}}
-{{/button-with-confirmation}}
+</ButtonWithConfirmation>
 ```
 
 When the user enters their message into the input field,
 the message text will now be available to the component as `confirmValue`.
 Then, once they click the "OK" button, the `submitConfirm` action will be triggered, calling `onConfirm` with the provided `confirmValue`,
-thus invoking the `sendMessage` action in `send-message` with both the `messageType` and `messageText` arguments.
+thus invoking the `sendMessage` action in `SendMessage` with both the `messageType` and `messageText` arguments.
 
 ## Invoking Actions Directly on Component Collaborators
 
 Actions can be invoked on objects other than the component directly from the template.  For example, in our
-`send-message` component we might include a service that processes the `sendMessage` logic.
+`SendMessage` component we might include a service that processes the `sendMessage` logic.
 
 ```javascript {data-filename=app/components/send-message.js}
 import Component from '@ember/component';
@@ -375,12 +375,12 @@ export default Component.extend({
 We can tell the action to invoke the `sendMessage` action directly on the messaging service with the `target` attribute.
 
 ```handlebars {data-filename=app/templates/components/send-message.hbs}
-{{#button-with-confirmation
-    text="Click to send your message."
-    onConfirm=(action "sendMessage" "info" target=this.messaging)
-    as |confirmValue| }}
+<ButtonWithConfirmation
+    @text="Click to send your message."
+    @onConfirm={{action "sendMessage" "info" target=this.messaging}}
+    as |confirmValue|>
   {{input value=confirmValue}}
-{{/button-with-confirmation}}
+</ButtonWithConfirmation>
 ```
 
 By supplying the `target` attribute, the action helper will look to invoke the `sendMessage` action directly on the messaging
@@ -402,7 +402,7 @@ export default Ember.Service.extend({
 
 A component will often not know what information a parent needs to process an action, and will just pass all the
 information it has.
-For example, our `user-profile` component is going to notify its parent, `system-preferences-editor`, that a
+For example, our `UserProfile` component is going to notify its parent, `system-preferences-editor`, that a
 user's account was deleted, and passes along with it the full user profile object.
 
 
@@ -427,7 +427,7 @@ For this case, the action helper provides the `value` attribute to allow a paren
 object to pull out only what it needs.
 
 ```handlebars {data-filename=app/templates/components/system-preferences-editor.hbs}
-{{user-profile didDelete=(action "userDeleted" value="account.id")}}
+<UserProfile @didDelete={{action "userDeleted" value="account.id"}}/>
 ```
 
 Now when the `system-preferences-editor` handles the delete action, it receives only the user's account `id` string.
@@ -449,7 +449,7 @@ export default Component.extend({
 When your components go multiple template layers deep, it is common to need to handle an action several layers up the tree. 
 Using the action helper, parent components can pass actions to child components through templates alone without adding JavaScript code to those child components.
 
-For example, say we want to move account deletion from the `user-profile` component to its parent `system-preferences-editor`.
+For example, say we want to move account deletion from the `UserProfile` component to its parent `system-preferences-editor`.
 
 First we would move the `deleteUser` action from `user-profile.js` to the actions object on `system-preferences-editor`.
 
@@ -467,13 +467,13 @@ export default Component.extend({
 });
 ```
 
-Then our `system-preferences-editor` template passes its local `deleteUser` action into the `user-profile` as that
+Then our `system-preferences-editor` template passes its local `deleteUser` action into the `UserProfile` as that
 component's `deleteCurrentUser` property.
 
 ```handlebars {data-filename=app/templates/components/system-preferences-editor.hbs}
-{{user-profile
-  deleteCurrentUser=(action 'deleteUser' this.login.currentUser.id)
-}}
+<UserProfile
+  @deleteCurrentUser={{action 'deleteUser' this.login.currentUser.id}}
+/>
 ```
 
 The action `deleteUser` is in quotes, since `system-preferences-editor` is where the action is defined now. Quotes indicate that the action should be looked for in `actions` local to that component, rather than in those that have been passed from a parent.
@@ -481,10 +481,10 @@ The action `deleteUser` is in quotes, since `system-preferences-editor` is where
 In our `user-profile.hbs` template we change our action to call `deleteCurrentUser` as passed above.
 
 ```handlebars {data-filename=app/templates/components/user-profile.hbs}
-{{button-with-confirmation
-  onConfirm=(action this.deleteCurrentUser)
-  text="Click OK to delete your account."
-}}
+<ButtonWithConfirmation
+  @text="Click OK to delete your account."
+  @onConfirm={{action this.deleteCurrentUser}}
+/>
 ```
 
 Note that `deleteCurrentUser` is no longer in quotes here as opposed to [previously](#toc_passing-the-action-to-the-component). Quotes are used to initially pass the action down the component tree, but at every subsequent level you are instead passing the actual function reference (without quotes) in the action helper.

--- a/guides/v3.7.0/components/wrapping-content-in-a-component.md
+++ b/guides/v3.7.0/components/wrapping-content-in-a-component.md
@@ -7,10 +7,10 @@ For example, imagine we are building a `BlogPost` component that we can use in o
 <div class="body">{{this.body}}</div>
 ```
 
-Now, we can use the `<BlogPost/>` component and pass it properties in another template:
+Now, we can use the `<BlogPost />` component and pass it properties in another template:
 
 ```handlebars
-<BlogPost @title={{this.title}} @body={{this.body}}/>
+<BlogPost @title={{this.title}} @body={{this.body}} />
 ```
 
 See [Passing Properties to a Component](../passing-properties-to-a-component/) for more.
@@ -27,7 +27,7 @@ then make sure to add a closing tag.
 
 See the Handlebars documentation on [block expressions](http://handlebarsjs.com/#block-expressions) for more.
 
-In that case, we can use the `<BlogPost/>` component in **block form** and tell Ember where the block content should be rendered using the `{{yield}}` helper.
+In that case, we can use the `<BlogPost />` component in **block form** and tell Ember where the block content should be rendered using the `{{yield}}` helper.
 To update the example above, we'll first change the component's template:
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}

--- a/guides/v3.7.0/components/wrapping-content-in-a-component.md
+++ b/guides/v3.7.0/components/wrapping-content-in-a-component.md
@@ -1,16 +1,16 @@
 Sometimes, you may want to define a component that wraps content provided by other templates.
 
-For example, imagine we are building a `blog-post` component that we can use in our application to display a blog post:
+For example, imagine we are building a `BlogPost` component that we can use in our application to display a blog post:
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}
 <h1>{{this.title}}</h1>
 <div class="body">{{this.body}}</div>
 ```
 
-Now, we can use the `{{blog-post}}` component and pass it properties in another template:
+Now, we can use the `<BlogPost/>` component and pass it properties in another template:
 
 ```handlebars
-{{blog-post title=this.title body=this.body}}
+<BlogPost @title={{this.title}} @body={{this.body}}/>
 ```
 
 See [Passing Properties to a Component](../passing-properties-to-a-component/) for more.
@@ -27,7 +27,7 @@ then make sure to add a closing tag.
 
 See the Handlebars documentation on [block expressions](http://handlebarsjs.com/#block-expressions) for more.
 
-In that case, we can use the `{{blog-post}}` component in **block form** and tell Ember where the block content should be rendered using the `{{yield}}` helper.
+In that case, we can use the `<BlogPost/>` component in **block form** and tell Ember where the block content should be rendered using the `{{yield}}` helper.
 To update the example above, we'll first change the component's template:
 
 ```handlebars {data-filename=app/templates/components/blog-post.hbs}
@@ -41,10 +41,10 @@ This tells Ember that this content will be provided when the component is used.
 Next, we'll update the template using the component to use the block form:
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{#blog-post title=this.title}}
+<BlogPost @title={{post.title}}>
   <p class="author">by {{this.author}}</p>
   {{this.body}}
-{{/blog-post}}
+</BlogPost>
 ```
 
 It's important to note that the template scope inside the component block is the same as outside.
@@ -57,10 +57,10 @@ In our blog post component we want to provide a way for the user to configure wh
 We will give them the option to specify either `markdown-style` or `html-style`.
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{#blog-post editStyle="markdown-style"}}
+<BlogPost @editStyle="markdown-style">
   <p class="author">by {{this.author}}</p>
   {{this.body}}
-{{/blog-post}}
+</BlogPost>
 ```
 
 Supporting different editing styles will require different body components to provide special validation and highlighting.
@@ -78,10 +78,10 @@ Once yielded, the data can be accessed by the wrapped content by referencing the
 Now a component called `markdown-style` will be rendered in `{{post.body}}`.
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{#blog-post editStyle="markdown-style" postData=this.myText as |post|}}
+<BlogPost @editStyle="markdown-style" @postData={{this.myText}} as |post|>
   <p class="author">by {{this.author}}</p>
   {{post.body}}
-{{/blog-post}}
+</BlogPost>
 ```
 
 Finally, we need to share `myText` with the body in order to have it display.
@@ -106,10 +106,10 @@ When `{{post.body}}` is instantiated, it will have both the `editStyle` and `pos
 as well as the `bodyStyle` declared in the template.
 
 ```handlebars {data-filename=app/templates/index.hbs}
-{{#blog-post editStyle="markdown-style" postData=this.myText as |post|}}
+<BlogPost @editStyle="markdown-style" @postData={{this.myText}} as |post|>
   <p class="author">by {{this.author}}</p>
   {{post.body bodyStyle="compact-style"}}
-{{/blog-post}}
+</BlogPost>
 ```
 
 Components built this way are commonly referred to as "Contextual Components",

--- a/guides/v3.7.0/getting-started/core-concepts.md
+++ b/guides/v3.7.0/getting-started/core-concepts.md
@@ -42,7 +42,7 @@ Templates can also display properties provided to them from their context, which
 Here, `{{this.name}}` is a property provided by the template's context.
 
 Besides properties, double curly braces (`{{}}`) may also contain
-helpers and components, which we'll discuss later.
+helpers, which we'll discuss later.
 
 ## Models
 

--- a/guides/v3.7.0/getting-started/quick-start.md
+++ b/guides/v3.7.0/getting-started/quick-start.md
@@ -194,7 +194,6 @@ decreasing the coupling of our component to where it's used.
 
 Save this template and switch back to the `scientists` template.
 Replace all our old code with our new componentized version.
-Components look like HTML tags but instead of using angle brackets (`<tag>`) they use double curly braces (`{{component}}`).
 
 We're going to tell our component:
 
@@ -210,7 +209,7 @@ We're going to tell our component:
     <li>{{scientist}}</li>
   {{/each}}
 </ul>
-{{people-list title="List of Scientists" people=this.model}}
+<PeopleList @title="List of Scientists" @people={{this.model}} />
 ```
 
 Go back to your browser and you should see that the UI looks identical.

--- a/guides/v3.7.0/pages.yml
+++ b/guides/v3.7.0/pages.yml
@@ -98,6 +98,8 @@
   pages:
     - title: "Templating Basics"
       url: "handlebars-basics"
+    - title: "Angle Bracket Syntax"
+      url: "angle-bracket-syntax"
     - title: "Built-in Helpers"
       url: "built-in-helpers"
     - title: "Conditionals"

--- a/guides/v3.7.0/pages.yml
+++ b/guides/v3.7.0/pages.yml
@@ -98,8 +98,6 @@
   pages:
     - title: "Templating Basics"
       url: "handlebars-basics"
-    - title: "Angle Bracket Syntax"
-      url: "angle-bracket-syntax"
     - title: "Built-in Helpers"
       url: "built-in-helpers"
     - title: "Conditionals"
@@ -290,3 +288,9 @@
   pages:
     - title: "Web Development"
       url: "web-development"
+
+- title: 'Reference'
+  url: 'reference'
+  pages:
+    - title: "Syntax Conversion Guide"
+      url: "syntax-conversion-guide"

--- a/guides/v3.7.0/reference/syntax-conversion-guide.md
+++ b/guides/v3.7.0/reference/syntax-conversion-guide.md
@@ -1,3 +1,5 @@
+## Angle Bracket Syntax
+
 The [Angle Bracket Syntax](https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md) is an alternative style of invoking components in templates. The difference between the Angle Bracket Syntax and the Classic Invocation Syntax is purely syntactical and does not affect the semantics of invoking a component.
 
 **Classical Invocation Syntax:**

--- a/guides/v3.7.0/templates/angle-bracket-syntax.md
+++ b/guides/v3.7.0/templates/angle-bracket-syntax.md
@@ -1,0 +1,72 @@
+The [Angle Bracket Syntax](https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md) is an alternative style of invoking components in templates. The difference between the Angle Bracket Syntax and the Classic Invocation Syntax is purely syntactical and does not affect the semantics of invoking a component.
+
+**Classical Invocation Syntax:**
+```handlebars
+{{site-header user=this.user class=(if this.user.isAdmin "admin")}}
+```
+
+**Angle Bracket Syntax:**
+```handlebars
+<SiteHeader @user={{this.user}} class={{if this.user.isAdmin "admin"}} />
+```
+
+Consider the example above, the `site-header` component is represented in both the Classical Invocation and Angle Bracket syntaxes to illustrate the differences between them.
+
+As the syntax name suggests, the Angle Bracket Syntax replaces the outside curly braces `{{}}` with angle brackets `<>` and capitalizes the component name instead of having it be lowercase dash delimited.
+
+While the Angle Bracket Syntax may remind you of HTML elements, it comes with differentiating features such as using the `@` syntax for passing in arguments which sets it apart from traditional HTML elements easily.
+
+### Why Use the Angle Bracket Syntax?
+
+The main motivation for using the Angle Bracket Syntax is for clarity.
+
+Having a dedicated syntax for distinguishing between UI components enables developers to identify each piece of information. With the Angle Bracket Syntax, it is easier to tell apart helpers and components from variables, or see where the variables are defined.
+
+For example, `{{display-button}}` looks a lot like `{{displayButton}}`, but one is a component and one is a variable! The Angle Bracket Syntax would eliminate this confusion by clearly defining components with angle brackets `<>`.
+
+You could also never know whether an attribute was local to the component or passed in from a parent. Now, all these things are clear since parent variables are passed down and accessed using the `{{@name}}` syntax whereas local variables are accessed using the `{{this.name}}` syntax.
+
+### Leverage Existing Knowledge
+
+Since Angle Bracket notation is closely resembles the syntax for HTML elements, we enable developers to reuse their existing knowledge in creating templates for Ember components. This is especially useful for newer Ember developers as it provides syntactic sugar for creating component templates, reducing the learning curve.
+
+You can apply regular HTML attributes like `class`, `id`, `aria-role`, etc. when you use the component. Block form components also follow the same pattern as HTML elements where an HTML-like closing tag denotes where a component starts and ends.
+
+**Classical Invocation Syntax:**
+```handlebars
+{{#super-select selected=this.user.country as |s|}}
+  {{#each this.availableCountries as |country|}}
+    {{#s.option value=country}}{{country.name}}{{/s.option}}
+  {{/each}}
+{{/super-select}}
+```
+
+**Angle Bracket Syntax:**
+```handlebars
+<SuperSelect @selected={{this.user.country}} as |Option|>
+  {{#each this.availableCountries as |country|}}
+    <Option @value={{country}}>{{country.name}}</Option>
+  {{/each}}
+</SuperSelect>
+```
+
+### Determining the Argument Scope
+
+The fundamental change is that the scope of args passed in and properties local to the component are no longer mashed together. There is a clear boundary between arguments passed down from the parent and arguments that is tracked in the local component.
+
+```handlebars
+{{@name}} {{!-- this is the arg passed down from the parent --}}
+{{this.name}} {{!-- this is the property that is tracked in the local component js --}}
+```
+
+Variables passed into a component have an `@` before them, also known as [named arguments](https://github.com/emberjs/rfcs/blob/master/text/0276-named-args.md). While variables created by the current component will have `this` in front of it.
+
+### Limitations
+
+- Positional arguments like `{{foo-bar "first" "second"}}` cannot be used with Angle Brackets.
+- Angle Bracket syntax requires using the `@myvariablename` notation when passing a variable into a component, with the variable name being lowercase
+- User defined components must be capitalized such as `<FooBar></FooBar>` or `<FooBar />`
+
+### What is happening with the Classical Invocation Syntax?
+
+The Classical Invocation Syntax – which uses “curlies” `{{}}` instead of angle brackets `<>` – is here to stay, the ability to accept positional arguments and "else" blocks makes them ideal for control-flow like components such as `{{liquid-if}}`.

--- a/guides/v3.7.0/templates/angle-bracket-syntax.md
+++ b/guides/v3.7.0/templates/angle-bracket-syntax.md
@@ -10,7 +10,7 @@ The [Angle Bracket Syntax](https://github.com/emberjs/rfcs/blob/master/text/0311
 <SiteHeader @user={{this.user}} class={{if this.user.isAdmin "admin"}} />
 ```
 
-Consider the example above, the `site-header` component is represented in both the Classical Invocation and Angle Bracket syntaxes to illustrate the differences between them.
+Consider the example above, the `site-header` component is represented in both the Classical Invocation and Angle Bracket syntax to illustrate the differences between them.
 
 As the syntax name suggests, the Angle Bracket Syntax replaces the outside curly braces `{{}}` with angle brackets `<>` and capitalizes the component name instead of having it be lowercase dash delimited.
 
@@ -52,7 +52,7 @@ You can apply regular HTML attributes like `class`, `id`, `aria-role`, etc. when
 
 ### Determining the Argument Scope
 
-The fundamental change is that the scope of args passed in and properties local to the component are no longer mashed together. There is a clear boundary between arguments passed down from the parent and arguments that is tracked in the local component.
+The fundamental change is that the scope of arguments passed in and properties local to the component are no longer mashed together. There is a clear boundary between arguments passed down from the parent and arguments that is tracked in the local component.
 
 ```handlebars
 {{@name}} {{!-- this is the arg passed down from the parent --}}

--- a/guides/v3.7.0/templates/built-in-helpers.md
+++ b/guides/v3.7.0/templates/built-in-helpers.md
@@ -72,11 +72,11 @@ Using the [`{{array}}`](https://www.emberjs.com/api/ember/release/classes/Ember.
 you can pass arrays directly from the template as an argument to your components.
 
 ```handlebars
-{{my-component people=(array
+<MyComponent @people={{array
     'Tom Dade'
     'Yehuda Katz'
-    this.myOtherPerson)
- }}
+    this.myOtherPerson}}
+ />
 ```
 
 In the component's template, you can then use the `people` argument as an array:

--- a/guides/v3.7.0/testing/index.md
+++ b/guides/v3.7.0/testing/index.md
@@ -92,7 +92,7 @@ module('Component | counter', function(hooks) {
   test('it should count clicks', async function(assert) {
     this.set('value', 0);
 
-    await render(hbs`{{x-counter value=value onUpdate=( … )}}`);
+    await render(hbs`<XCounter @value={{this.value}} @onUpdate={{( … )}}/>`);
     assert.equal(this.element.textContent, '0 clicks');
 
     await click('.counter');

--- a/guides/v3.7.0/testing/index.md
+++ b/guides/v3.7.0/testing/index.md
@@ -92,7 +92,7 @@ module('Component | counter', function(hooks) {
   test('it should count clicks', async function(assert) {
     this.set('value', 0);
 
-    await render(hbs`<XCounter @value={{this.value}} @onUpdate={{( … )}}/>`);
+    await render(hbs`<XCounter @value={{this.value}} @onUpdate={{( … )}} />`);
     assert.equal(this.element.textContent, '0 clicks');
 
     await click('.counter');

--- a/guides/v3.7.0/testing/index.md
+++ b/guides/v3.7.0/testing/index.md
@@ -80,7 +80,7 @@ In terms of setting up the test – Rendering Tests are roughly similar to Conta
 
 For the example below, we also import the `render` and `click` functions from ember-test-helpers to show and interact with the component being tested as well as `hbs` from [htmlbars-inline-precompile](https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile) to help with inline template definitions. With these APIs, we can test clicking on this component and check if the text is successfully updated with each click.
 
-```javascript {data-filename=components/tests/x-counter-test.js}
+```javascript {data-filename=components/tests/counter-test.js}
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
@@ -92,7 +92,7 @@ module('Component | counter', function(hooks) {
   test('it should count clicks', async function(assert) {
     this.set('value', 0);
 
-    await render(hbs`<XCounter @value={{this.value}} @onUpdate={{( … )}} />`);
+    await render(hbs`<Counter @value={{this.value}} @onUpdate={{( … )}} />`);
     assert.equal(this.element.textContent, '0 clicks');
 
     await click('.counter');

--- a/guides/v3.7.0/testing/testing-components.md
+++ b/guides/v3.7.0/testing/testing-components.md
@@ -77,7 +77,7 @@ module('Integration | Component | pretty color', function(hooks) {
     // set the outer context to red
     this.set('colorValue', 'red');
 
-    await render(hbs`{{pretty-color name=colorValue}}`);
+    await render(hbs`<PrettyColor @name={{this.colorValue}}/>`);
 
     assert.equal(this.element.querySelector('div').getAttribute('style'), 'color: red', 'starts as red');
   });
@@ -108,7 +108,7 @@ module('Integration | Component | pretty color', function(hooks) {
     // set the outer context to red
     this.set('colorValue', 'red');
 
-    await render(hbs`{{pretty-color name=colorValue}}`);
+    await render(hbs`<PrettyColor @name={{this.colorValue}}/>`);
 
     assert.equal(this.element.querySelector('div').getAttribute('style'), 'color: red', 'starts as red');
 
@@ -134,7 +134,7 @@ module('Integration | Component | pretty color', function(hooks) {
 
     this.set('colorValue', 'orange');
 
-    await render(hbs`{{pretty-color name=colorValue}}`);
+    await render(hbs`<PrettyColor @name={{this.colorValue}}/>`);
 
     assert.equal(this.element.textContent.trim(), 'Pretty Color: orange', 'text starts as orange');
 
@@ -191,7 +191,7 @@ module('Integration | Component | magic title', function(hooks) {
   test('should update title on button click', async function(assert) {
     assert.expect(2);
 
-    await render(hbs`{{magic-title}}`);
+    await render(hbs`<MagicTitle/>`);
 
     assert.equal(this.element.querySelector('h2').textContent.trim(), 'Hello World', 'initial text is hello world');
 
@@ -262,7 +262,7 @@ module('Integration | Component | comment form', function(hooks) {
       assert.deepEqual(actual, expected, 'submitted value is passed to external action');
     });
 
-    await render(hbs`{{comment-form submitComment=(action externalAction)}}`);
+    await render(hbs`<CommentForm @submitComment={{action externalAction}}>`);
 
     // fill out the form and force an onchange
     await fillIn('textarea', 'You are not a wizard!');
@@ -379,7 +379,7 @@ module('Integration | Component | location indicator', function(hooks) {
   });
 
   test('should reveal current location', async function(assert) {
-    await render(hbs`{{location-indicator}}`);
+    await render(hbs`<LocationIndicator/>`);
     assert.equal(this.element.textContent.trim(),
      'You currently are located in New York, USA');
   });
@@ -420,13 +420,13 @@ module('Integration | Component | location indicator', function(hooks) {
   });
 
   test('should reveal current location', async function(assert) {
-    await render(hbs`{{location-indicator}}`);
+    await render(hbs`<LocationIndicator/>`);
     assert.equal(this.element.textContent.trim(),
      'You currently are located in New York, USA');
   });
 
   test('should change displayed location when current location changes', async function (assert) {
-    await render(hbs`{{location-indicator}}`);
+    await render(hbs`<LocationIndicator/>`);
 
     assert.equal(this.element.textContent.trim(),
      'You currently are located in New York, USA', 'origin location should display');
@@ -512,7 +512,7 @@ module('Integration | Component | delayed typeahead', function(hooks) {
       this.set('results', stubResults);
     });
 
-    await render(hbs`{{delayed-typeahead fetchResults=fetchResults results=results}}`);
+    await render(hbs`<DelayedTypeahead @fetchResults={{this.fetchResults}} @results={{this.results}}/>`);
     this.element.querySelector('input').value = 'test';
     this.element.querySelector('input').dispatchEvent(new Event('keyup'));
 

--- a/guides/v3.7.0/testing/testing-components.md
+++ b/guides/v3.7.0/testing/testing-components.md
@@ -77,7 +77,7 @@ module('Integration | Component | pretty color', function(hooks) {
     // set the outer context to red
     this.set('colorValue', 'red');
 
-    await render(hbs`<PrettyColor @name={{this.colorValue}}/>`);
+    await render(hbs`<PrettyColor @name={{this.colorValue}} />`);
 
     assert.equal(this.element.querySelector('div').getAttribute('style'), 'color: red', 'starts as red');
   });
@@ -108,7 +108,7 @@ module('Integration | Component | pretty color', function(hooks) {
     // set the outer context to red
     this.set('colorValue', 'red');
 
-    await render(hbs`<PrettyColor @name={{this.colorValue}}/>`);
+    await render(hbs`<PrettyColor @name={{this.colorValue}} />`);
 
     assert.equal(this.element.querySelector('div').getAttribute('style'), 'color: red', 'starts as red');
 
@@ -134,7 +134,7 @@ module('Integration | Component | pretty color', function(hooks) {
 
     this.set('colorValue', 'orange');
 
-    await render(hbs`<PrettyColor @name={{this.colorValue}}/>`);
+    await render(hbs`<PrettyColor @name={{this.colorValue}} />`);
 
     assert.equal(this.element.textContent.trim(), 'Pretty Color: orange', 'text starts as orange');
 
@@ -191,7 +191,7 @@ module('Integration | Component | magic title', function(hooks) {
   test('should update title on button click', async function(assert) {
     assert.expect(2);
 
-    await render(hbs`<MagicTitle/>`);
+    await render(hbs`<MagicTitle />`);
 
     assert.equal(this.element.querySelector('h2').textContent.trim(), 'Hello World', 'initial text is hello world');
 
@@ -379,7 +379,7 @@ module('Integration | Component | location indicator', function(hooks) {
   });
 
   test('should reveal current location', async function(assert) {
-    await render(hbs`<LocationIndicator/>`);
+    await render(hbs`<LocationIndicator />`);
     assert.equal(this.element.textContent.trim(),
      'You currently are located in New York, USA');
   });
@@ -420,13 +420,13 @@ module('Integration | Component | location indicator', function(hooks) {
   });
 
   test('should reveal current location', async function(assert) {
-    await render(hbs`<LocationIndicator/>`);
+    await render(hbs`<LocationIndicator />`);
     assert.equal(this.element.textContent.trim(),
      'You currently are located in New York, USA');
   });
 
   test('should change displayed location when current location changes', async function (assert) {
-    await render(hbs`<LocationIndicator/>`);
+    await render(hbs`<LocationIndicator />`);
 
     assert.equal(this.element.textContent.trim(),
      'You currently are located in New York, USA', 'origin location should display');
@@ -512,7 +512,7 @@ module('Integration | Component | delayed typeahead', function(hooks) {
       this.set('results', stubResults);
     });
 
-    await render(hbs`<DelayedTypeahead @fetchResults={{this.fetchResults}} @results={{this.results}}/>`);
+    await render(hbs`<DelayedTypeahead @fetchResults={{this.fetchResults}} @results={{this.results}} />`);
     this.element.querySelector('input').value = 'test';
     this.element.querySelector('input').dispatchEvent(new Event('keyup'));
 

--- a/guides/v3.7.0/tutorial/autocomplete-component.md
+++ b/guides/v3.7.0/tutorial/autocomplete-component.md
@@ -42,13 +42,13 @@ as |filteredResults|
 >
   <ul class="results">
     {{#each filteredResults as |rentalUnit|}}
-      <li><RentalListing @rental={{rentalUnit}}/></li>
+      <li><RentalListing @rental={{rentalUnit}} /></li>
     {{/each}}
   </ul>
 </ListFilter>
 {{outlet}}
 {{#each this.model as |rentalUnit|}}
-  <RentalListing @rental={{rentalUnit}}/>
+  <RentalListing @rental={{rentalUnit}} />
 {{/each}}
 ```
 
@@ -323,7 +323,7 @@ module('Integration | Component | list-filter', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`<RentalListing/>`);
+    await render(hbs`<RentalListing />`);
 
     assert.equal(this.element.textContent.trim(), '');
 
@@ -397,7 +397,7 @@ module('Integration | Component | list-filter', function(hooks) {
     // you can set up and use your component in the same way your application
     // will use it.
     await render(hbs`
-      <ListFilter @filter={{action "filterByCity"}} as |results|>
+      <ListFilter @filter={{action filterByCity}} as |results|>
         <ul>
         {{#each results as |item|}}
           <li class="city">
@@ -443,7 +443,7 @@ module('Integration | Component | list-filter', function(hooks) {
     // with an integration test,
     // you can set up and use your component in the same way your application will use it.
     await render(hbs`
-      <ListFilter @filter={{action "filterByCity"}} as |results|>
+      <ListFilter @filter={{action filterByCity}} as |results|>
         <ul>
         {{#each results as |item|}}
           <li class="city">
@@ -497,7 +497,7 @@ test('should update with matching listings', async function (assert) {
   });
 
   await render(hbs`
-    <ListFilter @filter={{action "filterByCity"}} as |results|>
+    <ListFilter @filter={{action filterByCity}} as |results|>
       <ul>
       {{#each results as |item|}}
         <li class="city">

--- a/guides/v3.7.0/tutorial/autocomplete-component.md
+++ b/guides/v3.7.0/tutorial/autocomplete-component.md
@@ -340,7 +340,7 @@ module('Integration | Component | list-filter', function(hooks) {
 });
 ```
 
-Our ListFilter component takes a function as an argument, used to find the list of matching rentals based on the filter string provided by the user.
+Our `ListFilter` component takes a function as an argument, used to find the list of matching rentals based on the filter string provided by the user.
 
 ```javascript {data-filename="tests/integration/components/list-filter-test.js" data-diff="+5,+7,+8,+14,+15,+16"}
 import { module, test } from 'qunit';
@@ -559,7 +559,7 @@ import {
 
 In `app/components/list-filter.js`, we have as the top-level element rendered by the component a class called `list-filter`.
 We locate the search input within the component using the selector `.list-filter input`,
-since we know that there is only one input element located in the ListFilter component.
+since we know that there is only one input element located in the `ListFilter` component.
 
 Our test fills out "Seattle" as the search criteria in the search field,
 and then sends a `keyup` event to the same field with a code of `69` (the `e` key) to simulate a user typing, which is the event our code is looking for.

--- a/guides/v3.7.0/tutorial/autocomplete-component.md
+++ b/guides/v3.7.0/tutorial/autocomplete-component.md
@@ -16,9 +16,9 @@ As before when we created the [`rental-listing` component](../simple-component/)
 
 #### Providing Markup to a Component
 
-In our `app/templates/rentals.hbs` template file, we'll add a reference to our new `list-filter` component.
+In our `app/templates/rentals.hbs` template file, we'll add a reference to our new `ListFilter` component.
 
-Notice that below we "wrap" our rentals markup inside the open and closing mentions of `list-filter` on lines 12 and 21.
+Notice that below we "wrap" our rentals markup inside the open and closing mentions of `ListFilter` on lines 12 and 20.
 This is an example of the [**block form**](../../components/wrapping-content-in-a-component/) of a component,
 which allows a Handlebars template to be rendered _inside_ the component's template wherever the `{{yield}}` expression appears.
 
@@ -36,19 +36,19 @@ In this case we are passing, or "yielding", our filter data to the inner markup 
   {{/link-to}}
 </div>
 
-{{#list-filter
- filter=(action "filterByCity")
+<ListFilter
+ @filter={{action "filterByCity"}}
 as |filteredResults|
-}}
+>
   <ul class="results">
     {{#each filteredResults as |rentalUnit|}}
-      <li>{{rental-listing rental=rentalUnit}}</li>
+      <li><RentalListing @rental={{rentalUnit}}/></li>
     {{/each}}
   </ul>
-{{/list-filter}}
+</ListFilter>
 {{outlet}}
 {{#each this.model as |rentalUnit|}}
-  {{rental-listing rental=rentalUnit}}
+  <RentalListing @rental={{rentalUnit}}/>
 {{/each}}
 ```
 
@@ -304,7 +304,7 @@ Let's use a [component integration test](../../testing/testing-components/)
 to verify our component behavior,
 similar to [how we tested our rental listing component earlier](../simple-component/#toc_an-integration-test).
 
-Lets begin by opening the component integration test created when we generated our `list-filter` component, `tests/integration/components/list-filter-test.js`.
+Lets begin by opening the component integration test created when we generated our `ListFilter` component, `tests/integration/components/list-filter-test.js`.
 Remove the default test, and create a new test that verifies that by default, the component will list all items.
 
 ```javascript {data-filename="tests/integration/components/list-filter-test.js" data-diff="+9,+10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28"}
@@ -323,15 +323,15 @@ module('Integration | Component | list-filter', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`{{rental-listing}}`);
+    await render(hbs`<RentalListing/>`);
 
     assert.equal(this.element.textContent.trim(), '');
 
     // Template block usage:
     await render(hbs`
-      {{#rental-listing}}
+      <RentalListing>
         template block text
-      {{/rental-listing}}
+      </RentalListing>
     `);
 
     assert.equal(this.element.textContent.trim(), 'template block text');
@@ -340,7 +340,7 @@ module('Integration | Component | list-filter', function(hooks) {
 });
 ```
 
-Our list-filter component takes a function as an argument, used to find the list of matching rentals based on the filter string provided by the user.
+Our ListFilter component takes a function as an argument, used to find the list of matching rentals based on the filter string provided by the user.
 
 ```javascript {data-filename="tests/integration/components/list-filter-test.js" data-diff="+5,+7,+8,+14,+15,+16"}
 import { module, test } from 'qunit';
@@ -397,7 +397,7 @@ module('Integration | Component | list-filter', function(hooks) {
     // you can set up and use your component in the same way your application
     // will use it.
     await render(hbs`
-      {{#list-filter filter=(action filterByCity) as |results|}}
+      <ListFilter @filter={{action "filterByCity"}} as |results|>
         <ul>
         {{#each results as |item|}}
           <li class="city">
@@ -405,7 +405,7 @@ module('Integration | Component | list-filter', function(hooks) {
           </li>
         {{/each}}
         </ul>
-      {{/list-filter}}
+      </ListFilter>
     `);
 
   });
@@ -443,7 +443,7 @@ module('Integration | Component | list-filter', function(hooks) {
     // with an integration test,
     // you can set up and use your component in the same way your application will use it.
     await render(hbs`
-      {{#list-filter filter=(action filterByCity) as |results|}}
+      <ListFilter @filter={{action "filterByCity"}} as |results|>
         <ul>
         {{#each results as |item|}}
           <li class="city">
@@ -451,7 +451,7 @@ module('Integration | Component | list-filter', function(hooks) {
           </li>
         {{/each}}
         </ul>
-      {{/list-filter}}
+      </ListFilter>
     `);
 
     return settled().then(() => {
@@ -497,7 +497,7 @@ test('should update with matching listings', async function (assert) {
   });
 
   await render(hbs`
-    {{#list-filter filter=(action filterByCity) as |results|}}
+    <ListFilter @filter={{action "filterByCity"}} as |results|>
       <ul>
       {{#each results as |item|}}
         <li class="city">
@@ -505,7 +505,7 @@ test('should update with matching listings', async function (assert) {
         </li>
       {{/each}}
       </ul>
-    {{/list-filter}}
+    </ListFilter>
   `);
 
   // fill in the input field with 's'
@@ -525,7 +525,7 @@ You can verify this by starting up our test suite by typing `ember t -s` at the 
 
 ### Application Tests
 
-Now that we've tested that the `list-filter` component behaves as expected, let's test that the page itself also behaves properly with an application test.
+Now that we've tested that the `ListFilter` component behaves as expected, let's test that the page itself also behaves properly with an application test.
 We'll verify that a user visiting the rentals page can enter text into the search field and narrow the list of rentals by city.
 
 Open our existing application test, `tests/acceptance/list-rentals-test.js`, and implement the test labeled "should filter the list of rentals by city".
@@ -559,7 +559,7 @@ import {
 
 In `app/components/list-filter.js`, we have as the top-level element rendered by the component a class called `list-filter`.
 We locate the search input within the component using the selector `.list-filter input`,
-since we know that there is only one input element located in the list-filter component.
+since we know that there is only one input element located in the ListFilter component.
 
 Our test fills out "Seattle" as the search criteria in the search field,
 and then sends a `keyup` event to the same field with a code of `69` (the `e` key) to simulate a user typing, which is the event our code is looking for.
@@ -568,7 +568,7 @@ In the case of our code the key code sent can be anything, since we read the val
 We only use the key event to let our code know that it's time to make a search.
 
 The test locates the results of the search by finding elements with a class of `listing`,
-which we gave to our `rental-listing` component in the ["Building a Simple Component"](../simple-component/) section of the tutorial.
+which we gave to our `RentalListing` component in the ["Building a Simple Component"](../simple-component/) section of the tutorial.
 
 Since our data is hard-coded in Mirage, we know that there is only one rental with a city name of "Seattle",
 so we assert that the number of listings is one and that the location it displays is named, "Seattle".

--- a/guides/v3.7.0/tutorial/ember-cli.md
+++ b/guides/v3.7.0/tutorial/ember-cli.md
@@ -139,11 +139,11 @@ application. This template is most often used to house the application's layout,
 usually containing the header, footer, navigation bar, and so on.
 
 When we edit the `app/templates/application.hbs` file, we'll remove the
-component labeled `{{welcome-page}}`:
+component labeled `<WelcomePage/>`:
 
 ```handlebars {data-filename="app/templates/application.hbs" data-diff="-1,-2,-3"}
 {{!-- The following component displays Ember's default welcome message. --}}
-{{welcome-page}}
+<WelcomePage/>
 {{!-- Feel free to remove this! --}}
 
 {{outlet}}

--- a/guides/v3.7.0/tutorial/ember-cli.md
+++ b/guides/v3.7.0/tutorial/ember-cli.md
@@ -139,11 +139,11 @@ application. This template is most often used to house the application's layout,
 usually containing the header, footer, navigation bar, and so on.
 
 When we edit the `app/templates/application.hbs` file, we'll remove the
-component labeled `<WelcomePage/>`:
+component labeled `<WelcomePage />`:
 
 ```handlebars {data-filename="app/templates/application.hbs" data-diff="-1,-2,-3"}
 {{!-- The following component displays Ember's default welcome message. --}}
-<WelcomePage/>
+<WelcomePage />
 {{!-- Feel free to remove this! --}}
 
 {{outlet}}

--- a/guides/v3.7.0/tutorial/service.md
+++ b/guides/v3.7.0/tutorial/service.md
@@ -166,7 +166,7 @@ export default Component.extend({
 You may have noticed that `this.location` refers to a property location we haven't defined.
 This property will be passed in to the component by its parent template below.
 
-Finally open the template file for our `rental-listing` component and add the new `location-map` component.
+Finally open the template file for our `rental-listing` component and add the new `LocationMap` component.
 
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="+25"}
 <article class="listing">
@@ -193,7 +193,7 @@ Finally open the template file for our `rental-listing` component and add the ne
       <span>Number of bedrooms:</span> {{this.rental.bedrooms}}
     </div>
   </div>
-  {{location-map location=this.rental.city}}
+  <LocationMap @location={{this.rental.city}}/>
 </article>
 ```
 
@@ -321,7 +321,7 @@ module('Integration | Component | location map', function(hooks) {
 
   test('should append map element to container element', async function(assert) {
     this.set('myLocation', 'New York');
-    await render(hbs`{{location-map location=myLocation}}`);
+    await render(hbs`<LocationMap @location={{myLocation}}/>`);
     assert.ok(this.element.querySelector('.map-container > .map'), 'container should have map child');
     assert.equal(this.get('mapsService.calledWithLocation'), 'New York', 'should call service with New York');
   });
@@ -330,15 +330,15 @@ module('Integration | Component | location map', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`{{rental-listing}}`);
+    await render(hbs`<LocationMap/>`);
 
     assert.equal(this.element.textContent.trim(), '');
 
     // Template block usage:
     await render(hbs`
-      {{#location-map}}
+      <LocationMap>
         template block text
-      {{/location-map}}
+      </LocationMap>
     `);
 
     assert.equal(this.element.textContent.trim(), 'template block text');

--- a/guides/v3.7.0/tutorial/service.md
+++ b/guides/v3.7.0/tutorial/service.md
@@ -193,7 +193,7 @@ Finally open the template file for our `rental-listing` component and add the ne
       <span>Number of bedrooms:</span> {{this.rental.bedrooms}}
     </div>
   </div>
-  <LocationMap @location={{this.rental.city}}/>
+  <LocationMap @location={{this.rental.city}} />
 </article>
 ```
 
@@ -321,7 +321,7 @@ module('Integration | Component | location map', function(hooks) {
 
   test('should append map element to container element', async function(assert) {
     this.set('myLocation', 'New York');
-    await render(hbs`<LocationMap @location={{myLocation}}/>`);
+    await render(hbs`<LocationMap @location={{myLocation}} />`);
     assert.ok(this.element.querySelector('.map-container > .map'), 'container should have map child');
     assert.equal(this.get('mapsService.calledWithLocation'), 'New York', 'should call service with New York');
   });
@@ -330,7 +330,7 @@ module('Integration | Component | location map', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`<LocationMap/>`);
+    await render(hbs`<LocationMap />`);
 
     assert.equal(this.element.textContent.trim(), '');
 

--- a/guides/v3.7.0/tutorial/simple-component.md
+++ b/guides/v3.7.0/tutorial/simple-component.md
@@ -70,7 +70,7 @@ with our new `RentalListing` component:
 </div>
 
 {{#each this.model as |rentalUnit|}}
-  <RentalListing @rental={{rentalUnit}}/>
+  <RentalListing @rental={{rentalUnit}} />
 {{#each this.model as |rental|}}
   <article class="listing">
     <h3>{{rental.title}}</h3>
@@ -243,7 +243,7 @@ module('Integration | Component | rental listing', function (hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`<RentalListing/>`);
+    await render(hbs`<RentalListing />`);
 
     assert.equal(this.element.textContent.trim(), '');
 
@@ -318,11 +318,11 @@ module('Integration | Component | rental listing', function (hooks) {
   });
 
   test('should display rental details', async function(assert) {
-    await render(hbs`<RentalListing @rental={{this.rental}}/>`);
+    await render(hbs`<RentalListing @rental={{this.rental}} />`);
   });
 
   test('should toggle wide class on click', async function(assert) {
-    await render(hbs`<RentalListing @rental={{this.rental}}/>`);
+    await render(hbs`<RentalListing @rental={{this.rental}} />`);
   });
 });
 ```
@@ -333,7 +333,7 @@ In the first test, we just want to verify the output of the component, so we jus
 
 ```javascript {data-filename="tests/integration/components/rental-listing-test.js" data-diff="+3,+4"}
 test('should display rental details', async function(assert) {
-  await render(hbs`<RentalListing @rental={{this.rental}}/>`);
+  await render(hbs`<RentalListing @rental={{this.rental}} />`);
   assert.equal(this.element.querySelector('.listing h3').textContent.trim(), 'test-title', 'Title: test-title');
   assert.equal(this.element.querySelector('.listing .owner').textContent.trim(), 'Owner: test-owner', 'Owner: test-owner');
 });
@@ -346,7 +346,7 @@ Note that we find the image element using the CSS selector `.image`.
 
 ```javascript {data-filename="tests/integration/components/rental-listing-test.js" data-diff="+3,+4,+5,+6,+7"}
   test('should toggle wide class on click', async function(assert) {
-    await render(hbs`<RentalListing @rental={{this.rental}}/>`);
+    await render(hbs`<RentalListing @rental={{this.rental}} />`);
     assert.notOk(this.element.querySelector('.image.wide'), 'initially rendered small');
     await click('.image');
     assert.ok(this.element.querySelector('.image.wide'), 'rendered wide after click');
@@ -387,13 +387,13 @@ module('Integration | Component | rental listing', function (hooks) {
   });
 
   test('should display rental details', async function(assert) {
-    await render(hbs`<RentalListing @rental={{this.rental}}/>`);
+    await render(hbs`<RentalListing @rental={{this.rental}} />`);
     assert.equal(this.element.querySelector('.listing h3').textContent.trim(), 'test-title', 'Title: test-title');
     assert.equal(this.element.querySelector('.listing .owner').textContent.trim(), 'Owner: test-owner', 'Owner: test-owner');
   });
 
   test('should toggle wide class on click', async function(assert) {
-    await render(hbs`<RentalListing @rental={{this.rental}}/>`);
+    await render(hbs`<RentalListing @rental={{this.rental}} />`);
     assert.notOk(this.element.querySelector('.image.wide'), 'initially rendered small');
     await click('.image');
     assert.ok(this.element.querySelector('.image.wide'), 'rendered wide after click');

--- a/guides/v3.7.0/tutorial/simple-component.md
+++ b/guides/v3.7.0/tutorial/simple-component.md
@@ -7,9 +7,7 @@ Components can be included in any route's template, even multiple times, saving
 you from copy-and-pasting the same code around your application.
 
 Let's generate a `rental-listing` component that will manage the behavior for
-each of our rentals. A dash is required in every component name to avoid
-conflicting with a possible HTML element, so `rental-listing` is acceptable but
-`rental` isn't.
+each of our rentals. 
 
 ```bash
 ember g component rental-listing
@@ -31,7 +29,7 @@ A component consists of two parts:
 * A template that defines how it will look (`app/templates/components/rental-listing.hbs`)
 * A JavaScript source file (`app/components/rental-listing.js`) that defines how it will behave.
 
-Our new `rental-listing` component will manage how a user sees and interacts with a rental.
+Our new `RentalListing` component will manage how a user sees and interacts with a rental.
 To start, let's move the rental display details for a single rental from the `rentals.hbs` template into `rental-listing.hbs` and add the image field:
 
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-1,+2,+3,+4,+5,+6,+7,+8,+9,+10,+11,+12,+13,+14,+15,+16,+17,+18,+19"}
@@ -57,7 +55,7 @@ To start, let's move the rental display details for a single rental from the `re
 ```
 
 Now in our `rentals.hbs` template, let's replace the old HTML markup within our `{{#each}}` loop
-with our new `rental-listing` component:
+with our new `RentalListing` component:
 
 ```handlebars {data-filename="app/templates/rentals.hbs" data-diff="+12,+13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29"}
 <div class="jumbo">
@@ -72,7 +70,7 @@ with our new `rental-listing` component:
 </div>
 
 {{#each this.model as |rentalUnit|}}
-  {{rental-listing rental=rentalUnit}}
+  <RentalListing @rental={{rentalUnit}}/>
 {{#each this.model as |rental|}}
   <article class="listing">
     <h3>{{rental.title}}</h3>
@@ -93,7 +91,7 @@ with our new `rental-listing` component:
 ```
 
 For each `rentalUnit` in the `model` list, we are creating a new instance of our
-`rental-listing` component and passing in the `rentalUnit` by assigning it to
+`RentalListing` component and passing in the `rentalUnit` by assigning it to
 the component's `rental` attribute.
 
 Our app should behave now as before, with the addition of an image for each rental item.
@@ -166,7 +164,7 @@ export default Component.extend({
 In order to trigger this action, we need to use the `{{action}}` helper in our
 template:
 
-```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-2,+3,+4,+4,+6,+7"}
+```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-2,+3,+4,+5,+6,+7"}
 <article class="listing">
   <a class="image {{if this.isWide "wide"}}">
   <a
@@ -245,15 +243,15 @@ module('Integration | Component | rental listing', function (hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`{{rental-listing}}`);
+    await render(hbs`<RentalListing/>`);
 
     assert.equal(this.element.textContent.trim(), '');
 
     // Template block usage:
     await render(hbs`
-      {{#rental-listing}}
+      <RentalListing>
         template block text
-      {{/rental-listing}}
+      </RentalListing>
     `);
 
     assert.equal(this.element.textContent.trim(), 'template block text');
@@ -320,11 +318,11 @@ module('Integration | Component | rental listing', function (hooks) {
   });
 
   test('should display rental details', async function(assert) {
-    await render(hbs`{{rental-listing rental=rental}}`);
+    await render(hbs`<RentalListing @rental={{this.rental}}/>`);
   });
 
   test('should toggle wide class on click', async function(assert) {
-    await render(hbs`{{rental-listing rental=rental}}`);
+    await render(hbs`<RentalListing @rental={{this.rental}}/>`);
   });
 });
 ```
@@ -335,7 +333,7 @@ In the first test, we just want to verify the output of the component, so we jus
 
 ```javascript {data-filename="tests/integration/components/rental-listing-test.js" data-diff="+3,+4"}
 test('should display rental details', async function(assert) {
-  await render(hbs`{{rental-listing rental=rental}}`);
+  await render(hbs`<RentalListing @rental={{this.rental}}/>`);
   assert.equal(this.element.querySelector('.listing h3').textContent.trim(), 'test-title', 'Title: test-title');
   assert.equal(this.element.querySelector('.listing .owner').textContent.trim(), 'Owner: test-owner', 'Owner: test-owner');
 });
@@ -348,7 +346,7 @@ Note that we find the image element using the CSS selector `.image`.
 
 ```javascript {data-filename="tests/integration/components/rental-listing-test.js" data-diff="+3,+4,+5,+6,+7"}
   test('should toggle wide class on click', async function(assert) {
-    await render(hbs`{{rental-listing rental=rental}}`);
+    await render(hbs`<RentalListing @rental={{this.rental}}/>`);
     assert.notOk(this.element.querySelector('.image.wide'), 'initially rendered small');
     await click('.image');
     assert.ok(this.element.querySelector('.image.wide'), 'rendered wide after click');
@@ -389,13 +387,13 @@ module('Integration | Component | rental listing', function (hooks) {
   });
 
   test('should display rental details', async function(assert) {
-    await render(hbs`{{rental-listing rental=rental}}`);
+    await render(hbs`<RentalListing @rental={{this.rental}}/>`);
     assert.equal(this.element.querySelector('.listing h3').textContent.trim(), 'test-title', 'Title: test-title');
     assert.equal(this.element.querySelector('.listing .owner').textContent.trim(), 'Owner: test-owner', 'Owner: test-owner');
   });
 
   test('should toggle wide class on click', async function(assert) {
-    await render(hbs`{{rental-listing rental=rental}}`);
+    await render(hbs`<RentalListing @rental={{this.rental}}/>`);
     assert.notOk(this.element.querySelector('.image.wide'), 'initially rendered small');
     await click('.image');
     assert.ok(this.element.querySelector('.image.wide'), 'rendered wide after click');

--- a/guides/v3.7.0/tutorial/subroutes.md
+++ b/guides/v3.7.0/tutorial/subroutes.md
@@ -38,7 +38,7 @@ This is where the active nested route will be rendered.
    as |filteredResults|>
   <ul class="results">
     {{#each filteredResults as |rentalUnit|}}
-      <li><RentalListing @rental={{rentalUnit}}/></li>
+      <li><RentalListing @rental={{rentalUnit}} /></li>
     {{/each}}
   </ul>
 </ListFilter>
@@ -115,7 +115,7 @@ Now that we are returning all of our rentals to the nested route's model, we wil
    as |filteredResults|}}
   <ul class="results">
     {{#each filteredResults as |rentalUnit|}}
-      <li><RentalListing @rental={{rentalUnit}}/></li>
+      <li><RentalListing @rental={{rentalUnit}} /></li>
     {{/each}}
   </ul>
 </ListFilter>
@@ -128,7 +128,7 @@ Now that we are returning all of our rentals to the nested route's model, we wil
    as |filteredResults|}}
   <ul class="results">
     {{#each filteredResults as |rentalUnit|}}
-      <li><RentalListing @rental={{rentalUnit}}/></li>
+      <li><RentalListing @rental={{rentalUnit}} /></li>
     {{/each}}
   </ul>
 </ListFilter>
@@ -378,7 +378,7 @@ Clicking on the title will load the detail page for that rental.
       <span>Number of bedrooms:</span> {{this.rental.bedrooms}}
     </div>
   </div>
-  <LocationMap @location={{this.rental.city}}/>
+  <LocationMap @location={{this.rental.city}} />
 </article>
 ```
 ![Rental Page Nested Index Route](/images/subroutes/subroutes-super-rentals-index.png)

--- a/guides/v3.7.0/tutorial/subroutes.md
+++ b/guides/v3.7.0/tutorial/subroutes.md
@@ -33,15 +33,15 @@ This is where the active nested route will be rendered.
     About Us
   {{/link-to}}
 </div>
-{{#list-filter
-   filter=(action 'filterByCity')
-   as |filteredResults|}}
+<ListFilter
+   @filter={{action "filterByCity"}}
+   as |filteredResults|>
   <ul class="results">
     {{#each filteredResults as |rentalUnit|}}
-      <li>{{rental-listing rental=rentalUnit}}</li>
+      <li><RentalListing @rental={{rentalUnit}}/></li>
     {{/each}}
   </ul>
-{{/list-filter}}
+</ListFilter>
 {{outlet}}
 ```
 
@@ -110,28 +110,28 @@ Now that we are returning all of our rentals to the nested route's model, we wil
     About Us
   {{/link-to}}
 </div>
-{{#list-filter
-   filter=(action 'filterByCity')
+<ListFilter
+   @filter={{action "filterByCity"}}
    as |filteredResults|}}
   <ul class="results">
     {{#each filteredResults as |rentalUnit|}}
-      <li>{{rental-listing rental=rentalUnit}}</li>
+      <li><RentalListing @rental={{rentalUnit}}/></li>
     {{/each}}
   </ul>
-{{/list-filter}}
+</ListFilter>
 {{outlet}}
 ```
 
 ```handlebars {data-filename="app/templates/rentals/index.hbs" data-diff="+1,+2,+3,+4,+5,+6,+7,+8,+9"}
-{{#list-filter
-   filter=(action 'filterByCity')
+<ListFilter
+   @filter={{action "filterByCity"}}
    as |filteredResults|}}
   <ul class="results">
     {{#each filteredResults as |rentalUnit|}}
-      <li>{{rental-listing rental=rentalUnit}}</li>
+      <li><RentalListing @rental={{rentalUnit}}/></li>
     {{/each}}
   </ul>
-{{/list-filter}}
+</ListFilter>
 {{outlet}}
 ```
 
@@ -343,7 +343,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 ## Linking to a Specific Rental
 
-Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `rental-listing` component to navigate to individual pages.
+Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `RentalListing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
 When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://www.emberjs.com/api/ember/release/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
@@ -378,7 +378,7 @@ Clicking on the title will load the detail page for that rental.
       <span>Number of bedrooms:</span> {{this.rental.bedrooms}}
     </div>
   </div>
-  {{location-map location=this.rental.city}}
+  <LocationMap @location={{this.rental.city}}/>
 </article>
 ```
 ![Rental Page Nested Index Route](/images/subroutes/subroutes-super-rentals-index.png)


### PR DESCRIPTION
Here is the base of the angle bracket notation conversion. There are a few things that will need addressed:

Need a new image for /images/ember-core-concepts/ember-core-concepts.png to convert <RentalTitle>

`tutorial/simple-component` and `components/defining-a-component` :
Update:  "A dash is required in every component name to avoid conflicting with a possible HTML element, so rental-listing is acceptable but rental isn't."

Are these correct?
```
{{#each this.model as |post|}}
  <BlogPost @post.title @post.body/>
{{/each}}
```

```
<MyComponent @people={{array
    'Tom Dade'
    'Yehuda Katz'
    this.myOtherPerson}}
 />
```
