### PR TITLE
guides(templates): consistent use of `this`

### DIFF
--- a/guides/v3.7.0/templates/handlebars-basics.md
+++ b/guides/v3.7.0/templates/handlebars-basics.md
@@ -36,7 +36,7 @@ The above template and controller render as the following HTML:
 Hello, <strong>Trek Glowacki</strong>!
 ```
 
-Remember that `{{firstName}}` and `{{lastName}}` are bound data. That means
+Remember that `{{this.firstName}}` and `{{this.lastName}}` are bound data. That means
 if the value of one of those properties changes, the DOM will be updated
 automatically.
 


### PR DESCRIPTION
Add `this.` to value examples since the are used in the example above.