### PR TITLE
templates: updated built-in-helpers link to point at the index

### DIFF
--- a/guides/v3.7.0/templates/built-in-helpers.md
+++ b/guides/v3.7.0/templates/built-in-helpers.md
@@ -2,7 +2,7 @@ In the last section you learned how to write a helper.
 A helper is usually a simple function that can be used in any template.
 Ember comes with a few helpers that can make developing your templates a bit easier.
 These helpers can allow you to be more dynamic in passing data to another helper or component.
-For a full list of built-in Helpers, see the [Ember.Templates.helpers](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/)
+For a full list of built-in Helpers, see the [Ember.Templates.helpers](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/)
 API documentation.
 
 ### Using a helper to get a property dynamically


### PR DESCRIPTION
This is just a quick (optional) extension to https://github.com/ember-learn/guides-source/pull/375 that I wanted to propose and didn't want to slow down the merge process with a "change request" or comment. 

Essentially I think it might be a slightly better experience if we link people to the index page of the helpers so they can easily see everything that is available.

@jenweber if you don't agree then feel free to reject/close this PR 👍  