### PR TITLE
Add a few callouts to Angle Bracket Syntax

### DIFF
--- a/guides/release/components/defining-a-component.md
+++ b/guides/release/components/defining-a-component.md
@@ -32,7 +32,7 @@ Given the above template, you can now use the `<BlogPost />` component:
     <div class="cta-note-body">
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
-In Ember templates there are different ways to invoke a Component. The syntax above is referred to as Angle Bracket Syntax, and it might not look familiar if you are looking at older code samples that use the Classic Invocation Syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://emberjs.com/api/ember/3.6/classes/Component">Ember.js API documentation</a>.
+In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://emberjs.com/api/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">

--- a/guides/release/components/defining-a-component.md
+++ b/guides/release/components/defining-a-component.md
@@ -27,6 +27,18 @@ Given the above template, you can now use the `<BlogPost />` component:
 {{/each}}
 ```
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+In Ember templates there are different ways to invoke a Component. The syntax above is referred to as Angle Bracket Syntax, and it might not look familiar if you are looking at older code samples that use the Classic Invocation Syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://emberjs.com/api/ember/3.6/classes/Component">Ember.js API documentation</a>.
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+  </div>
+</div>
+
 Its model is populated in `model` hook in the route handler:
 
 ```javascript {data-filename=app/routes/index.js}

--- a/guides/release/tutorial/simple-component.md
+++ b/guides/release/tutorial/simple-component.md
@@ -95,7 +95,7 @@ with our new `RentalListing` component:
     <div class="cta-note-body">
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
-In Ember templates there are different ways to invoke a Component. The syntax above is referred to as Angle Bracket Syntax, and it might not look familiar if you are looking at older code samples that use the Classic Invocation Syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://emberjs.com/api/ember/3.6/classes/Component">Ember.js API documentation</a>.
+In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://emberjs.com/api/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">

--- a/guides/release/tutorial/simple-component.md
+++ b/guides/release/tutorial/simple-component.md
@@ -90,6 +90,18 @@ with our new `RentalListing` component:
 {{/each}}
 ```
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+In Ember templates there are different ways to invoke a Component. The syntax above is referred to as Angle Bracket Syntax, and it might not look familiar if you are looking at older code samples that use the Classic Invocation Syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://emberjs.com/api/ember/3.6/classes/Component">Ember.js API documentation</a>.
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+  </div>
+</div>
+
 For each `rentalUnit` in the `model` list, we are creating a new instance of our
 `RentalListing` component and passing in the `rentalUnit` by assigning it to
 the component's `rental` attribute.


### PR DESCRIPTION
@mansona I closed #420 in favor of this new PR because I didn't realize my local guides-source forked repo was so far behind upstream when I rebased. The rebase ended up cluttering the commit history for #420, so it just seemed easier/cleaner to open this new PR with the same changes.

@jenweber this adds the Angle Bracket Syntax callouts discussed previously in a few locations.

@locks not sure if you want to take a look since it references the syntax guide that you're updating in #401. 

FWIW the callouts don't seem to accept using MD links (the message body of the cta-note is a `<p>` tag), so I used `<a>` tags instead.

This is how it's looking:

<img width="879" alt="screen shot 2019-02-09 at 11 28 37 am" src="https://user-images.githubusercontent.com/6305935/52523300-e52ca600-2c5d-11e9-96dd-5123e6c15aa3.png">

AND

<img width="967" alt="screen shot 2019-02-09 at 11 28 16 am" src="https://user-images.githubusercontent.com/6305935/52523301-e78f0000-2c5d-11e9-8f68-e5364cb55038.png">