### PR TITLE
Accessibility Guide: improve guidance for disabling application template wrapper

### DIFF
--- a/guides/release/reference/accessibility-guide.md
+++ b/guides/release/reference/accessibility-guide.md
@@ -4,9 +4,15 @@ The purpose of this guide is to give every Ember developer a starting point for 
 
 ### Optional Feature: Application Template Wrapper
 
-If you are using the [application template wrapper](#toc_optional-features) enabled (default state), then you will need to add certain aria roles to your [landmark regions](https://www.w3.org/WAI/PF/aria/roles#landmark_roles), even if you are using native HTML elements, because those regions are not the direct child descendant of the body element (they are the children of the div that wraps the Ember app).
+If you are using the [application template wrapper](https://emberjs.com/blog/2018/02/16/ember-3-1-beta-released.html#toc_new-optional-feature-application-template-wrapper) enabled (default state), then you will need to add certain aria roles to your [landmark regions](https://www.w3.org/WAI/PF/aria/roles#landmark_roles), even if you are using native HTML elements, because those regions are not the direct child descendant of the body element (they are the children of the div that wraps the Ember app).
 
-If you disable the [application template wrapper](#toc_optional-features), you will not need to add role attributes to your landmark regions when they are the direct descendant of the body element, and they are using native HTML elements. This is the preferred approach for accessible applications. 
+If you disable the [application template wrapper](https://emberjs.com/blog/2018/02/16/ember-3-1-beta-released.html#toc_new-optional-feature-application-template-wrapper), you will not need to add role attributes to your landmark regions when they are the direct descendant of the body element, and they are using native HTML elements. This is the preferred approach for accessible applications. 
+
+To disable this feature:
+
+```
+$ ember feature:disable application-template-wrapper
+```
 
 **Application Template Wrapper Disabled** _(preferred)_
 

--- a/guides/release/reference/accessibility-guide.md
+++ b/guides/release/reference/accessibility-guide.md
@@ -10,8 +10,8 @@ If you disable the [application template wrapper](https://emberjs.com/blog/2018/
 
 To disable this feature:
 
-```
-$ ember feature:disable application-template-wrapper
+```bash
+ember feature:disable application-template-wrapper
 ```
 
 **Application Template Wrapper Disabled** _(preferred)_


### PR DESCRIPTION
For the the "application template wrapper" links, I'm not sure where these were intended to point. I'd be happy to change the target.

From just the current text, it's not clear how one would disable this feature. I added a codeblock for handy copy-pasting.

This PR is mostly just a note that the links were broken. Feel free to close it if some other solution makes sense.