### PR TITLE
Added missing quotation for 'Acceptance | list rentals'

### DIFF
--- a/guides/release/tutorial/acceptance-test.md
+++ b/guides/release/tutorial/acceptance-test.md
@@ -48,7 +48,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
-module('Acceptance | list rentals, function(hooks) {
+module('Acceptance | list rentals', function(hooks) {
   setupApplicationTest(hooks);
 
   test('visiting /list-rentals', async function(assert) {


### PR DESCRIPTION
In the Ember tutorial for [Planning Your App](https://guides.emberjs.com/release/tutorial/acceptance-test/), there's a missing closing quotation for the `tests/acceptance/list-rentals-test.js` JavaScript block.