### PR TITLE
Remove unnecessary slashes

### DIFF
--- a/guides/release/routing/specifying-a-routes-model.md
+++ b/guides/release/routing/specifying-a-routes-model.md
@@ -85,9 +85,9 @@ photo's ID (`params.photo_id`) as an argument to Ember Data's `findRecord`
 method.
 
 Note: A route with a dynamic segment will always have its `model` hook called when it is entered via the URL.
-If the route is entered through a transition (e.g. when using the [link-to](../../templates/links/) Handlebars helper/),
+If the route is entered through a transition (e.g. when using the [link-to](../../templates/links/) Handlebars helper),
 and a model context is provided (second argument to `link-to`), then the hook is not executed.
-If an identifier (such as an id or slug/) is provided instead then the model hook will be executed.
+If an identifier (such as an id or slug) is provided instead then the model hook will be executed.
 
 For example, transitioning to the `photo` route this way won't cause the `model` hook to be executed (because `link-to`
 was passed a model/):


### PR DESCRIPTION
Specifying a Route's Model > Dynamic Models had a few unnecessary slashes in parenthetical statements:

<img width="761" alt="image" src="https://user-images.githubusercontent.com/15832198/53293952-cbd24080-37ab-11e9-8936-8ca91b59a2b3.png">

This PR removes them:

<img width="754" alt="image" src="https://user-images.githubusercontent.com/15832198/53293953-d5f43f00-37ab-11e9-9251-e0e839a6c8d2.png">
