### PR TITLE
Fix error callback written with then instead of catch

### DIFF
--- a/guides/release/routing/defining-your-routes.md
+++ b/guides/release/routing/defining-your-routes.md
@@ -336,7 +336,7 @@ export default Route.extend({
       this.store.findRecord('user', id).then(function (user) {
         // Success callback
         this.transitionTo('user.profile', user);
-      }).then(function () {
+      }).catch(function () {
         // Error callback
         this.transitionTo('not-found', 404);
       }


### PR DESCRIPTION
In Defining Your Routes > Wildcard / globbing routes, there is a code sample that's intended to illustrate a promise with a success and error callback, but both are written with `then`:

<img width="754" alt="image" src="https://user-images.githubusercontent.com/15832198/53294022-143e2e00-37ad-11e9-97c8-9a7e7d2f220d.png">

This seems to be a bug, because the second `then` would receive a successful result from the first `then`, not an error. It seems that `catch` is intended instead. This PR corrects that:

<img width="754" alt="image" src="https://user-images.githubusercontent.com/15832198/53294031-2c15b200-37ad-11e9-8ca8-aa85f28b4263.png">
