### PR TITLE
Standardize 'Ajax' capitalization

### DIFF
--- a/guides/release/applications/run-loop.md
+++ b/guides/release/applications/run-loop.md
@@ -15,7 +15,7 @@ For example:
 - DOM update and event callbacks
 - `setTimeout` and `setInterval` callbacks
 - `postMessage` and `messageChannel` event handlers
-- AJAX callbacks
+- Ajax callbacks
 - WebSocket callbacks
 
 ## Why is the run loop useful?

--- a/guides/release/components/triggering-changes-with-actions.md
+++ b/guides/release/components/triggering-changes-with-actions.md
@@ -200,7 +200,7 @@ more reusable components.
 
 ## Handling Action Completion
 
-Often actions perform asynchronous tasks, such as making an ajax request to a server.
+Often actions perform asynchronous tasks, such as making an Ajax request to a server.
 Since actions are functions that can be passed in by a parent component, they are able to return values when called.
 The most common scenario is for an action to return a promise so that the component can handle the action's completion.
 

--- a/guides/release/models/customizing-adapters.md
+++ b/guides/release/models/customizing-adapters.md
@@ -203,7 +203,7 @@ Requests for `user-profile` would now target `/user_profile/1`.
 
 Some APIs require HTTP headers, e.g. to provide an API key. Arbitrary
 headers can be set as key/value pairs on the `JSONAPIAdapter`'s `headers`
-object and Ember Data will send them along with each ajax request.
+object and Ember Data will send them along with each Ajax request.
 (Note that we set headers in `init()` because default property values
 should not be arrays or objects.)
 

--- a/guides/release/models/index.md
+++ b/guides/release/models/index.md
@@ -56,7 +56,7 @@ guide.
 
 At first, using Ember Data may feel different than the way you're used
 to writing JavaScript applications. Many developers are familiar with
-using AJAX to fetch raw JSON data from an endpoint, which may appear
+using Ajax to fetch raw JSON data from an endpoint, which may appear
 easy at first. Over time, however, complexity leaks out into your
 application code, making it hard to maintain.
 

--- a/guides/release/models/pushing-records-into-the-store.md
+++ b/guides/release/models/pushing-records-into-the-store.md
@@ -122,7 +122,7 @@ endpoints. You may find your application has an endpoint that performs
 some business logic then creates several records. This likely does not
 map cleanly to Ember Data's existing `save()` API which is structured
 around persisting a single record. Instead you should make your own
-custom AJAX request and push the resulting model data into the store
+custom Ajax request and push the resulting model data into the store
 so it can be accessed by other parts of your application.
 
 

--- a/guides/release/routing/asynchronous-routing.md
+++ b/guides/release/routing/asynchronous-routing.md
@@ -34,7 +34,7 @@ Much of the power of promises comes from the fact that they can be
 chained together to perform sequential asynchronous operations:
 
 ```javascript
-// Note: jQuery AJAX methods return promises
+// Note: jQuery Ajax methods return promises
 let usernamesPromise = Ember.$.getJSON('/usernames.json');
 
 usernamesPromise.then(fetchPhotosOfUsers)


### PR DESCRIPTION
Previously the guides in some places had "Ajax", others "ajax", and others "AJAX". As discussed in #518, this PR standardizes on the capitalization "Ajax", which seems to be the most accepted.

Code references to `$.ajax()` are not changed, of course.