### PR TITLE
[OCTANE] [CHORE] Quickstart JS to use Class Syntax #541

### DIFF
--- a/guides/release/getting-started/core-concepts.md
+++ b/guides/release/getting-started/core-concepts.md
@@ -74,10 +74,10 @@ In the following example, the [`didRender()`](https://emberjs.com/api/ember/rele
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';
 
-export default Component.extend({
+export default class FooDidRenderExample extends Component {
   didRender() {
-    this._super(...arguments);
+    super(...arguments);
     console.log('I rendered!');
   }
-});
+}
 ```

--- a/guides/release/getting-started/core-concepts.md
+++ b/guides/release/getting-started/core-concepts.md
@@ -76,7 +76,7 @@ import Component from '@ember/component';
 
 export default class FooDidRenderExample extends Component {
   didRender() {
-    super(...arguments);
+    super.didRender(...arguments);
     console.log('I rendered!');
   }
 }

--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -131,11 +131,11 @@ We'll take the code created for us by the generator and add a `model()` method t
 ```javascript {data-filename="app/routes/scientists.js" data-diff="+4,+5,+6"}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class ScientistsRoute extends Route {
   model() {
     return ['Marie Curie', 'Mae Jemison', 'Albert Hofmann'];
   }
-});
+}
 ```
 
 This code example uses the latest features in JavaScript,
@@ -251,13 +251,12 @@ In the component, add an `actions` object with a `showPerson` function that aler
 ```javascript {data-filename="app/components/people-list.js" data-diff="+4,+5,+6,+7,+8"}
 import Component from '@ember/component';
 
-export default Component.extend({
-  actions: {
-    showPerson(person) {
-      alert(person);
-    }
+export default class PeopleList extends Component {
+  @action
+  showPerson(person) {
+    alert(person);
   }
-});
+}
 ```
 
 Now in the browser when a scientist's name is clicked,


### PR DESCRIPTION
Fixes #541

1. Change Route example to class syntax in core concepts
<img width="845" alt="screen shot 2019-03-01 at 6 04 44 pm" src="https://user-images.githubusercontent.com/2083049/53645381-bef79600-3c5e-11e9-9d55-e59ad555dc44.png">

2. Change PeopleList component to use class syntax
<img width="950" alt="screen shot 2019-03-01 at 6 04 56 pm" src="https://user-images.githubusercontent.com/2083049/53645386-c5860d80-3c5e-11e9-9f98-2055eb51d518.png">

3. didRender example to class syntax
<img width="899" alt="screen shot 2019-03-01 at 6 03 25 pm" src="https://user-images.githubusercontent.com/2083049/53645398-cc148500-3c5e-11e9-9bae-3fb32183e802.png">

