### PR TITLE
[TEST FIXES] Test case failures due to file rename changes

### DIFF
--- a/guides/release/components/block-params.md
+++ b/guides/release/components/block-params.md
@@ -1,4 +1,4 @@
-Components can have properties passed in ([Passing Properties to a Component](../passing-properties-to-a-component/)),
+Components can have properties passed in ([Passing Properties to a Component](../passing-arguments-and-html-attributes/)),
 but they can also return output to be used in a block expression.
 
 ### Return values from a component with `yield`

--- a/guides/release/components/wrapping-content-in-a-component.md
+++ b/guides/release/components/wrapping-content-in-a-component.md
@@ -13,7 +13,7 @@ Now, we can use the `<BlogPost />` component and pass it properties in another t
 <BlogPost @title={{this.title}} @body={{this.body}} />
 ```
 
-See [Passing Properties to a Component](../passing-properties-to-a-component/) for more.
+See [Passing Properties to a Component](../passing-arguments-and-html-attributes/) for more.
 
 In this case, the content we wanted to display came from the model.
 But what if we want the developer using our component to be able to provide custom HTML content?

--- a/guides/release/pages.yml
+++ b/guides/release/pages.yml
@@ -60,7 +60,7 @@
     - title: "The Component Lifecycle"
       url: "the-component-lifecycle"
     - title: "Passing Properties to a Component"
-      url: "passing-properties-to-a-component"
+      url: "passing-arguments-and-html-attributes"
     - title: "Wrapping Content in a Component"
       url: "wrapping-content-in-a-component"
     - title: "Customizing a Component's Element"

--- a/guides/release/reference/syntax-conversion-guide.md
+++ b/guides/release/reference/syntax-conversion-guide.md
@@ -61,7 +61,7 @@ In the following example, `"greeting"` and `"name"` are positional parameters:
 {{my-greeting "Hello" "World"}}
 ```
 
-As shown in the relevant ["Position Params"](../../components/passing-properties-to-a-component/#toc_positional-params) part of the Guides,
+As shown in the relevant ["Position Params"](../../components/passing-arguments-and-html-attributes/#toc_positional-params) part of the Guides,
 there are two ways to handle them inside the component.
 One way is to individually specify what component property the positional parameter should map to.
 The other way is to map all positional parameters to the `params` property and refer to them by their index.

--- a/guides/release/tutorial/autocomplete-component.md
+++ b/guides/release/tutorial/autocomplete-component.md
@@ -105,7 +105,7 @@ export default Component.extend({
 In the above example we use the `init` hook to seed our initial listings by calling the `filter` action with an empty value.
 Our `handleFilterEntry` action calls a function called `filter` based on the `value` attribute set by the input helper.
 
-The `filter` function is passed in by the calling object. This is a pattern known as [closure actions](../../components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component).
+The `filter` function is passed in by the calling object. This is a pattern known as [closure actions](../../components/adding-actions/#toc_passing-the-action-to-the-component).
 
 Notice the `then` function called on the result of calling the `filter` function.
 The code expects the `filter` function to return a promise.


### PR DESCRIPTION
This fixes the node-tests which are failing due to file rename
changes like:
1. passing-properties-to-a-component =>
passing-arguments-and-html-attributes
2. triggering-changes-with-actions => adding-actions

https://github.com/ember-learn/guides-source/issues/540#issuecomment-468694994