### PR TITLE
start fixing a few links in state management

### DIFF
--- a/guides/release/state-management/index.md
+++ b/guides/release/state-management/index.md
@@ -37,7 +37,7 @@ In Ember, we care mostly about _object_ state in the form of:
 - **Controller state**
 - **Service state**
 
-In the [Patterns for State][2] section, we discuss how you can store your
+In the [Patterns for State](./patterns-for-state) section, we discuss how you can store your
 application's state in these different types of objects, and how to think about
 state in general in Ember apps.
 

--- a/guides/release/state-management/patterns-for-state.md
+++ b/guides/release/state-management/patterns-for-state.md
@@ -118,7 +118,7 @@ a change. In Ember applications, state can change in three main ways:
 
 ### Actions
 
-As we discussed in the section on [Actions], they are methods on a component or
+As we discussed in the section on [Actions](../../templates/actions/), they are methods on a component or
 controller that can be used to update its state. Actions are passed down with
 the rest of a component's data when Ember renders:
 

--- a/guides/release/state-management/tracked-properties.md
+++ b/guides/release/state-management/tracked-properties.md
@@ -86,7 +86,7 @@ are used somewhere in your component, the component will update accordingly.
 
 Tracked properties can be updated like any other property, using standard
 JavaScript syntax. The primary way that state gets updated in an Ember
-application is via _actions_, [as discussed earlier][1]:
+application is via _actions_, [as discussed earlier](../../templates/actions/):
 
 ```hbs {data-filename=src/ui/components/hello/template.hbs}
 {{this.greeting}}, {{@name}}!


### PR DESCRIPTION
Fixes a couple links in State Management Guide: https://github.com/ember-learn/guides-source/pull/536
I didn't get to all of them and can create an issue if we want to track.
@pzuraq I think  broccoli-static-site-json or whatever converts the guides markdown does not support reference style links.