### PR TITLE
Small tweaks to handlebars-basics.md

### DIFF
--- a/guides/release/templates/handlebars-basics.md
+++ b/guides/release/templates/handlebars-basics.md
@@ -204,7 +204,7 @@ The user will see a value of `3` rendered in the template!
 
 Ember ships with several built-in helpers, which you will learn more about in the following guides.
 
-### Nested Helper Invocations
+### Nested Helpers
 
 Sometimes, you might see helpers invoked by placing them inside parentheses, `()`.
 This means that a Helper is being used inside of another Helper or Component.

--- a/guides/release/templates/handlebars-basics.md
+++ b/guides/release/templates/handlebars-basics.md
@@ -204,11 +204,11 @@ The user will see a value of `3` rendered in the template!
 
 Ember ships with several built-in helpers, which you will learn more about in the following guides.
 
-### Nested Helper
+### Nested Helper Invocations
 
-Sometimes, you might see helpers used inside of some parentheses, `()`.
-It means that a Helper is being used inside of another Helper or Component.
-This is referred to as a "nested" Helper.
+Sometimes, you might see helpers invoked by placing them inside parentheses, `()`.
+This means that a Helper is being used inside of another Helper or Component.
+This is referred to as a "nested" Helper Invocation.
 Parentheses must be used because curly braces `{{}}` cannot be nested.
 
 ```handlebars {data-filename=app/templates/application.hbs}

--- a/guides/release/templates/handlebars-basics.md
+++ b/guides/release/templates/handlebars-basics.md
@@ -20,7 +20,7 @@ You can write regular HTML markup there or in any other `hbs` file:
 </p>
 ```
 
-When you start an app with `ember serve`, your templates are compiled down to something that Embers rendering engine can process more easily. The compiler helps you catch some errors, such as forgetting to close a tag or missing a quotation mark.
+When you start an app with `ember serve`, your templates are compiled down to something that Ember's rendering engine can process more easily. The compiler helps you catch some errors, such as forgetting to close a tag or missing a quotation mark.
 Reading the error message on the page or in your browser's developer console will get you back on track.
 
 ## Types of templates

--- a/guides/release/templates/handlebars-basics.md
+++ b/guides/release/templates/handlebars-basics.md
@@ -20,7 +20,7 @@ You can write regular HTML markup there or in any other `hbs` file:
 </p>
 ```
 
-When you start an app with `ember serve`, the compiler may help you catch some errors, such as forgetting to close a tag or missing a quotation mark.
+When you start an app with `ember serve`, your templates are compiled down to something that Embers rendering engine can process more easily. The compiler helps you catch some errors, such as forgetting to close a tag or missing a quotation mark.
 Reading the error message on the page or in your browser's developer console will get you back on track.
 
 ## Types of templates
@@ -142,7 +142,7 @@ JavaScript file -->
 
 <!-- Some data passed down from a parent component 
 or controller -->
-{{weatherStatus}}
+{{@weatherStatus}}
 
 <!-- This button uses Ember Actions to make it interactive. 
 A method named `plantATree` is called when the button is
@@ -178,7 +178,7 @@ To pass in arguments associated with a Route, define the property from within a 
 
 Ember Helpers are a way to use JavaScript logic in your templates.
 For example, you could write a Helper function that capitalizes a word, does some math, converts a currency, or more.
-A Helper takes in `parameters`, which is an array of the values passed into the function, and should return a value.
+A Helper takes in two types of arguments `positional` (an array of the positional values passed in the template) and `named` (an object of the named values passed in the template) that are passed into the function, and should return a value.
 Ember gives you the ability to [write your own helpers](../writing-helpers/), and comes with some [helpers built-in](../built-in-helpers).
 
 For example, let's say you would like the ability to add two numbers together.
@@ -204,7 +204,7 @@ The user will see a value of `3` rendered in the template!
 
 Ember ships with several built-in helpers, which you will learn more about in the following guides.
 
-### Nested Helpers
+### Nested Helper
 
 Sometimes, you might see helpers used inside of some parentheses, `()`.
 It means that a Helper is being used inside of another Helper or Component.

--- a/guides/release/templates/handlebars-basics.md
+++ b/guides/release/templates/handlebars-basics.md
@@ -178,7 +178,7 @@ To pass in arguments associated with a Route, define the property from within a 
 
 Ember Helpers are a way to use JavaScript logic in your templates.
 For example, you could write a Helper function that capitalizes a word, does some math, converts a currency, or more.
-A Helper takes in two types of arguments `positional` (an array of the positional values passed in the template) or `named` (an object of the named values passed in the template), which are passed into the function, and should return a value.
+A Helper takes in two types of arguments, `positional` (an array of the positional values passed in the template) or `named` (an object of the named values passed in the template), which are passed into the function, and should return a value.
 Ember gives you the ability to [write your own helpers](../writing-helpers/), and comes with some [helpers built-in](../built-in-helpers).
 
 For example, let's say you would like the ability to add two numbers together.

--- a/guides/release/templates/handlebars-basics.md
+++ b/guides/release/templates/handlebars-basics.md
@@ -178,7 +178,7 @@ To pass in arguments associated with a Route, define the property from within a 
 
 Ember Helpers are a way to use JavaScript logic in your templates.
 For example, you could write a Helper function that capitalizes a word, does some math, converts a currency, or more.
-A Helper takes in two types of arguments `positional` (an array of the positional values passed in the template) and `named` (an object of the named values passed in the template) that are passed into the function, and should return a value.
+A Helper takes in two types of arguments `positional` (an array of the positional values passed in the template) or `named` (an object of the named values passed in the template), which are passed into the function, and should return a value.
 Ember gives you the ability to [write your own helpers](../writing-helpers/), and comes with some [helpers built-in](../built-in-helpers).
 
 For example, let's say you would like the ability to add two numbers together.

--- a/guides/release/templates/handlebars-basics.md
+++ b/guides/release/templates/handlebars-basics.md
@@ -5,10 +5,10 @@ If you want to learn in a step-by-step way, you should begin your journey in the
 
 ## Writing plain HTML
 
-Ember templates have some superpowers, but let's start with regular HTML.
+Templates in Ember have some superpowers, but let's start with regular HTML.
 For any file in an Ember app that has an extension ending in `.hbs`, you can write HTML markup in it as if it was an `.html` file.
 HTML is the language that browsers understand for laying out content on a web page.
-`.hbs` stands for Handlebars, the name of a tool that lets you write more than just HTML in your templates.
+`.hbs` stands for Handlebars, the name of a tool that lets you write more than just HTML.
 
 For example, every Ember app has a file called `application.hbs`.
 You can write regular HTML markup there or in any other `hbs` file:


### PR DESCRIPTION
* Updates naming of positional and named arguments for helpers
* Explains that templates are compiled before referencing "the compiler"
* Adds an `@` to the component template example showing "referencing an argument passed in to the component"
* Tweaks verbiage of "Nested Helpers" section to refer to nested helper invocation
* Tweaks "Ember's templates" to "Templates in Ember" (specifically because they are "glimmer templates" not "ember templates")