### PR TITLE
add script for extracting code blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Deployment credentials
 config/credentials.json
+
+/code

--- a/extractCode.js
+++ b/extractCode.js
@@ -1,0 +1,53 @@
+/* eslint-env node */
+/* eslint no-console:0 */
+
+const walkSync = require('walk-sync');
+const _ = require('lodash');
+const codeBlocks = require('gfm-code-blocks');
+const { extname, join, dirname } = require('path');
+const {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+} = require('fs');
+
+// these regexs are used against the lang definition of a code block to identify
+// the language. If you only want to check certain types then you should change
+// this line
+const templatesMatch = /^(handlebars|html|text|javascript|bash|sh|css|hbs|json|apacheconf)/;
+
+const mdFiles = _.chain(walkSync('guides/release'))
+  .filter(path => extname(path) === '.md')
+  .value();
+
+mdFiles.forEach((filename) => {
+  const source = readFileSync(join(__dirname, 'guides', 'release', filename), 'utf-8');
+  // console.log(filename);
+  const blocks = codeBlocks(source);
+
+  const codeOnly = blocks.reduce((prev, current) => {
+    if (!current.lang) {
+      console.error(`Missing lang in code block on ${filename}`);
+    }
+
+    if (current.lang.match(templatesMatch)) {
+      return `${prev}\n\n${current.block}`;
+    }
+
+    console.log(`Ignoring language ${current.lang}`);
+    return prev;
+  }, '');
+
+  if (codeOnly) {
+    const newFilename = join(__dirname, 'code', filename);
+
+    if (!existsSync(dirname(newFilename))) {
+      mkdirSync(dirname(newFilename), {
+        recursive: true,
+      });
+    }
+
+    writeFileSync(join(__dirname, 'code', filename), codeOnly);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12321,6 +12321,21 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "gfm-code-block-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gfm-code-block-regex/-/gfm-code-block-regex-1.0.0.tgz",
+      "integrity": "sha1-u4PH1ihOa1ty+gIZilisDSViFdI=",
+      "dev": true
+    },
+    "gfm-code-blocks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gfm-code-blocks/-/gfm-code-blocks-1.0.0.tgz",
+      "integrity": "sha1-YU0hBZuETGu8nViMCJslxOi8zw0=",
+      "dev": true,
+      "requires": {
+        "gfm-code-block-regex": "^1.0.0"
+      }
+    },
     "git-repo-info": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-config-airbnb-base": "^13.0.0",
     "eslint-plugin-ember": "^6.3.0",
     "eslint-plugin-import": "^2.16.0",
+    "gfm-code-blocks": "^1.0.0",
     "guidemaker": "^1.3.0",
     "guidemaker-ember-template": "^1.1.0",
     "loader.js": "^4.7.0",


### PR DESCRIPTION
I don't know how useful this would be going forward but if we want to have it available we could think about merging this in some way 🤔 I think for now we should leave this PR open and decide what to do with it in a more general way later 👍 

If anyone wants to use this script in another branch you can just run the following: 

```
git checkout extract-code-script extractCode.js
npm i gfm-code-blocks
```

And then you can run: 

```
node extractCode.js
``` 

and it will export all of the code samples into a `code` directory 
