### PR TITLE
change survey config to be generlized as infoBanner for Octane

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -57,8 +57,8 @@ module.exports = function(environment) {
       },
     ],
     infoBanner: {
-      link: 'https://emberjs.com/',
-      title: 'here'
+      link: 'https://emberjs.com/octane',
+      title: 'emberjs.com/octane'
     },
   };
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -56,9 +56,9 @@ module.exports = function(environment) {
         }
       },
     ],
-    survey: {
-      link: 'https://emberjs.com/ember-community-survey-2019/',
-      title: '2019 Ember Community Survey'
+    infoBanner: {
+      link: 'https://emberjs.com/',
+      title: 'here'
     },
   };
 


### PR DESCRIPTION
Sister PR to https://github.com/ember-learn/guidemaker-ember-template/pull/12 which should be merged first.

Before merging this, we need to make the guidemaker-ember-template release, reference it in package.json of this app, update the lock file, and then this can be merged. We should also specify the correct link once it is decided, either before merging this PR or we should open another issue.

![Screen Shot 2019-03-13 at 12 46 23 AM](https://user-images.githubusercontent.com/16627268/54254280-978bad80-4529-11e9-8b95-0f2c441624cb.png)
