### PR TITLE
docs(working-with-javascript): fix minor typos and invalid JavaScript

### DIFF
--- a/guides/release/working-with-javascript/classic-classes.md
+++ b/guides/release/working-with-javascript/classic-classes.md
@@ -67,7 +67,7 @@ let tom = Person.create();
 Unlike native classes, you _cannot_ use the `new` keyword to create instances of
 classic classes. Attempting to do so will throw an error. Otherwise, instances
 are very similar, they can be assigned values like you would on Plain Old
-Javascript Objects (POJOs):
+JavaScript Objects (POJOs):
 
 ```js
 let tom = Person.create();
@@ -293,7 +293,7 @@ mel.name = 'Melanie Sumner'; // Cannot set property name of #<Class> which has o
 ```
 
 We need to add a _setter_ in order to be able to set it. Generally, the setter
-function stores the value somewher, and the getter function retrieves it:
+function stores the value somewhere, and the getter function retrieves it:
 
 ```js
 const Person = EmberObject.extend({
@@ -486,7 +486,7 @@ _overriden_, and their values will be fully replaced on the child:
 ```js
 const Vehicle = EmberObject.extend({
   move() {
-    console.log('moving');
+    console.log('moving!');
   },
 });
 
@@ -518,7 +518,7 @@ const Vehicle = EmberObject.extend({
 const Aircraft = Vehicle.extend({
   move() {
     this._super();
-    console.log('flying');
+    console.log('flying!');
   },
 });
 
@@ -587,6 +587,7 @@ When doing this, you should keep the following in mind:
    ```js
    class Person extends EmberObject {
      constructor() {
+       super(...arguments);
        console.log('constructor: ', this.name);
      }
 

--- a/guides/release/working-with-javascript/native-classes.md
+++ b/guides/release/working-with-javascript/native-classes.md
@@ -60,7 +60,7 @@ You can create a new _instance_ of the class using the `new` keyword:
 let tom = new Person();
 ```
 
-Instances are like Plain Old Javascript Objects (POJOs) in many ways. You can
+Instances are like Plain Old JavaScript Objects (POJOs) in many ways. You can
 assign values to them however you like, and generally treat them the same:
 
 ```js
@@ -329,7 +329,7 @@ mel.name = 'Melanie Sumner';
 ```
 
 We need to add a _setter_ in order to be able to set it. Generally, the setter
-function stores the value somewher, and the getter function retrieves it:
+function stores the value somewhere, and the getter function retrieves it:
 
 ```js
 class Person {
@@ -615,7 +615,7 @@ class Vehicle {
 class Aircraft extends Vehicle {
   move() {
     super.move();
-    console.log('flying');
+    console.log('flying!');
   }
 }
 

--- a/guides/release/working-with-javascript/native-vs-classic-class-cheatsheet.md
+++ b/guides/release/working-with-javascript/native-vs-classic-class-cheatsheet.md
@@ -347,7 +347,7 @@ const Person = EmberObject.extend({
   const Aircraft = Vehicle.extend({
     move() {
       this._super();
-      console.log('flying');
+      console.log('flying!');
     },
   });
 


### PR DESCRIPTION
This is an attempt at fixing minor issues with the octane "Working with JavaScript" guides.

see https://github.com/ember-learn/guides-source/issues/588