### PR TITLE
[OCTANE] Fixing missing guide

### DIFF
--- a/guides/release/data-management/index.md
+++ b/guides/release/data-management/index.md
@@ -1,0 +1,1 @@
+Coming soon!

--- a/guides/release/pages.yml
+++ b/guides/release/pages.yml
@@ -109,8 +109,13 @@
   pages:
     - title: Introduction
       url: "services"
+
 - title: 'Data Management'
   url: 'data-management'
+  pages:
+    - title: "Overview"
+      url: "index"
+
 - title: "Ember Data"
   url: 'models'
   pages:


### PR DESCRIPTION
This just fixes the last 404 guide that is missing from the Table of contents

![Screenshot 2019-03-14 at 15 23 28](https://user-images.githubusercontent.com/594890/54369075-31a83e80-466d-11e9-9faf-69dbaed6e69c.png)
