### PR TITLE
[OCTANE] remove double semi, other semi colon

### DIFF
--- a/guides/release/testing/testing-components.md
+++ b/guides/release/testing/testing-components.md
@@ -225,7 +225,7 @@ export default class CommentFormComponent extends Component {
 
   @action
   submitComment() {
-    this.args.submitComment({ comment: this.comment });;
+    this.args.submitComment({ comment: this.comment });
   }
 }
 ```
@@ -298,7 +298,7 @@ export default class LocationIndicatorComponent extends Component {
   get country() {
     return this.location.getCurrentCountry();
   }
-};
+}
 ```
 
 ```handlebars {data-filename="app/templates/components/location-indicator.hbs"}
@@ -468,7 +468,7 @@ import { action } from '@ember/object';
 import { debounce } from '@ember/runloop';
 
 export default class DelayedTypeaheadComponent extends Component {
-  @action 
+  @action
   handleTyping() {
     //the fetchResults function is passed into the component from its parent
     debounce(this, this.fetchResults, this.searchValue, 250);


### PR DESCRIPTION
I just learned the semi-colon's are optional after the class definition and methods so it doesn't *really* matter. Though, I've observed most examples in the octane branch do not include them so I think it is best to make the style consistent. @maciej-ka so don't take my nit picking over semi colons personally 😄 
We could continue @mansona's work (https://github.com/ember-learn/guides-source/pull/589#issue-260513096) and automate prettifying the code snippets.