### PR TITLE
Adjust robots.txt and Google Analytics for staging deployment

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -27,7 +27,7 @@ const Router = EmberRouter.extend({
       const title = this.getWithDefault('currentRouteName', 'unknown');
 
       // this is constant for this app and is only used to identify page views in the GA dashboard
-      const hostname = 'guides.emberjs.com';
+      const hostname = 'octane-guides-preview.emberjs.com';
 
       this.metrics.trackPage({ page, title, hostname });
     });

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 # http://www.robotstxt.org
 User-agent: *
-Disallow:
+Disallow: /


### PR DESCRIPTION
I think this resolves the blocker for standing up `octane-guides-preview.emberjs.com`

closes #610 