### PR TITLE
Convert Routes to Native Classes and hide unfinished content

### DIFF
--- a/guides/release/components/actions-and-events.md
+++ b/guides/release/components/actions-and-events.md
@@ -581,6 +581,6 @@ When you encounter a string based action it should be refactored to use the
 It is then recommended to use the action modifier directly with decorated
 functions.
 
-```hbs
+```handlebars
 <button {{action this.confirmDelete this.user}}>Confirm Delete</button>
 ```

--- a/guides/release/components/arguments-and-attributes.md
+++ b/guides/release/components/arguments-and-attributes.md
@@ -64,7 +64,7 @@ standard identifier can:
 ```
 
 You can pass strings as arguments to components, or you can pass literal values
-using double curly brackets:
+using double curly braces:
 
 ```handlebars
 <Tooltip
@@ -74,7 +74,7 @@ using double curly brackets:
 />
 ```
 
-Note that if you do _not_ wrap literal values in double curly brackets, they are
+Note that if you do _not_ wrap literal values in double curly braces, they are
 treated as strings, like standard HTML attributes:
 
 ```handlebars

--- a/guides/release/components/component-basics.md
+++ b/guides/release/components/component-basics.md
@@ -77,7 +77,7 @@ counterpart, _actions_ - later on.
 You can also use template helpers, modifiers, and other components within your
 component template:
 
-```hbs
+```handlebars
 {{#if @useCustomButton}}
   <CustomButton @onClick={{@sayHello}}>
     {{this.buttonText}}

--- a/guides/release/components/glimmer-components-dom.md
+++ b/guides/release/components/glimmer-components-dom.md
@@ -196,7 +196,7 @@ export default class Counter extends Component {
     <div class="cta-note-body">
       <div class="cta-note-heading">Tomster says...</div>
       <div class="cta-note-message">
-        "Element modifiers" appear inside free-floating curly brackets inside of an opening
+        "Element modifiers" appear inside free-floating curly braces inside of an opening
         tag. Unlike <strong>attribute syntax</strong>, which works by substitution
         (and therefore affects the HTML output of your page), element modifiers work
         by passing the element to a function that can do anything with it.

--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -16,7 +16,7 @@ Type this into your terminal:
 
 <!-- needs-octane-release-update -->
 ```bash
-ember new octane-app -b @ember/octane
+npm install -g ember-cli
 ```
 
 Don't have npm? [Learn how to install Node.js and npm here](https://docs.npmjs.com/getting-started/installing-node).
@@ -30,7 +30,7 @@ you will have access to a new `ember` command in your terminal.
 You can use the `ember new` command to create a new application.
 
 ```bash
-ember new ember-quickstart -b @ember/octane
+ember new ember-quickstart -b @ember/octane-app-blueprint
 ```
 
 This one command will create a new directory called `ember-quickstart` and set up a new Ember application inside of it.

--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -246,7 +246,7 @@ Now, when the `li` element is clicked, a `showPerson` method will be called in t
 
 Add the action to the `people-list.js` file:
 
-```javascript {data-filename="app/components/people-list.js" data-diff="+4,+5,+6,+7,+8"}
+```javascript {data-filename="app/components/people-list.js" data-diff="+2,+5,+6,+7,+8"}
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 

--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -14,8 +14,9 @@ You can install Ember with a single command using npm,
 the Node.js package manager.
 Type this into your terminal:
 
+<!-- needs-octane-release-update -->
 ```bash
-npm install -g ember-cli
+ember new octane-app -b @ember/octane
 ```
 
 Don't have npm? [Learn how to install Node.js and npm here](https://docs.npmjs.com/getting-started/installing-node).
@@ -29,7 +30,7 @@ you will have access to a new `ember` command in your terminal.
 You can use the `ember new` command to create a new application.
 
 ```bash
-ember new ember-quickstart
+ember new ember-quickstart -b @ember/octane
 ```
 
 This one command will create a new directory called `ember-quickstart` and set up a new Ember application inside of it.
@@ -138,9 +139,8 @@ export default class ScientistsRoute extends Route {
 }
 ```
 
-This code example uses the latest features in JavaScript,
-some of which you may not be familiar with.
-Learn more with this [overview of the newest JavaScript features](https://ponyfoo.com/articles/es6).
+This code example uses a feature of JavaScript called Classes.
+Learn more with this [overview of the latest JavaScript features](https://ponyfoo.com/articles/es6).
 
 In a route's `model()` method, you return whatever data you want to make available to the template.
 If you need to fetch data asynchronously,
@@ -242,11 +242,9 @@ First add an `action` helper to the `li` in your `people-list` component.
 The `action` helper allows you to add event listeners to elements and call named functions.
 By default, the `action` helper adds a `click` event listener,
 but it can be used to listen for any element event.
-Now, when the `li` element is clicked a `showPerson` function will be called from the `actions` object in the `people-list` component.
-Think of this like calling `this.actions.showPerson(person)` from our template.
+Now, when the `li` element is clicked, a `showPerson` method will be called in the `people-list` component.
 
-To handle this function call you need to modify the `people-list` component file to add the function to be called.
-In the component, add an `actions` object with a `showPerson` function that alerts the first argument.
+Add the action to the `people-list.js` file:
 
 ```javascript {data-filename="app/components/people-list.js" data-diff="+4,+5,+6,+7,+8"}
 import Component from '@glimmer/component';
@@ -259,6 +257,8 @@ export default class PeopleList extends Component {
   }
 }
 ```
+
+The `@action` is something called a decorator, and it lets your Ember app know that the `showPerson` method should be available for the template to use.
 
 Now in the browser when a scientist's name is clicked,
 this function is called and the person's name is alerted.

--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -258,7 +258,7 @@ export default class PeopleList extends Component {
 }
 ```
 
-The `@action` is something called a decorator, and it lets your Ember app know that the `showPerson` method should be available for the template to use.
+The `@action` is something called a decorator, and it lets your Ember app know that the `showPerson` method should be invocable by name in the component's template via `{{action "showPerson"}}`
 
 Now in the browser when a scientist's name is clicked,
 this function is called and the person's name is alerted.

--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -14,7 +14,6 @@ You can install Ember with a single command using npm,
 the Node.js package manager.
 Type this into your terminal:
 
-<!-- needs-octane-release-update -->
 ```bash
 npm install -g ember-cli
 ```
@@ -29,6 +28,7 @@ Once you've installed Ember CLI via npm,
 you will have access to a new `ember` command in your terminal.
 You can use the `ember new` command to create a new application.
 
+<!-- needs-octane-release-update -->
 ```bash
 ember new ember-quickstart -b @ember/octane-app-blueprint
 ```

--- a/guides/release/pages.yml
+++ b/guides/release/pages.yml
@@ -63,8 +63,6 @@
       url: "yields"
     - title: "Contextual Components"
       url: "contextual-components"
-    - title: "Classic Components"
-      url: "classsic-components"
     - title: "Working with the DOM"
       url: "glimmer-components-dom"
 - title: "Routing"

--- a/guides/release/pages.yml
+++ b/guides/release/pages.yml
@@ -109,9 +109,8 @@
 - title: "Services"
   url: "services"
   pages:
-    - title: Introduction
-      url: "services"
-
+    - title: Overview
+      url: "index" 
 - title: "Data Management"
   url: "data-management"
   pages:

--- a/guides/release/pages.yml
+++ b/guides/release/pages.yml
@@ -109,7 +109,7 @@
 - title: "Services"
   url: "services"
   pages:
-    - title: Overview
+    - title: "Overview"
       url: "index" 
 - title: "Data Management"
   url: "data-management"

--- a/guides/release/pages.yml
+++ b/guides/release/pages.yml
@@ -61,8 +61,6 @@
       url: "actions-and-events"
     - title: "Yields"
       url: "yields"
-    - title: "Interacting with the DOM"
-      url: "interacting-with-the-dom"
     - title: "Contextual Components"
       url: "contextual-components"
     - title: "Classic Components"

--- a/guides/release/pages.yml
+++ b/guides/release/pages.yml
@@ -12,11 +12,11 @@
       url: "index"
     - title: "Core Concepts"
       url: "core-concepts"
-- title: "Anatomy of an App"
-  url: "anatomy-of-an-app"
-  pages:
-    - title: "Overview"
-      url: "index"
+# - title: "Anatomy of an App"
+#   url: "anatomy-of-an-app"
+#   pages:
+#     - title: "Overview"
+#       url: "index"
 - title: "Templating"
   url: "templates"
   pages:

--- a/guides/release/pages.yml
+++ b/guides/release/pages.yml
@@ -100,18 +100,18 @@
       url: "tracked-properties"
     - title: "Patterns for State"
       url: "patterns-for-state"
-    - title: "Computed Properties"
-      url: "computed-properties"
+    # - title: "Computed Properties"
+    #   url: "computed-properties"
 - title: "Services"
   url: "services"
   pages:
-    - title: "Overview"
-      url: "index" 
-- title: "Data Management"
-  url: "data-management"
-  pages:
-    - title: "Overview"
-      url: "index"
+    - title: Overview
+      url: "index"    
+# - title: "Data Management"
+#   url: "data-management"
+#   pages:
+#     - title: "Overview"
+#       url: "index"
 
 - title: "Ember Data"
   url: "models"
@@ -195,12 +195,12 @@
 - title: "Upgrading"
   url: "upgrading"
   pages:
-    - title: "Overview"
-      url: "index"
+    # - title: "Overview"
+    #   url: "index"
     - title: "Editions"
       url: "editions"
-    - title: "Deprecations"
-      url: "deprecations"
+    # - title: "Deprecations"
+    #   url: "deprecations"
 - title: "Developer Tools"
   url: "ember-inspector"
   pages:

--- a/guides/release/reference/accessibility-guide.md
+++ b/guides/release/reference/accessibility-guide.md
@@ -16,7 +16,7 @@ ember feature:disable application-template-wrapper
 
 **Application Template Wrapper Disabled** _(preferred)_
 
-```hbs
+```handlebars
 <body>
   <header></header>
   <main></main>
@@ -26,7 +26,7 @@ ember feature:disable application-template-wrapper
 
 **Application Template Wrapper Enabled**
 
-```hbs
+```handlebars
 <body>
   <div class="ember-view">
     <header role="banner"></header>

--- a/guides/release/reference/syntax-conversion-guide.md
+++ b/guides/release/reference/syntax-conversion-guide.md
@@ -106,7 +106,7 @@ export default Component.extend({
 
 Although Angle Bracket syntax is considered to be the best approach, classic invocation syntax is fine to keep using.
 In some cases, classic invocation is still required. 
-When you need direct support for positional arguments or if your components are nested within the file tree, you should still reach for those curly brackets:
+When you need direct support for positional arguments or if your components are nested within the file tree, you should still reach for those curly braces:
 
 ```handlebars
 {{some-component param1 param2}}

--- a/guides/release/routing/asynchronous-routing.md
+++ b/guides/release/routing/asynchronous-routing.md
@@ -162,5 +162,5 @@ export default class FunkyRoute extends Route {
       return { msg: 'Recovered from rejected promise' };
     });
   }
-};
+}
 ```

--- a/guides/release/routing/asynchronous-routing.md
+++ b/guides/release/routing/asynchronous-routing.md
@@ -137,7 +137,7 @@ export default class GoodForNothingRoute extends Route {
     // Uncomment the line below to bubble this error event:
     // return true;
   }
-};
+}
 ```
 
 In the above example, the error event would stop right at

--- a/guides/release/routing/asynchronous-routing.md
+++ b/guides/release/routing/asynchronous-routing.md
@@ -79,19 +79,19 @@ A basic example:
 import Route from '@ember/routing/route';
 import { later } from '@ember/runloop';
 
-export default Route.extend({
+export default class TardyRoute extends Route {
   model() {
     return new Promise(function(resolve) {
       later(function() {
         resolve({ msg: 'Hold Your Horses' });
       }, 3000);
     });
-  },
+  }
 
   setupController(controller, model) {
     console.log(model.msg); // "Hold Your Horses"
   }
-});
+};
 ```
 
 When transitioning into `route:tardy`, the `model()` hook will be called and
@@ -120,24 +120,24 @@ along the way, e.g.:
 
 ```javascript {data-filename=app/routes/good-for-nothing.js}
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
-export default Route.extend({
+export default class GoodForNothingRoute extends Route {
   model() {
     return Promise.reject("FAIL");
-  },
-
-  actions: {
-    error(reason) {
-      alert(reason); // "FAIL"
-
-      // Can transition to another route here, e.g.
-      // this.transitionTo('index');
-
-      // Uncomment the line below to bubble this error event:
-      // return true;
-    }
   }
-});
+
+  @action
+  error(reason) {
+    alert(reason); // "FAIL"
+
+    // Can transition to another route here, e.g.
+    // this.transitionTo('index');
+
+    // Uncomment the line below to bubble this error event:
+    // return true;
+  }
+};
 ```
 
 In the above example, the error event would stop right at
@@ -154,7 +154,7 @@ them into fulfills that won't halt the transition.
 ```javascript {data-filename=app/routes/funky.js}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class FunkyRoute extends Route {
   model() {
     return iHopeThisWorks().catch(function() {
       // Promise rejected, fulfill with some default value to
@@ -162,5 +162,5 @@ export default Route.extend({
       return { msg: 'Recovered from rejected promise' };
     });
   }
-});
+};
 ```

--- a/guides/release/routing/asynchronous-routing.md
+++ b/guides/release/routing/asynchronous-routing.md
@@ -91,7 +91,7 @@ export default class TardyRoute extends Route {
   setupController(controller, model) {
     console.log(model.msg); // "Hold Your Horses"
   }
-};
+}
 ```
 
 When transitioning into `route:tardy`, the `model()` hook will be called and

--- a/guides/release/routing/defining-your-routes.md
+++ b/guides/release/routing/defining-your-routes.md
@@ -327,22 +327,21 @@ Note that if you want to manually transition to this wildcard route, you need to
 
 ```javascript {data-filename=app/routes/some-route.js}
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
-export default Route.extend({
+export default class SomeRouteRoute extends Route {
   // …
-
-  actions: {
-    visitUserProfile(id) {
-      this.store.findRecord('user', id).then(function (user) {
-        // Success callback
-        this.transitionTo('user.profile', user);
-      }).catch(function () {
-        // Error callback
-        this.transitionTo('not-found', 404);
-      }
+  @action
+  visitUserProfile(id) {
+    this.store.findRecord('user', id).then(function (user) {
+      // Success callback
+      this.transitionTo('user.profile', user);
+    }).catch(function () {
+      // Error callback
+      this.transitionTo('not-found', 404);
     }
   }
-});
+}
 ```
 
 ## Route Handlers

--- a/guides/release/routing/defining-your-routes.md
+++ b/guides/release/routing/defining-your-routes.md
@@ -332,7 +332,7 @@ import { action } from '@ember/object';
 export default class SomeRouteRoute extends Route {
   // …
   @action
-  visitUserProfile(id) {
+  async visitUserProfile(id) {
     this.store.findRecord('user', id).then(function (user) {
       // Success callback
       this.transitionTo('user.profile', user);

--- a/guides/release/routing/loading-and-error-substates.md
+++ b/guides/release/routing/loading-and-error-substates.md
@@ -119,7 +119,7 @@ export default class FooSlowModelRoute extends Route {
     controller.set('currentlyLoading', true);
     return true; // allows the loading template to be shown
   }
-};
+}
 ```
 
 If the `loading` handler is not defined at the specific route,

--- a/guides/release/routing/loading-and-error-substates.md
+++ b/guides/release/routing/loading-and-error-substates.md
@@ -22,11 +22,11 @@ Router.map(function() {
 ```javascript {data-filename=app/routes/slow-model.js}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class SlowModelRoute extends Route {
   model() {
     return this.store.findAll('slow-model');
   }
-});
+};
 ```
 
 If you navigate to `slow-model`, in the `model` hook,
@@ -106,21 +106,20 @@ don't immediately resolve, a [`loading`](https://www.emberjs.com/api/ember/relea
 
 ```javascript {data-filename=app/routes/foo-slow-model.js}
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
-export default Route.extend({
+export default class FooSlowModelRoute extends Route {
   model() {
     return this.store.findAll('slow-model');
-  },
+  };
 
-  actions: {
-    loading(transition, originRoute) {
-      let controller = this.controllerFor('foo');
-      controller.set('currentlyLoading', true);
-
-      return true; // allows the loading template to be shown
-    }
+  @action
+  loading(transition, originRoute) {
+    let controller = this.controllerFor('foo');
+    controller.set('currentlyLoading', true);
+    return true; // allows the loading template to be shown
   }
-});
+};
 ```
 
 If the `loading` handler is not defined at the specific route,
@@ -131,20 +130,19 @@ When using the `loading` handler, we can make use of the transition promise to k
 
 ```javascript {data-filename=app/routes/foo-slow-model.js}
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
-export default Route.extend({
-  …
-
-  actions: {
-    loading(transition, originRoute) {
-      let controller = this.controllerFor('foo');
-      controller.set('currentlyLoading', true);
-      transition.promise.finally(function() {
-          controller.set('currentlyLoading', false);
-      });
-    }
+export default class FooSlowModelRoute extends Route {
+  // ...
+  @action
+  loading(transition, originRoute) {
+    let controller = this.controllerFor('foo');
+    controller.set('currentlyLoading', true);
+    transition.promise.finally(function() {
+        controller.set('currentlyLoading', false);
+    });
   }
-});
+};
 ```
 
 In case we want both custom logic and the default behavior for the loading substate,
@@ -152,20 +150,20 @@ we can implement the `loading` action and let it bubble by returning `true`.
 
 ```javascript {data-filename=app/routes/foo-slow-model.js}
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
-export default Route.extend({
-  ...
-  actions: {
-    loading(transition) {
-      let start = new Date();
-      transition.promise.finally(() => {
-        this.notifier.notify(`Took ${new Date() - start}ms to load`);
-      });
+export default class FooSlowModelRoute extends Route {
+  // ...
+  @action
+  loading(transition) {
+    let start = new Date();
+    transition.promise.finally(() => {
+      this.notifier.notify(`Took ${new Date() - start}ms to load`);
+    });
 
-      return true;
-    }
+    return true;
   }
-});
+};
 ```
 
 ## `error` substates
@@ -206,7 +204,7 @@ called with the `error` as the model. See example below:
 ```javascript
 setupController(controller, error) {
   console.log(error.message);
-  this._super(...arguments);
+  super(...arguments);
 }
 ```
 
@@ -223,23 +221,23 @@ redirect to a login page, etc.
 
 ```javascript {data-filename=app/routes/articles-overview.js}
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
-export default Route.extend({
+export default class FooSlowModelRoute extends Route {
   model(params) {
     return this.store.findAll('privileged-model');
-  },
+  }
 
-  actions: {
-    error(error, transition) {
-      if (error.status === '403') {
-        this.replaceWith('login');
-      } else {
-        // Let the route above this handle the error.
-        return true;
-      }
+  @action
+  error(error, transition) {
+    if (error.status === '403') {
+      this.replaceWith('login');
+    } else {
+      // Let the route above this handle the error.
+      return true;
     }
   }
-});
+};
 ```
 
 Analogous to the `loading` event, you could manage the `error` event
@@ -250,17 +248,17 @@ we can handle the `error` event and let it bubble by returning `true`.
 
 ```javascript {data-filename=app/routes/articles-overview.js}
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
-export default Route.extend({
+export default class FooSlowModelRoute extends Route {
   model(params) {
     return this.get('store').findAll('privileged-model');
-  },
-  actions: {
-    error(error) {
-      this.notifier.error(error);
-
-      return true;
-    }
   }
-});
+
+  @action
+  error(error) {
+    this.notifier.error(error);
+    return true;
+  }
+};
 ```

--- a/guides/release/routing/loading-and-error-substates.md
+++ b/guides/release/routing/loading-and-error-substates.md
@@ -26,7 +26,7 @@ export default class SlowModelRoute extends Route {
   model() {
     return this.store.findAll('slow-model');
   }
-};
+}
 ```
 
 If you navigate to `slow-model`, in the `model` hook,

--- a/guides/release/routing/loading-and-error-substates.md
+++ b/guides/release/routing/loading-and-error-substates.md
@@ -135,7 +135,7 @@ import { action } from '@ember/object';
 export default class FooSlowModelRoute extends Route {
   // ...
   @action
-  loading(transition, originRoute) {
+  async loading(transition, originRoute) {
     let controller = this.controllerFor('foo');
     controller.set('currentlyLoading', true);
     transition.promise.finally(function() {
@@ -204,7 +204,7 @@ called with the `error` as the model. See example below:
 ```javascript
 setupController(controller, error) {
   console.log(error.message);
-  super(...arguments);
+  super.setupController(...arguments)
 }
 ```
 

--- a/guides/release/routing/loading-and-error-substates.md
+++ b/guides/release/routing/loading-and-error-substates.md
@@ -223,7 +223,7 @@ redirect to a login page, etc.
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 
-export default class FooSlowModelRoute extends Route {
+export default class ArticlesOverviewRoute extends Route {
   model(params) {
     return this.store.findAll('privileged-model');
   }
@@ -250,7 +250,7 @@ we can handle the `error` event and let it bubble by returning `true`.
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 
-export default class FooSlowModelRoute extends Route {
+export default class ArticlesOverviewRoute extends Route {
   model(params) {
     return this.get('store').findAll('privileged-model');
   }

--- a/guides/release/routing/preventing-and-retrying-transitions.md
+++ b/guides/release/routing/preventing-and-retrying-transitions.md
@@ -63,7 +63,7 @@ export default class DiscoRoute extends Route {
       transition.abort();
     }
   }
-};
+}
 ```
 
 ### Storing and Retrying a Transition

--- a/guides/release/routing/preventing-and-retrying-transitions.md
+++ b/guides/release/routing/preventing-and-retrying-transitions.md
@@ -91,7 +91,7 @@ export default class SomeAuthenticatedRoute extends Route {
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 
-export default class SomethingController extends Controller {
+export default class LoginController extends Controller {
   @action
   login() {
     // Log the user in, then reattempt previous transition if it exists.

--- a/guides/release/routing/preventing-and-retrying-transitions.md
+++ b/guides/release/routing/preventing-and-retrying-transitions.md
@@ -104,5 +104,5 @@ export default class SomethingController extends Controller {
       this.transitionToRoute('index');
     }
   }
-};
+}
 ```

--- a/guides/release/routing/preventing-and-retrying-transitions.md
+++ b/guides/release/routing/preventing-and-retrying-transitions.md
@@ -21,21 +21,21 @@ Here's one way this situation could be handled:
 
 ```javascript {data-filename=app/routes/form.js}
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
-export default Route.extend({
-  actions: {
-    willTransition(transition) {
-      if (this.controller.userHasEnteredData &&
-          !confirm('Are you sure you want to abandon progress?')) {
-        transition.abort();
-      } else {
-        // Bubble the `willTransition` action so that
-        // parent routes can decide whether or not to abort.
-        return true;
-      }
+export default class FormRoute extends Route {
+  @action
+  willTransition(transition) {
+    if (this.controller.userHasEnteredData &&
+        !confirm('Are you sure you want to abandon progress?')) {
+      transition.abort();
+    } else {
+      // Bubble the `willTransition` action so that
+      // parent routes can decide whether or not to abort.
+      return true;
     }
   }
-});
+};
 ```
 
 When the user clicks on a `{{link-to}}` helper, or when the app initiates a
@@ -56,14 +56,14 @@ destination routes to abort attempted transitions.
 ```javascript {data-filename=app/routes/disco.js}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class DiscoRoute extends Route {
   beforeModel(transition) {
     if (new Date() > new Date('January 1, 1980')) {
       alert('Sorry, you need a time machine to enter this route.');
       transition.abort();
     }
   }
-});
+};
 ```
 
 ### Storing and Retrying a Transition
@@ -76,7 +76,7 @@ they've logged in.
 ```javascript {data-filename=app/routes/some-authenticated.js}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class SomeAuthenticatedRoute extends Route {
   beforeModel(transition) {
     if (!this.controllerFor('auth').userIsLoggedIn) {
       let loginController = this.controllerFor('login');
@@ -84,25 +84,25 @@ export default Route.extend({
       this.transitionTo('login');
     }
   }
-});
+};
 ```
 
 ```javascript {data-filename=app/controllers/login.js}
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 
-export default Controller.extend({
-  actions: {
-    login() {
-      // Log the user in, then reattempt previous transition if it exists.
-      let previousTransition = this.previousTransition;
-      if (previousTransition) {
-        this.set('previousTransition', null);
-        previousTransition.retry();
-      } else {
-        // Default back to homepage
-        this.transitionToRoute('index');
-      }
+export default class SomethingController extends Controller {
+  @action
+  login() {
+    // Log the user in, then reattempt previous transition if it exists.
+    let previousTransition = this.previousTransition;
+    if (previousTransition) {
+      this.set('previousTransition', null);
+      previousTransition.retry();
+    } else {
+      // Default back to homepage
+      this.transitionToRoute('index');
     }
   }
-});
+};
 ```

--- a/guides/release/routing/preventing-and-retrying-transitions.md
+++ b/guides/release/routing/preventing-and-retrying-transitions.md
@@ -84,7 +84,7 @@ export default class SomeAuthenticatedRoute extends Route {
       this.transitionTo('login');
     }
   }
-};
+}
 ```
 
 ```javascript {data-filename=app/controllers/login.js}

--- a/guides/release/routing/query-params.md
+++ b/guides/release/routing/query-params.md
@@ -33,7 +33,7 @@ import Controller from '@ember/controller';
 export default class ArticlesController extends Controller {
   queryParams = ['category'];
   category = null;
-};
+}
 ```
 
 This sets up a binding between the `category` query param in the URL,
@@ -155,7 +155,7 @@ export default class ArticlesRoute extends Route {
     // which we can forward to the server.
     return this.store.query('article', params);
   }
-};
+}
 ```
 
 ```javascript {data-filename=app/controllers/articles.js}
@@ -184,7 +184,7 @@ export default class ArticlesRoute extends Route {
       replace: true
     }
   }
-};
+}
 ```
 
 This behavior is similar to `link-to`,
@@ -205,7 +205,7 @@ export default class ArticlesController extends Controller {
   }
 
   category = null
-};
+}
 ```
 
 This will cause changes to the `controller:articles`'s `category`
@@ -225,7 +225,7 @@ export default class ArticlesController extends Controller {
   category = null;
   page = 1;
   filter = 'recent';
-};
+}
 ```
 
 ### Default values and deserialization
@@ -239,7 +239,7 @@ import Controller from '@ember/controller';
 export default class ArticlesController extends Controller {
   queryParams = 'page';
   page = 1;
-};
+}
 ```
 
 This affects query param behavior in two ways:
@@ -314,7 +314,7 @@ export default class ArticlesRoute extends Route {
       controller.set('page', 1);
     }
   }
-};
+}
 ```
 
 In some cases, you might not want the sticky query param value to be
@@ -332,7 +332,7 @@ export default class ArticlesController extends Controller {
       scope: 'controller'
     }
   }]
-};
+}
 ```
 
 The following demonstrates how you can override both the scope and the query param URL key of a single controller query param property:
@@ -349,5 +349,5 @@ export default class ArticlesController extends Controller {
       }
     }
   ]
-};
+}
 ```

--- a/guides/release/routing/query-params.md
+++ b/guides/release/routing/query-params.md
@@ -55,8 +55,10 @@ export default class ArticlesController extends Controller {
   queryParams = ['category'];
   category = null;
 
-  @computed('category', 'model')
-  filteredArticles() {
+  @tracked category;
+  @tracked model;
+
+  get filteredArticles() {
     let category = this.category;
     let articles = this.model;
 

--- a/guides/release/routing/query-params.md
+++ b/guides/release/routing/query-params.md
@@ -30,10 +30,10 @@ as one of `controller:articles`'s `queryParams`:
 ```javascript {data-filename=app/controllers/articles.js}
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-  queryParams: ['category'],
-  category: null
-});
+export default class ArticlesController extends Controller {
+  queryParams = ['category'];
+  category = null;
+};
 ```
 
 This sets up a binding between the `category` query param in the URL,
@@ -51,11 +51,12 @@ array that the `articles` template will render:
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 
-export default Controller.extend({
-  queryParams: ['category'],
-  category: null,
+export default class ArticlesController extends Controller {
+  queryParams = ['category'];
+  category = null;
 
-  filteredArticles: computed('category', 'model', function() {
+  @computed('category', 'model')
+  filteredArticles() {
     let category = this.category;
     let articles = this.model;
 
@@ -64,8 +65,8 @@ export default Controller.extend({
     } else {
       return articles;
     }
-  })
-});
+  }
+};
 ```
 
 With this code, we have established the following behaviors:
@@ -138,12 +139,12 @@ you can set it as follows:
 ```javascript {data-filename=app/routes/articles.js}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-  queryParams: {
+export default class ArticlesRoute extends Route {
+  queryParams = {
     category: {
       refreshModel: true
     }
-  },
+  }
 
   model(params) {
     // This gets called upon entering 'articles' route
@@ -154,15 +155,15 @@ export default Route.extend({
     // which we can forward to the server.
     return this.store.query('article', params);
   }
-});
+};
 ```
 
 ```javascript {data-filename=app/controllers/articles.js}
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-  queryParams: ['category'],
-  category: null
+export default class ArticlesController extends Controller {
+  queryParams = ['category'];
+  category = null;
 });
 ```
 
@@ -177,13 +178,13 @@ you can specify this as follows:
 ```javascript {data-filename=app/routes/articles.js}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-  queryParams: {
+export default class ArticlesRoute extends Route {
+  queryParams = {
     category: {
       replace: true
     }
   }
-});
+};
 ```
 
 This behavior is similar to `link-to`,
@@ -198,13 +199,13 @@ You can also map a controller property to a different query param key using the 
 ```javascript {data-filename=app/controllers/articles.js}
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-  queryParams: {
+export default class ArticlesController extends Controller {
+  queryParams = {
     category: 'articles_category'
-  },
+  }
 
-  category: null
-});
+  category = null
+};
 ```
 
 This will cause changes to the `controller:articles`'s `category`
@@ -216,15 +217,15 @@ be provided along with strings in the `queryParams` array.
 ```javascript {data-filename=app/controllers/articles.js}
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-  queryParams: ['page', 'filter', {
+export default class ArticlesController extends Controller {
+  queryParams = ['page', 'filter', {
     category: 'articles_category'
-  }],
+  }]
 
-  category: null,
-  page: 1,
-  filter: 'recent'
-});
+  category = null;
+  page = 1;
+  filter = 'recent';
+};
 ```
 
 ### Default values and deserialization
@@ -235,10 +236,10 @@ the controller query param property `page` is considered to have a default value
 ```javascript {data-filename=app/controllers/articles.js}
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-  queryParams: 'page',
-  page: 1
-});
+export default class ArticlesController extends Controller {
+  queryParams = 'page';
+  page = 1;
+};
 ```
 
 This affects query param behavior in two ways:
@@ -306,14 +307,14 @@ The result of this is that all links pointing back into the exited route will us
 ```javascript {data-filename=app/routes/articles.js}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class ArticlesRoute extends Route {
   resetController(controller, isExiting, transition) {
     if (isExiting) {
       // isExiting would be false if only the route's model was changing
       controller.set('page', 1);
     }
   }
-});
+};
 ```
 
 In some cases, you might not want the sticky query param value to be
@@ -325,13 +326,13 @@ config hash:
 ```javascript {data-filename=app/controllers/articles.js}
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-  queryParams: [{
+export default class ArticlesController extends Controller {
+  queryParams = [{
     showMagnifyingGlass: {
       scope: 'controller'
     }
   }]
-});
+};
 ```
 
 The following demonstrates how you can override both the scope and the query param URL key of a single controller query param property:
@@ -339,8 +340,8 @@ The following demonstrates how you can override both the scope and the query par
 ```javascript {data-filename=app/controllers/articles.js}
 import Controller from '@ember/controller';
 
-export default Controller.extend({
-  queryParams: ['page', 'filter',
+export default class ArticlesController extends Controller {
+  queryParams = ['page', 'filter',
     {
       showMagnifyingGlass: {
         scope: 'controller',
@@ -348,5 +349,5 @@ export default Controller.extend({
       }
     }
   ]
-});
+};
 ```

--- a/guides/release/routing/query-params.md
+++ b/guides/release/routing/query-params.md
@@ -66,7 +66,7 @@ export default class ArticlesController extends Controller {
       return articles;
     }
   }
-};
+}
 ```
 
 With this code, we have established the following behaviors:

--- a/guides/release/routing/redirection.md
+++ b/guides/release/routing/redirection.md
@@ -110,5 +110,5 @@ export default class PostsRoute extends Route {
       this.transitionTo('posts.post', model.get('firstObject'));
     }
   }
-};
+}
 ```

--- a/guides/release/routing/redirection.md
+++ b/guides/release/routing/redirection.md
@@ -67,7 +67,7 @@ Router.map(function() {
 ```javascript {data-filename=app/routes/posts.js}
 import Route from '@ember/routing/route';
 
-export default class PostsRoute extends Route {{
+export default class PostsRoute extends Route {
   afterModel(model, transition) {
     if (model.get('length') === 1) {
       this.transitionTo('post', model.get('firstObject'));

--- a/guides/release/routing/redirection.md
+++ b/guides/release/routing/redirection.md
@@ -38,7 +38,7 @@ export default class IndexRoute extends Route {
   beforeModel(/* transition */) {
     this.transitionTo('posts'); // Implicitly aborts the on-going transition.
   }
-};
+}
 ```
 
 `beforeModel()` receives the current transition as an argument, which we can store and retry later.
@@ -73,7 +73,7 @@ export default class PostsRoute extends Route {{
       this.transitionTo('post', model.get('firstObject'));
     }
   }
-};
+}
 ```
 
 When transitioning to the `posts` route if it turns out that there is only one post,

--- a/guides/release/routing/redirection.md
+++ b/guides/release/routing/redirection.md
@@ -34,11 +34,11 @@ Router.map(function() {
 ```javascript {data-filename=app/routes/index.js}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class IndexRoute extends Route {
   beforeModel(/* transition */) {
     this.transitionTo('posts'); // Implicitly aborts the on-going transition.
   }
-});
+};
 ```
 
 `beforeModel()` receives the current transition as an argument, which we can store and retry later.
@@ -67,13 +67,13 @@ Router.map(function() {
 ```javascript {data-filename=app/routes/posts.js}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class PostsRoute extends Route {{
   afterModel(model, transition) {
     if (model.get('length') === 1) {
       this.transitionTo('post', model.get('firstObject'));
     }
   }
-});
+};
 ```
 
 When transitioning to the `posts` route if it turns out that there is only one post,
@@ -104,11 +104,11 @@ transition validated, and not cause the parent route's hooks to fire again:
 ```javascript {data-filename=app/routes/posts.js}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class PostsRoute extends Route {
   redirect(model, transition) {
     if (model.get('length') === 1) {
       this.transitionTo('posts.post', model.get('firstObject'));
     }
   }
-});
+};
 ```

--- a/guides/release/routing/rendering-a-template.md
+++ b/guides/release/routing/rendering-a-template.md
@@ -27,7 +27,7 @@ import Route from '@ember/routing/route';
 
 export default class PostsRoute extends Route {
   templateName = 'posts/favorite-posts';
-};
+}
 ```
 
 You can override the [`renderTemplate()`](https://www.emberjs.com/api/ember/release/classes/Route/methods/renderTemplate?anchor=renderTemplate) hook if you want finer control over template rendering.

--- a/guides/release/routing/rendering-a-template.md
+++ b/guides/release/routing/rendering-a-template.md
@@ -25,9 +25,9 @@ the template you want to render instead.
 ```javascript {data-filename=app/routes/posts.js}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-  templateName: 'posts/favorite-posts'
-});
+export default class PostsRoute extends Route {
+  templateName = 'posts/favorite-posts';
+};
 ```
 
 You can override the [`renderTemplate()`](https://www.emberjs.com/api/ember/release/classes/Route/methods/renderTemplate?anchor=renderTemplate) hook if you want finer control over template rendering.

--- a/guides/release/routing/specifying-a-routes-model.md
+++ b/guides/release/routing/specifying-a-routes-model.md
@@ -137,7 +137,7 @@ export default class SongsRoute extends Route {
       albums: this.store.findAll('album')
     });
   }
-};
+}
 ```
 
 In the `songs` template, we can specify both models and use the `{{#each}}` helper to display

--- a/guides/release/routing/specifying-a-routes-model.md
+++ b/guides/release/routing/specifying-a-routes-model.md
@@ -75,7 +75,7 @@ export default class PhotoRoute extends Route {
   model(params) {
     return this.store.findRecord('photo', params.photo_id);
   }
-};
+}
 ```
 
 In the `model` hook for routes with dynamic segments, it's your job to

--- a/guides/release/routing/specifying-a-routes-model.md
+++ b/guides/release/routing/specifying-a-routes-model.md
@@ -220,7 +220,7 @@ export default class AlbumRoute extends Route {
       songs: this.store.query('songs', { album: album_id })
     });
   }
-};
+}
 ```
 
 And calling `modelFor` returned the result of the `model` hook.

--- a/guides/release/routing/specifying-a-routes-model.md
+++ b/guides/release/routing/specifying-a-routes-model.md
@@ -19,7 +19,7 @@ export default class FavoritePostsRoute extends Route {
   model() {
     return this.store.query('post', { favorite: true });
   }
-};
+}
 ```
 
 Typically, the `model` [hook](../../getting-started/core-concepts/#toc_hooks) should return an [Ember Data](../../models/) record,

--- a/guides/release/routing/specifying-a-routes-model.md
+++ b/guides/release/routing/specifying-a-routes-model.md
@@ -180,7 +180,7 @@ export default class AlbumIndexRoute extends Route {
 
     return this.store.query('song', { album: album_id });
   }
-};
+}
 ```
 
 This is guaranteed to work because the parent route is loaded. But if you tried to

--- a/guides/release/routing/specifying-a-routes-model.md
+++ b/guides/release/routing/specifying-a-routes-model.md
@@ -15,11 +15,11 @@ hook in the `favorite-posts` route handler:
 ```javascript {data-filename=app/routes/favorite-posts.js}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class FavoritePostsRoute extends Route {
   model() {
     return this.store.query('post', { favorite: true });
   }
-});
+};
 ```
 
 Typically, the `model` [hook](../../getting-started/core-concepts/#toc_hooks) should return an [Ember Data](../../models/) record,
@@ -71,11 +71,11 @@ Router.map(function() {
 ```javascript {data-filename=app/routes/photo.js}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class PhotoRoute extends Route {
   model(params) {
     return this.store.findRecord('photo', params.photo_id);
   }
-});
+};
 ```
 
 In the `model` hook for routes with dynamic segments, it's your job to
@@ -130,14 +130,14 @@ When all of the promises in the object resolve, the returned promise will resolv
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 
-export default Route.extend({
+export default class SongsRoute extends Route {
   model() {
     return RSVP.hash({
       songs: this.store.findAll('song'),
       albums: this.store.findAll('album')
     });
   }
-});
+};
 ```
 
 In the `songs` template, we can specify both models and use the `{{#each}}` helper to display
@@ -174,13 +174,13 @@ In this scenario, you can use the `paramsFor` method to get the parameters of a 
 ```javascript {data-filename=app/routes/album/index.js}
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class AlbumIndexRoute extends Route {
   model() {
     let { album_id } = this.paramsFor('album');
 
     return this.store.query('song', { album: album_id });
   }
-});
+};
 ```
 
 This is guaranteed to work because the parent route is loaded. But if you tried to
@@ -213,14 +213,14 @@ In the case above, the parent route looked something like this:
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 
-export default Route.extend({
+export default class AlbumRoute extends Route {
   model({ album_id }) {
     return RSVP.hash({
       album: this.store.findRecord('album', album_id),
       songs: this.store.query('songs', { album: album_id })
     });
   }
-});
+};
 ```
 
 And calling `modelFor` returned the result of the `model` hook.

--- a/guides/release/state-management/patterns-for-state.md
+++ b/guides/release/state-management/patterns-for-state.md
@@ -48,19 +48,15 @@ In Ember, there are 3 primary types of state:
 [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Memory_Management#Garbage_collection
 
 In the section on components, we showed how Ember applications can be visualized
-as a tree of controllers and components:
+as a tree of controllers and components.
 
-```
-TODO: Diagram of components/controllers
-```
+<!-- TODO: Diagram of components/controllers -->
 
 A piece of state can exist on any one of the components or controllers in this
 tree, and be passed down to the children of that component or controller via
-component arguments:
+component arguments.
 
-```
-TODO: Diagram showing state being passed down several nodes
-```
+<!-- TODO: Diagram showing state being passed down several nodes -->
 
 Note that just because some state exists on a parent doesn't mean it exists on
 the child - it has to be passed down explicitly. Otherwise, we would come
@@ -72,19 +68,15 @@ pages and navigated away, destroying the components in that tree, any state that
 exists on the controller will stay there, and be used next time that page is
 rendered.
 
-```
-TODO: Diagram showing multiple controllers, only one with a subtree, maybe a
-transition between the two somehow, and state living on the controller.
-```
+<!-- TODO: Diagram showing multiple controllers, only one with a subtree, maybe a
+transition between the two somehow, and state living on the controller. -->
 
 Services also exist for the lifetime of a program, and can be injected into the
 any component or controller. State that is stored on a service is effectively
-available _anywhere_, which is a very powerful tool:
+available _anywhere_, which is a very powerful tool.
 
-```
-TODO: Diagram showing a service, separate from the component tree, containing
-state which is consumed by several components
-```
+<!-- TODO: Diagram showing a service, separate from the component tree, containing
+state which is consumed by several components -->
 
 Services can be used to centralize your state in one location, but if not used
 carefully and with solid conventions they can become messy quickly.
@@ -94,12 +86,10 @@ carefully and with solid conventions they can become messy quickly.
 If we're mapping the flow of state in an Ember application, we can start by
 looking at how it flows down the component tree on first render:
 
-```
-TODO: Diagram showing several components and a service. Pieces of state should
+<!-- TODO: Diagram showing several components and a service. Pieces of state should
 start in several places, one in the service, one in the root component, one in
 an arbitrary middle node, and then arrows should chart their path to rendered
-DOM
-```
+DOM -->
 
 Every piece of state starts in some component, controller, or service, and is
 passed downward into either another component, or the template, and finally the
@@ -120,27 +110,21 @@ a change. In Ember applications, state can change in three main ways:
 
 As we discussed in the section on [Actions](../../templates/actions/), they are methods on a component or
 controller that can be used to update its state. Actions are passed down with
-the rest of a component's data when Ember renders:
+the rest of a component's data when Ember renders.
 
-```
-TODO: Diagram showing the same Data Down as above, but with actions highlighted
-```
+<!-- TODO: Diagram showing the same Data Down as above, but with actions highlighted -->
 
 Eventually, the action is triggered in some child component or template. It then
 _flows_ upward to the component it originated from, and modifies some state
-there:
+there.
 
-```
-TODO: Diagram showing the flow back upwards from the action
-```
+<!-- TODO: Diagram showing the flow back upwards from the action -->
 
 Ember then re-renders any parts of that component that changed, including child
 components. Data flows _back_ downward in this way, toward the children of the
 modified component:
 
-```
-TODO: Diagram showing the data flowing downward during rerender
-```
+<!-- TODO: Diagram showing the data flowing downward during rerender -->
 
 This is what is meant by the "Data-Down, Actions-Up" flow that Ember users
 sometimes talk about, and that has been mentioned elsewhere in the guides. Data
@@ -148,18 +132,14 @@ starts in some root location, flows downward to child components, and actions
 flow back upward to mutate the data where it is "owned". We can create flow
 charts for most Ember apps that show the various cycles of state in it:
 
-```
-TODO: Diagram showing a more complex app (less detailed) with many DDAU cycles
-visible in it.
-```
+<!-- TODO: Diagram showing a more complex app (less detailed) with many DDAU cycles
+visible in it. -->
 
 We'll discuss what data/state ownership means more below. It's also important to
 note that actions can flow _outward_ to services, mutating service state:
 
-```
-TODO: Diagram showing an action flowing toward a service, and the service
-flowing back into several components.
-```
+<!-- TODO: Diagram showing an action flowing toward a service, and the service
+flowing back into several components. -->
 
 This can be done directly, by updating some state in the service, or by updating
 some state owned by the service that is shared, such as a tracked object, or a
@@ -200,11 +180,9 @@ to rerender.
 ### Data Loading & Background Events
 
 Whenever we load data, it's like we're scheduling an action to occur later and
-update some state in the current component or route:
+update some state in the current component or route.
 
-```
-TODO: Diagram showing a cycle within a single route/component
-```
+<!-- TODO: Diagram showing a cycle within a single route/component -->
 
 Once the data loads, it updates the state, and data flows downward like normal
 
@@ -218,10 +196,8 @@ Background events and data fetching can both trigger actions as well when they
 occur in components, in which case they may interact with other components in
 the component tree:
 
-```
-TODO: Diagram showing a cycle within a single route/component, triggering a
-DDAU cycle
-```
+<!-- TODO: Diagram showing a cycle within a single route/component, triggering a
+DDAU cycle -->
 
 ## State Ownership
 
@@ -256,22 +232,18 @@ time.
   their parents only, and if they trigger actions, they are actions that were
   passed down to them. _Container_ components are components that own state or
   load data, possibly from a data store or service.
-
-  ```
-  TODO: Diagram showing a container component that owns some state passing it
-  down to several children, and their action cycles mutating it.
-  ```
+ 
+<!-- TODO: Diagram showing a container component that owns some state passing it
+down to several children, and their action cycles mutating it. -->
 
 * **Object-Oriented** services like [Ember Data][4] or [Apollo][5] (used in
   Ember with [`ember-apollo-client`][6]) allow you to load and query data as
   objects, and mutate them where you see fit:
 
-  ```
-  TODO: Diagram showing state being loaded by the store, flowing down to
-  components, and then individual components updating state on the models. Also,
-  faded out, but other data cycles in the app to demonstrate that these aren't
-  "all-in" solutions.
-  ```
+<!-- TODO: Diagram showing state being loaded by the store, flowing down to
+components, and then individual components updating state on the models. Also,
+faded out, but other data cycles in the app to demonstrate that these aren't
+"all-in" solutions. -->
 
   In these solutions, each object owns its own state to degree, with the central
   store being the canonical list of _all_ objects and coordinating their
@@ -282,10 +254,8 @@ time.
   [`ember-redux`][8]) seek to capture _all_ application state in a single place, the
   centralized store, which owns all state:
 
-  ```
-  TODO: Diagram showing actions all flowing to the Redux store/service, and data
-  flowing out of it.
-  ```
+<!-- TODO: Diagram showing actions all flowing to the Redux store/service, and data
+flowing out of it. -->
 
   These solutions streamline data ownership by forcing it all to follow the same
   patterns universally, and ensure that all mutations to that data occur in the

--- a/guides/release/state-management/tracked-properties.md
+++ b/guides/release/state-management/tracked-properties.md
@@ -329,6 +329,6 @@ class ShoppingList {
 }
 ```
 
-### Tracking Helpers/Modifiers
+<!-- ### Tracking Helpers/Modifiers
 
-Coming Soon!
+TODO -->

--- a/guides/release/state-management/tracked-properties.md
+++ b/guides/release/state-management/tracked-properties.md
@@ -2,7 +2,7 @@ When Ember first renders a component, it renders the initial _state_ of that
 component - the state of the instance, and state of the arguments that are
 passed to it:
 
-```hbs {data-filename=app/templates/components/hello.hbs}
+```handlebars {data-filename=app/templates/components/hello.hbs}
 {{this.greeting}}, {{@name}}!
 ```
 
@@ -25,7 +25,7 @@ export default class Hello extends Component {
 }
 ```
 
-```hbs {data-filename=app/templates/application.hbs}
+```handlebars {data-filename=app/templates/application.hbs}
 <Hello @name="Jen Weber">
 ```
 
@@ -88,7 +88,7 @@ Tracked properties can be updated like any other property, using standard
 JavaScript syntax. The primary way that state gets updated in an Ember
 application is via _actions_, [as discussed earlier](../../templates/actions/):
 
-```hbs {data-filename=app/templates/components/hello.hbs}
+```handlebars {data-filename=app/templates/components/hello.hbs}
 {{this.greeting}}, {{@name}}!
 
 <select onchange={{this.updateLanguage}}>

--- a/guides/release/templates/built-in-helpers.md
+++ b/guides/release/templates/built-in-helpers.md
@@ -124,7 +124,7 @@ Hello, {{@firstName}} {{@lastName}}
 
 ## Development Helpers
 
-Handlebars and Ember come with a few helpers that can make developing your
+Ember comes with a few helpers that can make developing your
 templates a bit easier. These helpers make it simple to output variables into
 your browser's console, or activate the debugger from your templates.
 

--- a/guides/release/templates/handlebars-basics.md
+++ b/guides/release/templates/handlebars-basics.md
@@ -8,10 +8,8 @@ If you want to learn in a step-by-step way, you should begin your journey in the
 Ember templates have some superpowers, but let's start with regular HTML.
 For any file in an Ember app that has an extension ending in `.hbs`, you can write HTML markup in it as if it was an `.html` file.
 HTML is the language that browsers understand for laying out content on a web page.
-`.hbs` stands for Handlebars, the name of a tool that lets you write more than just HTML in your templates.
 
-For example, every Ember app has a file called `application.hbs`.
-You can write regular HTML markup there or in any other `hbs` file:
+Every Ember app has a file called `application.hbs`, and you can write regular HTML markup there or in any other `hbs` file:
 
 ```handlebars {data-filename=app/templates/application.hbs data-update=false}
 <h1>Starting simple</h1>
@@ -173,7 +171,7 @@ Lastly, it's important to know that arguments can be passed from one Component t
 <MyComponent @favoriteFramework={{this.favoriteFramework}} />
 ```
 
-To pass in arguments associated with a Route, define the property from within a Controller. Learn more about passing data between templates [here](../../components/passing-properties-to-a-component).
+To pass in arguments associated with a Route, define the property from within a [Controller](../../controllers/). Learn more about passing data between Component templates [here](../../components/arguments-and-attributes/).
 
 ## Helper functions
 

--- a/guides/release/upgrading/editions.md
+++ b/guides/release/upgrading/editions.md
@@ -165,7 +165,7 @@ benefits:
 </TodoList>
 ```
 
-As you can see, they use angle brackets instead of double curly brackets when
+As you can see, they use angle brackets instead of double curly braces when
 invoked, thus the name. This allows them to match up much more closely with
 HTML - as you can see from looking at the "after" example above, components open
 and close in the same way as HTML elements, and self closing components require
@@ -217,7 +217,7 @@ They also have a number of other differences and benefits:
 
   Like with attributes, both literal values and bound values can be passed to an
   argument. It's important to note that if you want to pass a primitive literal
-  value to an argument, it must be wrapped in double curly brackets:
+  value to an argument, it must be wrapped in double curly braces:
 
   ```hbs
   <Todo @done={{false}}/>

--- a/guides/release/upgrading/editions.md
+++ b/guides/release/upgrading/editions.md
@@ -153,7 +153,7 @@ Angle bracket syntax is a new way to invoke components that is much easier to
 read, helps distinguish between helper logic and components, and has other
 benefits:
 
-```hbs
+```handlebars
 <!-- Before -->
 {{#todo-list as |item|}}
   {{to-do item=item}}
@@ -177,7 +177,7 @@ They also have a number of other differences and benefits:
   `kebab-case` form.
 - Single word component names are completely OK in angle bracket form!
 
-  ```hbs
+  ```handlebars
   <!-- throws an error 🛑 -->
   {{todo}}
 
@@ -189,7 +189,7 @@ They also have a number of other differences and benefits:
   HTML attributes_. This means you can assign any valid HTML attribute, and it
   will be reflected onto the component directly:
 
-  ```hbs
+  ```handlebars
     <Todo
       role="list-item"
       data-test-todo-item
@@ -207,7 +207,7 @@ They also have a number of other differences and benefits:
 
 - _Arguments_ are passed by adding `@` to the front of the argument name:
 
-  ```hbs
+  ```handlebars
   <!-- Before -->
   {{todo item=item}}
 
@@ -219,7 +219,7 @@ They also have a number of other differences and benefits:
   argument. It's important to note that if you want to pass a primitive literal
   value to an argument, it must be wrapped in double curly braces:
 
-  ```hbs
+  ```handlebars
   <Todo @done={{false}}/>
   ```
 
@@ -232,7 +232,7 @@ They also have a number of other differences and benefits:
 
 - Yielded values work the same as in curly invocation:
 
-  ```hbs
+  ```handlebars
   <TodoList as |item|>
     <Todo @item={{item}}/>
   </TodoList>
@@ -240,7 +240,7 @@ They also have a number of other differences and benefits:
 
 - Yielded components can also be invoked with angle bracket syntax:
 
-  ```hbs
+  ```handlebars
   <TodoList as |Item|>
     <Item/>
   </TodoList>
@@ -263,11 +263,11 @@ highly recommended in general.
 Named arguments are a new syntax that allows you to refer to the arguments of a
 component _directly_ within your template:
 
-```hbs {data-filename=application.hbs}
+```handlebars {data-filename=application.hbs}
 <BlogPost @title="Hello, world!"/>
 ```
 
-```hbs {data-filename=blog-post.hbs}
+```handlebars {data-filename=blog-post.hbs}
 <h1>{{@title}}</h1>
 ```
 
@@ -276,11 +276,11 @@ the argument being passed into a component via angle bracket invocation, making
 it easier to remember and connect the two! However, you can still refer to
 argument values if the component was invoked using curly bracket syntax:
 
-```hbs {data-filename=application.hbs}
+```handlebars {data-filename=application.hbs}
 {{blog-post title="Hello, world!"}}
 ```
 
-```hbs {data-filename=blog-post.hbs}
+```handlebars {data-filename=blog-post.hbs}
 <!-- This still works -->
 <h1>{{@title}}</h1>
 ```
@@ -301,7 +301,7 @@ export default Component.extend({
 });
 ```
 
-```hbs {data-filename=blog-post.hbs}
+```handlebars {data-filename=blog-post.hbs}
 <!-- This is the original title, "Hello, world!" -->
 <h1>{{@title}}</h1>
 
@@ -314,7 +314,7 @@ was ever mutated by the component's class, if it even exists, or if it is
 directly from the external context. If you need to provide a default value,
 you'll have to do it via a getter or by using a helper in the template:
 
-```hbs {data-filename=blog-post.hbs}
+```handlebars {data-filename=blog-post.hbs}
 <!-- using {{or}} from ember-truth-helpers -->
 <h1>{{or @title "Untitled"}}</h1>
 ```
@@ -326,7 +326,7 @@ references to `this` in the template. This is a new requirement for any values
 that are rendered from the local context (e.g. the component or controller
 instance that backs the template).
 
-```hbs
+```handlebars
 <!-- Before -->
 {{title}}
 
@@ -347,7 +347,7 @@ Note that this only applies to component/controller properties. Local variables,
 introduced via a yield, can still be referred to directly since they're
 unambiguous:
 
-```hbs
+```handlebars
 {{#let "Title" as |title|}}
   <!-- This works, because it's a local variable and unambiguous -->
   {{title}}
@@ -637,12 +637,12 @@ export default class ApplicationController extends Controller {
 The action decorator also _binds_ actions, so you can refer to them directly in
 templates without the `{{action}}` helper anymore:
 
-```hbs
+```handlebars
 <!-- Before -->
 <button onclick={{action 'helloWorld'}}></button>
 ```
 
-```hbs
+```handlebars
 <!-- After -->
 <button onclick={{this.helloWorld}}></button>
 ```
@@ -650,7 +650,7 @@ templates without the `{{action}}` helper anymore:
 You should still use the `{{action}}` helper if you need to pass additional
 parameters to the action though:
 
-```hbs
+```handlebars
 <button onclick={{action this.helloWorld "some" "values"}}></button>
 ```
 
@@ -967,7 +967,7 @@ export default class ApplicationController extends Controller {
 
 And you could pass this downward into components for use:
 
-```hbs
+```handlebars
 <ul>
   {{#each this.people as |person|}}
     <li>{{person.name}}</li>
@@ -1111,7 +1111,7 @@ Glimmer components don't have a wrapping element. This is referred to as _outer
 HTML semantics_, and it means that whatever you see in the template is what you
 get in the final rendered DOM:
 
-```hbs
+```handlebars
 <!-- template.hbs -->
 <div>
   Hello, {{this.worldName}}!
@@ -1154,7 +1154,7 @@ components:
   });
   ```
 
-  ```hbs
+  ```handlebars
   {{this.text}}
   ```
 
@@ -1174,7 +1174,7 @@ components:
   }
   ```
 
-  ```hbs
+  ```handlebars
   <button onclick={{this.sayHello}}>
     {{this.text}}
   </button>
@@ -1193,7 +1193,7 @@ components:
   });
   ```
 
-  ```hbs
+  ```handlebars
   {{this.text}}
   ```
 
@@ -1207,7 +1207,7 @@ components:
   }
   ```
 
-  ```hbs
+  ```handlebars
   <div class="hello-world">
     {{this.text}}
   </div>
@@ -1227,7 +1227,7 @@ components:
   });
   ```
 
-  ```hbs
+  ```handlebars
   {{this.text}}
   ```
 
@@ -1242,7 +1242,7 @@ components:
   }
   ```
 
-  ```hbs
+  ```handlebars
   <div class="{{if this.darkMode 'dark-mode'}}">
     {{this.text}}
   </div>
@@ -1262,7 +1262,7 @@ components:
   });
   ```
 
-  ```hbs
+  ```handlebars
   {{this.text}}
   ```
 
@@ -1277,7 +1277,7 @@ components:
   }
   ```
 
-  ```hbs
+  ```handlebars
   <div role={{this.role}}>
     {{this.text}}
   </div>
@@ -1297,7 +1297,7 @@ element, with `class` being merged. In Glimmer components, there isn't
 necessarily a wrapping element to apply these attributes to! Or there may be
 _multiple_ wrapping elements:
 
-```hbs
+```handlebars
 <!--
   This template is text only, the component doesn't have
   any wrapping elements!
@@ -1305,7 +1305,7 @@ _multiple_ wrapping elements:
 Hello, world!
 ```
 
-```hbs
+```handlebars
 <!--
   This template has multiple top level elements, the h1
   and the p. Which one should we use?
@@ -1321,7 +1321,7 @@ Hello, world!
 Glimmer components allow you to use the special `...attributes` syntax to the
 elements you want to apply the attributes to:
 
-```hbs
+```handlebars
 <!--
   The paragraph gets the attributes, and not the h1
 -->
@@ -1335,7 +1335,7 @@ elements you want to apply the attributes to:
 
 Attributes can be applied to multiple elements as well:
 
-```hbs
+```handlebars
 <!-- Both elements get the attributes -->
 <h1 ...attributes>
   Hello, world!
@@ -1349,12 +1349,12 @@ Finally, if you don't apply `...attributes` to _any_ elements, then Ember will
 throw an error if someone tries to use attributes when invoking your component.
 This allows you to maintain control over the component if you want:
 
-```hbs
+```handlebars
 <!-- components/uncustomizable-button.hbs -->
 <button class="btn">Do a thing!</button>
 ```
 
-```hbs
+```handlebars
 <!-- This throws an error -->
 <UncustomizableButton class="customized-button-class"/>
 ```
@@ -1374,7 +1374,7 @@ export default Component.extend({
 });
 ```
 
-```hbs
+```handlebars
 {{this.text}}
 ```
 
@@ -1388,7 +1388,7 @@ export default class Hello extends Component {
 }
 ```
 
-```hbs
+```handlebars
 <div ...attributes>
   {{this.text}}
 </div>
@@ -1420,7 +1420,7 @@ export default Component.extend({
 });
 ```
 
-```hbs
+```handlebars
 <!-- Usage -->
 <Person @firstName="Kenneth" @lastName="Larsen" />
 ```
@@ -1437,7 +1437,7 @@ export default class Person extends Component {
 }
 ```
 
-```hbs
+```handlebars
 <!-- Usage -->
 <Person @firstName="Kenneth" @lastName="Larsen" />
 ```
@@ -1504,7 +1504,7 @@ export default Component.extend({
 });
 ```
 
-```hbs
+```handlebars
 <!-- templates/components/parent.hbs -->
 <Child @value={{this.value}} />
 ```
@@ -1520,7 +1520,7 @@ export default Component.extend({
 });
 ```
 
-```hbs
+```handlebars
 <!-- templates/components/child.hbs -->
 <button>
   Change value
@@ -1552,7 +1552,7 @@ export default class Parent extends Component {
 }
 ```
 
-```hbs
+```handlebars
 <!-- templates/components/parent.hbs -->
 <Child @value={{this.value}} @onClick={{this.updateValue}} />
 ```
@@ -1564,7 +1564,7 @@ import Component from '@ember/component';
 export default class Child extends Component {}
 ```
 
-```hbs
+```handlebars
 <!-- templates/components/child.hbs -->
 <button onclick={{action @onClick 'Hello, moon!'}}>
   Change value
@@ -1694,7 +1694,7 @@ export default class Form extends Component {
 }
 ```
 
-```hbs
+```handlebars
 <!-- templates/components/form.hbs -->
 <Text
   @value={{this.text}}
@@ -1783,7 +1783,7 @@ export default class ScrollComponent extends Component {
 }
 ```
 
-```hbs
+```handlebars
 <div
   {{did-insert this.registerListener}}
   {{will-destroy this.unregisterListener}}
@@ -1811,7 +1811,7 @@ export default class ScrollComponent extends Component {
 }
 ```
 
-```hbs
+```handlebars
 <div
   {{did-insert this.setColor @color}}
   {{did-update this.setColor @color}}
@@ -1838,13 +1838,13 @@ components. The three major differences with Glimmer components are:
 
 Before:
 
-```hbs
+```handlebars
 Hello, {{this.name}}!
 ```
 
 After:
 
-```hbs
+```handlebars
 <div>
   Hello, {{@name}}!
 </div>
@@ -1853,7 +1853,7 @@ After:
 One consequence of this is that attempting to change a component's state through
 bindings will not work:
 
-```hbs
+```handlebars
 <!--
   This does not work, since @value is
   an argument and is immutable
@@ -1869,7 +1869,7 @@ bindings will not work:
 
 Additionally, the `mut` helper generally can't be used for the same reason:
 
-```hbs
+```handlebars
 <!-- This does not work -->
 <input
   value={{@value}}

--- a/guides/release/upgrading/editions.md
+++ b/guides/release/upgrading/editions.md
@@ -135,9 +135,9 @@ ember new octane-app -b @ember/octane
 Once Octane is released, the default blueprint will be updated to reflect the
 Octane defaults and specifying this blueprint will no longer be necessary.
 
-### File Layout
+<!-- ### File Layout
 
-TODO
+TODO -->
 
 ### Templates
 

--- a/guides/release/working-with-javascript/native-classes.md
+++ b/guides/release/working-with-javascript/native-classes.md
@@ -312,12 +312,12 @@ that is _accessed_ like a property. For example:
 ```js
 class Person {
   get name() {
-    return 'Mel Sumner';
+    return 'Melanie Sumner';
   }
 }
 
 let mel = new Person();
-console.log(mel.name); // 'Mel Sumner'
+console.log(mel.name); // 'Melanie Sumner'
 ```
 
 Even though `get name` is a method, we can treat it like a normal property.
@@ -333,7 +333,7 @@ function stores the value somewhere, and the getter function retrieves it:
 
 ```js
 class Person {
-  _name = 'Mel Sumner';
+  _name = 'Melanie Sumner';
 
   get name() {
     return this._name;
@@ -345,8 +345,8 @@ class Person {
 }
 
 let mel = new Person();
-console.log(mel.name); // 'Mel Sumner'
-console.log(mel._name); // 'Mel Sumner'
+console.log(mel.name); // 'Melanie Sumner'
+console.log(mel._name); // 'Melanie Sumner'
 
 mel.name = 'Melanie Sumner';
 console.log(mel.name); // 'Melanie Sumner'

--- a/guides/release/working-with-javascript/native-classes.md
+++ b/guides/release/working-with-javascript/native-classes.md
@@ -316,15 +316,15 @@ class Person {
   }
 }
 
-let mel = new Person();
-console.log(mel.name); // 'Melanie Sumner'
+let melanie = new Person();
+console.log(melanie.name); // 'Melanie Sumner'
 ```
 
 Even though `get name` is a method, we can treat it like a normal property.
 However, if we try to set the name property to a new value, we get an error:
 
 ```js
-mel.name = 'Melanie Sumner';
+melanie.name = 'Melanie Sumner';
 // Cannot set property name of #<Person> which has only a getter
 ```
 
@@ -344,13 +344,13 @@ class Person {
   }
 }
 
-let mel = new Person();
-console.log(mel.name); // 'Melanie Sumner'
-console.log(mel._name); // 'Melanie Sumner'
+let melanie = new Person();
+console.log(melanie.name); // 'Melanie Sumner'
+console.log(melanie._name); // 'Melanie Sumner'
 
-mel.name = 'Melanie Sumner';
-console.log(mel.name); // 'Melanie Sumner'
-console.log(mel._name); // 'Melanie Sumner'
+melanie.name = 'Melanie Sumner';
+console.log(melanie.name); // 'Melanie Sumner'
+console.log(melanie._name); // 'Melanie Sumner'
 ```
 
 Getters can also be used on their own to calculate values dynamically:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12561,7 +12561,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -18491,7 +18491,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },


### PR DESCRIPTION
There's more work to do to hide unfinished content, but this is a good stopping point for someone to review.

See the commit logs for a summary of the work that was done. This includes converting Routes to clas syntax.

I need someone to look over the use of `super` in `loading-and-error-substates.md`:

```javascript
setupController(controller, error) {
  console.log(error.message);
  super(...arguments);
}
```

As well as in general `query-params.md` because I have questions about whether these things need some kind of decorator like tracked.

#633 