### PR TITLE
Fixes bad advice for non-interactive elements

### DIFF
--- a/guides/release/templates/actions.md
+++ b/guides/release/templates/actions.md
@@ -153,22 +153,15 @@ object, which is the value of the input field the user typed. (e.g 'Foo Fighters
 
 ## Attaching Actions to Non-Clickable Elements
 
-Note that actions may be attached to any element of the DOM, but not all
-respond to the `click` event. For example, if an action is attached to an `a`
-link without an `href` attribute, or to a `div`, some browsers won't execute
-the associated function. If it's really needed to define actions over such
-elements, a CSS workaround exists to make them clickable, `cursor: pointer`.
-For example:
+Note that while Ember currently permits you to add an action to any DOM element, not all DOM elements are eligible to receive focus, according to HTML standards.
 
-```css
-[data-ember-action]:not(:disabled) {
-  cursor: pointer;
-}
-```
+For example, if an action is attached to an `a` link
+without an `href` attribute, or to a `div`, some browsers won't execute the
+associated function. 
 
-Keep in mind that even with this workaround in place, the `click` event will
-not automatically trigger via keyboard driven `click` equivalents (such as
-the `enter` key when focused). Browsers will trigger this on clickable
-elements only by default. This also doesn't make an element accessible to
-users of assistive technology. You will need to add additional things like
-`role` and/or `tabindex` to make this accessible for your users.
+Always check to see that the element you are adding an action to is interactive, according to
+[web accessibility and browser standards](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#Interactive_elements).
+As a rule of thumb, if you find yourself adding an action an `<a>` tag, you should turn it into a `<button>` instead.
+
+For more information about building accessible apps in Ember, see the
+[Accessibility Guide](../../reference/accessibility-guide/).


### PR DESCRIPTION
We should teach how to write accessible apps, not work around
a11y features.

Sister PR to https://github.com/ember-learn/guides-source/pull/639 which targets `octane` instead