### PR TITLE
Octane: Quickstart a11y improvements

### DIFF
--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -192,8 +192,6 @@ Note that we've changed the title from a hard-coded string ("List of Scientists"
 We've also renamed `scientist` to the more-generic `person`,
 decreasing the coupling of our component to where it's used.
 
-_Note: While the button element will ensure that your code is accessible, you may require an extra style or two if you wish to have it look like regular text. You might be tempted to use a regular link here, but that will cause your accessibility tests to fail._
-
 Save this template and switch back to the `scientists` template.
 Replace all our old code with our new componentized version.
 
@@ -247,6 +245,8 @@ The `action` helper allows you to add event listeners to elements and call named
 By default, the `action` helper adds a `click` event listener,
 but it can be used to listen for any element event.
 Now, when the `button` inside the `li` element is clicked, a `showPerson` method will be called in the `people-list` component.
+
+_Note: While the button element will ensure that your code is accessible, you may require an extra style or two if you wish to have it look like regular text. You might be tempted to use a regular link here, but that will cause your accessibility tests to fail._
 
 Add the action to the `people-list.js` file:
 

--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -192,6 +192,8 @@ Note that we've changed the title from a hard-coded string ("List of Scientists"
 We've also renamed `scientist` to the more-generic `person`,
 decreasing the coupling of our component to where it's used.
 
+_Note: While the button element will ensure that your code is accessible, you may require an extra style or two if you wish to have it look like regular text. You might be tempted to use a regular link here, but that will cause your accessibility tests to fail._
+
 Save this template and switch back to the `scientists` template.
 Replace all our old code with our new componentized version.
 

--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -226,15 +226,17 @@ So far, your application is listing data,
 but there is no way for the user to interact with the information.
 In web applications you often want to listen for user events like clicks or hovers.
 Ember makes this easy to do.
-First add an `action` helper to the `li` in your `people-list` component.
+First, create a button insiide the `li` in your `people-list` component, and add an `action` helper to it.
 
-```handlebars {data-filename="app/templates/components/people-list.hbs" data-diff="-5,+6"}
+```handlebars {data-filename="app/templates/components/people-list.hbs" data-diff="-5,+6,+7,+8"}
 <h2>{{this.title}}</h2>
 
 <ul>
   {{#each this.people as |person|}}
     <li>{{person}}</li>
-    <li {{action "showPerson" person}}>{{person}}</li>
+    <li>
+      <button {{action "showPerson" person}}>{{person}}</button>
+    </li>
   {{/each}}
 </ul>
 ```
@@ -242,7 +244,7 @@ First add an `action` helper to the `li` in your `people-list` component.
 The `action` helper allows you to add event listeners to elements and call named functions.
 By default, the `action` helper adds a `click` event listener,
 but it can be used to listen for any element event.
-Now, when the `li` element is clicked, a `showPerson` method will be called in the `people-list` component.
+Now, when the `button` inside the `li` element is clicked, a `showPerson` method will be called in the `people-list` component.
 
 Add the action to the `people-list.js` file:
 


### PR DESCRIPTION
Fixes #655, hopefully in a way that doesn't require too much re-working of associated content

This template change avoids encouraging readers to use click event listeners w/ non-focusable and non-interactive elements

```diff
<h2>{{this.title}}</h2>

<ul>
  {{#each this.people as |person|}}
-    <li>{{person}}</li>
+    <li>
+      <button {{action "showPerson" person}}>{{person}}</button>
+    </li>
  {{/each}}
</ul>
```