### PR TITLE
Fix arg defaults example

### DIFF
--- a/guides/release/upgrading/editions.md
+++ b/guides/release/upgrading/editions.md
@@ -1480,7 +1480,7 @@ export default class Person extends Component {
   }
 
   get fullName() {
-    return `${this.args.firstName} ${this.args.lastName}`;
+    return `${this.firstName} ${this.lastName}`;
   }
 }
 ```


### PR DESCRIPTION
Because this example is showing how to create defaulted args, it should actually use them.