### PR TITLE
Angle bracket <BuiltIn /> components

### DIFF
--- a/guides/release/routing/defining-your-routes.md
+++ b/guides/release/routing/defining-your-routes.md
@@ -39,19 +39,21 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`{{link-to}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`<LinkTo />`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
-{{#link-to "index"}}<img class="logo">{{/link-to}}
+<LinkTo @route="index">
+  <img class="logo">
+</LinkTo>
 
 <nav>
-  {{#link-to "about"}}About{{/link-to}}
-  {{#link-to "favorites"}}Favorites{{/link-to}}
+  <LinkTo @route="about">About</LinkTo>
+  <LinkTo @route="favorites">Favorites</LinkTo>
 </nav>
 ```
 
-The `{{link-to}}` helper will also add an `active` class to the link that
+The `<LinkTo />` component will also add an `active` class to the link that
 points to the currently active route.
 
 Multi-word route names are conventionally dasherized, such as:
@@ -64,7 +66,7 @@ Router.map(function() {
 
 The route defined above will by default use the `blog-post.js` route handler,
 the `blog-post.hbs` template, and be referred to as `blog-post` in any
-`{{link-to}}` helpers.
+`<LinkTo />` components.
 
 Multi-word route names that break this convention, such as:
 
@@ -76,7 +78,7 @@ Router.map(function() {
 
 will still by default use the `blog-post.js` route handler and the
 `blog-post.hbs` template, but will be referred to as `blog_post` in any
-`{{link-to}}` helpers.
+`<LinkTo />` components.
 
 ## Nested Routes
 
@@ -355,7 +357,7 @@ handlers](https://www.emberjs.com/api/ember/release/classes/Route).
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
-- From a template, use [`{{link-to}}`](https://emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) as mentioned above
+- From a template, use [`<LinkTo />`](https://emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) as mentioned above
 - From a route, use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
 - From a controller, use the [`transitionToRoute()`](https://emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
 - From anywhere else in your application, such as a component, inject the [Router Service](https://emberjs.com/api/ember/release/classes/RouterService) and use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/release/routing/preventing-and-retrying-transitions.md
+++ b/guides/release/routing/preventing-and-retrying-transitions.md
@@ -7,7 +7,7 @@ later time by calling `transition.retry()`.
 
 ### Preventing Transitions via `willTransition`
 
-When a transition is attempted, whether via `{{link-to}}`, `transitionTo`,
+When a transition is attempted, whether via `<LinkTo />`, `transitionTo`,
 or a URL change, a `willTransition` action is fired on the currently
 active routes. This gives each active route, starting with the leaf-most
 route, the opportunity to decide whether or not the transition should occur.
@@ -38,7 +38,7 @@ export default class FormRoute extends Route {
 };
 ```
 
-When the user clicks on a `{{link-to}}` helper, or when the app initiates a
+When the user clicks on a `<LinkTo />` component, or when the app initiates a
 transition by using `transitionTo`, the transition will be aborted and the URL
 will remain unchanged. However, if the browser back button is used to
 navigate away from `route:form`, or if the user manually changes the URL, the

--- a/guides/release/templates/binding-element-attributes.md
+++ b/guides/release/templates/binding-element-attributes.md
@@ -66,7 +66,7 @@ Which will render the following HTML:
       <div class="cta-note-message">
 This API uses a recent and new feature in Ember: Angle bracket invocation
 syntax of an Ember component. If this doesn't look familiar you may be
-working with classic component invocation syntax (for example <code>{{link-to}}</code>).
+working with classic component invocation syntax (for example <code>{{my-component}}</code>).
 For more examples of ways to use components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a> or the <a href="https://guides.emberjs.com/v3.6.0/templates/binding-element-attributes/">previous version of this Guide entry</a>.
       </div>
     </div>

--- a/guides/release/templates/links.md
+++ b/guides/release/templates/links.md
@@ -189,7 +189,7 @@ For more information on how to use query parameters see the [query parameters](.
 
 When generating a link, you may want to customize its HTML attributes. For
 example, it is quite common to want to add additional CSS classes to the
-generated link tag, or specifying the appropiate ARIA attributes. You can
+generated link tag, or specifying the appropriate ARIA attributes. You can
 simply pass them along with the invocation:
 
 ```handlebars {data-filename=app/templates/photos/edit.hbs}

--- a/guides/release/templates/links.md
+++ b/guides/release/templates/links.md
@@ -43,7 +43,7 @@ would look something like this:
 </ul>
 ```
 
-By default, Ember.js will replace each dymaic segment in the URL with the
+By default, Ember.js will replace each dynamic segment in the URL with the
 model object's `id` property. In the example above, the `@model` argument
 is the `photo` objects, and their `id` properties are used to fill in the
 dynamic segment in the URL; in this case, either `1`, `2`, or `3`. This

--- a/guides/release/templates/links.md
+++ b/guides/release/templates/links.md
@@ -140,7 +140,7 @@ Note that while `:comment_id` is populated with each comment's `id` (based on
 the `@model` argument), the `:photo_id` segment is automatically assumed to be
 the same as the corresponding segment in current URL, i.e. `2`.
 
-Ember is only able to infer the dynamic segments becuase the `photo` route is
+Ember is only able to infer the dynamic segments because the `photo` route is
 currently active. If we were to invoke the `<LinkTo />` component for the same
 `photos.photo.comment` route, but from the `photos` route's template, it will
 result in an error, as we did not pass enough model objects to populate all the

--- a/guides/release/templates/links.md
+++ b/guides/release/templates/links.md
@@ -1,7 +1,7 @@
-## The `{{link-to}}` Component
+## The `<LinkTo />` Component
 
 You create a link to a route using the
-[`{{link-to}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`<LinkTo />`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -14,56 +14,84 @@ Router.map(function() {
 
 ```handlebars {data-filename=app/templates/photos.hbs}
 <ul>
-  {{#each this.photos as |photo|}}
-    <li>{{#link-to "photos.edit" photo}}{{photo.title}}{{/link-to}}</li>
+  {{#each this.photos as |p|}}
+    <li>
+      <LinkTo @route="photos.edit" @model={{p}}>{{p.title}}</LinkTo>
+    </li>
   {{/each}}
 </ul>
 ```
 
-If the model for the `photos` template is a list of three photos, the
-rendered HTML would look something like this:
+The `@route` argument is the name of the route to link to, and the `@model`
+argument is a model object to fill in the [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments)
+for the route.
+
+For example, if `this.photos` is a list of three photos, the rendered HTML
+would look something like this:
 
 ```html
 <ul>
-  <li><a href="/photos/1">Happy Kittens</a></li>
-  <li><a href="/photos/2">Puppy Running</a></li>
-  <li><a href="/photos/3">Mountain Landscape</a></li>
+  <li>
+    <a href="/photos/1">Happy Kittens</a>
+  </li>
+  <li>
+    <a href="/photos/2">Puppy Running</a>
+  </li>
+  <li>
+    <a href="/photos/3">Mountain Landscape</a>
+  </li>
 </ul>
 ```
 
-The `{{link-to}}` component takes one or two arguments:
+By default, Ember.js will replace each dymaic segment in the URL with the
+model object's `id` property. In the example above, the `@model` argument
+is the `photo` objects, and their `id` properties are used to fill in the
+dynamic segment in the URL; in this case, either `1`, `2`, or `3`. This
+behavior can be customized within `PhotoEditRoute`'s `serialize` hook.
 
-* The name of a route. In this example, it would be `index`, `photos`, or
-  `photos.edit`.
-* At most one model for each [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
-  By default, Ember.js will replace each segment with the value of the corresponding object's `id` property.
-  In the example above, the second argument is each `photo` object, and the `id` property is used to fill in
-  the dynamic segment with either `1`, `2`, or `3`. If there is no model to pass to the component, you can provide
-  an explicit value instead:
+Alternatively, you can explicitly provide a serialized `id`, in place of
+passing a model object:
 
 ```handlebars {data-filename=app/templates/photos.hbs}
-{{#link-to "photos.edit" 1}}
-  First Photo Ever
-{{/link-to}}
+<LinkTo @route="photos.edit" @model="1">First Photo Ever</LinkTo>
 ```
 
-When the rendered link matches the current route, and the same
-object instance is passed into the component, then the link is given
-`class="active"`. For example, if you were at the URL `/photos/2`,
-the first example above would render as:
+In this case, the provided `id` will be used to populate the URL's dynamic
+segment directly, bypassing the `serialize` hook entirely:
+
+```html
+<a href="/photos/1">First Photo Ever</a>
+```
+
+When the use click on the link, Ember will run the `PhotoEditRoute`'s `model`
+hook with `params.photo_id = 1`. On the other hand, if a model object was
+passed instead of the `id`, the model hook will _not_ run.
+
+### Active CSS Class
+
+When the generated link matches the current URL, then the generated link tag
+will be given the `active` CSS class. For example, if you were at the URL
+`/photos/2`, the first example above would render as:
 
 ```html
 <ul>
-  <li><a href="/photos/1">Happy Kittens</a></li>
-  <li><a href="/photos/2" class="active">Puppy Running</a></li>
-  <li><a href="/photos/3">Mountain Landscape</a></li>
+  <li>
+    <a href="/photos/1">Happy Kittens</a>
+  </li>
+  <li>
+    <a href="/photos/2" class="active">Puppy Running</a>
+  </li>
+  <li>
+    <a href="/photos/3">Mountain Landscape</a>
+  </li>
 </ul>
 ```
 
-### Example for Multiple Segments
+### Multiple Dynamic Segments
 
-If the route is nested, you can supply a model or an identifier for each dynamic
-segment.
+Sometimes, you may need to generate links for nested routes which can
+have multiple [dynamic segment](../../routing/defining-your-routes/#toc_dynamic-segments).
+For example, consider the following route definitions:
 
 ```javascript {data-filename=app/router.js}
 Router.map(function() {
@@ -76,90 +104,118 @@ Router.map(function() {
 });
 ```
 
-```handlebars {data-filename=app/templates/photo/index.hbs}
-<div class="photo">
-  {{this.body}}
-</div>
+Here, the `photos.photo.comment` route have two dynamic segments:
+`:photo_id` and `:comment_id`.
 
-<p>{{#link-to "photos.photo.comment" this.primaryComment}}Main Comment{{/link-to}}</p>
+When passing a `@model` object to the `<LinkTo />` component, that single model
+object will be used to populate the innermost dynamic segment. In this case,
+that would be `:comment_id`. The `:photo_id` will be inferred from the current
+URL.
+
+For example, if we are currently on `/photos/2`, then the following template:
+
+```handlebars {data-filename=app/templates/photos/photo.hbs}
+{{#each this.photo.comments as |comment|}}
+  <LinkTo @route="photos.photo.comment" @model={{comment}}>
+    {{excerpt comment.body}}...
+  </LinkTo>
+{{/comment}}
 ```
 
-If you specify only one model, it will represent the innermost dynamic segment `:comment_id`.
-The `:photo_id` segment will use the current photo.
+...will render something like this:
 
-Alternatively, you could pass both a photo's ID and a comment to the component:
-
-```handlebars {data-filename=app/templates/photo/index.hbs}
-<p>
-  {{#link-to 'photo.comment' 5 this.primaryComment}}
-    Main Comment for the Next Photo
-  {{/link-to}}
-</p>
+```html
+<a href="/photos/2/comment/37">
+  Aww this is...
+</a>
+<a href="/photos/2/comment/44">
+  Great puppy...
+</a>
+<a href="/photos/2/comment/45">
+  5/5 would pet...
+</a>
 ```
 
-In the above example, the model hook for `PhotoRoute` will run with `params.photo_id = 5`.  The `model` hook for
-`CommentRoute` _won't_ run since you supplied a model object for the `comment` segment. The comment's id will
-populate the URL according to `CommentRoute`'s `serialize` hook.
+Note that while `:comment_id` is populated with each comment's `id` (based on
+the `@model` argument), the `:photo_id` segment is automatically assumed to be
+the same as the corresponding segment in current URL, i.e. `2`.
 
-### Setting query-params
+Ember is only able to infer the dynamic segments becuase the `photo` route is
+currently active. If we were to invoke the `<LinkTo />` component for the same
+`photos.photo.comment` route, but from the `photos` route's template, it will
+result in an error, as we did not pass enough model objects to populate all the
+dynamic segments needed to generate the URL.
 
-The `query-params` helper can be used to set query params on a link:
+To solve this problem, or maybe to cross-link comments from photos other than
+the currently active one, you can pass an array of model objects using the
+`@models` argument and the `{{array}}` helper:
+
+```handlebars {data-filename=app/templates/photos.hbs}
+<h1>Latest Comments</h1>
+
+<ul>
+  {{#each this.latestComments as |comment|}}
+    <li>
+      <LinkTo @route="photos.photo.comment" @models={{array comment.photo comment}}>
+        {{excerpt comment.body}}...
+      </LinkTo>
+    </li>
+  {{/each}}
+</ul>
+```
+
+Here, we are passing an array of model objects (the photo, then the comment),
+which is exactly what is needed to populate all the dynamic segments.
+
+The `@model` argument is merely a special case for the more general `@models`
+argument. Therefore, it is an error to pass _both_ arguments at the same time.
+
+### Query Params
+
+The `@query` argument, along with the `{{hash}}` helper, can be used to set
+query params on a link:
 
 ```handlebars
 // Explicitly set target query params
-{{#link-to "posts" (query-params direction="asc")}}Sort{{/link-to}}
+<LinkTo @route="posts" @query={{hash direction="asc"}}>Sort</LinkTo>
 
 // Binding is also supported
-{{#link-to "posts" (query-params direction=this.otherDirection)}}Sort{{/link-to}}
+<LinkTo @route="posts" @query={{hash direction=this.otherDirection}}>Sort</LinkTo>
 ```
 
 For more information on how to use query parameters see the [query parameters](../../routing/query-params/) section in Routing.
 
-### Using link-to as an inline component
+### HTML Attributes
 
-In addition to being used as a block expression, the
-[`link-to`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
-component can also be used in inline form by specifying the link text as the first
-argument to the component:
+When generating a link, you may want to customize its HTML attributes. For
+example, it is quite common to want to add additional CSS classes to the
+generated link tag, or specifying the appropiate ARIA attributes. You can
+simply pass them along with the invocation:
 
-```handlebars
-A link in {{#link-to "index"}}Block Expression Form{{/link-to}},
-and a link in {{link-to "Inline Form" "index"}}.
+```handlebars {data-filename=app/templates/photos/edit.hbs}
+<LinkTo @route="photos" class="btn btn-primary" role="button" aria-pressed="false">
+  Discard Changes
+</LinkTo>
 ```
 
-The output of the above would be:
+CSS classes passed this way will be _in addition to_ the standard `ember-view`
+and possibly `active` classes.
 
-```html
-A link in <a href="/">Block Expression Form</a>,
-and a link in <a href="/">Inline Form</a>.
-```
-
-### Adding additional attributes on a link
-
-When generating a link you might want to set additional attributes for it. You can do this with additional
-arguments to the `link-to` component:
-
-```handlebars
-<p>
-  {{link-to "Edit this photo" "photo.edit" this.photo class="btn btn-primary"}}
-</p>
-```
-
-Many of the common HTML properties you would want to use like `class`, and `rel` will work. When
-adding class names, Ember will also apply the standard `ember-view` and possibly `active` class names.
+Note that the `<LinkTo />` component uses the element's `id` HTML attribute
+internally for event dispatching purposes. For that reason, if you would like
+to customize its HTML `id`, you must pass it as the `@id` argument instead.
+Overriding the components `id` attribute directly will stop the link from
+functioning correctly.
 
 ### Replacing history entries
 
-The default behavior for
-[`link-to`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
-is to add entries to the browser's history when transitioning between the
-routes. However, to replace the current entry in the browser's history you
-can use the `replace=true` option:
+The default behavior for the `<LinkTo />` component is to add entries to the
+browser's history when transitioning between routes. However, to replace the
+current entry in the browser's history instead, you can use the `@replace`
+option:
 
 ```handlebars
-<p>
-  {{#link-to "photo.comment" 5 this.primaryComment replace=true}}
-    Main Comment for the Next Photo
-  {{/link-to}}
-</p>
+<LinkTo @route="photo.comment" @model={{this.topComment}} @replace={{true}}>
+  Top comment for the current photo
+</Link>
 ```


### PR DESCRIPTION
Per [RFC #459](https://emberjs.github.io/rfcs/0459-angle-bracket-built-in-components.html), we need to update the Octane guides to use `<AngleBracket />` invocation syntax for the built-in components: `<Input />`, `<Textarea />` and `<LinkTo />`.

The feature has landed (behind a feature flag) in ember.js in https://github.com/emberjs/ember.js/pull/17735 (`<Input />`, `<Textarea />`) and https://github.com/emberjs/ember.js/pull/17772 (`<LinkTo />`). The API docs have not been updated yet, but the RFC text and the tests should be a good enough reference for the time being.

In this PR, I started the work by converting the main `<LinkTo />` guide, which is probably the trickiest.  I preserved the flow of the guide but updated the content to fit the new API whenever it makes sense.

I would like to hand of this work to other editors, but I'm happy to answer any questions or help review related PRs.