### PR TITLE
Refactor links to inline

### DIFF
--- a/.local.dic
+++ b/.local.dic
@@ -77,8 +77,8 @@ mixins
 modularity
 naïve
 nav
-*NPM
 NVDA
+*NPM
 Orca
 Param
 param

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,26 +126,17 @@ When linking to API pages:
 
 ## Spellchecking/linting
 
-The guides are spellchecked and linted for markdown consistency. You can test your contributions by running `npm run lint:md`. Linting and spellchecking must pass or they will fail in Travis-CI. 
+The guides are spellchecked and linted for markdown consistency. You can test your contributions by running `npm run lint:md`. Linting and spellchecking must pass or testing in Travis-CI will fail. 
 
-Markdown issues that will generate errors include:
+In addition to spelling errors, the following markdown issues that will generate errors:
 - Lists and text must be left justified, otherwise the linter will generate indentation errors
-- URL references must be followed by empty brackets `[]`.  See example below
-- Unused URL reference definitions - comment them out if using them later
 - Missing URL reference definitions
 
 Most other markdown errors should be self explanatory.
 
-URL reference and definition:
-```markdown
-This is a link to [something][]
+Spellchecking uses a custom [ember-dictionary](https://github.com/maxwondercorn/ember-dictionary) with words and terms common to the Ember community, such as `SemVer`. Words and terms that are associated with a specific guide can be placed in the `.local.dic` dictionary file. 
 
-[something]: https:\\www.something.com
-```
-
-Spellchecking uses a custom [ember-dictionary][] with words and terms common to the Ember community, such as `SemVer`. Words and terms that are associated with a specific guide can be placed in the `.local.dic` dictionary file. 
-
-See the [ember-dictionary][] GitHub repo for specifics on using the local dictionary and adding words to the standard dictionary.
+See the [ember-dictionary](https://github.com/maxwondercorn/ember-dictionary) GitHub repo for specifics on using the local dictionary and adding words to the standard dictionary.
 
 ## Writing
 
@@ -157,5 +148,3 @@ Write once, edit twice (at least!) before opening a PR. When you edit your own w
 * Did I include links where appropriate?
 
 You'll be amazed at how much better your writing gets as you edit and re-edit!
-
-[ember-dictionary]: https://github.com/maxwondercorn/ember-dictionary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ When linking to API pages:
 
 ## Spellchecking/linting
 
-The guides are spellchecked and linted for markdown consistency. You can test your contributions by running `npm run lint::md`. Linting and spellchecking must pass or they will fail in Travis-CI. 
+The guides are spellchecked and linted for markdown consistency. You can test your contributions by running `npm run lint:md`. Linting and spellchecking must pass or they will fail in Travis-CI. 
 
 Markdown issues that will generate errors include:
 - Lists and text must be left justified, otherwise the linter will generate indentation errors

--- a/guides/release/components/the-component-lifecycle.md
+++ b/guides/release/components/the-component-lifecycle.md
@@ -124,11 +124,9 @@ Ember guarantees that, by the time `didInsertElement()` is called:
 
 1. The component's element has been both created and inserted into the
    DOM.
-2. The component's element is accessible via the component's [`this.element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element
-) property.
+2. The component's element is accessible via the component's [`this.element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property.
 
-The [`element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element
-) property allows you to access the component's DOM element.
+The [`element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property allows you to access the component's DOM element.
 For example, you can set an attribute using the `Element.setAttribute()` method:
 
 ```javascript {data-filename=app/components/profile-editor.js}
@@ -142,8 +140,7 @@ export default Component.extend({
 });
 ```
 
-The [`element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element
-) property will, by default, return a DOM object for the component's root element, but you can also target child elements within the component's template by passing a selector to `querySelector` or `querySelectorAll`:
+The [`element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property will, by default, return a DOM object for the component's root element, but you can also target child elements within the component's template by passing a selector to `querySelector` or `querySelectorAll`:
 
 ```javascript {data-filename=app/components/profile-editor.js}
 import Component from '@ember/component';
@@ -199,8 +196,7 @@ There are a few things to note about the `didInsertElement()` hook:
 
 - It is only triggered once when the component element is first rendered.
 - In cases where you have components nested inside other components, the child component will always receive the `didInsertElement()` call before its parent does.
-- Setting properties on the component in [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons,
-  is not allowed.
+- Setting properties on the component in [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons, is not allowed.
 - While [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
   particularly when order of execution is important.
 
@@ -256,8 +252,7 @@ export default Component.extend({
 
 ### Detaching and Tearing Down Component Elements with `willDestroyElement`
 
-When a component detects that it is time to remove itself from the DOM, Ember will trigger the [`willDestroyElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/willDestroyElement?anchor=willDestroyElement) method,
-allowing for any teardown logic to be performed.
+When a component detects that it is time to remove itself from the DOM, Ember will trigger the [`willDestroyElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/willDestroyElement?anchor=willDestroyElement) method, allowing for any teardown logic to be performed.
 
 Component teardown can be triggered by a number of different conditions.
 For instance, the user may navigate to a different route, or a conditional Handlebars block surrounding your component may change:

--- a/guides/release/components/the-component-lifecycle.md
+++ b/guides/release/components/the-component-lifecycle.md
@@ -118,15 +118,17 @@ Suppose you want to integrate your favorite date picker library into an Ember pr
 Typically, 3rd party JS/jQuery libraries require a DOM element to bind to.
 So, where is the best place to initialize and attach the library?
 
-After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`][did-insert-element] hook.
+After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) hook.
 
 Ember guarantees that, by the time `didInsertElement()` is called:
 
 1. The component's element has been both created and inserted into the
    DOM.
-2. The component's element is accessible via the component's [`this.element`][element] property.
+2. The component's element is accessible via the component's [`this.element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element
+) property.
 
-The [`element`][element] property allows you to access the component's DOM element.
+The [`element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element
+) property allows you to access the component's DOM element.
 For example, you can set an attribute using the `Element.setAttribute()` method:
 
 ```javascript {data-filename=app/components/profile-editor.js}
@@ -140,7 +142,8 @@ export default Component.extend({
 });
 ```
 
-The [`element`][element] property will, by default, return a DOM object for the component's root element, but you can also target child elements within the component's template by passing a selector to `querySelector` or `querySelectorAll`:
+The [`element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element
+) property will, by default, return a DOM object for the component's root element, but you can also target child elements within the component's template by passing a selector to `querySelector` or `querySelectorAll`:
 
 ```javascript {data-filename=app/components/profile-editor.js}
 import Component from '@ember/component';
@@ -156,7 +159,7 @@ export default Component.extend({
 });
 ```
 
-Let's initialize our date picker by overriding the [`didInsertElement()`][did-insert-element] method.
+Let's initialize our date picker by overriding the [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) method.
 
 Date picker libraries usually attach to an `<input>` element, so we will use `this.element.querySelector` to find an appropriate input within our component's template.
 
@@ -171,7 +174,7 @@ export default Component.extend({
 });
 ```
 
-[`didInsertElement()`][did-insert-element] is also a good place to
+[`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is also a good place to
 attach event listeners. This is particularly useful for custom events or
 other browser events which do not have a [built-in event
 handler](./handling-events/#toc_event-names).
@@ -196,13 +199,10 @@ There are a few things to note about the `didInsertElement()` hook:
 
 - It is only triggered once when the component element is first rendered.
 - In cases where you have components nested inside other components, the child component will always receive the `didInsertElement()` call before its parent does.
-- Setting properties on the component in [`didInsertElement()`][did-insert-element] triggers a re-render, and for performance reasons,
+- Setting properties on the component in [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons,
   is not allowed.
-- While [`didInsertElement()`][did-insert-element] is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
+- While [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
   particularly when order of execution is important.
-
-[did-insert-element]: https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement
-[element]: https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element
 
 ### Making Updates to the Rendered DOM with `didRender`
 

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -64,7 +64,7 @@ It is used for event handling, and to provide some APIs like `this.$()` in compo
 With the release of ember-source v3.4.0, an optional feature flag was introduced that allows users to opt out of jQuery.
 To enable it, run the following command after setting up `@ember/optional-features`:
 
-```shell
+```bash
 ember feature:disable jquery-integration
 ```
 

--- a/guides/release/ember-inspector/data.md
+++ b/guides/release/ember-inspector/data.md
@@ -32,5 +32,4 @@ You can also filter records by entering a query in the search box.
 ### Building a Data Custom Adapter
 
 You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js
-) as an example for how to build your data adapter and [DataAdapter](https://emberjs.com/api/ember/release/classes/DataAdapter) documentation.
+using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter and [DataAdapter](https://emberjs.com/api/ember/release/classes/DataAdapter) documentation.

--- a/guides/release/ember-inspector/data.md
+++ b/guides/release/ember-inspector/data.md
@@ -1,8 +1,9 @@
-You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter](#toc_building-a-data-custom-adapter) below if you maintain your own persistence library. 
-
-When you open the Data tab, you will see a list of model types defined
-in your application, along with the number of loaded records.
-The Inspector displays the loaded records when you click on a model type.
+You can inspect your models by clicking on the `Data` tab. Check out 
+[Building a Data Custom Adapter](#toc_building-a-data-custom-adapter) below if 
+you maintain your own persistence library. When you open the Data tab, you will 
+see a list of model types defined in your application, along with the number of 
+loaded records. The Inspector displays the loaded records when you click 
+on a model type.
 
 <img src="/images/guides/ember-inspector/data-screenshot.png" width="680"/>
 

--- a/guides/release/ember-inspector/data.md
+++ b/guides/release/ember-inspector/data.md
@@ -1,5 +1,4 @@
-You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter][building-data-adapter] below if you maintain your own persistence library. 
-[building-data-adapter]:#toc_building-a-data-custom-adapter
+You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter](#toc_building-a-data-custom-adapter) below if you maintain your own persistence library. 
 
 When you open the Data tab, you will see a list of model types defined
 in your application, along with the number of loaded records.
@@ -32,9 +31,6 @@ You can also filter records by entering a query in the search box.
 
 ### Building a Data Custom Adapter
 
-You can use your own data persistence library with the Inspector. Build a [data adapter][data-adapter-docs], and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter][ember-data-data-adapter] as an example for how to build your data adapter and [DataAdapter][class-data-adapter] documentation.
-
-[data-adapter-docs]: https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js
-[ember-data-data-adapter]:https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js
-[class-data-adapter]:https://emberjs.com/api/ember/release/classes/DataAdapter
+You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
+using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js
+) as an example for how to build your data adapter and [DataAdapter](https://emberjs.com/api/ember/release/classes/DataAdapter) documentation.

--- a/guides/release/ember-inspector/data.md
+++ b/guides/release/ember-inspector/data.md
@@ -10,8 +10,7 @@ The Inspector displays the loaded records when you click on a model type.
 
 Each row in the list corresponds to one record. The first four model attributes are shown in the list view. Clicking on the record will open the Object Inspector for that record, and display all attributes.
 
-<img src="/images/guides/ember-inspector/data-object-inspector.png"
-width="680"/>
+<img src="/images/guides/ember-inspector/data-object-inspector.png" width="680"/>
 
 ### Record States and Filtering
 
@@ -19,13 +18,11 @@ The Data tab is kept in sync with the data loaded in your application.
 Any record additions, deletions, or changes are reflected immediately. If you have unsaved
 records, they will be displayed in green by clicking on the New pill.
 
-<img src="/images/guides/ember-inspector/data-new-records.png"
-width="680"/>
+<img src="/images/guides/ember-inspector/data-new-records.png" width="680"/>
 
 Click on the Modified pill to display unsaved record modifications.
 
-<img src="/images/guides/ember-inspector/data-modified-records.png"
-width="680"/>
+<img src="/images/guides/ember-inspector/data-modified-records.png" width="680"/>
 
 You can also filter records by entering a query in the search box.
 

--- a/guides/release/ember-inspector/info.md
+++ b/guides/release/ember-inspector/info.md
@@ -12,6 +12,4 @@ Ember.libraries.register(libraryName, libraryVersion);
 
 #### Ember CLI
 
-If you're using the [ember-cli-app-version][] addon, your application's name and version will be added to the list automatically.
-
-[ember-cli-app-version]: https://github.com/embersherpa/ember-cli-app-version
+If you're using the [ember-cli-app-version](https://github.com/embersherpa/ember-cli-app-version) addon, your application's name and version will be added to the list automatically.

--- a/guides/release/ember-inspector/installation.md
+++ b/guides/release/ember-inspector/installation.md
@@ -37,7 +37,7 @@ Make sure the "Display the Tomster" checkbox is checked.
 ### Firefox
 
 Visit the Add-on page on the [Mozilla Addons
-site][ember-inspector-mozilla].
+site](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/).
 
 Click on "Add to Firefox".
 
@@ -47,9 +47,6 @@ Once installed, go to an Ember application, open the Developer Tools,
 and click on the `Ember` tab.
 
 <img src="/images/guides/ember-inspector/installation-firefox-panel.png" width="680">
-
-[ember-inspector-mozilla]: https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/
-
 
 #### Enable Tomster
 

--- a/guides/release/ember-inspector/object-inspector.md
+++ b/guides/release/ember-inspector/object-inspector.md
@@ -15,9 +15,8 @@ The Inspector displays the parent objects and mixins that are composed into the 
 Each property value in this view is bound to your application, so if the value of a
 property updates in your app, it will be reflected in the Inspector.
 
-If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
+If a property name is preceded by a calculator icon, that means it is a [computed property](../../object-model/computed-properties/). If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]: ../../object-model/computed-properties/
 
 ### Exposing Objects to the Console
 
@@ -91,7 +90,4 @@ width="450">
 Library authors can customize how any object will display in the Inspector.
 By defining a `_debugInfo` method, an object can tell the Inspector how it should be rendered.
 For an example on how to customize an object's properties, see [Ember Data's
-customization][ember-data-debug-info].
-
-
-[ember-data-debug-info]: https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js
+customization](https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js).

--- a/guides/release/index.md
+++ b/guides/release/index.md
@@ -40,13 +40,13 @@ We will try to link to appropriate documentation whenever a concept is introduce
 
 To make the most out of the guides, you should have a working knowledge of:
 
-* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network][mdn].
-* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network][promises] section.
-* **ES2015 modules** - you will better understand [Ember CLI's][ember-cli] project structure and import paths if you are comfortable with [JavaScript Modules][js-modules].
+* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web).
+* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) section.
+* **ES2015 modules** - you will better understand [Ember CLI's](https://ember-cli.com/) project structure and import paths if you are comfortable with [JavaScript Modules](http://jsmodules.io/).
 * **ES2015 syntax** - Ember CLI comes with Babel.js by default so you can
 take advantage of newer language features such as arrow functions, template
 strings, destructuring, and more. You can check the
-[Babel.js documentation][babeljs] or read [Understanding ECMAScript 6][es6]
+[Babel.js documentation](https://babeljs.io/docs/learn-es2015/) or read [Understanding ECMAScript 6](https://leanpub.com/understandinges6/read)
 online.
 
 ## A Note on Mobile Performance
@@ -85,7 +85,7 @@ the existing guides, we are happy to help you help us!
 Some of the more common ways to report a problem with the guides are:
 
 * Using the pencil icon on the top-right of each guide page
-* Opening an issue or pull request to [the GitHub repository][gh-guides]
+* Opening an issue or pull request to [the GitHub repository](https://github.com/ember-learn/guides-source/)
 
 Clicking the pencil icon will bring you to GitHub's editor for that
 guide so you can edit right away, using the Markdown markup language.
@@ -93,25 +93,11 @@ This is the fastest way to correct a typo, a missing word, or an error in
 a code sample.
 
 If you wish to make a more significant contribution be sure to check our
-[issue tracker][gh-guides-issues] to see if your issue is already being
+[issue tracker](https://github.com/ember-learn/guides-source/issues) to see if your issue is already being
 addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
-can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
+can check out our [contributing guide](https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md). If your
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord](https://discordapp.com/invite/zT3asNS).
 
 Good luck!
-
-[ember-cli]: https://ember-cli.com/
-
-[mdn]: https://developer.mozilla.org/en-US/docs/Web
-[promises]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-[js-modules]: http://jsmodules.io/
-[babeljs]: https://babeljs.io/docs/learn-es2015/
-[es6]: https://leanpub.com/understandinges6/read
-
-[gh-guides]: https://github.com/ember-learn/guides-source/
-[gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
-[gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
-
-[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/release/models/creating-updating-and-deleting-records.md
+++ b/guides/release/models/creating-updating-and-deleting-records.md
@@ -163,6 +163,4 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 });
 ```
 
-The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`][findRecord] automatically schedules a fetch of the record from the adapter.
-
-[findRecord]: <https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord>
+The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](<https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord>) automatically schedules a fetch of the record from the adapter.

--- a/guides/release/models/index.md
+++ b/guides/release/models/index.md
@@ -43,10 +43,8 @@ Typically, most models are loaded from and saved to a server that uses a
 database to store data. Usually you will send JSON representations of
 models back and forth to an HTTP server that you have written. However,
 Ember makes it easy to use other durable storage, such as saving to the
-user's hard disk with [IndexedDB][indexeddb], or hosted storage solutions that let you
+user's hard disk with [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API), or hosted storage solutions that let you
 avoid writing and hosting your own servers.
-
-[indexeddb]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 
 Once you've loaded your models from storage, components know how to
 translate model data into a UI that your user can interact with.  For
@@ -70,13 +68,11 @@ This will allow your code to evolve and grow, with better maintainability.
 ## Ember Data flexibility
 
 Thanks to its use of the _adapter pattern_, Ember Data can be configured
-to work with many different kinds of backends. There is [an entire ecosystem of adapters][adapters]
+to work with many different kinds of backends. There is [an entire ecosystem of adapters](http://emberobserver.com/categories/ember-data-adapters)
 and several [built-in adapters](./customizing-adapters/)
 that allow your Ember app to talk to different types of servers.
 
-[adapters]: http://emberobserver.com/categories/ember-data-adapters
-
-By default, Ember Data is designed to work out of the box with [JSON:API][json-api].
+By default, Ember Data is designed to work out of the box with [JSON:API](http://jsonapi.org).
 JSON:API is a formal specification for building conventional, robust, and performant
 APIs that allow clients and servers to communicate model data.
 
@@ -84,10 +80,8 @@ JSON:API standardizes how JavaScript applications talk to servers, so
 you decrease the coupling between your frontend and backend, and have
 more freedom to change pieces of your stack.
 
-[json-api]: http://jsonapi.org
-
 If you need to integrate your Ember.js app with a server that does not
-have an [adapter][adapters] available (for example, you hand-rolled an API server
+have an [adapter](http://emberobserver.com/categories/ember-data-adapters) available (for example, you hand-rolled an API server
 that does not adhere to any JSON specification), Ember Data is designed
 to **be configurable** to work with whatever data your server returns.
 

--- a/guides/release/object-model/classes-and-instances.md
+++ b/guides/release/object-model/classes-and-instances.md
@@ -133,10 +133,7 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`](https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init
-) method is invoked
-automatically. This is the ideal place to implement setup required on new
-instances:
+When a new instance is created, its [`init()`](https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init) method is invoked automatically. This is the ideal place to implement setup required on new instances:
 
 ```javascript
 import EmberObject from '@ember/object';

--- a/guides/release/object-model/classes-and-instances.md
+++ b/guides/release/object-model/classes-and-instances.md
@@ -4,11 +4,9 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`][1] method on
-[`EmberObject`][2]:
+To define a new Ember _class_, call the [`extend()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://www.emberjs.com/api/ember/release/modules/@ember%2Fobject):
 
-[1]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend
-[2]: https://www.emberjs.com/api/ember/release/modules/@ember%2Fobject
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -24,9 +22,7 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`][3] class:
-
-[3]: https://www.emberjs.com/api/ember/release/classes/Component
+of Ember's built-in [`Component`](https://www.emberjs.com/api/ember/release/classes/Component) class:
 
 ```javascript {data-filename=app/components/todo-item.js}
 import Component from '@ember/component';
@@ -71,11 +67,9 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`][4] hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`](https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
-
-[4]: https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse
 
 ```javascript
 normalizeResponse(store, primaryModelClass, payload, id, requestType)  {
@@ -89,11 +83,9 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`][5] method. Any methods, properties and
+class by calling its [`create()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
-
-[5]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/create?anchor=create
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -141,11 +133,10 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`][6] method is invoked
+When a new instance is created, its [`init()`](https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init
+) method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
-
-[6]: https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -230,7 +221,7 @@ Person.create({
 
 When reading a property value of an object, you can in most cases use the common JavaScript dot notation, e.g. `myObject.myProperty`. 
 
-[Ember proxy objects][9] are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`][7] accessor method to read values.
+[Ember proxy objects](https://emberjs.com/api/ember/3.3/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
 
 Let's look at the following `blogPost` Ember Data model:
 
@@ -248,7 +239,7 @@ export default Model.extend({
 
 To access the blog post's title you can simply write `blogPost.title`, whereas only the syntax `blogPost.get('comments')` will return the post's comments.
 
-Always use Ember's [`set()`][8] method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
+Always use Ember's [`set()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/set?anchor=set) method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -263,7 +254,3 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
-
-[7]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/get?anchor=get
-[8]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/set?anchor=set
-[9]: https://emberjs.com/api/ember/3.3/classes/ObjectProxy

--- a/guides/release/reference/accessibility-guide.md
+++ b/guides/release/reference/accessibility-guide.md
@@ -69,7 +69,7 @@ Here is a checklist of some things to keep in mind when developing your applicat
   - All interactive elements must have an accessible name.
 - The values for the role attribute are predefined by the ARIA specification. This is not something an author can define a custom value for (that is not listed in the spec). [Learn more about roles in the specification.](https://www.w3.org/TR/wai-aria/#roles_categorization)
 - In general, avoid making your own keyboard shortcuts. [Screen readers already provide quite a few.](https://dequeuniversity.com/screenreaders/) There is some nuance here, so proceed with caution should you choose to do so. 
-- "Completely accessible" may be somewhat of a misnomer. Practical accessibility looks more like 90% coding to the spec and 10% filing browser bugs (or keeping track of existing browser bugs). Keep in mind that if you choose to implement a workaround for a browser bug, you will need to put an issue in your product backlog to follow up on browser bugs at a later date.
+- "Completely accessible" may be somewhat of a misnomer. Practical accessibility looks more like 90% coding to the spec and 10% filing browser bugs (or keeping track of existing browser bugs). Keep in mind that if you choose to implement a workaround for a browser bug, you will need to put an issue in your product backlog to follow up on browser bugs at a later date. 
 
 ### Focus
 

--- a/guides/release/templates/writing-helpers.md
+++ b/guides/release/templates/writing-helpers.md
@@ -247,7 +247,8 @@ access to services in your application, and can optionally save state as well,
 although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
-should export a subclass of [`Ember.Helper`](https://www.emberjs.com/api/ember/release/classes/Helper). Helper classes must contain a
+should export a subclass of [`Ember.Helper`](https://www.emberjs.com/api/ember/release/classes/Helper). 
+Helper classes must contain a
 [`compute`](https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
 [`Ember.Helper.helper`](https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
@@ -344,8 +345,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`](https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe
-)), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently

--- a/guides/release/templates/writing-helpers.md
+++ b/guides/release/templates/writing-helpers.md
@@ -7,9 +7,7 @@ For example, imagine we have an `Invoice` model that contains a
 `totalDue` attribute, which represents the total amount due for that
 invoice.  Because we do not want our company to go out of business due
 to strange JavaScript rounding errors, [we store this value in cents
-instead of a floating point dollar value][currency-stackoverflow].
-
-[currency-stackoverflow]: http://stackoverflow.com/a/3730040
+instead of a floating point dollar value](http://stackoverflow.com/a/3730040).
 
 However, if we display dollar values to our users as "100¢" instead of
 "$1.00", they may be very confused. We can write a helper to
@@ -249,9 +247,9 @@ access to services in your application, and can optionally save state as well,
 although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
-should export a subclass of [`Ember.Helper`][1]. Helper classes must contain a
-[`compute`][2] method that behaves the same as the function passed to
-[`Ember.Helper.helper`][3].  In order to access a service, you must first inject it
+should export a subclass of [`Ember.Helper`](https://www.emberjs.com/api/ember/release/classes/Helper). Helper classes must contain a
+[`compute`](https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`Ember.Helper.helper`](https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -332,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`][4] string utility:
+[`htmlSafe`](https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -346,7 +344,8 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`][4]), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe
+)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently
@@ -394,7 +393,3 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
-[1]: https://www.emberjs.com/api/ember/release/classes/Helper
-[2]: https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=compute
-[3]: https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=helper
-[4]: https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe

--- a/guides/release/templates/writing-helpers.md
+++ b/guides/release/templates/writing-helpers.md
@@ -344,9 +344,9 @@ export function makeBold([param, ...rest]) {
 export default helper(makeBold);
 ```
 
-If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`](https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe), Ember knows that you have vouched on its behalf that it
-contains no malicious HTML.
+If you return a `SafeString` (a string that has been wrapped in a call to 
+[`htmlSafe`](https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe)), 
+Ember knows that you have vouched on its behalf that it contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently
 introduced an XSS vulnerability into our application! By blindly marking

--- a/guides/release/testing/acceptance.md
+++ b/guides/release/testing/acceptance.md
@@ -83,20 +83,20 @@ your application, making it much easier to write deterministic tests.
 
 Some of these handy helpers are:
 
-* [`click(selector)`][1]
+* [`click(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click)
   - Clicks an element and triggers any actions triggered by the element's `click`
     event and returns a promise that fulfills when all resulting async behavior
     is complete.
-* [`fillIn(selector, value)`][2]
+* [`fillIn(selector, value)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin)
   - Fills in the selected input with the given value and returns a promise that
      fulfills when all resulting async behavior is complete. Works with `<select>` elements as well as `<input>` elements. Keep in mind that with `<select>` elements, `value` must be set to the _value_ of the `<option>` tag, rather than its _content_ (for example, `true` rather than `"Yes"`).
-* [`triggerKeyEvent(selector, type, keyCode)`][3]
+* [`triggerKeyEvent(selector, type, keyCode)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerkeyevent)
   - Simulates a key event type, e.g. `keypress`, `keydown`, `keyup` with the
     desired keyCode on element found by the selector.
-* [`triggerEvent(selector, type, options)`][4]
+* [`triggerEvent(selector, type, options)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent)
   - Triggers the given event, e.g. `blur`, `dblclick` on the element identified
     by the provided selector.
-* [`visit(url)`][5]
+* [`visit(url)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit)
   - Visits the given route and returns a promise that fulfills when all resulting
      async behavior is complete.
 
@@ -130,18 +130,18 @@ previous steps in the test have completed.
 
 Synchronous helpers are performed immediately when triggered.
 
-* [`currentRouteName()`][6]: returns the currently active route name.
-* [`currentURL()`][7]: returns the current URL.
-* [`find(selector)`][8]: finds one element within the app's root element
+* [`currentRouteName()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename): returns the currently active route name.
+* [`currentURL()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl): returns the current URL.
+* [`find(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find): finds one element within the app's root element
   that matches the given selector. Scoping to the root element is useful
   to avoid conflicts with the test framework's reporter.
-* [`findAll(selector)`][9]: like `find(selector)`, but finds all elements
+* [`findAll(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall): like `find(selector)`, but finds all elements
   that match the given selector. Equivalent to calling querySelectorAll()
   on the test root element. Returns an array of matched elements.
 
 ## Debugging Your Tests
 
-During the development of you tests or when you refactor you application's code, the execution of your tests may fail. In order to help you understand why, [`pauseTest()`][10] and [`resumeTest()`][11] can help you.
+During the development of you tests or when you refactor you application's code, the execution of your tests may fail. In order to help you understand why, [`pauseTest()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#pausetest) and [`resumeTest()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#resumetest) can help you.
 
 To try them out, do the following steps:
 
@@ -152,15 +152,3 @@ To try them out, do the following steps:
 When the execution of the test come upon `await pauseTest()`, the test will be paused, allowing you to inspect the state of your application.
 
 You can now type `resumeTest()` in the console of your browser to continue the test execution.
-
-[1]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click
-[2]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin
-[3]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerkeyevent
-[4]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent
-[5]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit
-[6]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename
-[7]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl
-[8]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find
-[9]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall
-[10]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#pausetest
-[11]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#resumetest

--- a/guides/release/testing/index.md
+++ b/guides/release/testing/index.md
@@ -1,6 +1,6 @@
 Testing is a core part of the Ember framework and its development cycle.
 
-[QUnit][] is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
+[QUnit](http://qunitjs.com/) is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
 
 The testing pattern presented below is consistent across different testing frameworks. Only the setup test functions from [ember-qunit](https://github.com/emberjs/ember-qunit) needs to be replaced with the respective setup functions in the testing addon used in order to use other testing frameworks.
 
@@ -68,7 +68,7 @@ Examples of Container Tests are:
 * A serializer properly converts the blog request payload into a blog post model object.
 * Blog dates are properly formatted through a `time` service.
 
-You can read more about these type of tests in the [Testing Routes][] and [Testing Controllers][] section.
+You can read more about these type of tests in the [Testing Routes](./testing-routes) and [Testing Controllers](./testing-controllers) section.
 
 ### Rendering Tests
 
@@ -112,7 +112,7 @@ Examples of Rendering Tests are:
 
 Rendering Tests are used to test Components and Helpers where we need to render a layout and assert some interaction byproduct occurs.
 
-You can read more about it in the [Testing Components][] or the [Testing Helpers][] section.
+You can read more about it in the [Testing Components](./testing-components) or the [Testing Helpers](./testing-helpers) section.
 
 ### Application Tests
 
@@ -148,7 +148,7 @@ Examples of Application Tests are:
 * After saving a new post successfully, a user is then shown the list of prior posts.
 * A visitor does not have access to the admin panel.
 
-You can read more about how to create these kinds of tests in the [Application tests][] section.
+You can read more about how to create these kinds of tests in the [Application tests](./acceptance) section.
 
 ### Testing Blueprints
 
@@ -189,7 +189,7 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 Tests can also be executed when you are running a local development server (started by running `ember server`),
 at the `/tests` URI which renders the `tests/index.html` template.
 
-These commands run your tests using [Testem][] to make testing multiple browsers very easy.
+These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy.
 You can configure Testem using the `testem.js` file in your application root.
 
 #### Choosing the Tests to Run
@@ -200,11 +200,3 @@ When using QUnit it is possible to exclude tests by adding an exclamation point 
 
 You can also run a group of tests which you have scoped with a `module` before; e.g. for testing the module called `Unit | Service | location` only,
 run `ember test --module='Unit | Service | location'`.
-
-[QUnit]: http://qunitjs.com/
-[Testem]: https://github.com/airportyh/testem
-[Application tests]: ./acceptance
-[Testing Components]: ./testing-components
-[Testing Controllers]: ./testing-controllers
-[Testing Routes]: ./testing-routes
-[Testing Helpers]: ./testing-helpers

--- a/guides/release/testing/testing-controllers.md
+++ b/guides/release/testing/testing-controllers.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Controller extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Controller extends Ember.Object._
 
 Controllers can be tested using the `setupTest` helper which is part
 of the ember-qunit framework. The tests written for instances like `Ember.Controller` are
@@ -79,5 +79,3 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/

--- a/guides/release/testing/testing-helpers.md
+++ b/guides/release/testing/testing-helpers.md
@@ -1,4 +1,4 @@
-_Testing helpers follows previous patterns shown in [Testing Components][],
+_Testing helpers follows previous patterns shown in [Testing Components](../testing-components/),
 because helpers are rendered to templates just like components._
 
 Helpers are best tested with rendering tests, but can also be tested with unit
@@ -6,7 +6,8 @@ tests. Rendering tests will provide better coverage for helpers, as it more
 closely simulates the lifecycle of a helper than in isolation.
 
 We're going to demonstrate how to test helpers by testing the `format-currency`
-helper from [Writing Helpers][].
+helper from [Writing Helpers](../../templates/writing-helpers/
+).
 
 > You can follow along by generating your own helper with `ember generate helper
 > format-currency`.
@@ -42,12 +43,13 @@ module('Unit | Helper | format currency', function(hooks) {
 });
 ```
 
-As seen in the [Writing Helpers][] guide. The helper function expects the unnamed
+As seen in the [Writing Helpers](../../templates/writing-helpers/
+) guide. The helper function expects the unnamed
 arguments as an array as the first argument. It expects the named arguments as
 an object as the second argument.
 
 Now we can move on to a more complex test case that ensures our helper is rendered correctly as well. This can be done
-with the `setupRenderingTest` helper, as shown in [Testing Components][].
+with the `setupRenderingTest` helper, as shown in [Testing Components](../testing-components/).
 
 ```javascript {data-filename=tests/integration/helpers/format-currency-test.js}
 import { module, test } from 'qunit';
@@ -94,6 +96,3 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
-
-[Testing Components]: ../testing-components/
-[Writing Helpers]: ../../templates/writing-helpers/

--- a/guides/release/testing/testing-helpers.md
+++ b/guides/release/testing/testing-helpers.md
@@ -6,8 +6,7 @@ tests. Rendering tests will provide better coverage for helpers, as it more
 closely simulates the lifecycle of a helper than in isolation.
 
 We're going to demonstrate how to test helpers by testing the `format-currency`
-helper from [Writing Helpers](../../templates/writing-helpers/
-).
+helper from [Writing Helpers](../../templates/writing-helpers/).
 
 > You can follow along by generating your own helper with `ember generate helper
 > format-currency`.
@@ -43,13 +42,14 @@ module('Unit | Helper | format currency', function(hooks) {
 });
 ```
 
-As seen in the [Writing Helpers](../../templates/writing-helpers/
-) guide. The helper function expects the unnamed
-arguments as an array as the first argument. It expects the named arguments as
+As seen in the [Writing Helpers](../../templates/writing-helpers/) guide. 
+The helper function expects the unnamed arguments as an array as the 
+first argument. It expects the named arguments as
 an object as the second argument.
 
-Now we can move on to a more complex test case that ensures our helper is rendered correctly as well. This can be done
-with the `setupRenderingTest` helper, as shown in [Testing Components](../testing-components/).
+Now we can move on to a more complex test case that ensures our helper is rendered 
+correctly as well. This can be done with the `setupRenderingTest` helper, as shown 
+in [Testing Components](../testing-components/).
 
 ```javascript {data-filename=tests/integration/helpers/format-currency-test.js}
 import { module, test } from 'qunit';

--- a/guides/release/testing/testing-models.md
+++ b/guides/release/testing/testing-models.md
@@ -1,7 +1,7 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because DS.Model extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because DS.Model extends Ember.Object._
 
-[Ember Data][] Models can be tested in a module that uses the `setupTest` helper.
+[Ember Data](https://github.com/emberjs/data) Models can be tested in a module that uses the `setupTest` helper.
 
 Let's assume we have a `Player` model that has `level` and `levelName`
 attributes. We want to call `levelUp()` to increment the `level` and assign a
@@ -104,9 +104,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests][] for examples of deeper relationship testing if you
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
 feel the need to do it._
-
-[Ember Data]: https://github.com/emberjs/data
-[Testing Basics]: ../unit-testing-basics/
-[Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/release/testing/testing-routes.md
+++ b/guides/release/testing/testing-routes.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Route extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Route extends Ember.Object._
 
 Testing routes can be done both via application tests or container tests. Application tests
 will likely provide better coverage for routes because routes are typically used
@@ -34,7 +34,7 @@ export default Route.extend({
 });
 ```
 
-In this route we've [separated our concerns][]:
+In this route we've [separated our concerns](http://en.wikipedia.org/wiki/Separation_of_concerns):
 The action `displayAlert` contains the code that is called when the action is
 received, and the private function `_displayAlert` performs the work. While not
 necessarily obvious here because of the small size of the functions, separating
@@ -86,6 +86,3 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/
-[separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v3.0.0/components/the-component-lifecycle.md
+++ b/guides/v3.0.0/components/the-component-lifecycle.md
@@ -116,17 +116,17 @@ Suppose you want to integrate your favorite date picker library into an Ember pr
 Typically, 3rd party JS/jQuery libraries require a DOM element to bind to.
 So, where is the best place to initialize and attach the library?
 
-After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`][did-insert-element] hook.
+After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`](https://www.emberjs.com/api/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement) hook.
 
 Ember guarantees that, by the time `didInsertElement()` is called:
 
 1. The component's element has been both created and inserted into the
    DOM.
 2. The component's element is accessible via the component's
-   [`$()`][dollar]
+   [`$()`](https://www.emberjs.com/api/ember/2.16/classes/Component/methods/$?anchor=%24)
    method.
 
-A component's [`$()`][dollar] method allows you to access the component's DOM element by returning a jQuery element.
+A component's [`$()`](https://www.emberjs.com/api/ember/2.16/classes/Component/methods/$?anchor=%24) method allows you to access the component's DOM element by returning a jQuery element.
 For example, you can set an attribute using jQuery's `attr()` method:
 
 ```javascript {data-filename=app/components/profile-editor.js}
@@ -140,7 +140,7 @@ export default Component.extend({
 });
 ```
 
-[`$()`][dollar] will, by default, return a jQuery object for the component's root element, but you can also target child elements within the component's template by passing a selector:
+[`$()`](https://www.emberjs.com/api/ember/2.16/classes/Component/methods/$?anchor=%24) will, by default, return a jQuery object for the component's root element, but you can also target child elements within the component's template by passing a selector:
 
 ```javascript {data-filename=app/components/profile-editor.js}
 import Component from '@ember/component';
@@ -153,7 +153,7 @@ export default Component.extend({
 });
 ```
 
-Let's initialize our date picker by overriding the [`didInsertElement()`][did-insert-element] method.
+Let's initialize our date picker by overriding the [`didInsertElement()`](https://www.emberjs.com/api/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement) method.
 
 Date picker libraries usually attach to an `<input>` element, so we will use jQuery to find an appropriate input within our component's template.
 
@@ -168,10 +168,10 @@ export default Component.extend({
 });
 ```
 
-[`didInsertElement()`][did-insert-element] is also a good place to
+[`didInsertElement()`](https://www.emberjs.com/api/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement) is also a good place to
 attach event listeners. This is particularly useful for custom events or
 other browser events which do not have a [built-in event
-handler][event-names].
+handler](../handling-events/#toc_event-names).
 
 For example, perhaps you have some custom CSS animations trigger when the component
 is rendered and you want to handle some cleanup when it ends:
@@ -193,14 +193,10 @@ There are a few things to note about the `didInsertElement()` hook:
 
 - It is only triggered once when the component element is first rendered.
 - In cases where you have components nested inside other components, the child component will always receive the `didInsertElement()` call before its parent does.
-- Setting properties on the component in [`didInsertElement()`][did-insert-element] triggers a re-render, and for performance reasons,
+- Setting properties on the component in [`didInsertElement()`](https://www.emberjs.com/api/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons,
   is not allowed.
-- While [`didInsertElement()`][did-insert-element] is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
+- While [`didInsertElement()`](https://www.emberjs.com/api/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement) is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
   particularly when order of execution is important.
-
-[did-insert-element]: https://www.emberjs.com/api/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement
-[dollar]: https://www.emberjs.com/api/ember/2.16/classes/Component/methods/$?anchor=%24
-[event-names]: ../handling-events/#toc_event-names
 
 ### Making Updates to the Rendered DOM with `didRender`
 

--- a/guides/v3.0.0/ember-inspector/data.md
+++ b/guides/v3.0.0/ember-inspector/data.md
@@ -1,5 +1,4 @@
-You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter][building-data-adapter] below if you maintain your own persistence library. 
-[building-data-adapter]:#toc_building-a-data-custom-adapter
+You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter](#toc_building-a-data-custom-adapter) below if you maintain your own persistence library. 
 
 When you open the Data tab, you will see a list of model types defined
 in your application, along with the number of loaded records.
@@ -32,8 +31,5 @@ You can also filter records by entering a query in the search box.
 
 ### Building a Data Custom Adapter
 
-You can use your own data persistence library with the Inspector. Build a [data adapter][data-adapter-docs], and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter][ember-data-data-adapter] as an example for how to build your data adapter.
-
-[data-adapter-docs]: https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js
-[ember-data-data-adapter]:https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js
+You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
+using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter.

--- a/guides/v3.0.0/ember-inspector/info.md
+++ b/guides/v3.0.0/ember-inspector/info.md
@@ -12,6 +12,4 @@ Ember.libraries.register(libraryName, libraryVersion);
 
 #### Ember CLI
 
-If you're using the [ember-cli-app-version][] addon, your application's name and version will be added to the list automatically.
-
-[ember-cli-app-version]: https://github.com/embersherpa/ember-cli-app-version
+If you're using the [ember-cli-app-version](https://github.com/embersherpa/ember-cli-app-version) addon, your application's name and version will be added to the list automatically.

--- a/guides/v3.0.0/ember-inspector/installation.md
+++ b/guides/v3.0.0/ember-inspector/installation.md
@@ -37,7 +37,7 @@ Make sure the "Display the Tomster" checkbox is checked.
 ### Firefox
 
 Visit the Add-on page on the [Mozilla Addons
-site][ember-inspector-mozilla].
+site](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/).
 
 Click on "Add to Firefox".
 
@@ -47,9 +47,6 @@ Once installed, go to an Ember application, open the Developer Tools,
 and click on the `Ember` tab.
 
 <img src="/images/guides/ember-inspector/installation-firefox-panel.png" width="680">
-
-[ember-inspector-mozilla]: https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/
-
 
 #### Enable Tomster
 

--- a/guides/v3.0.0/ember-inspector/object-inspector.md
+++ b/guides/v3.0.0/ember-inspector/object-inspector.md
@@ -15,9 +15,7 @@ The Inspector displays the parent objects and mixins that are composed into the 
 Each property value in this view is bound to your application, so if the value of a
 property updates in your app, it will be reflected in the Inspector.
 
-If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
-click on the calculator to compute it.
-[computed-property]: ../../object-model/computed-properties/
+If a property name is preceded by a calculator icon, that means it is a [computed property](../../object-model/computed-properties/). If the value of a computed property hasn't yet been computed, you can click on the calculator to compute it.
 
 ### Exposing Objects to the Console
 
@@ -91,7 +89,4 @@ width="450">
 Library authors can customize how any object will display in the Inspector.
 By defining a `_debugInfo` method, an object can tell the Inspector how it should be rendered.
 For an example on how to customize an object's properties, see [Ember Data's
-customization][ember-data-debug-info].
-
-
-[ember-data-debug-info]: https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js
+customization](https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js).

--- a/guides/v3.0.0/index.md
+++ b/guides/v3.0.0/index.md
@@ -40,13 +40,13 @@ We will try to link to appropriate documentation whenever a concept is introduce
 
 To make the most out of the guides, you should have a working knowledge of:
 
-* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network][mdn].
-* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network][promises] section.
-* **ES2015 modules** - you will better understand [Ember CLI's][ember-cli] project structure and import paths if you are comfortable with [JavaScript Modules][js-modules].
+* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web).
+* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) section.
+* **ES2015 modules** - you will better understand [Ember CLI's](https://ember-cli.com/) project structure and import paths if you are comfortable with [JavaScript Modules](http://jsmodules.io/).
 * **ES2015 syntax** - Ember CLI comes with Babel.js by default so you can
 take advantage of newer language features such as arrow functions, template
 strings, destructuring, and more. You can check the
-[Babel.js documentation][babeljs] or read [Understanding ECMAScript 6][es6]
+[Babel.js documentation](https://babeljs.io/docs/learn-es2015/) or read [Understanding ECMAScript 6](https://leanpub.com/understandinges6/read)
 online.
 
 ## A Note on Mobile Performance
@@ -85,7 +85,7 @@ the existing guides, we are happy to help you help us!
 Some of the more common ways to report a problem with the guides are:
 
 * Using the pencil icon on the top-right of each guide page
-* Opening an issue or pull request to [the GitHub repository][gh-guides]
+* Opening an issue or pull request to [the GitHub repository](https://github.com/ember-learn/guides-source/)
 
 Clicking the pencil icon will bring you to GitHub's editor for that
 guide so you can edit right away, using the Markdown markup language.
@@ -93,25 +93,11 @@ This is the fastest way to correct a typo, a missing word, or an error in
 a code sample.
 
 If you wish to make a more significant contribution be sure to check our
-[issue tracker][gh-guides-issues] to see if your issue is already being
+[issue tracker](https://github.com/ember-learn/guides-source/issues) to see if your issue is already being
 addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
-can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
+can check out our [contributing guide](https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md). If your
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord](https://discordapp.com/invite/zT3asNS).
 
 Good luck!
-
-[ember-cli]: https://ember-cli.com/
-
-[mdn]: https://developer.mozilla.org/en-US/docs/Web
-[promises]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-[js-modules]: http://jsmodules.io/
-[babeljs]: https://babeljs.io/docs/learn-es2015/
-[es6]: https://leanpub.com/understandinges6/read
-
-[gh-guides]: https://github.com/ember-learn/guides-source/
-[gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
-[gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
-
-[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v3.0.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.0.0/models/creating-updating-and-deleting-records.md
@@ -163,6 +163,4 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 });
 ```
 
-The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`][findRecord] automatically schedules a fetch of the record from the adapter.
-
-[findRecord]: <https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/findRecord?anchor=findRecord>
+The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.Store/methods/findRecord?anchor=findRecord) automatically schedules a fetch of the record from the adapter.

--- a/guides/v3.0.0/models/index.md
+++ b/guides/v3.0.0/models/index.md
@@ -17,10 +17,8 @@ Typically, most models are loaded from and saved to a server that uses a
 database to store data. Usually you will send JSON representations of
 models back and forth to an HTTP server that you have written. However,
 Ember makes it easy to use other durable storage, such as saving to the
-user's hard disk with [IndexedDB][indexeddb], or hosted storage solutions that let you
+user's hard disk with [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API), or hosted storage solutions that let you
 avoid writing and hosting your own servers.
-
-[indexeddb]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 
 Once you've loaded your models from storage, components know how to
 translate model data into a UI that your user can interact with.  For
@@ -35,10 +33,8 @@ create new models in the browser.
 
 Thanks to its use of the _adapter pattern_, Ember Data can be configured
 to work with many different kinds of backends. There is [an entire
-ecosystem of adapters][adapters] that allow your Ember app to talk to different
+ecosystem of adapters](http://emberobserver.com/categories/ember-data-adapters) that allow your Ember app to talk to different
 types of servers without you writing any networking code.
-
-[adapters]: http://emberobserver.com/categories/ember-data-adapters
 
 If you need to integrate your Ember.js app with a server that does not
 have an adapter available (for example, you hand-rolled an API server
@@ -157,11 +153,9 @@ will be shared among developers on your team, following them leads
 to code that is easier to maintain and understand.
 
 Rather than create an arbitrary set of conventions, Ember Data is
-designed to work out of the box with [JSON API][json-api]. JSON API is a
+designed to work out of the box with [JSON API](http://jsonapi.org). JSON API is a
 formal specification for building conventional, robust, and performant
 APIs that allow clients and servers to communicate model data.
-
-[json-api]: http://jsonapi.org
 
 JSON API standardizes how JavaScript applications talk to servers, so
 you decrease the coupling between your frontend and backend, and have

--- a/guides/v3.0.0/object-model/classes-and-instances.md
+++ b/guides/v3.0.0/object-model/classes-and-instances.md
@@ -4,11 +4,8 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`][1] method on
-[`EmberObject`][2]:
-
-[1]: https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/extend?anchor=extend
-[2]: https://www.emberjs.com/api/ember/2.16/modules/@ember%2Fobject
+To define a new Ember _class_, call the [`extend()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://www.emberjs.com/api/ember/2.16/modules/@ember%2Fobject):
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -24,9 +21,8 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`][3] class:
+of Ember's built-in [`Component`](https://www.emberjs.com/api/ember/2.16/classes/Component) class:
 
-[3]: https://www.emberjs.com/api/ember/2.16/classes/Component
 
 ```javascript {data-filename=app/components/todo-item.js}
 import Component from '@ember/component';
@@ -71,11 +67,9 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`][4] hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
-
-[4]: https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse
 
 ```javascript
 normalizeResponse(store, primaryModelClass, payload, id, requestType)  {
@@ -89,11 +83,9 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`][5] method. Any methods, properties and
+class by calling its [`create()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
-
-[5]: https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/create?anchor=create
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -141,11 +133,9 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`][6] method is invoked
+When a new instance is created, its [`init()`](https://www.emberjs.com/api/ember/2.16/classes/EmberObject/methods/init?anchor=init) method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
-
-[6]: https://www.emberjs.com/api/ember/2.16/classes/EmberObject/methods/init?anchor=init
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -226,11 +216,9 @@ Person.create({
 
 ### Accessing Object Properties
 
-When accessing the properties of an object, use the [`get()`][7]
-and [`set()`][8] accessor methods:
+When accessing the properties of an object, use the [`get()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/get?anchor=get)
+and [`set()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/set?anchor=set) accessor methods:
 
-[7]: https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/get?anchor=get
-[8]: https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/set?anchor=set
 
 ```javascript
 import EmberObject from '@ember/object';

--- a/guides/v3.0.0/templates/writing-helpers.md
+++ b/guides/v3.0.0/templates/writing-helpers.md
@@ -7,9 +7,7 @@ For example, imagine we have an `Invoice` model that contains a
 `totalDue` attribute, which represents the total amount due for that
 invoice.  Because we do not want our company to go out of business due
 to strange JavaScript rounding errors, [we store this value in cents
-instead of a floating point dollar value][currency-stackoverflow].
-
-[currency-stackoverflow]: http://stackoverflow.com/a/3730040
+instead of a floating point dollar value](http://stackoverflow.com/a/3730040).
 
 However, if we display dollar values to our users as "100¢" instead of
 "$1.00", they may be very confused. We can write a helper to
@@ -249,9 +247,9 @@ access to services in your application, and can optionally save state as well,
 although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
-should export a subclass of [`Ember.Helper`][1]. Helper classes must contain a
-[`compute`][2] method that behaves the same as the function passed to
-[`Ember.Helper.helper`][3].  In order to access a service, you must first inject it
+should export a subclass of [`Ember.Helper`](https://www.emberjs.com/api/ember/release/classes/Helper). Helper classes must contain a
+[`compute`](https://www.emberjs.com/api/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`Ember.Helper.helper`](https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -332,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`][4] string utility:
+[`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -346,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`][4]), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently
@@ -394,7 +392,3 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
-[1]: https://www.emberjs.com/api/ember/2.16/classes/Helper
-[2]: https://www.emberjs.com/api/ember/2.16/classes/Helper/methods/compute?anchor=compute
-[3]: http://emberjs.com/api/classes/Ember.Helper.html#method_helper
-[4]: https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe

--- a/guides/v3.0.0/testing/acceptance.md
+++ b/guides/v3.0.0/testing/acceptance.md
@@ -83,20 +83,20 @@ your application, making it much easier to write deterministic tests.
 
 Some of these handy helpers are:
 
-* [`click(selector)`][1]
+* [`click(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click)
   - Clicks an element and triggers any actions triggered by the element's `click`
     event and returns a promise that fulfills when all resulting async behavior
     is complete.
-* [`fillIn(selector, value)`][2]
+* [`fillIn(selector, value)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin)
   - Fills in the selected input with the given value and returns a promise that
      fulfills when all resulting async behavior is complete. Works with `<select>` elements as well as `<input>` elements. Keep in mind that with `<select>` elements, `value` must be set to the _value_ of the `<option>` tag, rather than its _content_ (for example, `true` rather than `"Yes"`).
-* [`triggerKeyEvent(selector, type, keyCode)`][3]
+* [`triggerKeyEvent(selector, type, keyCode)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md)
   - Simulates a key event type, e.g. `keypress`, `keydown`, `keyup` with the
     desired keyCode on element found by the selector.
-* [`triggerEvent(selector, type, options)`][4]
+* [`triggerEvent(selector, type, options)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent)
   - Triggers the given event, e.g. `blur`, `dblclick` on the element identified
     by the provided selector.
-* [`visit(url)`][5]
+* [`visit(url)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit)
   - Visits the given route and returns a promise that fulfills when all resulting
      async behavior is complete.
 
@@ -130,27 +130,14 @@ previous steps in the test have completed.
 
 Synchronous helpers are performed immediately when triggered.
 
-* [`currentRouteName()`][6]
+* [`currentRouteName()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename)
   - Returns the currently active route name.
-* [`currentURL()`][7]
+* [`currentURL()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl)
   - Returns the current URL.
-* [`find(selector, context)`][8]
+* [`find(selector, context)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find)
   - Finds an element within the app's root element and within the context
     (optional). Scoping to the root element is especially useful to avoid
     conflicts with the test framework's reporter, and this is done by default
     if the context is not specified.
-* [`findAll(selector)`][9]
-  - Find all elements matched by the given selector. Equivalent to calling
-    querySelectorAll() on the test root element.  Returns an array of matched
-    elements.
-
-
-[1]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click
-[2]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin
-[3]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md
-[4]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent
-[5]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit
-[6]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename
-[7]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl
-[8]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find
-[9]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall
+* [`findAll(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall)
+  - Find all elements matched by the given selector. Equivalent to calling querySelectorAll() on the test root element.  Returns an array of matched elements.

--- a/guides/v3.0.0/testing/index.md
+++ b/guides/v3.0.0/testing/index.md
@@ -3,7 +3,7 @@ Testing is a core part of the Ember framework and its development cycle.
 Let's assume you are writing an Ember application which will serve as a blog.
 This application would likely include models such as `user` and `post`.
 It would also include interactions such as _login_ and _create post_.
-Let's finally assume that you would like to have [automated tests][] in place for your application.
+Let's finally assume that you would like to have [automated tests](http://en.wikipedia.org/wiki/Test_automation) in place for your application.
 
 There are four different types of test setups you can choose from:
 
@@ -21,7 +21,7 @@ In the example scenario above, some of the tests you might write are:
 * A visitor does not have access to the admin panel.
 
 For tests that require a full application setup we can use the `setupApplicationTest` helper.
-You can read more about how to create these kinds of tests in the [Application tests][] section.
+You can read more about how to create these kinds of tests in the [Application tests](./acceptance) section.
 
 ### Rendering Tests
 
@@ -43,7 +43,7 @@ Examples of these kinds of tests are:
 * The blog post list scrolls to position a new post at the top of the viewport.
 
 We can create an isolated rendering test with the `setupRenderingTest` helper.
-You can read more about it in the [Testing Components][] or the [Testing Helpers][] section.
+You can read more about it in the [Testing Components](./testing-components) or the [Testing Helpers](./testing-helpers/) section.
 
 ### Container Tests
 
@@ -59,7 +59,7 @@ Some specific examples of these type of tests are:
 * Blog dates are properly formatted through a `time` service.
 
 We can create these isolated container tests with the `setupTest` helper.
-You can read more about these type of tests in the [Testing Routes][] and [Testing Controllers][] section.
+You can read more about these type of tests in the [Testing Routes](./testing-routes) and [Testing Controllers](./testing-controllers) section.
 
 ### Simple Unit Tests
 
@@ -77,7 +77,7 @@ as they neither require the application's container to be setup nor any user int
 
 ### Testing Frameworks
 
-[QUnit][] is the default testing framework for this guide, but others are supported, too through addons, e.g. [ember-mocha](https://github.com/emberjs/ember-mocha).
+[QUnit](http://qunitjs.com/) is the default testing framework for this guide, but others are supported, too through addons, e.g. [ember-mocha](https://github.com/emberjs/ember-mocha).
 
 ### Testing Blueprints
 
@@ -123,7 +123,7 @@ whereas tests executed under `ember test --server` are run with the configuratio
 This could cause differences in execution, such as which libraries are loaded and available.
 Therefore it's recommended that you use `ember test --server` for test execution.
 
-These commands run your tests using [Testem][] to make testing multiple browsers very easy.
+These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy.
 You can configure Testem using the `testem.js` file in your application root.
 
 #### Choosing the Tests to Run
@@ -134,12 +134,3 @@ When using QUnit it is possible to exclude tests by adding an exclamation point 
 
 You can also run a group of tests which you have scoped with a `module` before; e.g. for testing the module called `Unit | Service | location` only,
 run `ember test --module='Unit | Service | location'`.
-
-[automated tests]: http://en.wikipedia.org/wiki/Test_automation
-[QUnit]: http://qunitjs.com/
-[Testem]: https://github.com/airportyh/testem
-[Application tests]: ./acceptance/
-[Testing Components]: ./testing-components/
-[Testing Controllers]: ./testing-controllers
-[Testing Routes]: ./testing-routes
-[Testing Helpers]: ./testing-helpers/

--- a/guides/v3.0.0/testing/testing-controllers.md
+++ b/guides/v3.0.0/testing/testing-controllers.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follows previous patterns shown
-in [Testing Basics][] because Ember.Controller extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Controller extends Ember.Object._
 
 Controllers can be tested using the `setupTest` helper which is part
 of the ember-qunit framework. The tests written for instances like `Ember.Controller` are
@@ -145,7 +145,3 @@ module('Unit | Controller | comments', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/
-<!-- This definition flagged as not used - should be deleted? -->
-<!-- [needs]: ../../controllers/dependencies-between-controllers/ -->

--- a/guides/v3.0.0/testing/testing-helpers.md
+++ b/guides/v3.0.0/testing/testing-helpers.md
@@ -1,4 +1,4 @@
-_Testing helpers follows previous patterns shown in [Testing Components][],
+_Testing helpers follows previous patterns shown in [Testing Components](../testing-components/),
 because helpers are rendered to templates just like components._
 
 Helpers are best tested with rendering tests, but can also be tested with unit
@@ -6,7 +6,7 @@ tests. Rendering tests will provide better coverage for helpers, as it more
 closely simulates the lifecycle of a helper than in isolation.
 
 We're going to demonstrate how to test helpers by testing the `format-currency`
-helper from [Writing Helpers][].
+helper from [Writing Helpers](../../templates/writing-helpers/).
 
 > You can follow along by generating your own helper with `ember generate helper
 > format-currency`.
@@ -42,12 +42,12 @@ module('Unit | Helper | format currency', function(hooks) {
 });
 ```
 
-As seen in the [Writing Helpers][] guide. The helper function expects the unnamed
+As seen in the [Writing Helpers](../../templates/writing-helpers/) guide. The helper function expects the unnamed
 arguments as an array as the first argument. It expects the named arguments as
 an object as the second argument.
 
 Now we can move on to a more complex test case that ensures our helper is rendered correctly as well. This can be done
-with the `setupRenderingTest` helper, as shown in [Testing Components][].
+with the `setupRenderingTest` helper, as shown in [Testing Components](../testing-components/).
 
 ```javascript {data-filename=tests/integration/helpers/format-currency-test.js}
 import { module, test } from 'qunit';
@@ -94,6 +94,3 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
-
-[Testing Components]: ../testing-components/
-[Writing Helpers]: ../../templates/writing-helpers/

--- a/guides/v3.0.0/testing/testing-models.md
+++ b/guides/v3.0.0/testing/testing-models.md
@@ -1,7 +1,7 @@
 _Container testing methods and computed properties follows previous patterns shown
-in [Testing Basics][] because DS.Model extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because DS.Model extends Ember.Object._
 
-[Ember Data][] Models can be tested in a module that uses the `setupTest` helper.
+[Ember Data](https://github.com/emberjs/data) Models can be tested in a module that uses the `setupTest` helper.
 
 Let's assume we have a `Player` model that has `level` and `levelName`
 attributes. We want to call `levelUp()` to increment the `level` and assign a
@@ -102,9 +102,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests][] for examples of deeper relationship testing if you
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
 feel the need to do it._
-
-[Ember Data]: https://github.com/emberjs/data
-[Testing Basics]: ../unit-testing-basics/
-[Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v3.0.0/testing/testing-routes.md
+++ b/guides/v3.0.0/testing/testing-routes.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follows previous patterns shown
-in [Testing Basics][] because Ember.Route extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Route extends Ember.Object._
 
 Testing routes can be done both via application tests or container tests. Application tests
 will likely provide better coverage for routes because routes are typically used
@@ -34,7 +34,7 @@ export default Route.extend({
 });
 ```
 
-In this route we've [separated our concerns][]:
+In this route we've [separated our concerns](http://en.wikipedia.org/wiki/Separation_of_concerns):
 The action `displayAlert` contains the code that is called when the action is
 received, and the private function `_displayAlert` performs the work. While not
 necessarily obvious here because of the small size of the functions, separating
@@ -86,6 +86,3 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/
-[separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v3.1.0/components/the-component-lifecycle.md
+++ b/guides/v3.1.0/components/the-component-lifecycle.md
@@ -117,17 +117,17 @@ Suppose you want to integrate your favorite date picker library into an Ember pr
 Typically, 3rd party JS/jQuery libraries require a DOM element to bind to.
 So, where is the best place to initialize and attach the library?
 
-After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`][did-insert-element] hook.
+After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) hook.
 
 Ember guarantees that, by the time `didInsertElement()` is called:
 
 1. The component's element has been both created and inserted into the
    DOM.
 2. The component's element is accessible via the component's
-   [`$()`][dollar]
+   [`$()`](https://www.emberjs.com/api/ember/release/classes/Component/methods/$?anchor=%24)
    method.
 
-A component's [`$()`][dollar] method allows you to access the component's DOM element by returning a jQuery element.
+A component's [`$()`](https://www.emberjs.com/api/ember/release/classes/Component/methods/$?anchor=%24) method allows you to access the component's DOM element by returning a jQuery element.
 For example, you can set an attribute using jQuery's `attr()` method:
 
 ```javascript {data-filename=app/components/profile-editor.js}
@@ -141,7 +141,7 @@ export default Component.extend({
 });
 ```
 
-[`$()`][dollar] will, by default, return a jQuery object for the component's root element, but you can also target child elements within the component's template by passing a selector:
+[`$()`](https://www.emberjs.com/api/ember/release/classes/Component/methods/$?anchor=%24) will, by default, return a jQuery object for the component's root element, but you can also target child elements within the component's template by passing a selector:
 
 ```javascript {data-filename=app/components/profile-editor.js}
 import Component from '@ember/component';
@@ -154,7 +154,7 @@ export default Component.extend({
 });
 ```
 
-Let's initialize our date picker by overriding the [`didInsertElement()`][did-insert-element] method.
+Let's initialize our date picker by overriding the [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) method.
 
 Date picker libraries usually attach to an `<input>` element, so we will use jQuery to find an appropriate input within our component's template.
 
@@ -169,7 +169,7 @@ export default Component.extend({
 });
 ```
 
-[`didInsertElement()`][did-insert-element] is also a good place to
+[`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is also a good place to
 attach event listeners. This is particularly useful for custom events or
 other browser events which do not have a [built-in event
 handler](./handling-events/#toc_event-names).
@@ -194,13 +194,10 @@ There are a few things to note about the `didInsertElement()` hook:
 
 - It is only triggered once when the component element is first rendered.
 - In cases where you have components nested inside other components, the child component will always receive the `didInsertElement()` call before its parent does.
-- Setting properties on the component in [`didInsertElement()`][did-insert-element] triggers a re-render, and for performance reasons,
+- Setting properties on the component in [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons,
   is not allowed.
-- While [`didInsertElement()`][did-insert-element] is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
+- While [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
   particularly when order of execution is important.
-
-[did-insert-element]: https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement
-[dollar]: https://www.emberjs.com/api/ember/release/classes/Component/methods/$?anchor=%24
 
 ### Making Updates to the Rendered DOM with `didRender`
 

--- a/guides/v3.1.0/ember-inspector/data.md
+++ b/guides/v3.1.0/ember-inspector/data.md
@@ -1,5 +1,4 @@
-You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter][building-data-adapter] below if you maintain your own persistence library. 
-[building-data-adapter]:#toc_building-a-data-custom-adapter
+You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter](#toc_building-a-data-custom-adapter) below if you maintain your own persistence library. 
 
 When you open the Data tab, you will see a list of model types defined
 in your application, along with the number of loaded records.
@@ -32,8 +31,5 @@ You can also filter records by entering a query in the search box.
 
 ### Building a Data Custom Adapter
 
-You can use your own data persistence library with the Inspector. Build a [data adapter][data-adapter-docs], and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter][ember-data-data-adapter] as an example for how to build your data adapter.
-
-[data-adapter-docs]: https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js
-[ember-data-data-adapter]:https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js
+You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
+using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter.

--- a/guides/v3.1.0/ember-inspector/info.md
+++ b/guides/v3.1.0/ember-inspector/info.md
@@ -12,6 +12,4 @@ Ember.libraries.register(libraryName, libraryVersion);
 
 #### Ember CLI
 
-If you're using the [ember-cli-app-version][] addon, your application's name and version will be added to the list automatically.
-
-[ember-cli-app-version]: https://github.com/embersherpa/ember-cli-app-version
+If you're using the [ember-cli-app-version](https://github.com/embersherpa/ember-cli-app-version) addon, your application's name and version will be added to the list automatically.

--- a/guides/v3.1.0/ember-inspector/installation.md
+++ b/guides/v3.1.0/ember-inspector/installation.md
@@ -37,7 +37,7 @@ Make sure the "Display the Tomster" checkbox is checked.
 ### Firefox
 
 Visit the Add-on page on the [Mozilla Addons
-site][ember-inspector-mozilla].
+site](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/).
 
 Click on "Add to Firefox".
 
@@ -47,9 +47,6 @@ Once installed, go to an Ember application, open the Developer Tools,
 and click on the `Ember` tab.
 
 <img src="/images/guides/ember-inspector/installation-firefox-panel.png" width="680">
-
-[ember-inspector-mozilla]: https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/
-
 
 #### Enable Tomster
 

--- a/guides/v3.1.0/ember-inspector/object-inspector.md
+++ b/guides/v3.1.0/ember-inspector/object-inspector.md
@@ -15,9 +15,7 @@ The Inspector displays the parent objects and mixins that are composed into the 
 Each property value in this view is bound to your application, so if the value of a
 property updates in your app, it will be reflected in the Inspector.
 
-If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
-click on the calculator to compute it.
-[computed-property]: ../../object-model/computed-properties/
+If a property name is preceded by a calculator icon, that means it is a [computed property](../../object-model/computed-properties/). If the value of a computed property hasn't yet been computed, you can click on the calculator to compute it.
 
 ### Exposing Objects to the Console
 
@@ -91,7 +89,4 @@ width="450">
 Library authors can customize how any object will display in the Inspector.
 By defining a `_debugInfo` method, an object can tell the Inspector how it should be rendered.
 For an example on how to customize an object's properties, see [Ember Data's
-customization][ember-data-debug-info].
-
-
-[ember-data-debug-info]: https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js
+customization](https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js).

--- a/guides/v3.1.0/index.md
+++ b/guides/v3.1.0/index.md
@@ -40,13 +40,13 @@ We will try to link to appropriate documentation whenever a concept is introduce
 
 To make the most out of the guides, you should have a working knowledge of:
 
-* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network][mdn].
-* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network][promises] section.
-* **ES2015 modules** - you will better understand [Ember CLI's][ember-cli] project structure and import paths if you are comfortable with [JavaScript Modules][js-modules].
+* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web).
+* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) section.
+* **ES2015 modules** - you will better understand [Ember CLI's](https://ember-cli.com/) project structure and import paths if you are comfortable with [JavaScript Modules](http://jsmodules.io/).
 * **ES2015 syntax** - Ember CLI comes with Babel.js by default so you can
 take advantage of newer language features such as arrow functions, template
 strings, destructuring, and more. You can check the
-[Babel.js documentation][babeljs] or read [Understanding ECMAScript 6][es6]
+[Babel.js documentation](https://babeljs.io/docs/learn-es2015/) or read [Understanding ECMAScript 6](https://leanpub.com/understandinges6/read)
 online.
 
 ## A Note on Mobile Performance
@@ -85,7 +85,7 @@ the existing guides, we are happy to help you help us!
 Some of the more common ways to report a problem with the guides are:
 
 * Using the pencil icon on the top-right of each guide page
-* Opening an issue or pull request to [the GitHub repository][gh-guides]
+* Opening an issue or pull request to [the GitHub repository](https://github.com/ember-learn/guides-source/)
 
 Clicking the pencil icon will bring you to GitHub's editor for that
 guide so you can edit right away, using the Markdown markup language.
@@ -93,25 +93,11 @@ This is the fastest way to correct a typo, a missing word, or an error in
 a code sample.
 
 If you wish to make a more significant contribution be sure to check our
-[issue tracker][gh-guides-issues] to see if your issue is already being
+[issue tracker](https://github.com/ember-learn/guides-source/issues) to see if your issue is already being
 addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
-can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
+can check out our [contributing guide](https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md). If your
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord](https://discordapp.com/invite/zT3asNS).
 
 Good luck!
-
-[ember-cli]: https://ember-cli.com/
-
-[mdn]: https://developer.mozilla.org/en-US/docs/Web
-[promises]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-[js-modules]: http://jsmodules.io/
-[babeljs]: https://babeljs.io/docs/learn-es2015/
-[es6]: https://leanpub.com/understandinges6/read
-
-[gh-guides]: https://github.com/ember-learn/guides-source/
-[gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
-[gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
-
-[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v3.1.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.1.0/models/creating-updating-and-deleting-records.md
@@ -163,6 +163,4 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 });
 ```
 
-The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`][findRecord] automatically schedules a fetch of the record from the adapter.
-
-[findRecord]: <https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord>
+The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord) automatically schedules a fetch of the record from the adapter.

--- a/guides/v3.1.0/models/index.md
+++ b/guides/v3.1.0/models/index.md
@@ -17,10 +17,8 @@ Typically, most models are loaded from and saved to a server that uses a
 database to store data. Usually you will send JSON representations of
 models back and forth to an HTTP server that you have written. However,
 Ember makes it easy to use other durable storage, such as saving to the
-user's hard disk with [IndexedDB][indexeddb], or hosted storage solutions that let you
+user's hard disk with [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API), or hosted storage solutions that let you
 avoid writing and hosting your own servers.
-
-[indexeddb]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 
 Once you've loaded your models from storage, components know how to
 translate model data into a UI that your user can interact with.  For
@@ -35,10 +33,8 @@ create new models in the browser.
 
 Thanks to its use of the _adapter pattern_, Ember Data can be configured
 to work with many different kinds of backends. There is [an entire
-ecosystem of adapters][adapters] that allow your Ember app to talk to different
+ecosystem of adapters](http://emberobserver.com/categories/ember-data-adapters) that allow your Ember app to talk to different
 types of servers without you writing any networking code.
-
-[adapters]: http://emberobserver.com/categories/ember-data-adapters
 
 If you need to integrate your Ember.js app with a server that does not
 have an adapter available (for example, you hand-rolled an API server
@@ -157,11 +153,9 @@ will be shared among developers on your team, following them leads
 to code that is easier to maintain and understand.
 
 Rather than creating an arbitrary set of conventions, Ember Data is
-designed to work out of the box with [JSON API][json-api]. JSON API is a
+designed to work out of the box with [JSON API](http://jsonapi.org). JSON API is a
 formal specification for building conventional, robust, and performant
 APIs that allow clients and servers to communicate model data.
-
-[json-api]: http://jsonapi.org
 
 JSON API standardizes how JavaScript applications talk to servers, so
 you decrease the coupling between your frontend and backend, and have

--- a/guides/v3.1.0/object-model/classes-and-instances.md
+++ b/guides/v3.1.0/object-model/classes-and-instances.md
@@ -4,11 +4,8 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`][1] method on
-[`EmberObject`][2]:
-
-[1]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend
-[2]: https://www.emberjs.com/api/ember/release/modules/@ember%2Fobject
+To define a new Ember _class_, call the [`extend()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://www.emberjs.com/api/ember/2.16/modules/@ember%2Fobject):
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -24,9 +21,8 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`][3] class:
+of Ember's built-in [`Component`](https://www.emberjs.com/api/ember/2.16/classes/Component) class:
 
-[3]: https://www.emberjs.com/api/ember/release/classes/Component
 
 ```javascript {data-filename=app/components/todo-item.js}
 import Component from '@ember/component';
@@ -71,11 +67,9 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`][4] hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
-
-[4]: https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse
 
 ```javascript
 normalizeResponse(store, primaryModelClass, payload, id, requestType)  {
@@ -89,11 +83,9 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`][5] method. Any methods, properties and
+class by calling its [`create()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
-
-[5]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/create?anchor=create
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -141,11 +133,9 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`][6] method is invoked
+When a new instance is created, its [`init()`](https://www.emberjs.com/api/ember/2.16/classes/EmberObject/methods/init?anchor=init) method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
-
-[6]: https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -226,11 +216,9 @@ Person.create({
 
 ### Accessing Object Properties
 
-When accessing the properties of an object, use the [`get()`][7]
-and [`set()`][8] accessor methods:
+When accessing the properties of an object, use the [`get()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/get?anchor=get)
+and [`set()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/set?anchor=set) accessor methods:
 
-[7]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/get?anchor=get
-[8]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/set?anchor=set
 
 ```javascript
 import EmberObject from '@ember/object';

--- a/guides/v3.1.0/templates/writing-helpers.md
+++ b/guides/v3.1.0/templates/writing-helpers.md
@@ -7,9 +7,7 @@ For example, imagine we have an `Invoice` model that contains a
 `totalDue` attribute, which represents the total amount due for that
 invoice.  Because we do not want our company to go out of business due
 to strange JavaScript rounding errors, [we store this value in cents
-instead of a floating point dollar value][currency-stackoverflow].
-
-[currency-stackoverflow]: http://stackoverflow.com/a/3730040
+instead of a floating point dollar value](http://stackoverflow.com/a/3730040).
 
 However, if we display dollar values to our users as "100¢" instead of
 "$1.00", they may be very confused. We can write a helper to
@@ -249,9 +247,9 @@ access to services in your application, and can optionally save state as well,
 although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
-should export a subclass of [`Ember.Helper`][1]. Helper classes must contain a
-[`compute`][2] method that behaves the same as the function passed to
-[`Ember.Helper.helper`][3].  In order to access a service, you must first inject it
+should export a subclass of [`Ember.Helper`](https://www.emberjs.com/api/ember/release/classes/Helper). Helper classes must contain a
+[`compute`](https://www.emberjs.com/api/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`Ember.Helper.helper`](https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -332,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`][4] string utility:
+[`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -346,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`][4]), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently
@@ -394,7 +392,3 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
-[1]: https://www.emberjs.com/api/ember/release/classes/Helper
-[2]: https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=compute
-[3]: https://emberjs.com/api/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper
-[4]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe

--- a/guides/v3.1.0/testing/acceptance.md
+++ b/guides/v3.1.0/testing/acceptance.md
@@ -83,20 +83,20 @@ your application, making it much easier to write deterministic tests.
 
 Some of these handy helpers are:
 
-* [`click(selector)`][1]
+* [`click(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click)
   - Clicks an element and triggers any actions triggered by the element's `click`
     event and returns a promise that fulfills when all resulting async behavior
     is complete.
-* [`fillIn(selector, value)`][2]
+* [`fillIn(selector, value)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin)
   - Fills in the selected input with the given value and returns a promise that
      fulfills when all resulting async behavior is complete. Works with `<select>` elements as well as `<input>` elements. Keep in mind that with `<select>` elements, `value` must be set to the _value_ of the `<option>` tag, rather than its _content_ (for example, `true` rather than `"Yes"`).
-* [`triggerKeyEvent(selector, type, keyCode)`][3]
+* [`triggerKeyEvent(selector, type, keyCode)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md)
   - Simulates a key event type, e.g. `keypress`, `keydown`, `keyup` with the
     desired keyCode on element found by the selector.
-* [`triggerEvent(selector, type, options)`][4]
+* [`triggerEvent(selector, type, options)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent)
   - Triggers the given event, e.g. `blur`, `dblclick` on the element identified
     by the provided selector.
-* [`visit(url)`][5]
+* [`visit(url)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit)
   - Visits the given route and returns a promise that fulfills when all resulting
      async behavior is complete.
 
@@ -130,27 +130,14 @@ previous steps in the test have completed.
 
 Synchronous helpers are performed immediately when triggered.
 
-* [`currentRouteName()`][6]
+* [`currentRouteName()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename)
   - Returns the currently active route name.
-* [`currentURL()`][7]
+* [`currentURL()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl)
   - Returns the current URL.
-* [`find(selector, context)`][8]
+* [`find(selector, context)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find)
   - Finds an element within the app's root element and within the context
     (optional). Scoping to the root element is especially useful to avoid
     conflicts with the test framework's reporter, and this is done by default
     if the context is not specified.
-* [`findAll(selector)`][9]
-  - Find all elements matched by the given selector. Equivalent to calling
-    querySelectorAll() on the test root element.  Returns an array of matched
-    elements.
-
-
-[1]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click
-[2]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin
-[3]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md
-[4]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent
-[5]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit
-[6]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename
-[7]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl
-[8]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find
-[9]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall
+* [`findAll(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall)
+  - Find all elements matched by the given selector. Equivalent to calling querySelectorAll() on the test root element.  Returns an array of matched elements.

--- a/guides/v3.1.0/testing/index.md
+++ b/guides/v3.1.0/testing/index.md
@@ -1,6 +1,6 @@
 Testing is a core part of the Ember framework and its development cycle.
 
-[QUnit][] is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
+[QUnit](http://qunitjs.com/) is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
 
 The testing pattern presented below is consistent across different testing frameworks. Only the setup test functions from [ember-qunit](https://github.com/emberjs/ember-qunit) needs to be replaced with the respective setup functions in the testing addon used in order to use other testing frameworks.
 
@@ -68,7 +68,7 @@ Examples of Container Tests are:
 * A serializer properly converts the blog request payload into a blog post model object.
 * Blog dates are properly formatted through a `time` service.
 
-You can read more about these type of tests in the [Testing Routes][] and [Testing Controllers][] section.
+You can read more about these type of tests in the [Testing Routes](./testing-routes) and [Testing Controllers](./testing-controllers) section.
 
 ### Rendering Tests
 
@@ -112,7 +112,7 @@ Examples of Rendering Tests are:
 
 Rendering Tests are used to test Components and Helpers where we need to render a layout and assert some interaction byproduct occurs.
 
-You can read more about it in the [Testing Components][] or the [Testing Helpers][] section.
+You can read more about it in the [Testing Components](./testing-components) or the [Testing Helpers](./testing-helpers) section.
 
 ### Application Tests
 
@@ -148,7 +148,7 @@ Examples of Application Tests are:
 * After saving a new post successfully, a user is then shown the list of prior posts.
 * A visitor does not have access to the admin panel.
 
-You can read more about how to create these kinds of tests in the [Application tests][] section.
+You can read more about how to create these kinds of tests in the [Application tests](./acceptance) section.
 
 ### Testing Blueprints
 
@@ -189,7 +189,7 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 Tests can also be executed when you are running a local development server (started by running `ember server`),
 at the `/tests` URI which renders the `tests/index.html` template.
 
-These commands run your tests using [Testem][] to make testing multiple browsers very easy.
+These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy.
 You can configure Testem using the `testem.js` file in your application root.
 
 #### Choosing the Tests to Run
@@ -200,11 +200,3 @@ When using QUnit it is possible to exclude tests by adding an exclamation point 
 
 You can also run a group of tests which you have scoped with a `module` before; e.g. for testing the module called `Unit | Service | location` only,
 run `ember test --module='Unit | Service | location'`.
-
-[QUnit]: http://qunitjs.com/
-[Testem]: https://github.com/airportyh/testem
-[Application tests]: ./acceptance
-[Testing Components]: ./testing-components
-[Testing Controllers]: ./testing-controllers
-[Testing Routes]: ./testing-routes
-[Testing Helpers]: ./testing-helpers

--- a/guides/v3.1.0/testing/testing-controllers.md
+++ b/guides/v3.1.0/testing/testing-controllers.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Controller extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Controller extends Ember.Object._
 
 Controllers can be tested using the `setupTest` helper which is part
 of the ember-qunit framework. The tests written for instances like `Ember.Controller` are
@@ -79,5 +79,3 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/

--- a/guides/v3.1.0/testing/testing-helpers.md
+++ b/guides/v3.1.0/testing/testing-helpers.md
@@ -1,4 +1,4 @@
-_Testing helpers follows previous patterns shown in [Testing Components][],
+_Testing helpers follows previous patterns shown in [Testing Components](../testing-components/),
 because helpers are rendered to templates just like components._
 
 Helpers are best tested with rendering tests, but can also be tested with unit
@@ -6,7 +6,7 @@ tests. Rendering tests will provide better coverage for helpers, as it more
 closely simulates the lifecycle of a helper than in isolation.
 
 We're going to demonstrate how to test helpers by testing the `format-currency`
-helper from [Writing Helpers][].
+helper from [Writing Helpers](../../templates/writing-helpers/).
 
 > You can follow along by generating your own helper with `ember generate helper
 > format-currency`.
@@ -42,12 +42,12 @@ module('Unit | Helper | format currency', function(hooks) {
 });
 ```
 
-As seen in the [Writing Helpers][] guide. The helper function expects the unnamed
+As seen in the [Writing Helpers](../../templates/writing-helpers/) guide. The helper function expects the unnamed
 arguments as an array as the first argument. It expects the named arguments as
 an object as the second argument.
 
 Now we can move on to a more complex test case that ensures our helper is rendered correctly as well. This can be done
-with the `setupRenderingTest` helper, as shown in [Testing Components][].
+with the `setupRenderingTest` helper, as shown in [Testing Components](../testing-components/).
 
 ```javascript {data-filename=tests/integration/helpers/format-currency-test.js}
 import { module, test } from 'qunit';
@@ -94,6 +94,3 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
-
-[Testing Components]: ../testing-components/
-[Writing Helpers]: ../../templates/writing-helpers/

--- a/guides/v3.1.0/testing/testing-models.md
+++ b/guides/v3.1.0/testing/testing-models.md
@@ -1,7 +1,7 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because DS.Model extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because DS.Model extends Ember.Object._
 
-[Ember Data][] Models can be tested in a module that uses the `setupTest` helper.
+[Ember Data](https://github.com/emberjs/data) Models can be tested in a module that uses the `setupTest` helper.
 
 Let's assume we have a `Player` model that has `level` and `levelName`
 attributes. We want to call `levelUp()` to increment the `level` and assign a
@@ -104,9 +104,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests][] for examples of deeper relationship testing if you
-feel the need to do it._
-
-[Ember Data]: https://github.com/emberjs/data
-[Testing Basics]: ../unit-testing-basics/
-[Ember Data tests]: https://github.com/emberjs/data/tree/master/tests
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
+feel the need to do it.

--- a/guides/v3.1.0/testing/testing-routes.md
+++ b/guides/v3.1.0/testing/testing-routes.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Route extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Route extends Ember.Object._
 
 Testing routes can be done both via application tests or container tests. Application tests
 will likely provide better coverage for routes because routes are typically used
@@ -34,7 +34,7 @@ export default Route.extend({
 });
 ```
 
-In this route we've [separated our concerns][]:
+In this route we've [separated our concerns](http://en.wikipedia.org/wiki/Separation_of_concerns):
 The action `displayAlert` contains the code that is called when the action is
 received, and the private function `_displayAlert` performs the work. While not
 necessarily obvious here because of the small size of the functions, separating
@@ -86,6 +86,3 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/
-[separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v3.2.0/components/the-component-lifecycle.md
+++ b/guides/v3.2.0/components/the-component-lifecycle.md
@@ -117,17 +117,17 @@ Suppose you want to integrate your favorite date picker library into an Ember pr
 Typically, 3rd party JS/jQuery libraries require a DOM element to bind to.
 So, where is the best place to initialize and attach the library?
 
-After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`][did-insert-element] hook.
+After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) hook.
 
 Ember guarantees that, by the time `didInsertElement()` is called:
 
 1. The component's element has been both created and inserted into the
    DOM.
 2. The component's element is accessible via the component's
-   [`$()`][dollar]
+   [`$()`](https://www.emberjs.com/api/ember/release/classes/Component/methods/$?anchor=%24)
    method.
 
-A component's [`$()`][dollar] method allows you to access the component's DOM element by returning a jQuery element.
+A component's [`$()`](https://www.emberjs.com/api/ember/release/classes/Component/methods/$?anchor=%24) method allows you to access the component's DOM element by returning a jQuery element.
 For example, you can set an attribute using jQuery's `attr()` method:
 
 ```javascript {data-filename=app/components/profile-editor.js}
@@ -141,7 +141,7 @@ export default Component.extend({
 });
 ```
 
-[`$()`][dollar] will, by default, return a jQuery object for the component's root element, but you can also target child elements within the component's template by passing a selector:
+[`$()`](https://www.emberjs.com/api/ember/release/classes/Component/methods/$?anchor=%24) will, by default, return a jQuery object for the component's root element, but you can also target child elements within the component's template by passing a selector:
 
 ```javascript {data-filename=app/components/profile-editor.js}
 import Component from '@ember/component';
@@ -154,7 +154,7 @@ export default Component.extend({
 });
 ```
 
-Let's initialize our date picker by overriding the [`didInsertElement()`][did-insert-element] method.
+Let's initialize our date picker by overriding the [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) method.
 
 Date picker libraries usually attach to an `<input>` element, so we will use jQuery to find an appropriate input within our component's template.
 
@@ -169,7 +169,7 @@ export default Component.extend({
 });
 ```
 
-[`didInsertElement()`][did-insert-element] is also a good place to
+[`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is also a good place to
 attach event listeners. This is particularly useful for custom events or
 other browser events which do not have a [built-in event
 handler](./handling-events/#toc_event-names).
@@ -194,13 +194,10 @@ There are a few things to note about the `didInsertElement()` hook:
 
 - It is only triggered once when the component element is first rendered.
 - In cases where you have components nested inside other components, the child component will always receive the `didInsertElement()` call before its parent does.
-- Setting properties on the component in [`didInsertElement()`][did-insert-element] triggers a re-render, and for performance reasons,
+- Setting properties on the component in [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons,
   is not allowed.
-- While [`didInsertElement()`][did-insert-element] is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
+- While [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
   particularly when order of execution is important.
-
-[did-insert-element]: https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement
-[dollar]: https://www.emberjs.com/api/ember/release/classes/Component/methods/$?anchor=%24
 
 ### Making Updates to the Rendered DOM with `didRender`
 

--- a/guides/v3.2.0/ember-inspector/data.md
+++ b/guides/v3.2.0/ember-inspector/data.md
@@ -1,5 +1,4 @@
-You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter][building-data-adapter] below if you maintain your own persistence library. 
-[building-data-adapter]:#toc_building-a-data-custom-adapter
+You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter](#toc_building-a-data-custom-adapter) below if you maintain your own persistence library. 
 
 When you open the Data tab, you will see a list of model types defined
 in your application, along with the number of loaded records.
@@ -32,8 +31,5 @@ You can also filter records by entering a query in the search box.
 
 ### Building a Data Custom Adapter
 
-You can use your own data persistence library with the Inspector. Build a [data adapter][data-adapter-docs], and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter][ember-data-data-adapter] as an example for how to build your data adapter.
-
-[data-adapter-docs]: https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js
-[ember-data-data-adapter]:https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js
+You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
+using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter.

--- a/guides/v3.2.0/ember-inspector/info.md
+++ b/guides/v3.2.0/ember-inspector/info.md
@@ -12,6 +12,4 @@ Ember.libraries.register(libraryName, libraryVersion);
 
 #### Ember CLI
 
-If you're using the [ember-cli-app-version][] addon, your application's name and version will be added to the list automatically.
-
-[ember-cli-app-version]: https://github.com/embersherpa/ember-cli-app-version
+If you're using the [ember-cli-app-version](https://github.com/embersherpa/ember-cli-app-version) addon, your application's name and version will be added to the list automatically.

--- a/guides/v3.2.0/ember-inspector/installation.md
+++ b/guides/v3.2.0/ember-inspector/installation.md
@@ -37,7 +37,7 @@ Make sure the "Display the Tomster" checkbox is checked.
 ### Firefox
 
 Visit the Add-on page on the [Mozilla Addons
-site][ember-inspector-mozilla].
+site](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/).
 
 Click on "Add to Firefox".
 
@@ -47,9 +47,6 @@ Once installed, go to an Ember application, open the Developer Tools,
 and click on the `Ember` tab.
 
 <img src="/images/guides/ember-inspector/installation-firefox-panel.png" width="680">
-
-[ember-inspector-mozilla]: https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/
-
 
 #### Enable Tomster
 

--- a/guides/v3.2.0/ember-inspector/object-inspector.md
+++ b/guides/v3.2.0/ember-inspector/object-inspector.md
@@ -15,9 +15,7 @@ The Inspector displays the parent objects and mixins that are composed into the 
 Each property value in this view is bound to your application, so if the value of a
 property updates in your app, it will be reflected in the Inspector.
 
-If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
-click on the calculator to compute it.
-[computed-property]: ../../object-model/computed-properties/
+If a property name is preceded by a calculator icon, that means it is a [computed property](../../object-model/computed-properties/). If the value of a computed property hasn't yet been computed, you can click on the calculator to compute it.
 
 ### Exposing Objects to the Console
 
@@ -91,7 +89,4 @@ width="450">
 Library authors can customize how any object will display in the Inspector.
 By defining a `_debugInfo` method, an object can tell the Inspector how it should be rendered.
 For an example on how to customize an object's properties, see [Ember Data's
-customization][ember-data-debug-info].
-
-
-[ember-data-debug-info]: https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js
+customization](https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js).

--- a/guides/v3.2.0/index.md
+++ b/guides/v3.2.0/index.md
@@ -40,13 +40,13 @@ We will try to link to appropriate documentation whenever a concept is introduce
 
 To make the most out of the guides, you should have a working knowledge of:
 
-* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network][mdn].
-* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network][promises] section.
-* **ES2015 modules** - you will better understand [Ember CLI's][ember-cli] project structure and import paths if you are comfortable with [JavaScript Modules][js-modules].
+* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web).
+* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) section.
+* **ES2015 modules** - you will better understand [Ember CLI's](https://ember-cli.com/) project structure and import paths if you are comfortable with [JavaScript Modules](http://jsmodules.io/).
 * **ES2015 syntax** - Ember CLI comes with Babel.js by default so you can
 take advantage of newer language features such as arrow functions, template
 strings, destructuring, and more. You can check the
-[Babel.js documentation][babeljs] or read [Understanding ECMAScript 6][es6]
+[Babel.js documentation](https://babeljs.io/docs/learn-es2015/) or read [Understanding ECMAScript 6](https://leanpub.com/understandinges6/read)
 online.
 
 ## A Note on Mobile Performance
@@ -85,7 +85,7 @@ the existing guides, we are happy to help you help us!
 Some of the more common ways to report a problem with the guides are:
 
 * Using the pencil icon on the top-right of each guide page
-* Opening an issue or pull request to [the GitHub repository][gh-guides]
+* Opening an issue or pull request to [the GitHub repository](https://github.com/ember-learn/guides-source/)
 
 Clicking the pencil icon will bring you to GitHub's editor for that
 guide so you can edit right away, using the Markdown markup language.
@@ -93,25 +93,11 @@ This is the fastest way to correct a typo, a missing word, or an error in
 a code sample.
 
 If you wish to make a more significant contribution be sure to check our
-[issue tracker][gh-guides-issues] to see if your issue is already being
+[issue tracker](https://github.com/ember-learn/guides-source/issues) to see if your issue is already being
 addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
-can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
+can check out our [contributing guide](https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md). If your
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord](https://discordapp.com/invite/zT3asNS).
 
 Good luck!
-
-[ember-cli]: https://ember-cli.com/
-
-[mdn]: https://developer.mozilla.org/en-US/docs/Web
-[promises]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-[js-modules]: http://jsmodules.io/
-[babeljs]: https://babeljs.io/docs/learn-es2015/
-[es6]: https://leanpub.com/understandinges6/read
-
-[gh-guides]: https://github.com/ember-learn/guides-source/
-[gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
-[gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
-
-[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v3.2.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.2.0/models/creating-updating-and-deleting-records.md
@@ -163,6 +163,4 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 });
 ```
 
-The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`][findRecord] automatically schedules a fetch of the record from the adapter.
-
-[findRecord]: <https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord>
+The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord) automatically schedules a fetch of the record from the adapter.

--- a/guides/v3.2.0/models/index.md
+++ b/guides/v3.2.0/models/index.md
@@ -17,10 +17,8 @@ Typically, most models are loaded from and saved to a server that uses a
 database to store data. Usually you will send JSON representations of
 models back and forth to an HTTP server that you have written. However,
 Ember makes it easy to use other durable storage, such as saving to the
-user's hard disk with [IndexedDB][indexeddb], or hosted storage solutions that let you
+user's hard disk with [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API), or hosted storage solutions that let you
 avoid writing and hosting your own servers.
-
-[indexeddb]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 
 Once you've loaded your models from storage, components know how to
 translate model data into a UI that your user can interact with.  For
@@ -35,10 +33,8 @@ create new models in the browser.
 
 Thanks to its use of the _adapter pattern_, Ember Data can be configured
 to work with many different kinds of backends. There is [an entire
-ecosystem of adapters][adapters] that allow your Ember app to talk to different
+ecosystem of adapters](http://emberobserver.com/categories/ember-data-adapters) that allow your Ember app to talk to different
 types of servers without you writing any networking code.
-
-[adapters]: http://emberobserver.com/categories/ember-data-adapters
 
 If you need to integrate your Ember.js app with a server that does not
 have an adapter available (for example, you hand-rolled an API server
@@ -157,11 +153,9 @@ will be shared among developers on your team, following them leads
 to code that is easier to maintain and understand.
 
 Rather than creating an arbitrary set of conventions, Ember Data is
-designed to work out of the box with [JSON API][json-api]. JSON API is a
+designed to work out of the box with [JSON API](http://jsonapi.org). JSON API is a
 formal specification for building conventional, robust, and performant
 APIs that allow clients and servers to communicate model data.
-
-[json-api]: http://jsonapi.org
 
 JSON API standardizes how JavaScript applications talk to servers, so
 you decrease the coupling between your frontend and backend, and have

--- a/guides/v3.2.0/object-model/classes-and-instances.md
+++ b/guides/v3.2.0/object-model/classes-and-instances.md
@@ -4,11 +4,8 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`][1] method on
-[`EmberObject`][2]:
-
-[1]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend
-[2]: https://www.emberjs.com/api/ember/release/modules/@ember%2Fobject
+To define a new Ember _class_, call the [`extend()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://www.emberjs.com/api/ember/2.16/modules/@ember%2Fobject):
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -24,9 +21,8 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`][3] class:
+of Ember's built-in [`Component`](https://www.emberjs.com/api/ember/2.16/classes/Component) class:
 
-[3]: https://www.emberjs.com/api/ember/release/classes/Component
 
 ```javascript {data-filename=app/components/todo-item.js}
 import Component from '@ember/component';
@@ -71,11 +67,9 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`][4] hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`](https://www.emberjs.com/api/ember-data/2.16/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
-
-[4]: https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse
 
 ```javascript
 normalizeResponse(store, primaryModelClass, payload, id, requestType)  {
@@ -89,11 +83,9 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`][5] method. Any methods, properties and
+class by calling its [`create()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
-
-[5]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/create?anchor=create
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -141,11 +133,9 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`][6] method is invoked
+When a new instance is created, its [`init()`](https://www.emberjs.com/api/ember/2.16/classes/EmberObject/methods/init?anchor=init) method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
-
-[6]: https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -226,11 +216,9 @@ Person.create({
 
 ### Accessing Object Properties
 
-When accessing the properties of an object, use the [`get()`][7]
-and [`set()`][8] accessor methods:
+When accessing the properties of an object, use the [`get()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/get?anchor=get)
+and [`set()`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fobject/methods/set?anchor=set) accessor methods:
 
-[7]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/get?anchor=get
-[8]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/set?anchor=set
 
 ```javascript
 import EmberObject from '@ember/object';

--- a/guides/v3.2.0/templates/writing-helpers.md
+++ b/guides/v3.2.0/templates/writing-helpers.md
@@ -7,9 +7,7 @@ For example, imagine we have an `Invoice` model that contains a
 `totalDue` attribute, which represents the total amount due for that
 invoice.  Because we do not want our company to go out of business due
 to strange JavaScript rounding errors, [we store this value in cents
-instead of a floating point dollar value][currency-stackoverflow].
-
-[currency-stackoverflow]: http://stackoverflow.com/a/3730040
+instead of a floating point dollar value](http://stackoverflow.com/a/3730040).
 
 However, if we display dollar values to our users as "100¢" instead of
 "$1.00", they may be very confused. We can write a helper to
@@ -249,9 +247,9 @@ access to services in your application, and can optionally save state as well,
 although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
-should export a subclass of [`Ember.Helper`][1]. Helper classes must contain a
-[`compute`][2] method that behaves the same as the function passed to
-[`Ember.Helper.helper`][3].  In order to access a service, you must first inject it
+should export a subclass of [`Ember.Helper`](https://www.emberjs.com/api/ember/release/classes/Helper). Helper classes must contain a
+[`compute`](https://www.emberjs.com/api/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`Ember.Helper.helper`](https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -332,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`][4] string utility:
+[`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -346,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`][4]), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently
@@ -394,7 +392,3 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
-[1]: https://www.emberjs.com/api/ember/release/classes/Helper
-[2]: https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=compute
-[3]: https://emberjs.com/api/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper
-[4]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe

--- a/guides/v3.2.0/testing/acceptance.md
+++ b/guides/v3.2.0/testing/acceptance.md
@@ -83,20 +83,20 @@ your application, making it much easier to write deterministic tests.
 
 Some of these handy helpers are:
 
-* [`click(selector)`][1]
+* [`click(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click)
   - Clicks an element and triggers any actions triggered by the element's `click`
     event and returns a promise that fulfills when all resulting async behavior
     is complete.
-* [`fillIn(selector, value)`][2]
+* [`fillIn(selector, value)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin)
   - Fills in the selected input with the given value and returns a promise that
      fulfills when all resulting async behavior is complete. Works with `<select>` elements as well as `<input>` elements. Keep in mind that with `<select>` elements, `value` must be set to the _value_ of the `<option>` tag, rather than its _content_ (for example, `true` rather than `"Yes"`).
-* [`triggerKeyEvent(selector, type, keyCode)`][3]
+* [`triggerKeyEvent(selector, type, keyCode)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md)
   - Simulates a key event type, e.g. `keypress`, `keydown`, `keyup` with the
     desired keyCode on element found by the selector.
-* [`triggerEvent(selector, type, options)`][4]
+* [`triggerEvent(selector, type, options)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent)
   - Triggers the given event, e.g. `blur`, `dblclick` on the element identified
     by the provided selector.
-* [`visit(url)`][5]
+* [`visit(url)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit)
   - Visits the given route and returns a promise that fulfills when all resulting
      async behavior is complete.
 
@@ -130,27 +130,14 @@ previous steps in the test have completed.
 
 Synchronous helpers are performed immediately when triggered.
 
-* [`currentRouteName()`][6]
+* [`currentRouteName()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename)
   - Returns the currently active route name.
-* [`currentURL()`][7]
+* [`currentURL()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl)
   - Returns the current URL.
-* [`find(selector, context)`][8]
+* [`find(selector, context)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find)
   - Finds an element within the app's root element and within the context
     (optional). Scoping to the root element is especially useful to avoid
     conflicts with the test framework's reporter, and this is done by default
     if the context is not specified.
-* [`findAll(selector)`][9]
-  - Find all elements matched by the given selector. Equivalent to calling
-    querySelectorAll() on the test root element.  Returns an array of matched
-    elements.
-
-
-[1]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click
-[2]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin
-[3]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md
-[4]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent
-[5]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit
-[6]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename
-[7]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl
-[8]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find
-[9]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall
+* [`findAll(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall)
+  - Find all elements matched by the given selector. Equivalent to calling querySelectorAll() on the test root element.  Returns an array of matched elements.

--- a/guides/v3.2.0/testing/index.md
+++ b/guides/v3.2.0/testing/index.md
@@ -1,6 +1,6 @@
 Testing is a core part of the Ember framework and its development cycle.
 
-[QUnit][] is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
+[QUnit](http://qunitjs.com/) is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
 
 The testing pattern presented below is consistent across different testing frameworks. Only the setup test functions from [ember-qunit](https://github.com/emberjs/ember-qunit) needs to be replaced with the respective setup functions in the testing addon used in order to use other testing frameworks.
 
@@ -68,7 +68,7 @@ Examples of Container Tests are:
 * A serializer properly converts the blog request payload into a blog post model object.
 * Blog dates are properly formatted through a `time` service.
 
-You can read more about these type of tests in the [Testing Routes][] and [Testing Controllers][] section.
+You can read more about these type of tests in the [Testing Routes](./testing-routes) and [Testing Controllers](./testing-controllers) section.
 
 ### Rendering Tests
 
@@ -112,7 +112,7 @@ Examples of Rendering Tests are:
 
 Rendering Tests are used to test Components and Helpers where we need to render a layout and assert some interaction byproduct occurs.
 
-You can read more about it in the [Testing Components][] or the [Testing Helpers][] section.
+You can read more about it in the [Testing Components](./testing-components) or the [Testing Helpers](./testing-helpers) section.
 
 ### Application Tests
 
@@ -148,7 +148,7 @@ Examples of Application Tests are:
 * After saving a new post successfully, a user is then shown the list of prior posts.
 * A visitor does not have access to the admin panel.
 
-You can read more about how to create these kinds of tests in the [Application tests][] section.
+You can read more about how to create these kinds of tests in the [Application tests](./acceptance) section.
 
 ### Testing Blueprints
 
@@ -189,7 +189,7 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 Tests can also be executed when you are running a local development server (started by running `ember server`),
 at the `/tests` URI which renders the `tests/index.html` template.
 
-These commands run your tests using [Testem][] to make testing multiple browsers very easy.
+These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy.
 You can configure Testem using the `testem.js` file in your application root.
 
 #### Choosing the Tests to Run
@@ -200,11 +200,3 @@ When using QUnit it is possible to exclude tests by adding an exclamation point 
 
 You can also run a group of tests which you have scoped with a `module` before; e.g. for testing the module called `Unit | Service | location` only,
 run `ember test --module='Unit | Service | location'`.
-
-[QUnit]: http://qunitjs.com/
-[Testem]: https://github.com/airportyh/testem
-[Application tests]: ./acceptance
-[Testing Components]: ./testing-components
-[Testing Controllers]: ./testing-controllers
-[Testing Routes]: ./testing-routes
-[Testing Helpers]: ./testing-helpers

--- a/guides/v3.2.0/testing/testing-controllers.md
+++ b/guides/v3.2.0/testing/testing-controllers.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Controller extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Controller extends Ember.Object._
 
 Controllers can be tested using the `setupTest` helper which is part
 of the ember-qunit framework. The tests written for instances like `Ember.Controller` are
@@ -79,5 +79,3 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/

--- a/guides/v3.2.0/testing/testing-helpers.md
+++ b/guides/v3.2.0/testing/testing-helpers.md
@@ -1,4 +1,4 @@
-_Testing helpers follows previous patterns shown in [Testing Components][],
+_Testing helpers follows previous patterns shown in [Testing Components](../testing-components/),
 because helpers are rendered to templates just like components._
 
 Helpers are best tested with rendering tests, but can also be tested with unit
@@ -6,7 +6,7 @@ tests. Rendering tests will provide better coverage for helpers, as it more
 closely simulates the lifecycle of a helper than in isolation.
 
 We're going to demonstrate how to test helpers by testing the `format-currency`
-helper from [Writing Helpers][].
+helper from [Writing Helpers](../../templates/writing-helpers/).
 
 > You can follow along by generating your own helper with `ember generate helper
 > format-currency`.
@@ -42,12 +42,12 @@ module('Unit | Helper | format currency', function(hooks) {
 });
 ```
 
-As seen in the [Writing Helpers][] guide. The helper function expects the unnamed
+As seen in the [Writing Helpers](../../templates/writing-helpers/) guide. The helper function expects the unnamed
 arguments as an array as the first argument. It expects the named arguments as
 an object as the second argument.
 
 Now we can move on to a more complex test case that ensures our helper is rendered correctly as well. This can be done
-with the `setupRenderingTest` helper, as shown in [Testing Components][].
+with the `setupRenderingTest` helper, as shown in [Testing Components](../testing-components/).
 
 ```javascript {data-filename=tests/integration/helpers/format-currency-test.js}
 import { module, test } from 'qunit';
@@ -94,6 +94,3 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
-
-[Testing Components]: ../testing-components/
-[Writing Helpers]: ../../templates/writing-helpers/

--- a/guides/v3.2.0/testing/testing-models.md
+++ b/guides/v3.2.0/testing/testing-models.md
@@ -1,7 +1,7 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because DS.Model extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because DS.Model extends Ember.Object._
 
-[Ember Data][] Models can be tested in a module that uses the `setupTest` helper.
+[Ember Data](https://github.com/emberjs/data) Models can be tested in a module that uses the `setupTest` helper.
 
 Let's assume we have a `Player` model that has `level` and `levelName`
 attributes. We want to call `levelUp()` to increment the `level` and assign a
@@ -104,9 +104,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests][] for examples of deeper relationship testing if you
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
 feel the need to do it._
-
-[Ember Data]: https://github.com/emberjs/data
-[Testing Basics]: ../unit-testing-basics/
-[Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v3.2.0/testing/testing-routes.md
+++ b/guides/v3.2.0/testing/testing-routes.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Route extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Route extends Ember.Object._
 
 Testing routes can be done both via application tests or container tests. Application tests
 will likely provide better coverage for routes because routes are typically used
@@ -34,7 +34,7 @@ export default Route.extend({
 });
 ```
 
-In this route we've [separated our concerns][]:
+In this route we've [separated our concerns](http://en.wikipedia.org/wiki/Separation_of_concerns):
 The action `displayAlert` contains the code that is called when the action is
 received, and the private function `_displayAlert` performs the work. While not
 necessarily obvious here because of the small size of the functions, separating
@@ -86,6 +86,3 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/
-[separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v3.3.0/components/the-component-lifecycle.md
+++ b/guides/v3.3.0/components/the-component-lifecycle.md
@@ -117,17 +117,17 @@ Suppose you want to integrate your favorite date picker library into an Ember pr
 Typically, 3rd party JS/jQuery libraries require a DOM element to bind to.
 So, where is the best place to initialize and attach the library?
 
-After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`][did-insert-element] hook.
+After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) hook.
 
 Ember guarantees that, by the time `didInsertElement()` is called:
 
 1. The component's element has been both created and inserted into the
    DOM.
 2. The component's element is accessible via the component's
-   [`$()`][dollar]
+   [`$()`](https://www.emberjs.com/api/ember/release/classes/Component/methods/$?anchor=%24)
    method.
 
-A component's [`$()`][dollar] method allows you to access the component's DOM element by returning a jQuery element.
+A component's [`$()`](https://www.emberjs.com/api/ember/release/classes/Component/methods/$?anchor=%24) method allows you to access the component's DOM element by returning a jQuery element.
 For example, you can set an attribute using jQuery's `attr()` method:
 
 ```javascript {data-filename=app/components/profile-editor.js}
@@ -141,7 +141,7 @@ export default Component.extend({
 });
 ```
 
-[`$()`][dollar] will, by default, return a jQuery object for the component's root element, but you can also target child elements within the component's template by passing a selector:
+[`$()`](https://www.emberjs.com/api/ember/release/classes/Component/methods/$?anchor=%24) will, by default, return a jQuery object for the component's root element, but you can also target child elements within the component's template by passing a selector:
 
 ```javascript {data-filename=app/components/profile-editor.js}
 import Component from '@ember/component';
@@ -154,7 +154,7 @@ export default Component.extend({
 });
 ```
 
-Let's initialize our date picker by overriding the [`didInsertElement()`][did-insert-element] method.
+Let's initialize our date picker by overriding the [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) method.
 
 Date picker libraries usually attach to an `<input>` element, so we will use jQuery to find an appropriate input within our component's template.
 
@@ -169,7 +169,7 @@ export default Component.extend({
 });
 ```
 
-[`didInsertElement()`][did-insert-element] is also a good place to
+[`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is also a good place to
 attach event listeners. This is particularly useful for custom events or
 other browser events which do not have a [built-in event
 handler](./handling-events/#toc_event-names).
@@ -194,13 +194,10 @@ There are a few things to note about the `didInsertElement()` hook:
 
 - It is only triggered once when the component element is first rendered.
 - In cases where you have components nested inside other components, the child component will always receive the `didInsertElement()` call before its parent does.
-- Setting properties on the component in [`didInsertElement()`][did-insert-element] triggers a re-render, and for performance reasons,
+- Setting properties on the component in [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons,
   is not allowed.
-- While [`didInsertElement()`][did-insert-element] is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
+- While [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
   particularly when order of execution is important.
-
-[did-insert-element]: https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement
-[dollar]: https://www.emberjs.com/api/ember/release/classes/Component/methods/$?anchor=%24
 
 ### Making Updates to the Rendered DOM with `didRender`
 

--- a/guides/v3.3.0/ember-inspector/data.md
+++ b/guides/v3.3.0/ember-inspector/data.md
@@ -1,5 +1,4 @@
-You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter][building-data-adapter] below if you maintain your own persistence library. 
-[building-data-adapter]:#toc_building-a-data-custom-adapter
+You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter](#toc_building-a-data-custom-adapter) below if you maintain your own persistence library. 
 
 When you open the Data tab, you will see a list of model types defined
 in your application, along with the number of loaded records.
@@ -32,8 +31,5 @@ You can also filter records by entering a query in the search box.
 
 ### Building a Data Custom Adapter
 
-You can use your own data persistence library with the Inspector. Build a [data adapter][data-adapter-docs], and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter][ember-data-data-adapter] as an example for how to build your data adapter.
-
-[data-adapter-docs]: https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js
-[ember-data-data-adapter]:https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js
+You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
+using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter.

--- a/guides/v3.3.0/ember-inspector/info.md
+++ b/guides/v3.3.0/ember-inspector/info.md
@@ -12,6 +12,4 @@ Ember.libraries.register(libraryName, libraryVersion);
 
 #### Ember CLI
 
-If you're using the [ember-cli-app-version][] addon, your application's name and version will be added to the list automatically.
-
-[ember-cli-app-version]: https://github.com/embersherpa/ember-cli-app-version
+If you're using the [ember-cli-app-version](https://github.com/embersherpa/ember-cli-app-version) addon, your application's name and version will be added to the list automatically.

--- a/guides/v3.3.0/ember-inspector/installation.md
+++ b/guides/v3.3.0/ember-inspector/installation.md
@@ -37,7 +37,7 @@ Make sure the "Display the Tomster" checkbox is checked.
 ### Firefox
 
 Visit the Add-on page on the [Mozilla Addons
-site][ember-inspector-mozilla].
+site](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/).
 
 Click on "Add to Firefox".
 
@@ -47,9 +47,6 @@ Once installed, go to an Ember application, open the Developer Tools,
 and click on the `Ember` tab.
 
 <img src="/images/guides/ember-inspector/installation-firefox-panel.png" width="680">
-
-[ember-inspector-mozilla]: https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/
-
 
 #### Enable Tomster
 

--- a/guides/v3.3.0/ember-inspector/object-inspector.md
+++ b/guides/v3.3.0/ember-inspector/object-inspector.md
@@ -15,9 +15,7 @@ The Inspector displays the parent objects and mixins that are composed into the 
 Each property value in this view is bound to your application, so if the value of a
 property updates in your app, it will be reflected in the Inspector.
 
-If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
-click on the calculator to compute it.
-[computed-property]: ../../object-model/computed-properties/
+If a property name is preceded by a calculator icon, that means it is a [computed property](../../object-model/computed-properties/). If the value of a computed property hasn't yet been computed, you can click on the calculator to compute it.
 
 ### Exposing Objects to the Console
 
@@ -91,7 +89,4 @@ width="450">
 Library authors can customize how any object will display in the Inspector.
 By defining a `_debugInfo` method, an object can tell the Inspector how it should be rendered.
 For an example on how to customize an object's properties, see [Ember Data's
-customization][ember-data-debug-info].
-
-
-[ember-data-debug-info]: https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js
+customization](https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js).

--- a/guides/v3.3.0/index.md
+++ b/guides/v3.3.0/index.md
@@ -40,13 +40,13 @@ We will try to link to appropriate documentation whenever a concept is introduce
 
 To make the most out of the guides, you should have a working knowledge of:
 
-* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network][mdn].
-* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network][promises] section.
-* **ES2015 modules** - you will better understand [Ember CLI's][ember-cli] project structure and import paths if you are comfortable with [JavaScript Modules][js-modules].
+* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web).
+* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) section.
+* **ES2015 modules** - you will better understand [Ember CLI's](https://ember-cli.com/) project structure and import paths if you are comfortable with [JavaScript Modules](http://jsmodules.io/).
 * **ES2015 syntax** - Ember CLI comes with Babel.js by default so you can
 take advantage of newer language features such as arrow functions, template
 strings, destructuring, and more. You can check the
-[Babel.js documentation][babeljs] or read [Understanding ECMAScript 6][es6]
+[Babel.js documentation](https://babeljs.io/docs/learn-es2015/) or read [Understanding ECMAScript 6](https://leanpub.com/understandinges6/read)
 online.
 
 ## A Note on Mobile Performance
@@ -85,7 +85,7 @@ the existing guides, we are happy to help you help us!
 Some of the more common ways to report a problem with the guides are:
 
 * Using the pencil icon on the top-right of each guide page
-* Opening an issue or pull request to [the GitHub repository][gh-guides]
+* Opening an issue or pull request to [the GitHub repository](https://github.com/ember-learn/guides-source/)
 
 Clicking the pencil icon will bring you to GitHub's editor for that
 guide so you can edit right away, using the Markdown markup language.
@@ -93,25 +93,11 @@ This is the fastest way to correct a typo, a missing word, or an error in
 a code sample.
 
 If you wish to make a more significant contribution be sure to check our
-[issue tracker][gh-guides-issues] to see if your issue is already being
+[issue tracker](https://github.com/ember-learn/guides-source/issues) to see if your issue is already being
 addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
-can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
+can check out our [contributing guide](https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md). If your
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord](https://discordapp.com/invite/zT3asNS).
 
 Good luck!
-
-[ember-cli]: https://ember-cli.com/
-
-[mdn]: https://developer.mozilla.org/en-US/docs/Web
-[promises]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-[js-modules]: http://jsmodules.io/
-[babeljs]: https://babeljs.io/docs/learn-es2015/
-[es6]: https://leanpub.com/understandinges6/read
-
-[gh-guides]: https://github.com/ember-learn/guides-source/
-[gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
-[gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
-
-[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v3.3.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.3.0/models/creating-updating-and-deleting-records.md
@@ -163,6 +163,4 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 });
 ```
 
-The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`][findRecord] automatically schedules a fetch of the record from the adapter.
-
-[findRecord]: <https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord>
+The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord) automatically schedules a fetch of the record from the adapter.

--- a/guides/v3.3.0/models/index.md
+++ b/guides/v3.3.0/models/index.md
@@ -17,10 +17,8 @@ Typically, most models are loaded from and saved to a server that uses a
 database to store data. Usually you will send JSON representations of
 models back and forth to an HTTP server that you have written. However,
 Ember makes it easy to use other durable storage, such as saving to the
-user's hard disk with [IndexedDB][indexeddb], or hosted storage solutions that let you
+user's hard disk with [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API), or hosted storage solutions that let you
 avoid writing and hosting your own servers.
-
-[indexeddb]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 
 Once you've loaded your models from storage, components know how to
 translate model data into a UI that your user can interact with.  For
@@ -35,10 +33,8 @@ create new models in the browser.
 
 Thanks to its use of the _adapter pattern_, Ember Data can be configured
 to work with many different kinds of backends. There is [an entire
-ecosystem of adapters][adapters] that allow your Ember app to talk to different
+ecosystem of adapters](http://emberobserver.com/categories/ember-data-adapters) that allow your Ember app to talk to different
 types of servers without you writing any networking code.
-
-[adapters]: http://emberobserver.com/categories/ember-data-adapters
 
 If you need to integrate your Ember.js app with a server that does not
 have an adapter available (for example, you hand-rolled an API server
@@ -157,11 +153,9 @@ will be shared among developers on your team, following them leads
 to code that is easier to maintain and understand.
 
 Rather than creating an arbitrary set of conventions, Ember Data is
-designed to work out of the box with [JSON API][json-api]. JSON API is a
+designed to work out of the box with [JSON API](http://jsonapi.org). JSON API is a
 formal specification for building conventional, robust, and performant
 APIs that allow clients and servers to communicate model data.
-
-[json-api]: http://jsonapi.org
 
 JSON API standardizes how JavaScript applications talk to servers, so
 you decrease the coupling between your frontend and backend, and have

--- a/guides/v3.3.0/object-model/classes-and-instances.md
+++ b/guides/v3.3.0/object-model/classes-and-instances.md
@@ -4,11 +4,9 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`][1] method on
-[`EmberObject`][2]:
+To define a new Ember _class_, call the [`extend()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://www.emberjs.com/api/ember/release/modules/@ember%2Fobject):
 
-[1]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend
-[2]: https://www.emberjs.com/api/ember/release/modules/@ember%2Fobject
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -24,9 +22,7 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`][3] class:
-
-[3]: https://www.emberjs.com/api/ember/release/classes/Component
+of Ember's built-in [`Component`](https://www.emberjs.com/api/ember/release/classes/Component) class:
 
 ```javascript {data-filename=app/components/todo-item.js}
 import Component from '@ember/component';
@@ -71,11 +67,9 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`][4] hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`](https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
-
-[4]: https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse
 
 ```javascript
 normalizeResponse(store, primaryModelClass, payload, id, requestType)  {
@@ -89,11 +83,11 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`][5] method. Any methods, properties and
+class by calling its [`create()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/create?anchor=create
+) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
 
-[5]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/create?anchor=create
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -141,11 +135,9 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`][6] method is invoked
+When a new instance is created, its [`init()`](https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init) method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
-
-[6]: https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -228,7 +220,7 @@ Person.create({
 
 When reading a property value of an object, you can in most cases use the common JavaScript dot notation, e.g. `myObject.myProperty`. 
 
-[Ember proxy objects][9] are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`][7] accessor method to read values.
+[Ember proxy objects](https://emberjs.com/api/ember/3.3/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
 
 Let's look at the following `blogPost` Ember Data model:
 
@@ -246,7 +238,7 @@ export default Model.extend({
 
 To access the blog post's title you can simply write `blogPost.title`, whereas only the syntax `blogPost.get('comments')` will return the post's comments.
 
-Always use Ember's [`set()`][8] method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
+Always use Ember's [`set()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/set?anchor=set) method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -261,7 +253,3 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
-
-[7]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/get?anchor=get
-[8]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/set?anchor=set
-[9]: https://emberjs.com/api/ember/3.3/classes/ObjectProxy

--- a/guides/v3.3.0/templates/writing-helpers.md
+++ b/guides/v3.3.0/templates/writing-helpers.md
@@ -7,9 +7,7 @@ For example, imagine we have an `Invoice` model that contains a
 `totalDue` attribute, which represents the total amount due for that
 invoice.  Because we do not want our company to go out of business due
 to strange JavaScript rounding errors, [we store this value in cents
-instead of a floating point dollar value][currency-stackoverflow].
-
-[currency-stackoverflow]: http://stackoverflow.com/a/3730040
+instead of a floating point dollar value](http://stackoverflow.com/a/3730040).
 
 However, if we display dollar values to our users as "100¢" instead of
 "$1.00", they may be very confused. We can write a helper to
@@ -249,9 +247,9 @@ access to services in your application, and can optionally save state as well,
 although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
-should export a subclass of [`Ember.Helper`][1]. Helper classes must contain a
-[`compute`][2] method that behaves the same as the function passed to
-[`Ember.Helper.helper`][3].  In order to access a service, you must first inject it
+should export a subclass of [`Ember.Helper`](https://www.emberjs.com/api/ember/release/classes/Helper). Helper classes must contain a
+[`compute`](https://www.emberjs.com/api/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`Ember.Helper.helper`](https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -332,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`][4] string utility:
+[`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -346,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`][4]), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently
@@ -394,7 +392,3 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
-[1]: https://www.emberjs.com/api/ember/release/classes/Helper
-[2]: https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=compute
-[3]: https://emberjs.com/api/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper
-[4]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe

--- a/guides/v3.3.0/testing/acceptance.md
+++ b/guides/v3.3.0/testing/acceptance.md
@@ -83,20 +83,20 @@ your application, making it much easier to write deterministic tests.
 
 Some of these handy helpers are:
 
-* [`click(selector)`][1]
+* [`click(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click)
   - Clicks an element and triggers any actions triggered by the element's `click`
     event and returns a promise that fulfills when all resulting async behavior
     is complete.
-* [`fillIn(selector, value)`][2]
+* [`fillIn(selector, value)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin)
   - Fills in the selected input with the given value and returns a promise that
      fulfills when all resulting async behavior is complete. Works with `<select>` elements as well as `<input>` elements. Keep in mind that with `<select>` elements, `value` must be set to the _value_ of the `<option>` tag, rather than its _content_ (for example, `true` rather than `"Yes"`).
-* [`triggerKeyEvent(selector, type, keyCode)`][3]
+* [`triggerKeyEvent(selector, type, keyCode)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md)
   - Simulates a key event type, e.g. `keypress`, `keydown`, `keyup` with the
     desired keyCode on element found by the selector.
-* [`triggerEvent(selector, type, options)`][4]
+* [`triggerEvent(selector, type, options)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent)
   - Triggers the given event, e.g. `blur`, `dblclick` on the element identified
     by the provided selector.
-* [`visit(url)`][5]
+* [`visit(url)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit)
   - Visits the given route and returns a promise that fulfills when all resulting
      async behavior is complete.
 
@@ -130,22 +130,9 @@ previous steps in the test have completed.
 
 Synchronous helpers are performed immediately when triggered.
 
-* [`currentRouteName()`][6]: returns the currently active route name.
-* [`currentURL()`][7]: returns the current URL.
-* [`find(selector)`][8]: finds one element within the app's root element
+* [`currentRouteName()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename): returns the currently active route name.
+* [`currentURL()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl): returns the current URL.
+* [`find(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find): finds one element within the app's root element
   that matches the given selector. Scoping to the root element is useful
   to avoid conflicts with the test framework's reporter.
-* [`findAll(selector)`][9]: like `find(selector)`, but finds all elements
-  that match the given selector. Equivalent to calling querySelectorAll()
-  on the test root element. Returns an array of matched elements.
-
-
-[1]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click
-[2]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin
-[3]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerkeyevent
-[4]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent
-[5]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit
-[6]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename
-[7]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl
-[8]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find
-[9]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall
+* [`findAll(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall): Like `find(selector)`, but finds all elements that match the given selector. Equivalent to calling querySelectorAll() on the test root element. Returns an array of matched elements.

--- a/guides/v3.3.0/testing/index.md
+++ b/guides/v3.3.0/testing/index.md
@@ -1,6 +1,6 @@
 Testing is a core part of the Ember framework and its development cycle.
 
-[QUnit][] is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
+[QUnit](http://qunitjs.com/) is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
 
 The testing pattern presented below is consistent across different testing frameworks. Only the setup test functions from [ember-qunit](https://github.com/emberjs/ember-qunit) needs to be replaced with the respective setup functions in the testing addon used in order to use other testing frameworks.
 
@@ -68,7 +68,7 @@ Examples of Container Tests are:
 * A serializer properly converts the blog request payload into a blog post model object.
 * Blog dates are properly formatted through a `time` service.
 
-You can read more about these type of tests in the [Testing Routes][] and [Testing Controllers][] section.
+You can read more about these type of tests in the [Testing Routes](./testing-routes) and [Testing Controllers](./testing-controllers) section.
 
 ### Rendering Tests
 
@@ -112,7 +112,7 @@ Examples of Rendering Tests are:
 
 Rendering Tests are used to test Components and Helpers where we need to render a layout and assert some interaction byproduct occurs.
 
-You can read more about it in the [Testing Components][] or the [Testing Helpers][] section.
+You can read more about it in the [Testing Components](./testing-components) or the [Testing Helpers](./testing-helpers) section.
 
 ### Application Tests
 
@@ -148,7 +148,7 @@ Examples of Application Tests are:
 * After saving a new post successfully, a user is then shown the list of prior posts.
 * A visitor does not have access to the admin panel.
 
-You can read more about how to create these kinds of tests in the [Application tests][] section.
+You can read more about how to create these kinds of tests in the [Application tests](./acceptance) section.
 
 ### Testing Blueprints
 
@@ -189,7 +189,7 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 Tests can also be executed when you are running a local development server (started by running `ember server`),
 at the `/tests` URI which renders the `tests/index.html` template.
 
-These commands run your tests using [Testem][] to make testing multiple browsers very easy.
+These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy.
 You can configure Testem using the `testem.js` file in your application root.
 
 #### Choosing the Tests to Run
@@ -200,11 +200,3 @@ When using QUnit it is possible to exclude tests by adding an exclamation point 
 
 You can also run a group of tests which you have scoped with a `module` before; e.g. for testing the module called `Unit | Service | location` only,
 run `ember test --module='Unit | Service | location'`.
-
-[QUnit]: http://qunitjs.com/
-[Testem]: https://github.com/airportyh/testem
-[Application tests]: ./acceptance
-[Testing Components]: ./testing-components
-[Testing Controllers]: ./testing-controllers
-[Testing Routes]: ./testing-routes
-[Testing Helpers]: ./testing-helpers

--- a/guides/v3.3.0/testing/testing-controllers.md
+++ b/guides/v3.3.0/testing/testing-controllers.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Controller extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Controller extends Ember.Object._
 
 Controllers can be tested using the `setupTest` helper which is part
 of the ember-qunit framework. The tests written for instances like `Ember.Controller` are
@@ -79,5 +79,3 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/

--- a/guides/v3.3.0/testing/testing-helpers.md
+++ b/guides/v3.3.0/testing/testing-helpers.md
@@ -1,4 +1,4 @@
-_Testing helpers follows previous patterns shown in [Testing Components][],
+_Testing helpers follows previous patterns shown in [Testing Components](../testing-components/),
 because helpers are rendered to templates just like components._
 
 Helpers are best tested with rendering tests, but can also be tested with unit
@@ -6,7 +6,7 @@ tests. Rendering tests will provide better coverage for helpers, as it more
 closely simulates the lifecycle of a helper than in isolation.
 
 We're going to demonstrate how to test helpers by testing the `format-currency`
-helper from [Writing Helpers][].
+helper from [Writing Helpers](../../templates/writing-helpers/).
 
 > You can follow along by generating your own helper with `ember generate helper
 > format-currency`.
@@ -42,12 +42,12 @@ module('Unit | Helper | format currency', function(hooks) {
 });
 ```
 
-As seen in the [Writing Helpers][] guide. The helper function expects the unnamed
+As seen in the [Writing Helpers](../../templates/writing-helpers/) guide. The helper function expects the unnamed
 arguments as an array as the first argument. It expects the named arguments as
 an object as the second argument.
 
 Now we can move on to a more complex test case that ensures our helper is rendered correctly as well. This can be done
-with the `setupRenderingTest` helper, as shown in [Testing Components][].
+with the `setupRenderingTest` helper, as shown in [Testing Components](../testing-components/).
 
 ```javascript {data-filename=tests/integration/helpers/format-currency-test.js}
 import { module, test } from 'qunit';
@@ -94,6 +94,3 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
-
-[Testing Components]: ../testing-components/
-[Writing Helpers]: ../../templates/writing-helpers/

--- a/guides/v3.3.0/testing/testing-models.md
+++ b/guides/v3.3.0/testing/testing-models.md
@@ -1,7 +1,7 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because DS.Model extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because DS.Model extends Ember.Object._
 
-[Ember Data][] Models can be tested in a module that uses the `setupTest` helper.
+[Ember Data](https://github.com/emberjs/data) Models can be tested in a module that uses the `setupTest` helper.
 
 Let's assume we have a `Player` model that has `level` and `levelName`
 attributes. We want to call `levelUp()` to increment the `level` and assign a
@@ -104,9 +104,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests][] for examples of deeper relationship testing if you
-feel the need to do it._
-
-[Ember Data]: https://github.com/emberjs/data
-[Testing Basics]: ../unit-testing-basics/
-[Ember Data tests]: https://github.com/emberjs/data/tree/master/tests
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
+feel the need to do it.

--- a/guides/v3.3.0/testing/testing-routes.md
+++ b/guides/v3.3.0/testing/testing-routes.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Route extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Route extends Ember.Object._
 
 Testing routes can be done both via application tests or container tests. Application tests
 will likely provide better coverage for routes because routes are typically used
@@ -34,7 +34,7 @@ export default Route.extend({
 });
 ```
 
-In this route we've [separated our concerns][]:
+In this route we've [separated our concerns](http://en.wikipedia.org/wiki/Separation_of_concerns):
 The action `displayAlert` contains the code that is called when the action is
 received, and the private function `_displayAlert` performs the work. While not
 necessarily obvious here because of the small size of the functions, separating
@@ -86,6 +86,3 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/
-[separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v3.4.0/components/the-component-lifecycle.md
+++ b/guides/v3.4.0/components/the-component-lifecycle.md
@@ -117,15 +117,15 @@ Suppose you want to integrate your favorite date picker library into an Ember pr
 Typically, 3rd party JS/jQuery libraries require a DOM element to bind to.
 So, where is the best place to initialize and attach the library?
 
-After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`][did-insert-element] hook.
+After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) hook.
 
 Ember guarantees that, by the time `didInsertElement()` is called:
 
 1. The component's element has been both created and inserted into the
    DOM.
-2. The component's element is accessible via the component's [`this.element`][element] property.
+2. The component's element is accessible via the component's [`this.element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property.
 
-The [`element`][element] property allows you to access the component's DOM element.
+The [`element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property allows you to access the component's DOM element.
 For example, you can set an attribute using the `Element.setAttribute()` method:
 
 ```javascript {data-filename=app/components/profile-editor.js}
@@ -139,7 +139,7 @@ export default Component.extend({
 });
 ```
 
-The [`element`][element] property will, by default, return a DOM object for the component's root element, but you can also target child elements within the component's template by passing a selector to `querySelector` or `querySelectorAll`:
+The [`element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property will, by default, return a DOM object for the component's root element, but you can also target child elements within the component's template by passing a selector to `querySelector` or `querySelectorAll`:
 
 ```javascript {data-filename=app/components/profile-editor.js}
 import Component from '@ember/component';
@@ -155,7 +155,7 @@ export default Component.extend({
 });
 ```
 
-Let's initialize our date picker by overriding the [`didInsertElement()`][did-insert-element] method.
+Let's initialize our date picker by overriding the [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) method.
 
 Date picker libraries usually attach to an `<input>` element, so we will use `this.element.querySelector` to find an appropriate input within our component's template.
 
@@ -170,7 +170,7 @@ export default Component.extend({
 });
 ```
 
-[`didInsertElement()`][did-insert-element] is also a good place to
+[`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is also a good place to
 attach event listeners. This is particularly useful for custom events or
 other browser events which do not have a [built-in event
 handler](./handling-events/#toc_event-names).
@@ -195,13 +195,10 @@ There are a few things to note about the `didInsertElement()` hook:
 
 - It is only triggered once when the component element is first rendered.
 - In cases where you have components nested inside other components, the child component will always receive the `didInsertElement()` call before its parent does.
-- Setting properties on the component in [`didInsertElement()`][did-insert-element] triggers a re-render, and for performance reasons,
+- Setting properties on the component in [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons,
   is not allowed.
-- While [`didInsertElement()`][did-insert-element] is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
+- While [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
   particularly when order of execution is important.
-
-[did-insert-element]: https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement
-[element]: https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element
 
 ### Making Updates to the Rendered DOM with `didRender`
 

--- a/guides/v3.4.0/configuring-ember/optional-features.md
+++ b/guides/v3.4.0/configuring-ember/optional-features.md
@@ -64,7 +64,7 @@ It is used for event handling, and to provide some APIs like `this.$()` in compo
 With the release of ember-source v3.4.0, an optional feature flag was introduced that allows users to opt out of jQuery.
 To enable it, run the following command after setting up `@ember/optional-features`:
 
-```shell
+```bash
 ember feature:disable jquery-integration
 ```
 

--- a/guides/v3.4.0/ember-inspector/data.md
+++ b/guides/v3.4.0/ember-inspector/data.md
@@ -1,5 +1,4 @@
-You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter][building-data-adapter] below if you maintain your own persistence library. 
-[building-data-adapter]:#toc_building-a-data-custom-adapter
+You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter](#toc_building-a-data-custom-adapter) below if you maintain your own persistence library. 
 
 When you open the Data tab, you will see a list of model types defined
 in your application, along with the number of loaded records.
@@ -32,8 +31,5 @@ You can also filter records by entering a query in the search box.
 
 ### Building a Data Custom Adapter
 
-You can use your own data persistence library with the Inspector. Build a [data adapter][data-adapter-docs], and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter][ember-data-data-adapter] as an example for how to build your data adapter.
-
-[data-adapter-docs]: https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js
-[ember-data-data-adapter]:https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js
+You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
+using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter.

--- a/guides/v3.4.0/ember-inspector/info.md
+++ b/guides/v3.4.0/ember-inspector/info.md
@@ -12,6 +12,4 @@ Ember.libraries.register(libraryName, libraryVersion);
 
 #### Ember CLI
 
-If you're using the [ember-cli-app-version][] addon, your application's name and version will be added to the list automatically.
-
-[ember-cli-app-version]: https://github.com/embersherpa/ember-cli-app-version
+If you're using the [ember-cli-app-version](https://github.com/embersherpa/ember-cli-app-version) addon, your application's name and version will be added to the list automatically.

--- a/guides/v3.4.0/ember-inspector/installation.md
+++ b/guides/v3.4.0/ember-inspector/installation.md
@@ -37,7 +37,7 @@ Make sure the "Display the Tomster" checkbox is checked.
 ### Firefox
 
 Visit the Add-on page on the [Mozilla Addons
-site][ember-inspector-mozilla].
+site](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/).
 
 Click on "Add to Firefox".
 
@@ -47,9 +47,6 @@ Once installed, go to an Ember application, open the Developer Tools,
 and click on the `Ember` tab.
 
 <img src="/images/guides/ember-inspector/installation-firefox-panel.png" width="680">
-
-[ember-inspector-mozilla]: https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/
-
 
 #### Enable Tomster
 

--- a/guides/v3.4.0/ember-inspector/object-inspector.md
+++ b/guides/v3.4.0/ember-inspector/object-inspector.md
@@ -15,9 +15,7 @@ The Inspector displays the parent objects and mixins that are composed into the 
 Each property value in this view is bound to your application, so if the value of a
 property updates in your app, it will be reflected in the Inspector.
 
-If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
-click on the calculator to compute it.
-[computed-property]: ../../object-model/computed-properties/
+If a property name is preceded by a calculator icon, that means it is a [computed property](../../object-model/computed-properties/). If the value of a computed property hasn't yet been computed, you can click on the calculator to compute it.
 
 ### Exposing Objects to the Console
 
@@ -91,7 +89,4 @@ width="450">
 Library authors can customize how any object will display in the Inspector.
 By defining a `_debugInfo` method, an object can tell the Inspector how it should be rendered.
 For an example on how to customize an object's properties, see [Ember Data's
-customization][ember-data-debug-info].
-
-
-[ember-data-debug-info]: https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js
+customization](https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js).

--- a/guides/v3.4.0/index.md
+++ b/guides/v3.4.0/index.md
@@ -40,13 +40,13 @@ We will try to link to appropriate documentation whenever a concept is introduce
 
 To make the most out of the guides, you should have a working knowledge of:
 
-* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network][mdn].
-* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network][promises] section.
-* **ES2015 modules** - you will better understand [Ember CLI's][ember-cli] project structure and import paths if you are comfortable with [JavaScript Modules][js-modules].
+* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web).
+* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) section.
+* **ES2015 modules** - you will better understand [Ember CLI's](https://ember-cli.com/) project structure and import paths if you are comfortable with [JavaScript Modules](http://jsmodules.io/).
 * **ES2015 syntax** - Ember CLI comes with Babel.js by default so you can
 take advantage of newer language features such as arrow functions, template
 strings, destructuring, and more. You can check the
-[Babel.js documentation][babeljs] or read [Understanding ECMAScript 6][es6]
+[Babel.js documentation](https://babeljs.io/docs/learn-es2015/) or read [Understanding ECMAScript 6](https://leanpub.com/understandinges6/read)
 online.
 
 ## A Note on Mobile Performance
@@ -85,7 +85,7 @@ the existing guides, we are happy to help you help us!
 Some of the more common ways to report a problem with the guides are:
 
 * Using the pencil icon on the top-right of each guide page
-* Opening an issue or pull request to [the GitHub repository][gh-guides]
+* Opening an issue or pull request to [the GitHub repository](https://github.com/ember-learn/guides-source/)
 
 Clicking the pencil icon will bring you to GitHub's editor for that
 guide so you can edit right away, using the Markdown markup language.
@@ -93,25 +93,11 @@ This is the fastest way to correct a typo, a missing word, or an error in
 a code sample.
 
 If you wish to make a more significant contribution be sure to check our
-[issue tracker][gh-guides-issues] to see if your issue is already being
+[issue tracker](https://github.com/ember-learn/guides-source/issues) to see if your issue is already being
 addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
-can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
+can check out our [contributing guide](https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md). If your
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord](https://discordapp.com/invite/zT3asNS).
 
 Good luck!
-
-[ember-cli]: https://ember-cli.com/
-
-[mdn]: https://developer.mozilla.org/en-US/docs/Web
-[promises]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-[js-modules]: http://jsmodules.io/
-[babeljs]: https://babeljs.io/docs/learn-es2015/
-[es6]: https://leanpub.com/understandinges6/read
-
-[gh-guides]: https://github.com/ember-learn/guides-source/
-[gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
-[gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
-
-[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v3.4.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.4.0/models/creating-updating-and-deleting-records.md
@@ -163,6 +163,4 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 });
 ```
 
-The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`][findRecord] automatically schedules a fetch of the record from the adapter.
-
-[findRecord]: <https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord>
+The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord) automatically schedules a fetch of the record from the adapter.

--- a/guides/v3.4.0/models/index.md
+++ b/guides/v3.4.0/models/index.md
@@ -43,10 +43,8 @@ Typically, most models are loaded from and saved to a server that uses a
 database to store data. Usually you will send JSON representations of
 models back and forth to an HTTP server that you have written. However,
 Ember makes it easy to use other durable storage, such as saving to the
-user's hard disk with [IndexedDB][indexeddb], or hosted storage solutions that let you
+user's hard disk with [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API), or hosted storage solutions that let you
 avoid writing and hosting your own servers.
-
-[indexeddb]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 
 Once you've loaded your models from storage, components know how to
 translate model data into a UI that your user can interact with.  For
@@ -56,10 +54,8 @@ guide.
 
 Thanks to its use of the _adapter pattern_, Ember Data can be configured
 to work with many different kinds of backends. There is [an entire
-ecosystem of adapters][adapters] that allow your Ember app to talk to different
+ecosystem of adapters](http://emberobserver.com/categories/ember-data-adapters) that allow your Ember app to talk to different
 types of servers without you writing any networking code.
-
-[adapters]: http://emberobserver.com/categories/ember-data-adapters
 
 If you need to integrate your Ember.js app with a server that does not
 have an adapter available (for example, you hand-rolled an API server
@@ -178,11 +174,9 @@ will be shared among developers on your team, following them leads
 to code that is easier to maintain and understand.
 
 Rather than creating an arbitrary set of conventions, Ember Data is
-designed to work out of the box with [JSON API][json-api]. JSON API is a
+designed to work out of the box with [JSON API](http://jsonapi.org). JSON API is a
 formal specification for building conventional, robust, and performant
 APIs that allow clients and servers to communicate model data.
-
-[json-api]: http://jsonapi.org
 
 JSON API standardizes how JavaScript applications talk to servers, so
 you decrease the coupling between your frontend and backend, and have

--- a/guides/v3.4.0/object-model/classes-and-instances.md
+++ b/guides/v3.4.0/object-model/classes-and-instances.md
@@ -4,11 +4,9 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`][1] method on
-[`EmberObject`][2]:
+To define a new Ember _class_, call the [`extend()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://www.emberjs.com/api/ember/release/modules/@ember%2Fobject):
 
-[1]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend
-[2]: https://www.emberjs.com/api/ember/release/modules/@ember%2Fobject
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -24,9 +22,7 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`][3] class:
-
-[3]: https://www.emberjs.com/api/ember/release/classes/Component
+of Ember's built-in [`Component`](https://www.emberjs.com/api/ember/release/classes/Component) class:
 
 ```javascript {data-filename=app/components/todo-item.js}
 import Component from '@ember/component';
@@ -71,11 +67,9 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`][4] hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`](https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
-
-[4]: https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse
 
 ```javascript
 normalizeResponse(store, primaryModelClass, payload, id, requestType)  {
@@ -89,11 +83,11 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`][5] method. Any methods, properties and
+class by calling its [`create()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/create?anchor=create
+) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
 
-[5]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/create?anchor=create
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -141,11 +135,9 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`][6] method is invoked
+When a new instance is created, its [`init()`](https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init) method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
-
-[6]: https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -228,7 +220,7 @@ Person.create({
 
 When reading a property value of an object, you can in most cases use the common JavaScript dot notation, e.g. `myObject.myProperty`. 
 
-[Ember proxy objects][9] are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`][7] accessor method to read values.
+[Ember proxy objects](https://emberjs.com/api/ember/3.3/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
 
 Let's look at the following `blogPost` Ember Data model:
 
@@ -246,7 +238,7 @@ export default Model.extend({
 
 To access the blog post's title you can simply write `blogPost.title`, whereas only the syntax `blogPost.get('comments')` will return the post's comments.
 
-Always use Ember's [`set()`][8] method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
+Always use Ember's [`set()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/set?anchor=set) method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -261,7 +253,3 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
-
-[7]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/get?anchor=get
-[8]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/set?anchor=set
-[9]: https://emberjs.com/api/ember/3.3/classes/ObjectProxy

--- a/guides/v3.4.0/templates/writing-helpers.md
+++ b/guides/v3.4.0/templates/writing-helpers.md
@@ -7,9 +7,7 @@ For example, imagine we have an `Invoice` model that contains a
 `totalDue` attribute, which represents the total amount due for that
 invoice.  Because we do not want our company to go out of business due
 to strange JavaScript rounding errors, [we store this value in cents
-instead of a floating point dollar value][currency-stackoverflow].
-
-[currency-stackoverflow]: http://stackoverflow.com/a/3730040
+instead of a floating point dollar value](http://stackoverflow.com/a/3730040).
 
 However, if we display dollar values to our users as "100¢" instead of
 "$1.00", they may be very confused. We can write a helper to
@@ -249,9 +247,9 @@ access to services in your application, and can optionally save state as well,
 although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
-should export a subclass of [`Ember.Helper`][1]. Helper classes must contain a
-[`compute`][2] method that behaves the same as the function passed to
-[`Ember.Helper.helper`][3].  In order to access a service, you must first inject it
+should export a subclass of [`Ember.Helper`](https://www.emberjs.com/api/ember/release/classes/Helper). Helper classes must contain a
+[`compute`](https://www.emberjs.com/api/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`Ember.Helper.helper`](https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -332,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`][4] string utility:
+[`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -346,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`][4]), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently
@@ -394,7 +392,3 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
-[1]: https://www.emberjs.com/api/ember/release/classes/Helper
-[2]: https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=compute
-[3]: https://emberjs.com/api/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper
-[4]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe

--- a/guides/v3.4.0/testing/acceptance.md
+++ b/guides/v3.4.0/testing/acceptance.md
@@ -83,20 +83,20 @@ your application, making it much easier to write deterministic tests.
 
 Some of these handy helpers are:
 
-* [`click(selector)`][1]
+* [`click(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click)
   - Clicks an element and triggers any actions triggered by the element's `click`
     event and returns a promise that fulfills when all resulting async behavior
     is complete.
-* [`fillIn(selector, value)`][2]
+* [`fillIn(selector, value)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin)
   - Fills in the selected input with the given value and returns a promise that
      fulfills when all resulting async behavior is complete. Works with `<select>` elements as well as `<input>` elements. Keep in mind that with `<select>` elements, `value` must be set to the _value_ of the `<option>` tag, rather than its _content_ (for example, `true` rather than `"Yes"`).
-* [`triggerKeyEvent(selector, type, keyCode)`][3]
+* [`triggerKeyEvent(selector, type, keyCode)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md)
   - Simulates a key event type, e.g. `keypress`, `keydown`, `keyup` with the
     desired keyCode on element found by the selector.
-* [`triggerEvent(selector, type, options)`][4]
+* [`triggerEvent(selector, type, options)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent)
   - Triggers the given event, e.g. `blur`, `dblclick` on the element identified
     by the provided selector.
-* [`visit(url)`][5]
+* [`visit(url)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit)
   - Visits the given route and returns a promise that fulfills when all resulting
      async behavior is complete.
 
@@ -130,22 +130,9 @@ previous steps in the test have completed.
 
 Synchronous helpers are performed immediately when triggered.
 
-* [`currentRouteName()`][6]: returns the currently active route name.
-* [`currentURL()`][7]: returns the current URL.
-* [`find(selector)`][8]: finds one element within the app's root element
+* [`currentRouteName()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename): returns the currently active route name.
+* [`currentURL()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl): returns the current URL.
+* [`find(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find): finds one element within the app's root element
   that matches the given selector. Scoping to the root element is useful
   to avoid conflicts with the test framework's reporter.
-* [`findAll(selector)`][9]: like `find(selector)`, but finds all elements
-  that match the given selector. Equivalent to calling querySelectorAll()
-  on the test root element. Returns an array of matched elements.
-
-
-[1]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click
-[2]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin
-[3]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerkeyevent
-[4]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent
-[5]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit
-[6]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename
-[7]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl
-[8]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find
-[9]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall
+* [`findAll(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall): Like `find(selector)`, but finds all elements that match the given selector. Equivalent to calling querySelectorAll() on the test root element. Returns an array of matched elements.

--- a/guides/v3.4.0/testing/index.md
+++ b/guides/v3.4.0/testing/index.md
@@ -1,6 +1,6 @@
 Testing is a core part of the Ember framework and its development cycle.
 
-[QUnit][] is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
+[QUnit](http://qunitjs.com/) is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
 
 The testing pattern presented below is consistent across different testing frameworks. Only the setup test functions from [ember-qunit](https://github.com/emberjs/ember-qunit) needs to be replaced with the respective setup functions in the testing addon used in order to use other testing frameworks.
 
@@ -68,7 +68,7 @@ Examples of Container Tests are:
 * A serializer properly converts the blog request payload into a blog post model object.
 * Blog dates are properly formatted through a `time` service.
 
-You can read more about these type of tests in the [Testing Routes][] and [Testing Controllers][] section.
+You can read more about these type of tests in the [Testing Routes](./testing-routes) and [Testing Controllers](./testing-controllers) section.
 
 ### Rendering Tests
 
@@ -112,7 +112,7 @@ Examples of Rendering Tests are:
 
 Rendering Tests are used to test Components and Helpers where we need to render a layout and assert some interaction byproduct occurs.
 
-You can read more about it in the [Testing Components][] or the [Testing Helpers][] section.
+You can read more about it in the [Testing Components](./testing-components) or the [Testing Helpers](./testing-helpers) section.
 
 ### Application Tests
 
@@ -148,7 +148,7 @@ Examples of Application Tests are:
 * After saving a new post successfully, a user is then shown the list of prior posts.
 * A visitor does not have access to the admin panel.
 
-You can read more about how to create these kinds of tests in the [Application tests][] section.
+You can read more about how to create these kinds of tests in the [Application tests](./acceptance) section.
 
 ### Testing Blueprints
 
@@ -189,7 +189,7 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 Tests can also be executed when you are running a local development server (started by running `ember server`),
 at the `/tests` URI which renders the `tests/index.html` template.
 
-These commands run your tests using [Testem][] to make testing multiple browsers very easy.
+These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy.
 You can configure Testem using the `testem.js` file in your application root.
 
 #### Choosing the Tests to Run
@@ -200,11 +200,3 @@ When using QUnit it is possible to exclude tests by adding an exclamation point 
 
 You can also run a group of tests which you have scoped with a `module` before; e.g. for testing the module called `Unit | Service | location` only,
 run `ember test --module='Unit | Service | location'`.
-
-[QUnit]: http://qunitjs.com/
-[Testem]: https://github.com/airportyh/testem
-[Application tests]: ./acceptance
-[Testing Components]: ./testing-components
-[Testing Controllers]: ./testing-controllers
-[Testing Routes]: ./testing-routes
-[Testing Helpers]: ./testing-helpers

--- a/guides/v3.4.0/testing/testing-controllers.md
+++ b/guides/v3.4.0/testing/testing-controllers.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Controller extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Controller extends Ember.Object._
 
 Controllers can be tested using the `setupTest` helper which is part
 of the ember-qunit framework. The tests written for instances like `Ember.Controller` are
@@ -79,5 +79,3 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/

--- a/guides/v3.4.0/testing/testing-helpers.md
+++ b/guides/v3.4.0/testing/testing-helpers.md
@@ -1,4 +1,4 @@
-_Testing helpers follows previous patterns shown in [Testing Components][],
+_Testing helpers follows previous patterns shown in [Testing Components](../testing-components/),
 because helpers are rendered to templates just like components._
 
 Helpers are best tested with rendering tests, but can also be tested with unit
@@ -6,7 +6,7 @@ tests. Rendering tests will provide better coverage for helpers, as it more
 closely simulates the lifecycle of a helper than in isolation.
 
 We're going to demonstrate how to test helpers by testing the `format-currency`
-helper from [Writing Helpers][].
+helper from [Writing Helpers](../../templates/writing-helpers/).
 
 > You can follow along by generating your own helper with `ember generate helper
 > format-currency`.
@@ -42,12 +42,12 @@ module('Unit | Helper | format currency', function(hooks) {
 });
 ```
 
-As seen in the [Writing Helpers][] guide. The helper function expects the unnamed
+As seen in the [Writing Helpers](../../templates/writing-helpers/) guide. The helper function expects the unnamed
 arguments as an array as the first argument. It expects the named arguments as
 an object as the second argument.
 
 Now we can move on to a more complex test case that ensures our helper is rendered correctly as well. This can be done
-with the `setupRenderingTest` helper, as shown in [Testing Components][].
+with the `setupRenderingTest` helper, as shown in [Testing Components](../testing-components/).
 
 ```javascript {data-filename=tests/integration/helpers/format-currency-test.js}
 import { module, test } from 'qunit';
@@ -94,6 +94,3 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
-
-[Testing Components]: ../testing-components/
-[Writing Helpers]: ../../templates/writing-helpers/

--- a/guides/v3.4.0/testing/testing-models.md
+++ b/guides/v3.4.0/testing/testing-models.md
@@ -1,7 +1,7 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because DS.Model extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because DS.Model extends Ember.Object._
 
-[Ember Data][] Models can be tested in a module that uses the `setupTest` helper.
+[Ember Data](https://github.com/emberjs/data) Models can be tested in a module that uses the `setupTest` helper.
 
 Let's assume we have a `Player` model that has `level` and `levelName`
 attributes. We want to call `levelUp()` to increment the `level` and assign a
@@ -104,9 +104,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests][] for examples of deeper relationship testing if you
-feel the need to do it._
-
-[Ember Data]: https://github.com/emberjs/data
-[Testing Basics]: ../unit-testing-basics/
-[Ember Data tests]: https://github.com/emberjs/data/tree/master/tests
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
+feel the need to do it.

--- a/guides/v3.4.0/testing/testing-routes.md
+++ b/guides/v3.4.0/testing/testing-routes.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Route extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Route extends Ember.Object._
 
 Testing routes can be done both via application tests or container tests. Application tests
 will likely provide better coverage for routes because routes are typically used
@@ -34,7 +34,7 @@ export default Route.extend({
 });
 ```
 
-In this route we've [separated our concerns][]:
+In this route we've [separated our concerns](http://en.wikipedia.org/wiki/Separation_of_concerns):
 The action `displayAlert` contains the code that is called when the action is
 received, and the private function `_displayAlert` performs the work. While not
 necessarily obvious here because of the small size of the functions, separating
@@ -86,6 +86,3 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/
-[separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v3.5.0/components/the-component-lifecycle.md
+++ b/guides/v3.5.0/components/the-component-lifecycle.md
@@ -117,15 +117,15 @@ Suppose you want to integrate your favorite date picker library into an Ember pr
 Typically, 3rd party JS/jQuery libraries require a DOM element to bind to.
 So, where is the best place to initialize and attach the library?
 
-After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`][did-insert-element] hook.
+After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) hook.
 
 Ember guarantees that, by the time `didInsertElement()` is called:
 
 1. The component's element has been both created and inserted into the
    DOM.
-2. The component's element is accessible via the component's [`this.element`][element] property.
+2. The component's element is accessible via the component's [`this.element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property.
 
-The [`element`][element] property allows you to access the component's DOM element.
+The [`element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property allows you to access the component's DOM element.
 For example, you can set an attribute using the `Element.setAttribute()` method:
 
 ```javascript {data-filename=app/components/profile-editor.js}
@@ -139,7 +139,7 @@ export default Component.extend({
 });
 ```
 
-The [`element`][element] property will, by default, return a DOM object for the component's root element, but you can also target child elements within the component's template by passing a selector to `querySelector` or `querySelectorAll`:
+The [`element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property will, by default, return a DOM object for the component's root element, but you can also target child elements within the component's template by passing a selector to `querySelector` or `querySelectorAll`:
 
 ```javascript {data-filename=app/components/profile-editor.js}
 import Component from '@ember/component';
@@ -155,7 +155,7 @@ export default Component.extend({
 });
 ```
 
-Let's initialize our date picker by overriding the [`didInsertElement()`][did-insert-element] method.
+Let's initialize our date picker by overriding the [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) method.
 
 Date picker libraries usually attach to an `<input>` element, so we will use `this.element.querySelector` to find an appropriate input within our component's template.
 
@@ -170,7 +170,7 @@ export default Component.extend({
 });
 ```
 
-[`didInsertElement()`][did-insert-element] is also a good place to
+[`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is also a good place to
 attach event listeners. This is particularly useful for custom events or
 other browser events which do not have a [built-in event
 handler](./handling-events/#toc_event-names).
@@ -195,13 +195,10 @@ There are a few things to note about the `didInsertElement()` hook:
 
 - It is only triggered once when the component element is first rendered.
 - In cases where you have components nested inside other components, the child component will always receive the `didInsertElement()` call before its parent does.
-- Setting properties on the component in [`didInsertElement()`][did-insert-element] triggers a re-render, and for performance reasons,
+- Setting properties on the component in [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons,
   is not allowed.
-- While [`didInsertElement()`][did-insert-element] is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
+- While [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
   particularly when order of execution is important.
-
-[did-insert-element]: https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement
-[element]: https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element
 
 ### Making Updates to the Rendered DOM with `didRender`
 

--- a/guides/v3.5.0/configuring-ember/optional-features.md
+++ b/guides/v3.5.0/configuring-ember/optional-features.md
@@ -64,7 +64,7 @@ It is used for event handling, and to provide some APIs like `this.$()` in compo
 With the release of ember-source v3.4.0, an optional feature flag was introduced that allows users to opt out of jQuery.
 To enable it, run the following command after setting up `@ember/optional-features`:
 
-```shell
+```bash
 ember feature:disable jquery-integration
 ```
 

--- a/guides/v3.5.0/ember-inspector/data.md
+++ b/guides/v3.5.0/ember-inspector/data.md
@@ -1,5 +1,4 @@
-You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter][building-data-adapter] below if you maintain your own persistence library. 
-[building-data-adapter]:#toc_building-a-data-custom-adapter
+You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter](#toc_building-a-data-custom-adapter) below if you maintain your own persistence library. 
 
 When you open the Data tab, you will see a list of model types defined
 in your application, along with the number of loaded records.
@@ -32,8 +31,5 @@ You can also filter records by entering a query in the search box.
 
 ### Building a Data Custom Adapter
 
-You can use your own data persistence library with the Inspector. Build a [data adapter][data-adapter-docs], and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter][ember-data-data-adapter] as an example for how to build your data adapter.
-
-[data-adapter-docs]: https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js
-[ember-data-data-adapter]:https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js
+You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
+using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter.

--- a/guides/v3.5.0/ember-inspector/info.md
+++ b/guides/v3.5.0/ember-inspector/info.md
@@ -12,6 +12,4 @@ Ember.libraries.register(libraryName, libraryVersion);
 
 #### Ember CLI
 
-If you're using the [ember-cli-app-version][] addon, your application's name and version will be added to the list automatically.
-
-[ember-cli-app-version]: https://github.com/embersherpa/ember-cli-app-version
+If you're using the [ember-cli-app-version](https://github.com/embersherpa/ember-cli-app-version) addon, your application's name and version will be added to the list automatically.

--- a/guides/v3.5.0/ember-inspector/installation.md
+++ b/guides/v3.5.0/ember-inspector/installation.md
@@ -37,7 +37,7 @@ Make sure the "Display the Tomster" checkbox is checked.
 ### Firefox
 
 Visit the Add-on page on the [Mozilla Addons
-site][ember-inspector-mozilla].
+site](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/).
 
 Click on "Add to Firefox".
 
@@ -47,9 +47,6 @@ Once installed, go to an Ember application, open the Developer Tools,
 and click on the `Ember` tab.
 
 <img src="/images/guides/ember-inspector/installation-firefox-panel.png" width="680">
-
-[ember-inspector-mozilla]: https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/
-
 
 #### Enable Tomster
 

--- a/guides/v3.5.0/ember-inspector/object-inspector.md
+++ b/guides/v3.5.0/ember-inspector/object-inspector.md
@@ -15,9 +15,7 @@ The Inspector displays the parent objects and mixins that are composed into the 
 Each property value in this view is bound to your application, so if the value of a
 property updates in your app, it will be reflected in the Inspector.
 
-If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
-click on the calculator to compute it.
-[computed-property]: ../../object-model/computed-properties/
+If a property name is preceded by a calculator icon, that means it is a [computed property](../../object-model/computed-properties/). If the value of a computed property hasn't yet been computed, you can click on the calculator to compute it.
 
 ### Exposing Objects to the Console
 
@@ -91,7 +89,4 @@ width="450">
 Library authors can customize how any object will display in the Inspector.
 By defining a `_debugInfo` method, an object can tell the Inspector how it should be rendered.
 For an example on how to customize an object's properties, see [Ember Data's
-customization][ember-data-debug-info].
-
-
-[ember-data-debug-info]: https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js
+customization](https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js).

--- a/guides/v3.5.0/index.md
+++ b/guides/v3.5.0/index.md
@@ -40,13 +40,13 @@ We will try to link to appropriate documentation whenever a concept is introduce
 
 To make the most out of the guides, you should have a working knowledge of:
 
-* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network][mdn].
-* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network][promises] section.
-* **ES2015 modules** - you will better understand [Ember CLI's][ember-cli] project structure and import paths if you are comfortable with [JavaScript Modules][js-modules].
+* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web).
+* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) section.
+* **ES2015 modules** - you will better understand [Ember CLI's](https://ember-cli.com/) project structure and import paths if you are comfortable with [JavaScript Modules](http://jsmodules.io/).
 * **ES2015 syntax** - Ember CLI comes with Babel.js by default so you can
 take advantage of newer language features such as arrow functions, template
 strings, destructuring, and more. You can check the
-[Babel.js documentation][babeljs] or read [Understanding ECMAScript 6][es6]
+[Babel.js documentation](https://babeljs.io/docs/learn-es2015/) or read [Understanding ECMAScript 6](https://leanpub.com/understandinges6/read)
 online.
 
 ## A Note on Mobile Performance
@@ -85,7 +85,7 @@ the existing guides, we are happy to help you help us!
 Some of the more common ways to report a problem with the guides are:
 
 * Using the pencil icon on the top-right of each guide page
-* Opening an issue or pull request to [the GitHub repository][gh-guides]
+* Opening an issue or pull request to [the GitHub repository](https://github.com/ember-learn/guides-source/)
 
 Clicking the pencil icon will bring you to GitHub's editor for that
 guide so you can edit right away, using the Markdown markup language.
@@ -93,25 +93,11 @@ This is the fastest way to correct a typo, a missing word, or an error in
 a code sample.
 
 If you wish to make a more significant contribution be sure to check our
-[issue tracker][gh-guides-issues] to see if your issue is already being
+[issue tracker](https://github.com/ember-learn/guides-source/issues) to see if your issue is already being
 addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
-can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
+can check out our [contributing guide](https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md). If your
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord](https://discordapp.com/invite/zT3asNS).
 
 Good luck!
-
-[ember-cli]: https://ember-cli.com/
-
-[mdn]: https://developer.mozilla.org/en-US/docs/Web
-[promises]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-[js-modules]: http://jsmodules.io/
-[babeljs]: https://babeljs.io/docs/learn-es2015/
-[es6]: https://leanpub.com/understandinges6/read
-
-[gh-guides]: https://github.com/ember-learn/guides-source/
-[gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
-[gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
-
-[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v3.5.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.5.0/models/creating-updating-and-deleting-records.md
@@ -163,6 +163,5 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 });
 ```
 
-The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`][findRecord] automatically schedules a fetch of the record from the adapter.
-
-[findRecord]: <https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord>
+The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](<https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord>
+) automatically schedules a fetch of the record from the adapter.

--- a/guides/v3.5.0/models/index.md
+++ b/guides/v3.5.0/models/index.md
@@ -43,10 +43,8 @@ Typically, most models are loaded from and saved to a server that uses a
 database to store data. Usually you will send JSON representations of
 models back and forth to an HTTP server that you have written. However,
 Ember makes it easy to use other durable storage, such as saving to the
-user's hard disk with [IndexedDB][indexeddb], or hosted storage solutions that let you
+user's hard disk with [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API), or hosted storage solutions that let you
 avoid writing and hosting your own servers.
-
-[indexeddb]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 
 Once you've loaded your models from storage, components know how to
 translate model data into a UI that your user can interact with.  For
@@ -70,13 +68,10 @@ This will allow your code to evolve and grow, with better maintainability.
 ## Ember Data flexibility
 
 Thanks to its use of the _adapter pattern_, Ember Data can be configured
-to work with many different kinds of backends. There is [an entire ecosystem of adapters][adapters]
-and several [built-in adapters](./customizing-adapters/)
+to work with many different kinds of backends. There is [an entire ecosystem of adapters](http://emberobserver.com/categories/ember-data-adapters) and several [built-in adapters](./customizing-adapters/)
 that allow your Ember app to talk to different types of servers.
 
-[adapters]: http://emberobserver.com/categories/ember-data-adapters
-
-By default, Ember Data is designed to work out of the box with [JSON API][json-api].
+By default, Ember Data is designed to work out of the box with [JSON API](http://jsonapi.org).
 JSON API is a formal specification for building conventional, robust, and performant
 APIs that allow clients and servers to communicate model data.
 
@@ -84,10 +79,8 @@ JSON API standardizes how JavaScript applications talk to servers, so
 you decrease the coupling between your frontend and backend, and have
 more freedom to change pieces of your stack.
 
-[json-api]: http://jsonapi.org
-
 If you need to integrate your Ember.js app with a server that does not
-have an [adapter][adapters] available (for example, you hand-rolled an API server
+have an [adapter](http://emberobserver.com/categories/ember-data-adapters) available (for example, you hand-rolled an API server
 that does not adhere to any JSON specification), Ember Data is designed
 to **be configurable** to work with whatever data your server returns.
 

--- a/guides/v3.5.0/object-model/classes-and-instances.md
+++ b/guides/v3.5.0/object-model/classes-and-instances.md
@@ -4,11 +4,9 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`][1] method on
-[`EmberObject`][2]:
+To define a new Ember _class_, call the [`extend()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://www.emberjs.com/api/ember/release/modules/@ember%2Fobject):
 
-[1]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend
-[2]: https://www.emberjs.com/api/ember/release/modules/@ember%2Fobject
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -24,9 +22,7 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`][3] class:
-
-[3]: https://www.emberjs.com/api/ember/release/classes/Component
+of Ember's built-in [`Component`](https://www.emberjs.com/api/ember/release/classes/Component) class:
 
 ```javascript {data-filename=app/components/todo-item.js}
 import Component from '@ember/component';
@@ -71,11 +67,9 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`][4] hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`](https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
-
-[4]: https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse
 
 ```javascript
 normalizeResponse(store, primaryModelClass, payload, id, requestType)  {
@@ -89,11 +83,11 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`][5] method. Any methods, properties and
+class by calling its [`create()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/create?anchor=create
+) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
 
-[5]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/create?anchor=create
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -141,11 +135,9 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`][6] method is invoked
+When a new instance is created, its [`init()`](https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init) method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
-
-[6]: https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -228,7 +220,7 @@ Person.create({
 
 When reading a property value of an object, you can in most cases use the common JavaScript dot notation, e.g. `myObject.myProperty`. 
 
-[Ember proxy objects][9] are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`][7] accessor method to read values.
+[Ember proxy objects](https://emberjs.com/api/ember/3.3/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
 
 Let's look at the following `blogPost` Ember Data model:
 
@@ -246,7 +238,7 @@ export default Model.extend({
 
 To access the blog post's title you can simply write `blogPost.title`, whereas only the syntax `blogPost.get('comments')` will return the post's comments.
 
-Always use Ember's [`set()`][8] method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
+Always use Ember's [`set()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/set?anchor=set) method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -261,7 +253,3 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
-
-[7]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/get?anchor=get
-[8]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/set?anchor=set
-[9]: https://emberjs.com/api/ember/3.3/classes/ObjectProxy

--- a/guides/v3.5.0/templates/writing-helpers.md
+++ b/guides/v3.5.0/templates/writing-helpers.md
@@ -7,9 +7,7 @@ For example, imagine we have an `Invoice` model that contains a
 `totalDue` attribute, which represents the total amount due for that
 invoice.  Because we do not want our company to go out of business due
 to strange JavaScript rounding errors, [we store this value in cents
-instead of a floating point dollar value][currency-stackoverflow].
-
-[currency-stackoverflow]: http://stackoverflow.com/a/3730040
+instead of a floating point dollar value](http://stackoverflow.com/a/3730040).
 
 However, if we display dollar values to our users as "100¢" instead of
 "$1.00", they may be very confused. We can write a helper to
@@ -249,9 +247,9 @@ access to services in your application, and can optionally save state as well,
 although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
-should export a subclass of [`Ember.Helper`][1]. Helper classes must contain a
-[`compute`][2] method that behaves the same as the function passed to
-[`Ember.Helper.helper`][3].  In order to access a service, you must first inject it
+should export a subclass of [`Ember.Helper`](https://www.emberjs.com/api/ember/release/classes/Helper). Helper classes must contain a
+[`compute`](https://www.emberjs.com/api/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`Ember.Helper.helper`](https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -332,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`][4] string utility:
+[`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -346,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`][4]), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently
@@ -394,7 +392,3 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
-[1]: https://www.emberjs.com/api/ember/release/classes/Helper
-[2]: https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=compute
-[3]: https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=helper
-[4]: https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe

--- a/guides/v3.5.0/testing/acceptance.md
+++ b/guides/v3.5.0/testing/acceptance.md
@@ -83,20 +83,20 @@ your application, making it much easier to write deterministic tests.
 
 Some of these handy helpers are:
 
-* [`click(selector)`][1]
+* [`click(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click)
   - Clicks an element and triggers any actions triggered by the element's `click`
     event and returns a promise that fulfills when all resulting async behavior
     is complete.
-* [`fillIn(selector, value)`][2]
+* [`fillIn(selector, value)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin)
   - Fills in the selected input with the given value and returns a promise that
      fulfills when all resulting async behavior is complete. Works with `<select>` elements as well as `<input>` elements. Keep in mind that with `<select>` elements, `value` must be set to the _value_ of the `<option>` tag, rather than its _content_ (for example, `true` rather than `"Yes"`).
-* [`triggerKeyEvent(selector, type, keyCode)`][3]
+* [`triggerKeyEvent(selector, type, keyCode)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md)
   - Simulates a key event type, e.g. `keypress`, `keydown`, `keyup` with the
     desired keyCode on element found by the selector.
-* [`triggerEvent(selector, type, options)`][4]
+* [`triggerEvent(selector, type, options)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent)
   - Triggers the given event, e.g. `blur`, `dblclick` on the element identified
     by the provided selector.
-* [`visit(url)`][5]
+* [`visit(url)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit)
   - Visits the given route and returns a promise that fulfills when all resulting
      async behavior is complete.
 
@@ -130,22 +130,9 @@ previous steps in the test have completed.
 
 Synchronous helpers are performed immediately when triggered.
 
-* [`currentRouteName()`][6]: returns the currently active route name.
-* [`currentURL()`][7]: returns the current URL.
-* [`find(selector)`][8]: finds one element within the app's root element
+* [`currentRouteName()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename): returns the currently active route name.
+* [`currentURL()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl): returns the current URL.
+* [`find(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find): finds one element within the app's root element
   that matches the given selector. Scoping to the root element is useful
   to avoid conflicts with the test framework's reporter.
-* [`findAll(selector)`][9]: like `find(selector)`, but finds all elements
-  that match the given selector. Equivalent to calling querySelectorAll()
-  on the test root element. Returns an array of matched elements.
-
-
-[1]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click
-[2]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin
-[3]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerkeyevent
-[4]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent
-[5]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit
-[6]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename
-[7]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl
-[8]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find
-[9]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall
+* [`findAll(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall): Like `find(selector)`, but finds all elements that match the given selector. Equivalent to calling querySelectorAll() on the test root element. Returns an array of matched elements.

--- a/guides/v3.5.0/testing/index.md
+++ b/guides/v3.5.0/testing/index.md
@@ -1,6 +1,6 @@
 Testing is a core part of the Ember framework and its development cycle.
 
-[QUnit][] is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
+[QUnit](http://qunitjs.com/) is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
 
 The testing pattern presented below is consistent across different testing frameworks. Only the setup test functions from [ember-qunit](https://github.com/emberjs/ember-qunit) needs to be replaced with the respective setup functions in the testing addon used in order to use other testing frameworks.
 
@@ -68,7 +68,7 @@ Examples of Container Tests are:
 * A serializer properly converts the blog request payload into a blog post model object.
 * Blog dates are properly formatted through a `time` service.
 
-You can read more about these type of tests in the [Testing Routes][] and [Testing Controllers][] section.
+You can read more about these type of tests in the [Testing Routes](./testing-routes) and [Testing Controllers](./testing-controllers) section.
 
 ### Rendering Tests
 
@@ -112,7 +112,7 @@ Examples of Rendering Tests are:
 
 Rendering Tests are used to test Components and Helpers where we need to render a layout and assert some interaction byproduct occurs.
 
-You can read more about it in the [Testing Components][] or the [Testing Helpers][] section.
+You can read more about it in the [Testing Components](./testing-components) or the [Testing Helpers](./testing-helpers) section.
 
 ### Application Tests
 
@@ -148,7 +148,7 @@ Examples of Application Tests are:
 * After saving a new post successfully, a user is then shown the list of prior posts.
 * A visitor does not have access to the admin panel.
 
-You can read more about how to create these kinds of tests in the [Application tests][] section.
+You can read more about how to create these kinds of tests in the [Application tests](./acceptance) section.
 
 ### Testing Blueprints
 
@@ -189,7 +189,7 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 Tests can also be executed when you are running a local development server (started by running `ember server`),
 at the `/tests` URI which renders the `tests/index.html` template.
 
-These commands run your tests using [Testem][] to make testing multiple browsers very easy.
+These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy.
 You can configure Testem using the `testem.js` file in your application root.
 
 #### Choosing the Tests to Run
@@ -200,11 +200,3 @@ When using QUnit it is possible to exclude tests by adding an exclamation point 
 
 You can also run a group of tests which you have scoped with a `module` before; e.g. for testing the module called `Unit | Service | location` only,
 run `ember test --module='Unit | Service | location'`.
-
-[QUnit]: http://qunitjs.com/
-[Testem]: https://github.com/airportyh/testem
-[Application tests]: ./acceptance
-[Testing Components]: ./testing-components
-[Testing Controllers]: ./testing-controllers
-[Testing Routes]: ./testing-routes
-[Testing Helpers]: ./testing-helpers

--- a/guides/v3.5.0/testing/testing-controllers.md
+++ b/guides/v3.5.0/testing/testing-controllers.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Controller extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Controller extends Ember.Object._
 
 Controllers can be tested using the `setupTest` helper which is part
 of the ember-qunit framework. The tests written for instances like `Ember.Controller` are
@@ -79,5 +79,3 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/

--- a/guides/v3.5.0/testing/testing-helpers.md
+++ b/guides/v3.5.0/testing/testing-helpers.md
@@ -1,4 +1,4 @@
-_Testing helpers follows previous patterns shown in [Testing Components][],
+_Testing helpers follows previous patterns shown in [Testing Components](../testing-components/),
 because helpers are rendered to templates just like components._
 
 Helpers are best tested with rendering tests, but can also be tested with unit
@@ -6,7 +6,7 @@ tests. Rendering tests will provide better coverage for helpers, as it more
 closely simulates the lifecycle of a helper than in isolation.
 
 We're going to demonstrate how to test helpers by testing the `format-currency`
-helper from [Writing Helpers][].
+helper from [Writing Helpers](../../templates/writing-helpers/).
 
 > You can follow along by generating your own helper with `ember generate helper
 > format-currency`.
@@ -42,12 +42,12 @@ module('Unit | Helper | format currency', function(hooks) {
 });
 ```
 
-As seen in the [Writing Helpers][] guide. The helper function expects the unnamed
+As seen in the [Writing Helpers](../../templates/writing-helpers/) guide. The helper function expects the unnamed
 arguments as an array as the first argument. It expects the named arguments as
 an object as the second argument.
 
 Now we can move on to a more complex test case that ensures our helper is rendered correctly as well. This can be done
-with the `setupRenderingTest` helper, as shown in [Testing Components][].
+with the `setupRenderingTest` helper, as shown in [Testing Components](../testing-components/).
 
 ```javascript {data-filename=tests/integration/helpers/format-currency-test.js}
 import { module, test } from 'qunit';
@@ -94,6 +94,3 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
-
-[Testing Components]: ../testing-components/
-[Writing Helpers]: ../../templates/writing-helpers/

--- a/guides/v3.5.0/testing/testing-models.md
+++ b/guides/v3.5.0/testing/testing-models.md
@@ -1,7 +1,7 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because DS.Model extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because DS.Model extends Ember.Object._
 
-[Ember Data][] Models can be tested in a module that uses the `setupTest` helper.
+[Ember Data](https://github.com/emberjs/data) Models can be tested in a module that uses the `setupTest` helper.
 
 Let's assume we have a `Player` model that has `level` and `levelName`
 attributes. We want to call `levelUp()` to increment the `level` and assign a
@@ -104,9 +104,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests][] for examples of deeper relationship testing if you
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
 feel the need to do it._
-
-[Ember Data]: https://github.com/emberjs/data
-[Testing Basics]: ../unit-testing-basics/
-[Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v3.5.0/testing/testing-routes.md
+++ b/guides/v3.5.0/testing/testing-routes.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Route extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Route extends Ember.Object._
 
 Testing routes can be done both via application tests or container tests. Application tests
 will likely provide better coverage for routes because routes are typically used
@@ -34,7 +34,7 @@ export default Route.extend({
 });
 ```
 
-In this route we've [separated our concerns][]:
+In this route we've [separated our concerns](http://en.wikipedia.org/wiki/Separation_of_concerns):
 The action `displayAlert` contains the code that is called when the action is
 received, and the private function `_displayAlert` performs the work. While not
 necessarily obvious here because of the small size of the functions, separating
@@ -86,6 +86,3 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/
-[separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v3.6.0/components/the-component-lifecycle.md
+++ b/guides/v3.6.0/components/the-component-lifecycle.md
@@ -117,15 +117,15 @@ Suppose you want to integrate your favorite date picker library into an Ember pr
 Typically, 3rd party JS/jQuery libraries require a DOM element to bind to.
 So, where is the best place to initialize and attach the library?
 
-After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`][did-insert-element] hook.
+After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) hook.
 
 Ember guarantees that, by the time `didInsertElement()` is called:
 
 1. The component's element has been both created and inserted into the
    DOM.
-2. The component's element is accessible via the component's [`this.element`][element] property.
+2. The component's element is accessible via the component's [`this.element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property.
 
-The [`element`][element] property allows you to access the component's DOM element.
+The [`element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property allows you to access the component's DOM element.
 For example, you can set an attribute using the `Element.setAttribute()` method:
 
 ```javascript {data-filename=app/components/profile-editor.js}
@@ -139,7 +139,7 @@ export default Component.extend({
 });
 ```
 
-The [`element`][element] property will, by default, return a DOM object for the component's root element, but you can also target child elements within the component's template by passing a selector to `querySelector` or `querySelectorAll`:
+The [`element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property will, by default, return a DOM object for the component's root element, but you can also target child elements within the component's template by passing a selector to `querySelector` or `querySelectorAll`:
 
 ```javascript {data-filename=app/components/profile-editor.js}
 import Component from '@ember/component';
@@ -155,7 +155,7 @@ export default Component.extend({
 });
 ```
 
-Let's initialize our date picker by overriding the [`didInsertElement()`][did-insert-element] method.
+Let's initialize our date picker by overriding the [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) method.
 
 Date picker libraries usually attach to an `<input>` element, so we will use `this.element.querySelector` to find an appropriate input within our component's template.
 
@@ -170,7 +170,7 @@ export default Component.extend({
 });
 ```
 
-[`didInsertElement()`][did-insert-element] is also a good place to
+[`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is also a good place to
 attach event listeners. This is particularly useful for custom events or
 other browser events which do not have a [built-in event
 handler](./handling-events/#toc_event-names).
@@ -195,13 +195,10 @@ There are a few things to note about the `didInsertElement()` hook:
 
 - It is only triggered once when the component element is first rendered.
 - In cases where you have components nested inside other components, the child component will always receive the `didInsertElement()` call before its parent does.
-- Setting properties on the component in [`didInsertElement()`][did-insert-element] triggers a re-render, and for performance reasons,
+- Setting properties on the component in [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons,
   is not allowed.
-- While [`didInsertElement()`][did-insert-element] is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
+- While [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
   particularly when order of execution is important.
-
-[did-insert-element]: https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement
-[element]: https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element
 
 ### Making Updates to the Rendered DOM with `didRender`
 

--- a/guides/v3.6.0/configuring-ember/optional-features.md
+++ b/guides/v3.6.0/configuring-ember/optional-features.md
@@ -64,7 +64,7 @@ It is used for event handling, and to provide some APIs like `this.$()` in compo
 With the release of ember-source v3.4.0, an optional feature flag was introduced that allows users to opt out of jQuery.
 To enable it, run the following command after setting up `@ember/optional-features`:
 
-```shell
+```bash
 ember feature:disable jquery-integration
 ```
 

--- a/guides/v3.6.0/ember-inspector/data.md
+++ b/guides/v3.6.0/ember-inspector/data.md
@@ -1,5 +1,4 @@
-You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter][building-data-adapter] below if you maintain your own persistence library. 
-[building-data-adapter]:#toc_building-a-data-custom-adapter
+You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter](#toc_building-a-data-custom-adapter) below if you maintain your own persistence library. 
 
 When you open the Data tab, you will see a list of model types defined
 in your application, along with the number of loaded records.
@@ -32,8 +31,5 @@ You can also filter records by entering a query in the search box.
 
 ### Building a Data Custom Adapter
 
-You can use your own data persistence library with the Inspector. Build a [data adapter][data-adapter-docs], and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter][ember-data-data-adapter] as an example for how to build your data adapter.
-
-[data-adapter-docs]: https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js
-[ember-data-data-adapter]:https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js
+You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
+using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter.

--- a/guides/v3.6.0/ember-inspector/info.md
+++ b/guides/v3.6.0/ember-inspector/info.md
@@ -12,6 +12,4 @@ Ember.libraries.register(libraryName, libraryVersion);
 
 #### Ember CLI
 
-If you're using the [ember-cli-app-version][] addon, your application's name and version will be added to the list automatically.
-
-[ember-cli-app-version]: https://github.com/embersherpa/ember-cli-app-version
+If you're using the [ember-cli-app-version](https://github.com/embersherpa/ember-cli-app-version) addon, your application's name and version will be added to the list automatically.

--- a/guides/v3.6.0/ember-inspector/installation.md
+++ b/guides/v3.6.0/ember-inspector/installation.md
@@ -37,7 +37,7 @@ Make sure the "Display the Tomster" checkbox is checked.
 ### Firefox
 
 Visit the Add-on page on the [Mozilla Addons
-site][ember-inspector-mozilla].
+site](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/).
 
 Click on "Add to Firefox".
 
@@ -47,9 +47,6 @@ Once installed, go to an Ember application, open the Developer Tools,
 and click on the `Ember` tab.
 
 <img src="/images/guides/ember-inspector/installation-firefox-panel.png" width="680">
-
-[ember-inspector-mozilla]: https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/
-
 
 #### Enable Tomster
 

--- a/guides/v3.6.0/ember-inspector/object-inspector.md
+++ b/guides/v3.6.0/ember-inspector/object-inspector.md
@@ -15,9 +15,8 @@ The Inspector displays the parent objects and mixins that are composed into the 
 Each property value in this view is bound to your application, so if the value of a
 property updates in your app, it will be reflected in the Inspector.
 
-If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
+If a property name is preceded by a calculator icon, that means it is a [computed property](../../object-model/computed-properties/). If the value of a computed property hasn't yet been computed, you can
 click on the calculator to compute it.
-[computed-property]: ../../object-model/computed-properties/
 
 ### Exposing Objects to the Console
 
@@ -91,7 +90,4 @@ width="450">
 Library authors can customize how any object will display in the Inspector.
 By defining a `_debugInfo` method, an object can tell the Inspector how it should be rendered.
 For an example on how to customize an object's properties, see [Ember Data's
-customization][ember-data-debug-info].
-
-
-[ember-data-debug-info]: https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js
+customization](https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js).

--- a/guides/v3.6.0/index.md
+++ b/guides/v3.6.0/index.md
@@ -40,13 +40,13 @@ We will try to link to appropriate documentation whenever a concept is introduce
 
 To make the most out of the guides, you should have a working knowledge of:
 
-* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network][mdn].
-* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network][promises] section.
-* **ES2015 modules** - you will better understand [Ember CLI's][ember-cli] project structure and import paths if you are comfortable with [JavaScript Modules][js-modules].
+* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web).
+* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) section.
+* **ES2015 modules** - you will better understand [Ember CLI's](https://ember-cli.com/) project structure and import paths if you are comfortable with [JavaScript Modules](http://jsmodules.io/).
 * **ES2015 syntax** - Ember CLI comes with Babel.js by default so you can
 take advantage of newer language features such as arrow functions, template
 strings, destructuring, and more. You can check the
-[Babel.js documentation][babeljs] or read [Understanding ECMAScript 6][es6]
+[Babel.js documentation](https://babeljs.io/docs/learn-es2015/) or read [Understanding ECMAScript 6](https://leanpub.com/understandinges6/read)
 online.
 
 ## A Note on Mobile Performance
@@ -85,7 +85,7 @@ the existing guides, we are happy to help you help us!
 Some of the more common ways to report a problem with the guides are:
 
 * Using the pencil icon on the top-right of each guide page
-* Opening an issue or pull request to [the GitHub repository][gh-guides]
+* Opening an issue or pull request to [the GitHub repository](https://github.com/ember-learn/guides-source/)
 
 Clicking the pencil icon will bring you to GitHub's editor for that
 guide so you can edit right away, using the Markdown markup language.
@@ -93,25 +93,11 @@ This is the fastest way to correct a typo, a missing word, or an error in
 a code sample.
 
 If you wish to make a more significant contribution be sure to check our
-[issue tracker][gh-guides-issues] to see if your issue is already being
+[issue tracker](https://github.com/ember-learn/guides-source/issues) to see if your issue is already being
 addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
-can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
+can check out our [contributing guide](https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md). If your
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord](https://discordapp.com/invite/zT3asNS).
 
 Good luck!
-
-[ember-cli]: https://ember-cli.com/
-
-[mdn]: https://developer.mozilla.org/en-US/docs/Web
-[promises]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-[js-modules]: http://jsmodules.io/
-[babeljs]: https://babeljs.io/docs/learn-es2015/
-[es6]: https://leanpub.com/understandinges6/read
-
-[gh-guides]: https://github.com/ember-learn/guides-source/
-[gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
-[gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
-
-[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v3.6.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.6.0/models/creating-updating-and-deleting-records.md
@@ -163,6 +163,5 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 });
 ```
 
-The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`][findRecord] automatically schedules a fetch of the record from the adapter.
-
-[findRecord]: <https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord>
+The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](<https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord>
+) automatically schedules a fetch of the record from the adapter.

--- a/guides/v3.6.0/models/index.md
+++ b/guides/v3.6.0/models/index.md
@@ -43,10 +43,8 @@ Typically, most models are loaded from and saved to a server that uses a
 database to store data. Usually you will send JSON representations of
 models back and forth to an HTTP server that you have written. However,
 Ember makes it easy to use other durable storage, such as saving to the
-user's hard disk with [IndexedDB][indexeddb], or hosted storage solutions that let you
+user's hard disk with [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API), or hosted storage solutions that let you
 avoid writing and hosting your own servers.
-
-[indexeddb]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 
 Once you've loaded your models from storage, components know how to
 translate model data into a UI that your user can interact with.  For
@@ -70,13 +68,11 @@ This will allow your code to evolve and grow, with better maintainability.
 ## Ember Data flexibility
 
 Thanks to its use of the _adapter pattern_, Ember Data can be configured
-to work with many different kinds of backends. There is [an entire ecosystem of adapters][adapters]
+to work with many different kinds of backends. There is [an entire ecosystem of adapters](http://emberobserver.com/categories/ember-data-adapters)
 and several [built-in adapters](./customizing-adapters/)
 that allow your Ember app to talk to different types of servers.
 
-[adapters]: http://emberobserver.com/categories/ember-data-adapters
-
-By default, Ember Data is designed to work out of the box with [JSON API][json-api].
+By default, Ember Data is designed to work out of the box with [JSON API](http://jsonapi.org).
 JSON API is a formal specification for building conventional, robust, and performant
 APIs that allow clients and servers to communicate model data.
 
@@ -84,10 +80,8 @@ JSON API standardizes how JavaScript applications talk to servers, so
 you decrease the coupling between your frontend and backend, and have
 more freedom to change pieces of your stack.
 
-[json-api]: http://jsonapi.org
-
 If you need to integrate your Ember.js app with a server that does not
-have an [adapter][adapters] available (for example, you hand-rolled an API server
+have an [adapter](http://emberobserver.com/categories/ember-data-adapters) available (for example, you hand-rolled an API server
 that does not adhere to any JSON specification), Ember Data is designed
 to **be configurable** to work with whatever data your server returns.
 

--- a/guides/v3.6.0/object-model/classes-and-instances.md
+++ b/guides/v3.6.0/object-model/classes-and-instances.md
@@ -4,11 +4,9 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`][1] method on
-[`EmberObject`][2]:
+To define a new Ember _class_, call the [`extend()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://www.emberjs.com/api/ember/release/modules/@ember%2Fobject):
 
-[1]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend
-[2]: https://www.emberjs.com/api/ember/release/modules/@ember%2Fobject
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -24,9 +22,7 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`][3] class:
-
-[3]: https://www.emberjs.com/api/ember/release/classes/Component
+of Ember's built-in [`Component`](https://www.emberjs.com/api/ember/release/classes/Component) class:
 
 ```javascript {data-filename=app/components/todo-item.js}
 import Component from '@ember/component';
@@ -71,11 +67,9 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`][4] hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`](https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
-
-[4]: https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse
 
 ```javascript
 normalizeResponse(store, primaryModelClass, payload, id, requestType)  {
@@ -89,11 +83,11 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`][5] method. Any methods, properties and
+class by calling its [`create()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/create?anchor=create
+) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
 
-[5]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/create?anchor=create
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -141,11 +135,9 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`][6] method is invoked
+When a new instance is created, its [`init()`](https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init) method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
-
-[6]: https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -228,7 +220,7 @@ Person.create({
 
 When reading a property value of an object, you can in most cases use the common JavaScript dot notation, e.g. `myObject.myProperty`. 
 
-[Ember proxy objects][9] are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`][7] accessor method to read values.
+[Ember proxy objects](https://emberjs.com/api/ember/3.3/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
 
 Let's look at the following `blogPost` Ember Data model:
 
@@ -246,7 +238,7 @@ export default Model.extend({
 
 To access the blog post's title you can simply write `blogPost.title`, whereas only the syntax `blogPost.get('comments')` will return the post's comments.
 
-Always use Ember's [`set()`][8] method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
+Always use Ember's [`set()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/set?anchor=set) method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -261,7 +253,3 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
-
-[7]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/get?anchor=get
-[8]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/set?anchor=set
-[9]: https://emberjs.com/api/ember/3.3/classes/ObjectProxy

--- a/guides/v3.6.0/templates/writing-helpers.md
+++ b/guides/v3.6.0/templates/writing-helpers.md
@@ -7,9 +7,7 @@ For example, imagine we have an `Invoice` model that contains a
 `totalDue` attribute, which represents the total amount due for that
 invoice.  Because we do not want our company to go out of business due
 to strange JavaScript rounding errors, [we store this value in cents
-instead of a floating point dollar value][currency-stackoverflow].
-
-[currency-stackoverflow]: http://stackoverflow.com/a/3730040
+instead of a floating point dollar value](http://stackoverflow.com/a/3730040).
 
 However, if we display dollar values to our users as "100¢" instead of
 "$1.00", they may be very confused. We can write a helper to
@@ -249,9 +247,9 @@ access to services in your application, and can optionally save state as well,
 although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
-should export a subclass of [`Ember.Helper`][1]. Helper classes must contain a
-[`compute`][2] method that behaves the same as the function passed to
-[`Ember.Helper.helper`][3].  In order to access a service, you must first inject it
+should export a subclass of [`Ember.Helper`](https://www.emberjs.com/api/ember/release/classes/Helper). Helper classes must contain a
+[`compute`](https://www.emberjs.com/api/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`Ember.Helper.helper`](https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -332,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`][4] string utility:
+[`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -346,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`][4]), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently
@@ -394,7 +392,3 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
-[1]: https://www.emberjs.com/api/ember/release/classes/Helper
-[2]: https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=compute
-[3]: https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=helper
-[4]: https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe

--- a/guides/v3.6.0/testing/acceptance.md
+++ b/guides/v3.6.0/testing/acceptance.md
@@ -83,20 +83,20 @@ your application, making it much easier to write deterministic tests.
 
 Some of these handy helpers are:
 
-* [`click(selector)`][1]
+* [`click(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click)
   - Clicks an element and triggers any actions triggered by the element's `click`
     event and returns a promise that fulfills when all resulting async behavior
     is complete.
-* [`fillIn(selector, value)`][2]
+* [`fillIn(selector, value)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin)
   - Fills in the selected input with the given value and returns a promise that
      fulfills when all resulting async behavior is complete. Works with `<select>` elements as well as `<input>` elements. Keep in mind that with `<select>` elements, `value` must be set to the _value_ of the `<option>` tag, rather than its _content_ (for example, `true` rather than `"Yes"`).
-* [`triggerKeyEvent(selector, type, keyCode)`][3]
+* [`triggerKeyEvent(selector, type, keyCode)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md)
   - Simulates a key event type, e.g. `keypress`, `keydown`, `keyup` with the
     desired keyCode on element found by the selector.
-* [`triggerEvent(selector, type, options)`][4]
+* [`triggerEvent(selector, type, options)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent)
   - Triggers the given event, e.g. `blur`, `dblclick` on the element identified
     by the provided selector.
-* [`visit(url)`][5]
+* [`visit(url)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit)
   - Visits the given route and returns a promise that fulfills when all resulting
      async behavior is complete.
 
@@ -130,22 +130,9 @@ previous steps in the test have completed.
 
 Synchronous helpers are performed immediately when triggered.
 
-* [`currentRouteName()`][6]: returns the currently active route name.
-* [`currentURL()`][7]: returns the current URL.
-* [`find(selector)`][8]: finds one element within the app's root element
+* [`currentRouteName()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename): returns the currently active route name.
+* [`currentURL()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl): returns the current URL.
+* [`find(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find): finds one element within the app's root element
   that matches the given selector. Scoping to the root element is useful
   to avoid conflicts with the test framework's reporter.
-* [`findAll(selector)`][9]: like `find(selector)`, but finds all elements
-  that match the given selector. Equivalent to calling querySelectorAll()
-  on the test root element. Returns an array of matched elements.
-
-
-[1]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click
-[2]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin
-[3]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerkeyevent
-[4]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent
-[5]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit
-[6]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename
-[7]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl
-[8]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find
-[9]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall
+* [`findAll(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall): Like `find(selector)`, but finds all elements that match the given selector. Equivalent to calling querySelectorAll() on the test root element. Returns an array of matched elements.

--- a/guides/v3.6.0/testing/index.md
+++ b/guides/v3.6.0/testing/index.md
@@ -1,6 +1,6 @@
 Testing is a core part of the Ember framework and its development cycle.
 
-[QUnit][] is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
+[QUnit](http://qunitjs.com/) is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
 
 The testing pattern presented below is consistent across different testing frameworks. Only the setup test functions from [ember-qunit](https://github.com/emberjs/ember-qunit) needs to be replaced with the respective setup functions in the testing addon used in order to use other testing frameworks.
 
@@ -68,7 +68,7 @@ Examples of Container Tests are:
 * A serializer properly converts the blog request payload into a blog post model object.
 * Blog dates are properly formatted through a `time` service.
 
-You can read more about these type of tests in the [Testing Routes][] and [Testing Controllers][] section.
+You can read more about these type of tests in the [Testing Routes](./testing-routes) and [Testing Controllers](./testing-controllers) section.
 
 ### Rendering Tests
 
@@ -112,7 +112,7 @@ Examples of Rendering Tests are:
 
 Rendering Tests are used to test Components and Helpers where we need to render a layout and assert some interaction byproduct occurs.
 
-You can read more about it in the [Testing Components][] or the [Testing Helpers][] section.
+You can read more about it in the [Testing Components](./testing-components) or the [Testing Helpers](./testing-helpers) section.
 
 ### Application Tests
 
@@ -148,7 +148,7 @@ Examples of Application Tests are:
 * After saving a new post successfully, a user is then shown the list of prior posts.
 * A visitor does not have access to the admin panel.
 
-You can read more about how to create these kinds of tests in the [Application tests][] section.
+You can read more about how to create these kinds of tests in the [Application tests](./acceptance) section.
 
 ### Testing Blueprints
 
@@ -189,7 +189,7 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 Tests can also be executed when you are running a local development server (started by running `ember server`),
 at the `/tests` URI which renders the `tests/index.html` template.
 
-These commands run your tests using [Testem][] to make testing multiple browsers very easy.
+These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy.
 You can configure Testem using the `testem.js` file in your application root.
 
 #### Choosing the Tests to Run
@@ -200,11 +200,3 @@ When using QUnit it is possible to exclude tests by adding an exclamation point 
 
 You can also run a group of tests which you have scoped with a `module` before; e.g. for testing the module called `Unit | Service | location` only,
 run `ember test --module='Unit | Service | location'`.
-
-[QUnit]: http://qunitjs.com/
-[Testem]: https://github.com/airportyh/testem
-[Application tests]: ./acceptance
-[Testing Components]: ./testing-components
-[Testing Controllers]: ./testing-controllers
-[Testing Routes]: ./testing-routes
-[Testing Helpers]: ./testing-helpers

--- a/guides/v3.6.0/testing/testing-controllers.md
+++ b/guides/v3.6.0/testing/testing-controllers.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Controller extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Controller extends Ember.Object._
 
 Controllers can be tested using the `setupTest` helper which is part
 of the ember-qunit framework. The tests written for instances like `Ember.Controller` are
@@ -79,5 +79,3 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/

--- a/guides/v3.6.0/testing/testing-helpers.md
+++ b/guides/v3.6.0/testing/testing-helpers.md
@@ -1,4 +1,4 @@
-_Testing helpers follows previous patterns shown in [Testing Components][],
+_Testing helpers follows previous patterns shown in [Testing Components](../testing-components/),
 because helpers are rendered to templates just like components._
 
 Helpers are best tested with rendering tests, but can also be tested with unit
@@ -6,7 +6,7 @@ tests. Rendering tests will provide better coverage for helpers, as it more
 closely simulates the lifecycle of a helper than in isolation.
 
 We're going to demonstrate how to test helpers by testing the `format-currency`
-helper from [Writing Helpers][].
+helper from [Writing Helpers](../../templates/writing-helpers/).
 
 > You can follow along by generating your own helper with `ember generate helper
 > format-currency`.
@@ -42,12 +42,12 @@ module('Unit | Helper | format currency', function(hooks) {
 });
 ```
 
-As seen in the [Writing Helpers][] guide. The helper function expects the unnamed
+As seen in the [Writing Helpers](../../templates/writing-helpers/) guide. The helper function expects the unnamed
 arguments as an array as the first argument. It expects the named arguments as
 an object as the second argument.
 
 Now we can move on to a more complex test case that ensures our helper is rendered correctly as well. This can be done
-with the `setupRenderingTest` helper, as shown in [Testing Components][].
+with the `setupRenderingTest` helper, as shown in [Testing Components](../testing-components/).
 
 ```javascript {data-filename=tests/integration/helpers/format-currency-test.js}
 import { module, test } from 'qunit';
@@ -94,6 +94,3 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
-
-[Testing Components]: ../testing-components/
-[Writing Helpers]: ../../templates/writing-helpers/

--- a/guides/v3.6.0/testing/testing-models.md
+++ b/guides/v3.6.0/testing/testing-models.md
@@ -1,7 +1,7 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because DS.Model extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because DS.Model extends Ember.Object._
 
-[Ember Data][] Models can be tested in a module that uses the `setupTest` helper.
+[Ember Data](https://github.com/emberjs/data) Models can be tested in a module that uses the `setupTest` helper.
 
 Let's assume we have a `Player` model that has `level` and `levelName`
 attributes. We want to call `levelUp()` to increment the `level` and assign a
@@ -104,9 +104,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests][] for examples of deeper relationship testing if you
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
 feel the need to do it._
-
-[Ember Data]: https://github.com/emberjs/data
-[Testing Basics]: ../unit-testing-basics/
-[Ember Data tests]: https://github.com/emberjs/data/tree/master/tests

--- a/guides/v3.6.0/testing/testing-routes.md
+++ b/guides/v3.6.0/testing/testing-routes.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Route extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Route extends Ember.Object._
 
 Testing routes can be done both via application tests or container tests. Application tests
 will likely provide better coverage for routes because routes are typically used
@@ -34,7 +34,7 @@ export default Route.extend({
 });
 ```
 
-In this route we've [separated our concerns][]:
+In this route we've [separated our concerns](http://en.wikipedia.org/wiki/Separation_of_concerns):
 The action `displayAlert` contains the code that is called when the action is
 received, and the private function `_displayAlert` performs the work. While not
 necessarily obvious here because of the small size of the functions, separating
@@ -86,6 +86,3 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/
-[separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns

--- a/guides/v3.7.0/components/the-component-lifecycle.md
+++ b/guides/v3.7.0/components/the-component-lifecycle.md
@@ -117,15 +117,15 @@ Suppose you want to integrate your favorite date picker library into an Ember pr
 Typically, 3rd party JS/jQuery libraries require a DOM element to bind to.
 So, where is the best place to initialize and attach the library?
 
-After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`][did-insert-element] hook.
+After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) hook.
 
 Ember guarantees that, by the time `didInsertElement()` is called:
 
 1. The component's element has been both created and inserted into the
    DOM.
-2. The component's element is accessible via the component's [`this.element`][element] property.
+2. The component's element is accessible via the component's [`this.element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property.
 
-The [`element`][element] property allows you to access the component's DOM element.
+The [`element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property allows you to access the component's DOM element.
 For example, you can set an attribute using the `Element.setAttribute()` method:
 
 ```javascript {data-filename=app/components/profile-editor.js}
@@ -139,7 +139,7 @@ export default Component.extend({
 });
 ```
 
-The [`element`][element] property will, by default, return a DOM object for the component's root element, but you can also target child elements within the component's template by passing a selector to `querySelector` or `querySelectorAll`:
+The [`element`](https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element) property will, by default, return a DOM object for the component's root element, but you can also target child elements within the component's template by passing a selector to `querySelector` or `querySelectorAll`:
 
 ```javascript {data-filename=app/components/profile-editor.js}
 import Component from '@ember/component';
@@ -155,7 +155,7 @@ export default Component.extend({
 });
 ```
 
-Let's initialize our date picker by overriding the [`didInsertElement()`][did-insert-element] method.
+Let's initialize our date picker by overriding the [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) method.
 
 Date picker libraries usually attach to an `<input>` element, so we will use `this.element.querySelector` to find an appropriate input within our component's template.
 
@@ -170,7 +170,7 @@ export default Component.extend({
 });
 ```
 
-[`didInsertElement()`][did-insert-element] is also a good place to
+[`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is also a good place to
 attach event listeners. This is particularly useful for custom events or
 other browser events which do not have a [built-in event
 handler](./handling-events/#toc_event-names).
@@ -195,13 +195,10 @@ There are a few things to note about the `didInsertElement()` hook:
 
 - It is only triggered once when the component element is first rendered.
 - In cases where you have components nested inside other components, the child component will always receive the `didInsertElement()` call before its parent does.
-- Setting properties on the component in [`didInsertElement()`][did-insert-element] triggers a re-render, and for performance reasons,
+- Setting properties on the component in [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons,
   is not allowed.
-- While [`didInsertElement()`][did-insert-element] is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
+- While [`didInsertElement()`](https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement) is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
   particularly when order of execution is important.
-
-[did-insert-element]: https://www.emberjs.com/api/ember/release/classes/Component/events/didInsertElement?anchor=didInsertElement
-[element]: https://emberjs.com/api/ember/release/classes/Component/properties/element?anchor=element
 
 ### Making Updates to the Rendered DOM with `didRender`
 

--- a/guides/v3.7.0/configuring-ember/optional-features.md
+++ b/guides/v3.7.0/configuring-ember/optional-features.md
@@ -64,7 +64,7 @@ It is used for event handling, and to provide some APIs like `this.$()` in compo
 With the release of ember-source v3.4.0, an optional feature flag was introduced that allows users to opt out of jQuery.
 To enable it, run the following command after setting up `@ember/optional-features`:
 
-```shell
+```bash
 ember feature:disable jquery-integration
 ```
 

--- a/guides/v3.7.0/ember-inspector/data.md
+++ b/guides/v3.7.0/ember-inspector/data.md
@@ -1,5 +1,4 @@
-You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter][building-data-adapter] below if you maintain your own persistence library. 
-[building-data-adapter]:#toc_building-a-data-custom-adapter
+You can inspect your models by clicking on the `Data` tab. Check out [Building a Data Custom Adapter](#toc_building-a-data-custom-adapter) below if you maintain your own persistence library. 
 
 When you open the Data tab, you will see a list of model types defined
 in your application, along with the number of loaded records.
@@ -32,9 +31,5 @@ You can also filter records by entering a query in the search box.
 
 ### Building a Data Custom Adapter
 
-You can use your own data persistence library with the Inspector. Build a [data adapter][data-adapter-docs], and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter][ember-data-data-adapter] as an example for how to build your data adapter and [DataAdapter][class-data-adapter] documentation.
-
-[data-adapter-docs]: https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js
-[ember-data-data-adapter]:https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js
-[class-data-adapter]:https://emberjs.com/api/ember/release/classes/DataAdapter
+You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
+using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter and [DataAdapter](https://emberjs.com/api/ember/release/classes/DataAdapter) documentation.

--- a/guides/v3.7.0/ember-inspector/info.md
+++ b/guides/v3.7.0/ember-inspector/info.md
@@ -12,6 +12,4 @@ Ember.libraries.register(libraryName, libraryVersion);
 
 #### Ember CLI
 
-If you're using the [ember-cli-app-version][] addon, your application's name and version will be added to the list automatically.
-
-[ember-cli-app-version]: https://github.com/embersherpa/ember-cli-app-version
+If you're using the [ember-cli-app-version](https://github.com/embersherpa/ember-cli-app-version) addon, your application's name and version will be added to the list automatically.

--- a/guides/v3.7.0/ember-inspector/installation.md
+++ b/guides/v3.7.0/ember-inspector/installation.md
@@ -37,7 +37,7 @@ Make sure the "Display the Tomster" checkbox is checked.
 ### Firefox
 
 Visit the Add-on page on the [Mozilla Addons
-site][ember-inspector-mozilla].
+site](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/).
 
 Click on "Add to Firefox".
 
@@ -47,8 +47,6 @@ Once installed, go to an Ember application, open the Developer Tools,
 and click on the `Ember` tab.
 
 <img src="/images/guides/ember-inspector/installation-firefox-panel.png" width="680">
-
-[ember-inspector-mozilla]: https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/
 
 
 #### Enable Tomster

--- a/guides/v3.7.0/ember-inspector/object-inspector.md
+++ b/guides/v3.7.0/ember-inspector/object-inspector.md
@@ -15,9 +15,7 @@ The Inspector displays the parent objects and mixins that are composed into the 
 Each property value in this view is bound to your application, so if the value of a
 property updates in your app, it will be reflected in the Inspector.
 
-If a property name is preceded by a calculator icon, that means it is a [computed property][computed-property]. If the value of a computed property hasn't yet been computed, you can
-click on the calculator to compute it.
-[computed-property]: ../../object-model/computed-properties/
+If a property name is preceded by a calculator icon, that means it is a [computed property](../../object-model/computed-properties/). If the value of a computed property hasn't yet been computed, you can click on the calculator to compute it.
 
 ### Exposing Objects to the Console
 
@@ -91,7 +89,4 @@ width="450">
 Library authors can customize how any object will display in the Inspector.
 By defining a `_debugInfo` method, an object can tell the Inspector how it should be rendered.
 For an example on how to customize an object's properties, see [Ember Data's
-customization][ember-data-debug-info].
-
-
-[ember-data-debug-info]: https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js
+customization](https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/system/debug/debug_info.js).

--- a/guides/v3.7.0/index.md
+++ b/guides/v3.7.0/index.md
@@ -40,13 +40,13 @@ We will try to link to appropriate documentation whenever a concept is introduce
 
 To make the most out of the guides, you should have a working knowledge of:
 
-* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network][mdn].
-* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network][promises] section.
-* **ES2015 modules** - you will better understand [Ember CLI's][ember-cli] project structure and import paths if you are comfortable with [JavaScript Modules][js-modules].
+* **HTML, CSS, JavaScript** - the building blocks of web pages. You can find documentation of each of these technologies at the [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web).
+* **Promises** - the native way to deal with asynchrony in your JavaScript code. See the relevant [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) section.
+* **ES2015 modules** - you will better understand [Ember CLI's](https://ember-cli.com/) project structure and import paths if you are comfortable with [JavaScript Modules](http://jsmodules.io/).
 * **ES2015 syntax** - Ember CLI comes with Babel.js by default so you can
 take advantage of newer language features such as arrow functions, template
 strings, destructuring, and more. You can check the
-[Babel.js documentation][babeljs] or read [Understanding ECMAScript 6][es6]
+[Babel.js documentation](https://babeljs.io/docs/learn-es2015/) or read [Understanding ECMAScript 6](https://leanpub.com/understandinges6/read)
 online.
 
 ## A Note on Mobile Performance
@@ -85,7 +85,7 @@ the existing guides, we are happy to help you help us!
 Some of the more common ways to report a problem with the guides are:
 
 * Using the pencil icon on the top-right of each guide page
-* Opening an issue or pull request to [the GitHub repository][gh-guides]
+* Opening an issue or pull request to [the GitHub repository](https://github.com/ember-learn/guides-source/)
 
 Clicking the pencil icon will bring you to GitHub's editor for that
 guide so you can edit right away, using the Markdown markup language.
@@ -93,25 +93,11 @@ This is the fastest way to correct a typo, a missing word, or an error in
 a code sample.
 
 If you wish to make a more significant contribution be sure to check our
-[issue tracker][gh-guides-issues] to see if your issue is already being
+[issue tracker](https://github.com/ember-learn/guides-source/issues) to see if your issue is already being
 addressed. If you don't find an active issue, open a new one.
 
 If you have any questions about styling or the contributing process, you
-can check out our [contributing guide][gh-guides-contributing]. If your
-question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord][discord].
+can check out our [contributing guide](https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md). If your
+question persists, reach us in the `#dev-ember-learning` channel on the [Ember Community Discord](https://discordapp.com/invite/zT3asNS).
 
 Good luck!
-
-[ember-cli]: https://ember-cli.com/
-
-[mdn]: https://developer.mozilla.org/en-US/docs/Web
-[promises]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-[js-modules]: http://jsmodules.io/
-[babeljs]: https://babeljs.io/docs/learn-es2015/
-[es6]: https://leanpub.com/understandinges6/read
-
-[gh-guides]: https://github.com/ember-learn/guides-source/
-[gh-guides-issues]: https://github.com/ember-learn/guides-source/issues
-[gh-guides-contributing]: https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md
-
-[discord]: https://discordapp.com/invite/zT3asNS

--- a/guides/v3.7.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.7.0/models/creating-updating-and-deleting-records.md
@@ -163,6 +163,5 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 });
 ```
 
-The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`][findRecord] automatically schedules a fetch of the record from the adapter.
-
-[findRecord]: <https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord>
+The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](<https://www.emberjs.com/api/ember-data/release/classes/DS.Store/methods/findRecord?anchor=findRecord>
+) automatically schedules a fetch of the record from the adapter.

--- a/guides/v3.7.0/models/index.md
+++ b/guides/v3.7.0/models/index.md
@@ -43,10 +43,8 @@ Typically, most models are loaded from and saved to a server that uses a
 database to store data. Usually you will send JSON representations of
 models back and forth to an HTTP server that you have written. However,
 Ember makes it easy to use other durable storage, such as saving to the
-user's hard disk with [IndexedDB][indexeddb], or hosted storage solutions that let you
+user's hard disk with [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API), or hosted storage solutions that let you
 avoid writing and hosting your own servers.
-
-[indexeddb]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 
 Once you've loaded your models from storage, components know how to
 translate model data into a UI that your user can interact with.  For
@@ -70,13 +68,11 @@ This will allow your code to evolve and grow, with better maintainability.
 ## Ember Data flexibility
 
 Thanks to its use of the _adapter pattern_, Ember Data can be configured
-to work with many different kinds of backends. There is [an entire ecosystem of adapters][adapters]
+to work with many different kinds of backends. There is [an entire ecosystem of adapters](http://emberobserver.com/categories/ember-data-adapters)
 and several [built-in adapters](./customizing-adapters/)
 that allow your Ember app to talk to different types of servers.
 
-[adapters]: http://emberobserver.com/categories/ember-data-adapters
-
-By default, Ember Data is designed to work out of the box with [JSON:API][json-api].
+By default, Ember Data is designed to work out of the box with [JSON:API](http://jsonapi.org).
 JSON:API is a formal specification for building conventional, robust, and performant
 APIs that allow clients and servers to communicate model data.
 
@@ -84,10 +80,8 @@ JSON:API standardizes how JavaScript applications talk to servers, so
 you decrease the coupling between your frontend and backend, and have
 more freedom to change pieces of your stack.
 
-[json-api]: http://jsonapi.org
-
 If you need to integrate your Ember.js app with a server that does not
-have an [adapter][adapters] available (for example, you hand-rolled an API server
+have an [adapter](http://emberobserver.com/categories/ember-data-adapters) available (for example, you hand-rolled an API server
 that does not adhere to any JSON specification), Ember Data is designed
 to **be configurable** to work with whatever data your server returns.
 

--- a/guides/v3.7.0/object-model/classes-and-instances.md
+++ b/guides/v3.7.0/object-model/classes-and-instances.md
@@ -4,11 +4,9 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`][1] method on
-[`EmberObject`][2]:
+To define a new Ember _class_, call the [`extend()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://www.emberjs.com/api/ember/release/modules/@ember%2Fobject):
 
-[1]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend
-[2]: https://www.emberjs.com/api/ember/release/modules/@ember%2Fobject
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -24,9 +22,7 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`][3] class:
-
-[3]: https://www.emberjs.com/api/ember/release/classes/Component
+of Ember's built-in [`Component`](https://www.emberjs.com/api/ember/release/classes/Component) class:
 
 ```javascript {data-filename=app/components/todo-item.js}
 import Component from '@ember/component';
@@ -71,11 +67,9 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`][4] hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`](https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
-
-[4]: https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse
 
 ```javascript
 normalizeResponse(store, primaryModelClass, payload, id, requestType)  {
@@ -89,11 +83,11 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`][5] method. Any methods, properties and
+class by calling its [`create()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/create?anchor=create
+) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
 
-[5]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/create?anchor=create
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -141,11 +135,9 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`][6] method is invoked
+When a new instance is created, its [`init()`](https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init) method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
-
-[6]: https://www.emberjs.com/api/ember/release/classes/EmberObject/methods/init?anchor=init
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -228,7 +220,7 @@ Person.create({
 
 When reading a property value of an object, you can in most cases use the common JavaScript dot notation, e.g. `myObject.myProperty`. 
 
-[Ember proxy objects][9] are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`][7] accessor method to read values.
+[Ember proxy objects](https://emberjs.com/api/ember/3.3/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
 
 Let's look at the following `blogPost` Ember Data model:
 
@@ -246,7 +238,7 @@ export default Model.extend({
 
 To access the blog post's title you can simply write `blogPost.title`, whereas only the syntax `blogPost.get('comments')` will return the post's comments.
 
-Always use Ember's [`set()`][8] method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
+Always use Ember's [`set()`](https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/set?anchor=set) method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -261,7 +253,3 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
-
-[7]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/get?anchor=get
-[8]: https://www.emberjs.com/api/ember/release/classes/@ember%2Fobject/methods/set?anchor=set
-[9]: https://emberjs.com/api/ember/3.3/classes/ObjectProxy

--- a/guides/v3.7.0/reference/accessibility-guide.md
+++ b/guides/v3.7.0/reference/accessibility-guide.md
@@ -69,7 +69,7 @@ Here is a checklist of some things to keep in mind when developing your applicat
   - All interactive elements must have an accessible name.
 - The values for the role attribute are predefined by the ARIA specification. This is not something an author can define a custom value for (that is not listed in the spec). [Learn more about roles in the specification.](https://www.w3.org/TR/wai-aria/#roles_categorization)
 - In general, avoid making your own keyboard shortcuts. [Screen readers already provide quite a few.](https://dequeuniversity.com/screenreaders/) There is some nuance here, so proceed with caution should you choose to do so. 
-- "Completely accessible" may be somewhat of a misnomer. Practical accessibility looks more like 90% coding to the spec and 10% filing browser bugs (or keeping track of existing browser bugs). Keep in mind that if you choose to implement a workaround for a browser bug, you will need to put an issue in your product backlog to follow up on browser bugs at a later date.
+- "Completely accessible" may be somewhat of a misnomer. Practical accessibility looks more like 90% coding to the spec and 10% filing browser bugs (or keeping track of existing browser bugs). Keep in mind that if you choose to implement a workaround for a browser bug, you will need to put an issue in your product backlog to follow up on browser bugs at a later date. 
 
 ### Focus
 

--- a/guides/v3.7.0/templates/writing-helpers.md
+++ b/guides/v3.7.0/templates/writing-helpers.md
@@ -7,9 +7,7 @@ For example, imagine we have an `Invoice` model that contains a
 `totalDue` attribute, which represents the total amount due for that
 invoice.  Because we do not want our company to go out of business due
 to strange JavaScript rounding errors, [we store this value in cents
-instead of a floating point dollar value][currency-stackoverflow].
-
-[currency-stackoverflow]: http://stackoverflow.com/a/3730040
+instead of a floating point dollar value](http://stackoverflow.com/a/3730040).
 
 However, if we display dollar values to our users as "100¢" instead of
 "$1.00", they may be very confused. We can write a helper to
@@ -249,9 +247,9 @@ access to services in your application, and can optionally save state as well,
 although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
-should export a subclass of [`Ember.Helper`][1]. Helper classes must contain a
-[`compute`][2] method that behaves the same as the function passed to
-[`Ember.Helper.helper`][3].  In order to access a service, you must first inject it
+should export a subclass of [`Ember.Helper`](https://www.emberjs.com/api/ember/release/classes/Helper). Helper classes must contain a
+[`compute`](https://www.emberjs.com/api/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`Ember.Helper.helper`](https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -332,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`][4] string utility:
+[`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -346,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`][4]), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://www.emberjs.com/api/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently
@@ -394,7 +392,3 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
-[1]: https://www.emberjs.com/api/ember/release/classes/Helper
-[2]: https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=compute
-[3]: https://www.emberjs.com/api/ember/release/classes/Helper/methods/compute?anchor=helper
-[4]: https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe

--- a/guides/v3.7.0/testing/acceptance.md
+++ b/guides/v3.7.0/testing/acceptance.md
@@ -83,20 +83,20 @@ your application, making it much easier to write deterministic tests.
 
 Some of these handy helpers are:
 
-* [`click(selector)`][1]
+* [`click(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click)
   - Clicks an element and triggers any actions triggered by the element's `click`
     event and returns a promise that fulfills when all resulting async behavior
     is complete.
-* [`fillIn(selector, value)`][2]
+* [`fillIn(selector, value)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin)
   - Fills in the selected input with the given value and returns a promise that
      fulfills when all resulting async behavior is complete. Works with `<select>` elements as well as `<input>` elements. Keep in mind that with `<select>` elements, `value` must be set to the _value_ of the `<option>` tag, rather than its _content_ (for example, `true` rather than `"Yes"`).
-* [`triggerKeyEvent(selector, type, keyCode)`][3]
+* [`triggerKeyEvent(selector, type, keyCode)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md)
   - Simulates a key event type, e.g. `keypress`, `keydown`, `keyup` with the
     desired keyCode on element found by the selector.
-* [`triggerEvent(selector, type, options)`][4]
+* [`triggerEvent(selector, type, options)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent)
   - Triggers the given event, e.g. `blur`, `dblclick` on the element identified
     by the provided selector.
-* [`visit(url)`][5]
+* [`visit(url)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit)
   - Visits the given route and returns a promise that fulfills when all resulting
      async behavior is complete.
 
@@ -130,18 +130,18 @@ previous steps in the test have completed.
 
 Synchronous helpers are performed immediately when triggered.
 
-* [`currentRouteName()`][6]: returns the currently active route name.
-* [`currentURL()`][7]: returns the current URL.
-* [`find(selector)`][8]: finds one element within the app's root element
+* [`currentRouteName()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename): returns the currently active route name.
+* [`currentURL()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl): returns the current URL.
+* [`find(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find): finds one element within the app's root element
   that matches the given selector. Scoping to the root element is useful
   to avoid conflicts with the test framework's reporter.
-* [`findAll(selector)`][9]: like `find(selector)`, but finds all elements
+* [`findAll(selector)`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall): Like `find(selector)`, but finds all elements
   that match the given selector. Equivalent to calling querySelectorAll()
   on the test root element. Returns an array of matched elements.
 
-## Debugging Your Tests
+  ## Debugging Your Tests
 
-During the development of you tests or when you refactor you application's code, the execution of your tests may fail. In order to help you understand why, [`pauseTest()`][10] and [`resumeTest()`][11] can help you.
+During the development of you tests or when you refactor you application's code, the execution of your tests may fail. In order to help you understand why, [`pauseTest()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#pausetest) and [`resumeTest()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#resumetest) can help you.
 
 To try them out, do the following steps:
 
@@ -152,15 +152,3 @@ To try them out, do the following steps:
 When the execution of the test come upon `await pauseTest()`, the test will be paused, allowing you to inspect the state of your application.
 
 You can now type `resumeTest()` in the console of your browser to continue the test execution.
-
-[1]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#click
-[2]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#fillin
-[3]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerkeyevent
-[4]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#triggerevent
-[5]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#visit
-[6]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename
-[7]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl
-[8]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#find
-[9]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#findall
-[10]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#pausetest
-[11]: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#resumetest

--- a/guides/v3.7.0/testing/index.md
+++ b/guides/v3.7.0/testing/index.md
@@ -1,6 +1,6 @@
 Testing is a core part of the Ember framework and its development cycle.
 
-[QUnit][] is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
+[QUnit](http://qunitjs.com/) is the default testing framework for this guide, but others are supported too, through addons such as [ember-mocha](https://github.com/emberjs/ember-mocha).
 
 The testing pattern presented below is consistent across different testing frameworks. Only the setup test functions from [ember-qunit](https://github.com/emberjs/ember-qunit) needs to be replaced with the respective setup functions in the testing addon used in order to use other testing frameworks.
 
@@ -68,7 +68,7 @@ Examples of Container Tests are:
 * A serializer properly converts the blog request payload into a blog post model object.
 * Blog dates are properly formatted through a `time` service.
 
-You can read more about these type of tests in the [Testing Routes][] and [Testing Controllers][] section.
+You can read more about these type of tests in the [Testing Routes](./testing-routes) and [Testing Controllers](./testing-controllers) section.
 
 ### Rendering Tests
 
@@ -112,7 +112,7 @@ Examples of Rendering Tests are:
 
 Rendering Tests are used to test Components and Helpers where we need to render a layout and assert some interaction byproduct occurs.
 
-You can read more about it in the [Testing Components][] or the [Testing Helpers][] section.
+You can read more about it in the [Testing Components](./testing-components) or the [Testing Helpers](./testing-helpers) section.
 
 ### Application Tests
 
@@ -148,7 +148,7 @@ Examples of Application Tests are:
 * After saving a new post successfully, a user is then shown the list of prior posts.
 * A visitor does not have access to the admin panel.
 
-You can read more about how to create these kinds of tests in the [Application tests][] section.
+You can read more about how to create these kinds of tests in the [Application tests](./acceptance) section.
 
 ### Testing Blueprints
 
@@ -189,7 +189,7 @@ Run your tests with `ember test` on the command-line. You can re-run your tests 
 Tests can also be executed when you are running a local development server (started by running `ember server`),
 at the `/tests` URI which renders the `tests/index.html` template.
 
-These commands run your tests using [Testem][] to make testing multiple browsers very easy.
+These commands run your tests using [Testem](https://github.com/airportyh/testem) to make testing multiple browsers very easy.
 You can configure Testem using the `testem.js` file in your application root.
 
 #### Choosing the Tests to Run
@@ -200,11 +200,3 @@ When using QUnit it is possible to exclude tests by adding an exclamation point 
 
 You can also run a group of tests which you have scoped with a `module` before; e.g. for testing the module called `Unit | Service | location` only,
 run `ember test --module='Unit | Service | location'`.
-
-[QUnit]: http://qunitjs.com/
-[Testem]: https://github.com/airportyh/testem
-[Application tests]: ./acceptance
-[Testing Components]: ./testing-components
-[Testing Controllers]: ./testing-controllers
-[Testing Routes]: ./testing-routes
-[Testing Helpers]: ./testing-helpers

--- a/guides/v3.7.0/testing/testing-controllers.md
+++ b/guides/v3.7.0/testing/testing-controllers.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Controller extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Controller extends Ember.Object._
 
 Controllers can be tested using the `setupTest` helper which is part
 of the ember-qunit framework. The tests written for instances like `Ember.Controller` are
@@ -79,5 +79,3 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/

--- a/guides/v3.7.0/testing/testing-helpers.md
+++ b/guides/v3.7.0/testing/testing-helpers.md
@@ -1,4 +1,4 @@
-_Testing helpers follows previous patterns shown in [Testing Components][],
+_Testing helpers follows previous patterns shown in [Testing Components](../testing-components/),
 because helpers are rendered to templates just like components._
 
 Helpers are best tested with rendering tests, but can also be tested with unit
@@ -6,7 +6,7 @@ tests. Rendering tests will provide better coverage for helpers, as it more
 closely simulates the lifecycle of a helper than in isolation.
 
 We're going to demonstrate how to test helpers by testing the `format-currency`
-helper from [Writing Helpers][].
+helper from [Writing Helpers](../../templates/writing-helpers/).
 
 > You can follow along by generating your own helper with `ember generate helper
 > format-currency`.
@@ -42,12 +42,12 @@ module('Unit | Helper | format currency', function(hooks) {
 });
 ```
 
-As seen in the [Writing Helpers][] guide. The helper function expects the unnamed
+As seen in the [Writing Helpers](../../templates/writing-helpers/) guide. The helper function expects the unnamed
 arguments as an array as the first argument. It expects the named arguments as
 an object as the second argument.
 
 Now we can move on to a more complex test case that ensures our helper is rendered correctly as well. This can be done
-with the `setupRenderingTest` helper, as shown in [Testing Components][].
+with the `setupRenderingTest` helper, as shown in [Testing Components](../testing-components/).
 
 ```javascript {data-filename=tests/integration/helpers/format-currency-test.js}
 import { module, test } from 'qunit';
@@ -94,6 +94,3 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
-
-[Testing Components]: ../testing-components/
-[Writing Helpers]: ../../templates/writing-helpers/

--- a/guides/v3.7.0/testing/testing-models.md
+++ b/guides/v3.7.0/testing/testing-models.md
@@ -1,7 +1,7 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because DS.Model extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because DS.Model extends Ember.Object._
 
-[Ember Data][] Models can be tested in a module that uses the `setupTest` helper.
+[Ember Data](https://github.com/emberjs/data) Models can be tested in a module that uses the `setupTest` helper.
 
 Let's assume we have a `Player` model that has `level` and `levelName`
 attributes. We want to call `levelUp()` to increment the `level` and assign a
@@ -104,9 +104,4 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests][] for examples of deeper relationship testing if you
-feel the need to do it._
-
-[Ember Data]: https://github.com/emberjs/data
-[Testing Basics]: ../unit-testing-basics/
-[Ember Data tests]: https://github.com/emberjs/data/tree/master/tests
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you feel the need to do it._

--- a/guides/v3.7.0/testing/testing-routes.md
+++ b/guides/v3.7.0/testing/testing-routes.md
@@ -1,5 +1,5 @@
 _Container testing methods and computed properties follow previous patterns shown
-in [Testing Basics][] because Ember.Route extends Ember.Object._
+in [Testing Basics](../unit-testing-basics/) because Ember.Route extends Ember.Object._
 
 Testing routes can be done both via application tests or container tests. Application tests
 will likely provide better coverage for routes because routes are typically used
@@ -34,7 +34,7 @@ export default Route.extend({
 });
 ```
 
-In this route we've [separated our concerns][]:
+In this route we've [separated our concerns](http://en.wikipedia.org/wiki/Separation_of_concerns):
 The action `displayAlert` contains the code that is called when the action is
 received, and the private function `_displayAlert` performs the work. While not
 necessarily obvious here because of the small size of the functions, separating
@@ -86,6 +86,3 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
-
-[Testing Basics]: ../unit-testing-basics/
-[separated our concerns]: http://en.wikipedia.org/wiki/Separation_of_concerns


### PR DESCRIPTION
Refactored markdown links to inline for consistency and match learning team requirements.  Links from 3.0.0 on have been converted to inline.

As I started this several weeks ago, I will probably do another PR to clean up links added after I started the refactoring

resolves #330 