### PR TITLE
Update docs for the built-in components for simple-component page

### DIFF
--- a/guides/release/tutorial/simple-component.md
+++ b/guides/release/tutorial/simple-component.md
@@ -64,9 +64,9 @@ with our new `RentalListing` component:
   <p>
     We hope you find exactly what you're looking for in a place to stay.
   </p>
-  {{#link-to "about" class="button"}}
+  <LinkTo @route="about" class="button">
     About Us
-  {{/link-to}}
+  </LinkTo>
 </div>
 
 {{#each this.model as |rentalUnit|}}


### PR DESCRIPTION
Updated the built-in components to use angle bracket syntax. See https://github.com/ember-learn/guides-source/issues/692

_Feeling a bit of deja vu..._