### PR TITLE
[OCTANE] Components/Actions and Events: Remove reference to the "target" attribute

### DIFF
--- a/guides/release/components/actions-and-events.md
+++ b/guides/release/components/actions-and-events.md
@@ -437,7 +437,7 @@ export default class SendMessage extends Component {
 ```
 
 We can tell the action to invoke the `sendMessage` action directly on the
-messaging service with the `target` attribute.
+messaging service.
 
 ```handlebars {data-filename=app/templates/components/send-message.hbs}
 <ButtonWithConfirmation


### PR DESCRIPTION
This sentence was never rewritten from the current guides. The `target` attribute is no longer used in Octane, so the last part of the sentence can be removed. 

