### PR TITLE
Add ember-cli to the list of main repositories

### DIFF
--- a/guides/release/contributing/repositories.md
+++ b/guides/release/contributing/repositories.md
@@ -5,6 +5,10 @@ Ember is made up of several libraries. If you wish to add a feature or fix a bug
 
 * [https://github.com/emberjs/ember.js](https://github.com/emberjs/ember.js)
 
+**Ember CLI** - The command line utility for Ember.
+
+* [https://github.com/ember-cli/ember-cli](https://github.com/ember-cli/ember-cli)
+
 **Ember Data** - A data persistence library for Ember.
 
 * [https://github.com/emberjs/data](https://github.com/emberjs/data)


### PR DESCRIPTION
In https://guides.emberjs.com/release/contributing/repositories/, add ember-cli to the list of main repositories