### PR TITLE
Update the URL link for Ember Data Tests hyperlink

### DIFF
--- a/guides/release/testing/testing-models.md
+++ b/guides/release/testing/testing-models.md
@@ -109,4 +109,4 @@ feel the need to do it._
 
 [Ember Data]: https://github.com/emberjs/data
 [Testing Basics]: ../unit-testing-basics/
-[Ember Data tests]: https://github.com/emberjs/data/tree/master/tests
+[Ember Data tests]: https://github.com/emberjs/data/tree/master/packages/-ember-data/tests


### PR DESCRIPTION
Seems, URL for Ember Data Tests are moved to another place and hence updating it with right URL