### PR TITLE
Add documentation when component tagName is an empty string

### DIFF
--- a/guides/release/components/customizing-a-components-element.md
+++ b/guides/release/components/customizing-a-components-element.md
@@ -34,7 +34,9 @@ export default Component.extend({
 </ul>
 ```
 
-If `tagName` is null:
+Note: It is not recommended to use null tagName .
+
+The following example explains usecase when `tagName` is null:
 
 When the `tagName` is assigned to null value, default `div` tag will be provided by ember but element bindings such as `classNameBindings` will not be available for the root element in component. 
 
@@ -52,7 +54,7 @@ export default Component.extend({
 </p>
 ```
 
-Above javascript and handlebars code for component will generate the following markup:
+This code will generate markup that looks like this:
 
 ```html
 <div class="ember-view" id="ember173">

--- a/guides/release/components/customizing-a-components-element.md
+++ b/guides/release/components/customizing-a-components-element.md
@@ -18,6 +18,7 @@ To use a tag other than `div`, subclass `Component` and assign it
 a `tagName` property. This property can be any valid HTML5 tag name as a
 string.
 
+
 ```javascript {data-filename=app/components/navigation-bar.js}
 import Component from '@ember/component';
 
@@ -31,6 +32,34 @@ export default Component.extend({
   <li>{{#link-to "home"}}Home{{/link-to}}</li>
   <li>{{#link-to "about"}}About{{/link-to}}</li>
 </ul>
+```
+
+If `tagName` is null:
+
+When the `tagName` is assigned to null value, default `div` tag will be provided by ember but element bindings such as `classNameBindings` will not be available for the root element in component. 
+
+```javascript
+import Component from '@ember/component';
+
+export default Component.extend({
+  tagName: ''
+});
+```
+
+```handlebars
+<p>
+  This is my component
+</p>
+```
+
+Above javascript and handlebars code for component will generate the following markup:
+
+```html
+<div class="ember-view" id="ember173">
+  <p>
+    This is my component
+  </p>
+</div>
 ```
 
 ### Customizing the Element's Class


### PR DESCRIPTION
During discussion with one of my colleagues today, realized that tagName: '' could still create a component with default <div> tag but the element bindings will not be available. This use case is not covered anywhere in ember guides.  Want to add documentation for the same to make sure this is covered in official guides.

Mention of this is relevant in preparation for ember octane features where we can get lot done with less code. Reference for octane component: https://blog.emberjs.com/2019/03/14/coming-soon-in-ember-octane-part-5.html