### PR TITLE
Update Ember Data Test link to correct URL

### DIFF
--- a/guides/release/testing/testing-models.md
+++ b/guides/release/testing/testing-models.md
@@ -104,5 +104,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/packages/-ember-data/tests) for examples of deeper relationship testing if you
 feel the need to do it._


### PR DESCRIPTION
Recent refactor of inline URL link's overrides the correct URL which was changes early.