### PR TITLE
Fix output diff for "Manipulating Attributes" example

### DIFF
--- a/guides/release/components/glimmer-components-dom.md
+++ b/guides/release/components/glimmer-components-dom.md
@@ -118,8 +118,9 @@ Just like in previous examples, you can think of attribute changes as substituti
 
 the output will be updated to:
 
-```html {data-filename="output" data-diff="-2,+3"}
+```html {data-filename="output" data-diff="-1,+2,-3,+4"}
 <article title="Hello world">
+<article title="Hello world!">
   <header><h1>Hello world</h1></header>
   <header><h1>Hello world!</h1></header>
   <section>This is the first article. [UPDATE] I am so excited!</section>


### PR DESCRIPTION
The output diff code had failed to show that the attribute is changed, instead only showing the text changing as in a previous example. Updated the code to show both attribute and text changing with appropriate diff markup.