### PR TITLE
add tutorial command correction for windows (#863)

### DIFF
--- a/guides/v3.9.0/tutorial/service.md
+++ b/guides/v3.9.0/tutorial/service.md
@@ -44,7 +44,8 @@ Next, add your new API key to the application by stopping the server and restart
 LEAFLET_MAPS_API_KEY=<your key here> ember s
 ```
 
-NOTE - If you are working on windows machine, use the set command
+> *__Note:__*  *All commands are primarily written for `bash`*
+> *If you are on `windows` machine and using the default command prompt go with the below syntax*
 
 ```bash
 set LEAFLET_MAPS_API_KEY=<your key here>

--- a/guides/v3.9.0/tutorial/service.md
+++ b/guides/v3.9.0/tutorial/service.md
@@ -44,7 +44,7 @@ Next, add your new API key to the application by stopping the server and restart
 LEAFLET_MAPS_API_KEY=<your key here> ember s
 ```
 
-> *__Note:__*  *All commands are primarily written for `bash`*
+> *__Note:__*  *All commands are written for `bash` by default.*
 > *If you are using a terminal other than bash, your commands may be different. For example, in a Windows command prompt, you would use the following syntax:*
 
 ```bash

--- a/guides/v3.9.0/tutorial/service.md
+++ b/guides/v3.9.0/tutorial/service.md
@@ -44,6 +44,13 @@ Next, add your new API key to the application by stopping the server and restart
 LEAFLET_MAPS_API_KEY=<your key here> ember s
 ```
 
+NOTE - If you are working on windows machine, use the set command
+
+```bash
+set LEAFLET_MAPS_API_KEY=<your key here>
+ember s
+```
+
 The application should start and work as we had it before.
 We will now have the APIs available we need to be able to display maps for our properties.
 

--- a/guides/v3.9.0/tutorial/service.md
+++ b/guides/v3.9.0/tutorial/service.md
@@ -45,7 +45,7 @@ LEAFLET_MAPS_API_KEY=<your key here> ember s
 ```
 
 > *__Note:__*  *All commands are primarily written for `bash`*
-> *If you are on `windows` machine and using the default command prompt go with the below syntax*
+> *If you are using a terminal other than bash, your commands may be different. For example, in a Windows command prompt, you would use the following syntax:*
 
 ```bash
 set LEAFLET_MAPS_API_KEY=<your key here>


### PR DESCRIPTION
Hi there, request you to review my change and merge so that the tutorial for beginners learning ember can't be tiresome. For a new guy trying to learn ember and reaching upto the services tutorial is a great journey but if that person is working on windows he/she may get misleaded with code snippets which won't be accepted by WINDOWS OS