### PR TITLE
Update tutorial/autocomplete-component.md

### DIFF
--- a/guides/release/tutorial/autocomplete-component.md
+++ b/guides/release/tutorial/autocomplete-component.md
@@ -18,13 +18,13 @@ As before when we created the [`rental-listing` component](../simple-component/)
 
 In our `app/templates/rentals.hbs` template file, we'll add a reference to our new `ListFilter` component.
 
-Notice that below we "wrap" our rentals markup inside the open and closing mentions of `ListFilter` on lines 12 and 20.
+Notice that below we "wrap" our rentals markup inside the open and closing mentions of `ListFilter` on lines 12 and 21.
 This is an example of the [**block form**](../../components/wrapping-content-in-a-component/) of a component,
 which allows a Handlebars template to be rendered _inside_ the component's template wherever the `{{yield}}` expression appears.
 
 In this case we are passing, or "yielding", our filter data to the inner markup as a variable called `filteredResults` (line 14/).
 
-```handlebars {data-filename="app/templates/rentals.hbs" data-diff="+1, +2, +3, +4, +5, +6, +7, +8, +9, +10,  +12,+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,-23,-24,-25"}
+```handlebars {data-filename="app/templates/rentals.hbs" data-diff="+12,+13,+14,+16,+17,+18,+19,+20,+21,+22,-23,-24,-25"}
 <div class="jumbo">
   <div class="right tomster"></div>
   <h2>Welcome!</h2>


### PR DESCRIPTION
The diff in the code snippet is incorrect and may be confusing for beginners.
Page: https://guides.emberjs.com/release/tutorial/autocomplete-component/

![Screen Shot 2019-06-20 at 3 09 52 PM](https://user-images.githubusercontent.com/8878596/59874935-7e3a9e80-936d-11e9-9ee1-64fed491d333.png)
