### PR TITLE
LinkTo documentation incorrectly had an attribute value as a string rather than interpolated variable

### DIFF
--- a/guides/release/templates/links.md
+++ b/guides/release/templates/links.md
@@ -15,7 +15,7 @@ Router.map(function() {
 ```handlebars {data-filename=app/templates/photos.hbs}
 <ul>
   {{#each this.photos as |photo|}}
-    <li><LinkTo @route="photos.edit" @model={{photo}}>{{photo.title}}</LinkTo></li>
+    <li><LinkTo @route="photos.edit" @model={{this.photo}}>{{this.photo.title}}</LinkTo></li>
   {{/each}}
 </ul>
 ```

--- a/guides/release/templates/links.md
+++ b/guides/release/templates/links.md
@@ -15,7 +15,7 @@ Router.map(function() {
 ```handlebars {data-filename=app/templates/photos.hbs}
 <ul>
   {{#each this.photos as |photo|}}
-    <li><LinkTo @route="photos.edit" @model="photo">{{photo.title}}</LinkTo></li>
+    <li><LinkTo @route="photos.edit" @model={{photo}}>{{photo.title}}</LinkTo></li>
   {{/each}}
 </ul>
 ```


### PR DESCRIPTION
The model property was supposed to reference the photo variable.