### PR TITLE
Fix asynchronous action component test example

### DIFF
--- a/guides/release/testing/testing-components.md
+++ b/guides/release/testing/testing-components.md
@@ -480,12 +480,12 @@ export default Component.extend({
 
 ```handlebars {data-filename="app/templates/components/delayed-typeahead.hbs"}
 <label for="search">Search</label>
-<Input @id="search" @value={{this.searchValue}} @key-up={{action 'handleTyping'}}>
+<Input @id="search" @value={{this.searchValue}} @key-up={{action "handleTyping"}} />
 
 <ul>
-{{#each this.results as |result|}}
-  <li class="result">{{result.name}}</li>
-{{/each}}
+  {{#each this.results as |result|}}
+    <li class="result">{{result.name}}</li>
+  {{/each}}
 </ul>
 ```
 


### PR DESCRIPTION
- The build complains that there's no close to `<Input>`.
- The linter complains about single quotes in handlebars.
- The linter complains about the `{{#each}}` indentation.

Incidentally I cannot get this test to pass in a fresh Ember 3.11.1 app. I tried running the tests in Chrome, CLI, Firefox, Safari. No matter what I do it appears that the `dispatchEvent` does not cause the `fetchResults` function to be called. I can't tell if this is because `dispatchEvent` won't trigger that or if `@fetchResults={{this.fetchResults}}` is not attaching the handler properly or some other problem.