### PR TITLE
Remove deprecated events

### DIFF
--- a/guides/release/components/handling-events.md
+++ b/guides/release/components/handling-events.md
@@ -151,11 +151,8 @@ Mouse events
 * `contextMenu`
 * `click`
 * `doubleClick`
-* `mouseMove`
 * `focusIn`
 * `focusOut`
-* `mouseEnter`
-* `mouseLeave`
 
 Form events:
 


### PR DESCRIPTION
As per https://github.com/emberjs/rfcs/blob/master/text/0486-deprecate-mouseenter.md