### PR TITLE
"classic" -> "curly" in syntax-conversion-guide

### DIFF
--- a/guides/release/reference/syntax-conversion-guide.md
+++ b/guides/release/reference/syntax-conversion-guide.md
@@ -105,7 +105,7 @@ To invoke it using angle bracket syntax, you would do the following:
 
 ### When to use curly invocation syntax?
 
-Although angle bracket syntax is considered to be the best approach, curly invocation syntax is fine to keep using.
+Although angle bracket syntax is considered to be the best approach, curly braces invocation syntax is fine to keep using.
 In some cases, curly invocation is still required. 
 For example, when you need direct support for positional arguments or if your components are nested within the file tree, you should still reach for those curly braces:
 

--- a/guides/release/reference/syntax-conversion-guide.md
+++ b/guides/release/reference/syntax-conversion-guide.md
@@ -1,6 +1,6 @@
 ## Angle Bracket Syntax
 
-There are two ways to invoke a component in a template: curly invocation syntax (`{{my-component}}`), and [angle bracket invocation syntax](https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md) (`<MyComponent />`).
+There are two ways to invoke a component in a template: curly braces invocation syntax (`{{my-component}}`), and [angle bracket invocation syntax](https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md) (`<MyComponent />`).
 The difference between them is syntactical.
 
 **Curly braces invocation syntax:**

--- a/guides/release/reference/syntax-conversion-guide.md
+++ b/guides/release/reference/syntax-conversion-guide.md
@@ -24,7 +24,7 @@ While the angle bracket syntax may remind you of HTML elements, it comes with di
 
 The angle bracket invocation syntax is useful when you wish to pass arbitrary HTML attributes to the component.
 This is possible because in angle bracket invocation syntax there is a distinction between passing a named argument and an HTML attribute,
-while in curly invocation syntax everything is an argument to the component, either named or positional.
+while in curly braces invocation syntax everything is an argument to the component, either named or positional.
 
 ### Leverage Existing Knowledge
 

--- a/guides/release/reference/syntax-conversion-guide.md
+++ b/guides/release/reference/syntax-conversion-guide.md
@@ -53,7 +53,7 @@ Block form components also follow the same pattern as HTML elements where an HTM
 
 ### Positional parameters
 
-The curly invocation syntax supports passing arguments to the component by their position.
+The curly braces invocation syntax supports passing arguments to the component by their position.
 In the following example, `"Hello"` and `"World"` are positional parameters:
 
 ```handlebars

--- a/guides/release/reference/syntax-conversion-guide.md
+++ b/guides/release/reference/syntax-conversion-guide.md
@@ -106,7 +106,7 @@ To invoke it using angle bracket syntax, you would do the following:
 ### When to use curly invocation syntax?
 
 Although angle bracket syntax is considered to be the best approach, curly braces invocation syntax is fine to keep using.
-In some cases, curly invocation is still required. 
+In some cases, curly braces invocation is still required. 
 For example, when you need direct support for positional arguments or if your components are nested within the file tree, you should still reach for those curly braces:
 
 ```handlebars

--- a/guides/release/reference/syntax-conversion-guide.md
+++ b/guides/release/reference/syntax-conversion-guide.md
@@ -3,7 +3,7 @@
 There are two ways to invoke a component in a template: curly invocation syntax (`{{my-component}}`), and [angle bracket invocation syntax](https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md) (`<MyComponent />`).
 The difference between them is syntactical.
 
-**Curly invocation syntax:**
+**Curly braces invocation syntax:**
 ```handlebars
 {{site-header user=this.user class=(if this.user.isAdmin "admin")}}
 ```

--- a/guides/release/reference/syntax-conversion-guide.md
+++ b/guides/release/reference/syntax-conversion-guide.md
@@ -1,10 +1,9 @@
 ## Angle Bracket Syntax
 
-There are two ways to invoke a component in a template: classic invocation syntax (`{{my-component}}`), and [angle bracket invocation syntax](https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md) (`<MyComponent />`).
+There are two ways to invoke a component in a template: curly invocation syntax (`{{my-component}}`), and [angle bracket invocation syntax](https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md) (`<MyComponent />`).
 The difference between them is syntactical.
-Classic invocation syntax may also be referred to as curly invocation syntax.
 
-**Classic invocation syntax:**
+**Curly invocation syntax:**
 ```handlebars
 {{site-header user=this.user class=(if this.user.isAdmin "admin")}}
 ```
@@ -17,24 +16,24 @@ Classic invocation syntax may also be referred to as curly invocation syntax.
 Consider the example above.
 The `site-header` component is represented in both invocation syntaxes to illustrate the differences between the two.
 
-As the name suggests, angle bracket invocation syntax replaces the outside curly braces `{{}}` with angle brackets `<>` and capitalizes the component name instead of having it be lowercase dash delimited.
+As the name suggests, angle bracket invocation syntax replaces the outside curly braces `{{}}` with angle brackets `<>` and capitalizes the component name instead of having it be lowercase dash-delimited.
 
-While the Angle Bracket Syntax may remind you of HTML elements, it comes with differentiating features such as using the `@` syntax for passing in arguments which sets it apart from traditional HTML elements easily.
+While the angle bracket syntax may remind you of HTML elements, it comes with differentiating features such as the `@` syntax for passing in arguments that sets it apart from traditional HTML elements.
 
 ### When to use angle bracket invocation syntax?
 
 The angle bracket invocation syntax is useful when you wish to pass arbitrary HTML attributes to the component.
 This is possible because in angle bracket invocation syntax there is a distinction between passing a named argument and an HTML attribute,
-while in classic invocation syntax everything is an argument to the component, either named or positional.
+while in curly invocation syntax everything is an argument to the component, either named or positional.
 
 ### Leverage Existing Knowledge
 
 Since Angle Bracket notation closely resembles the syntax for HTML elements, we enable developers to reuse their existing knowledge in creating templates for Ember components. This is especially useful for newer Ember developers as it provides syntactic sugar for creating component templates, reducing the learning curve.
 
 You can apply regular HTML attributes like `class`, `id`, `aria-role`, etc. when you use the component.
-Block form components also follow the same pattern as HTML elements where an HTML-like closing tag denotes where a component starts and ends.
+Block form components also follow the same pattern as HTML elements where an HTML-like closing tag denotes where a component ends.
 
-**Classic invocation syntax:**
+**Curly invocation syntax:**
 ```handlebars
 {{#super-select selected=this.user.country as |s|}}
   {{#each this.availableCountries as |country|}}
@@ -54,14 +53,14 @@ Block form components also follow the same pattern as HTML elements where an HTM
 
 ### Positional parameters
 
-The classic invocation syntax supports passing arguments to the component by their position.
-In the following example, `"greeting"` and `"name"` are positional parameters:
+The curly invocation syntax supports passing arguments to the component by their position.
+In the following example, `"Hello"` and `"World"` are positional parameters:
 
 ```handlebars
 {{my-greeting "Hello" "World"}}
 ```
 
-As shown in the relevant ["Position Params"](../../components/arguments-and-attributes/#toc_positional-params) part of the Guides,
+As shown in the relevant ["Positional Params"](../../components/arguments-and-attributes/#toc_positional-params) part of the Guides,
 there are two ways to handle them inside the component.
 One way is to individually specify what component property the positional parameter should map to.
 The other way is to map all positional parameters to the `params` property and refer to them by their index.
@@ -79,7 +78,7 @@ export default Component.extend({
 });
 ```
 
-To invoke it using the angle bracket syntax, you would do the following:
+To invoke it using angle bracket syntax, you would do the following:
 
 ```handlebars
 <MyGreeting @greeting="Hello" @name="World" />
@@ -87,7 +86,7 @@ To invoke it using the angle bracket syntax, you would do the following:
 
 #### `params` array
 
-If `my-greeting` has the following implementation:
+If `my-greeting` had the following implementation:
 
 ```javascript {data-filename="app/components/my-greeting.js"}
 import Component from '@ember/component';
@@ -98,15 +97,17 @@ export default Component.extend({
 });
 ```
 
+To invoke it using angle bracket syntax, you would do the following:
+
 ```handlebars
 <MyGreeting @params={{array "Hello" "World"}}>
 ```
 
-### When to use classic invocation syntax?
+### When to use curly invocation syntax?
 
-Although Angle Bracket syntax is considered to be the best approach, classic invocation syntax is fine to keep using.
-In some cases, classic invocation is still required. 
-When you need direct support for positional arguments or if your components are nested within the file tree, you should still reach for those curly braces:
+Although angle bracket syntax is considered to be the best approach, curly invocation syntax is fine to keep using.
+In some cases, curly invocation is still required. 
+For example, when you need direct support for positional arguments or if your components are nested within the file tree, you should still reach for those curly braces:
 
 ```handlebars
 {{some-component param1 param2}}


### PR DESCRIPTION
(This PR targets the `octane` branch).

And some light copy-editing.

Unified capitalization of "angle bracket syntax" to be lowercased throughout.

Fixes #929