### PR TITLE
Doc optional features "application wrapper" and "template only components"

### DIFF
--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -81,3 +81,65 @@ Without jQuery, any code that still relies on it will break, especially the foll
 - `this.$()` in component tests
 
 Note that this also applies to all addons that your app uses, so make sure they support being used without jQuery.
+
+### application-template-wrapper
+
+With this feature *disabled* Ember creates a wrapping div around the entire
+rendered application. Effectively, it is creating a `<div class="ember-view">`
+element which wraps the contents of an application's
+`app/templates/application.hbs` file.
+
+When *enabled*, this div will not be output. This is usually desirable, but
+may break the styling of an existing application in subtle ways:
+
+- Perhaps the application relied on the root `.ember-view` for styles (CSS).
+- Perhaps the `<div>` itself was the target of styles (e.g. `body > div > .some-child`).
+- The presence of a wrapping `<div>` means the application is contained in a
+  block-layout element. When removed, and depending on if the application
+  specifies a `rootElement` in `config/environment.js`, the application may no
+  longer be contained in a block-layout element.
+
+If your application relies on those behaviors it is still recommended that
+you *enable* this feature, and simply add an appropriate element to
+`app/templates/application.hbs` wrapping that template's `{{outlet}}`.
+
+For more information, see [RFC #280](https://github.com/emberjs/rfcs/blob/master/text/0280-remove-application-wrapper.md).
+
+### template-only-glimmer-components
+
+With this feature *disabled* Ember will create an implicit element for
+components which have no JavaScript file ("template-only components").
+
+Enabling this feature will result in only the contents of the template being
+rendered, and additionally in no classic Ember component instance being
+instantiated to provide it context.
+
+Some examples of how *enabling* this feature impacts app code are:
+
+- In template-only component templates statements like `{{this}}`,
+  `{{this.foo}}` and `{{foo}}` will be `undefined`. Accessing arguments as
+  `{{@foo}}` will continue to work.
+- If this feature is enabled in an application with existing template-only
+  components, the removal of the wrapping `<div>` will happen to all uses of
+  those template-only components. This can impact style and logic in a breaking
+  manner.
+- Passing classes to an invocation (i.e. `{{my-component class="..."}}`) will
+  no longer result in those classes being present on any element. This could
+  be a change in behavior which impacts any reflected attribute passed as an
+  argument, such as `id=` or `tagName=`.
+- Templates can use `...attributes` to target attributes and element modifiers
+  passed from an angle bracket invocation.
+
+Enabling this feature makes template-only components more consistent with
+angle-bracket invocation and with Glimmer components. Additionally it improves
+the performance of template-only components (there is no JS object instantiated
+to provide context) and makes them an excellent replacement for use of Ember's
+more complex and now discouraged API `{{partial`.
+
+It is recommended that you *enable* this feature. Existing applications adopting
+this optional feature should add a `.js` file for any existing template-only
+components containing a basic Ember component class. This will maintain
+backwards compatibility for existing templates while new template-only
+components gain the advantages of this feature.
+
+For more information, see [RFC #278](https://github.com/emberjs/rfcs/blob/master/text/0278-template-only-components.md).


### PR DESCRIPTION
Closes https://github.com/ember-learn/guides-source/issues/925

Document the optional features:

* application-template-wrapper
* template-only-glimmer-components