### PR TITLE
Making @tracked scope more explicit

### DIFF
--- a/guides/release/components/actions-and-events.md
+++ b/guides/release/components/actions-and-events.md
@@ -53,8 +53,8 @@ Now we have a button that can receive some text as an argument, with a modal
 confirmation that will show conditionally based on its `showConfirmation`
 property. You'll notice this property is decorated with the `@tracked`
 decorator - this is known as a _tracked property_, and indicates to Ember that
-the field will change in value over time. We'll discuss this more in the section
-on [State Management](../../state-management/).
+the field will change in value over the lifetime of the component. We'll
+discuss this more in the section on [State Management](../../state-management/).
 
 Next, we need to hook up the button to toggle that property. We'll
 do this with an _action_:

--- a/guides/release/state-management/tracked-properties.md
+++ b/guides/release/state-management/tracked-properties.md
@@ -47,7 +47,7 @@ should change.
 In order to tell Ember a value might change, we need to mark it as _trackable_.
 Trackable values are values that:
 
-1. Can change over time and
+1. Can change over their component’s lifetime and
 2. Should cause Ember to rerender if and when they change
 
 We can do this by marking the field with the `@tracked` decorator:

--- a/guides/release/upgrading/editions.md
+++ b/guides/release/upgrading/editions.md
@@ -690,7 +690,7 @@ Tracked properties replace computed properties. Unlike computed properties, whic
 every getter with the values it depends on, tracked properties only require you to
 annotate the values that are _trackable_, that is values that:
 
-1. Change over time and
+1. Change over the lifetime of their owner (such as a component) and
 2. May cause the DOM to update in response to those changes
 
 For example, a computed property like this:


### PR DESCRIPTION
I feel like saying that tracked properties are merely properties that "change in value over time" is a bit unclear. I've tried to add language that indicates that `@tracked` is for properties that change not "over time" but over the lifetime of their owner/component. I'm not sure the language I'm using is quite right, however.
