### PR TITLE
Explain how to deploy to ZEIT Now

### DIFF
--- a/guides/release/tutorial/deploying.md
+++ b/guides/release/tutorial/deploying.md
@@ -32,35 +32,11 @@ You can deploy your application to any web server by copying the output from `em
 scp -r dist/* myserver.com:/var/www/public/
 ```
 
-## Deploying to ZEIT Now
+## Deployment Options
 
-[ZEIT Now](https://zeit.co) is a cloud platform for websites and serverless APIs, that you can use to deploy your Ember projects to your personal domain (or a free `.now.sh` suffixed URL).
+There are many different deployment options for your Ember application. The following are a few options as submitted by community members.
 
-This guide will show you how to get started in a few quick steps:
-
-### Step 1: Installing Now CLI
-
-To install their command-line interface with [npm](https://www.npmjs.com/package/now), run the following command:
-
-```bash
-npm install -g now
-```
-
-### Step 2: Deploying
-
-You can deploy your application by running the following command in the root of the project directory:
-
-```bash
-now
-```
-
-**Alternatively**, you can also use their integration for [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab).
-
-That’s all!
-
-Your site will deploy, and you will receive a link similar to the following: https://ember.now-examples.now.sh
-
-## Deploying to surge.sh
+### Surge
 
 [Surge.sh](http://surge.sh/) allows you to publish any folder to the web for free.
 To deploy an Ember application you can simply deploy the folder produced by `ember build`.
@@ -95,6 +71,34 @@ surge dist funny-name.surge.sh
 
 Note we are building with the Google maps API key as shown above for UNIX platforms.
 For windows you will need to set the variable according the example in the previous section.
+
+### ZEIT Now
+
+[ZEIT Now](https://zeit.co) is a cloud platform for websites and serverless APIs, that you can use to deploy your Ember projects to your personal domain (or a free `.now.sh` suffixed URL).
+
+This guide will show you how to get started in a few quick steps:
+
+#### Step 1: Installing Now CLI
+
+To install their command-line interface with [npm](https://www.npmjs.com/package/now), run the following command:
+
+```bash
+npm install -g now
+```
+
+#### Step 2: Deploying
+
+You can deploy your application by running the following command in the root of the project directory:
+
+```bash
+now
+```
+
+**Alternatively**, you can also use their integration for [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab).
+
+That’s all!
+
+Your site will deploy, and you will receive a link similar to the following: https://ember.now-examples.now.sh
 
 ## Servers
 

--- a/guides/release/tutorial/deploying.md
+++ b/guides/release/tutorial/deploying.md
@@ -32,6 +32,34 @@ You can deploy your application to any web server by copying the output from `em
 scp -r dist/* myserver.com:/var/www/public/
 ```
 
+## Deploying to ZEIT Now
+
+[ZEIT Now](https://zeit.co) is a cloud platform for websites and serverless APIs, that you can use to deploy your Ember projects to your personal domain (or a free `.now.sh` suffixed URL).
+
+This guide will show you how to get started in a few quick steps:
+
+### Step 1: Installing Now CLI
+
+To install their command-line interface with [npm](https://www.npmjs.com/package/now), run the following command:
+
+```bash
+npm install -g now
+```
+
+### Step 2: Deploying
+
+You can deploy your application by running the following command in the root of the project directory:
+
+```bash
+now
+```
+
+**Alternatively**, you can also use their integration for [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab).
+
+That’s all!
+
+Your site will now deploy, and you will receive a link similar to the following: https://ember.now-examples.now.sh
+
 ## Deploying to surge.sh
 
 [Surge.sh](http://surge.sh/) allows you to publish any folder to the web for free.

--- a/guides/release/tutorial/deploying.md
+++ b/guides/release/tutorial/deploying.md
@@ -58,7 +58,7 @@ now
 
 That’s all!
 
-Your site will now deploy, and you will receive a link similar to the following: https://ember.now-examples.now.sh
+Your site will deploy, and you will receive a link similar to the following: https://ember.now-examples.now.sh
 
 ## Deploying to surge.sh
 


### PR DESCRIPTION
Now that ZEIT has launched [zero config deployments](https://twitter.com/zeithq/status/1159145442896166912), deploying a Ember site is now much easier:

![image](https://user-images.githubusercontent.com/6170607/62698816-603d0200-b9de-11e9-8fc3-77ca3e6324fa.png)
