### PR TITLE
Add a note about ED singular usage naming

### DIFF
--- a/guides/release/models/defining-models.md
+++ b/guides/release/models/defining-models.md
@@ -24,6 +24,17 @@ export default DS.Model.extend({
 After you have defined a model class, you can start [finding](../finding-records/)
 and [working with records](../creating-updating-and-deleting-records/) of that type.
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        Ember Data models are normally setup using the singular form (which is why we use `person` instead of `people` here)
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+  </div>
+</div>
 
 ## Defining Attributes
 


### PR DESCRIPTION
I just was working with someone on the help channel on Discord who had hit snags based around setting up an `ideas` model (with adapter/serializer) instead of an `idea` model. Thought it might be worth clarifying in the docs that the standard approach here is to go with a singular name