### PR TITLE
[DOCS] Update input-helpers.md

### DIFF
--- a/guides/release/templates/input-helpers.md
+++ b/guides/release/templates/input-helpers.md
@@ -93,10 +93,10 @@ Checkboxes support the following properties:
 Which can be bound or set as described in the previous section.
 
 
-Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.11/classes/Component), you will always need to define the event name in camelCase format:
+Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.11/classes/Component#event-handler-methods), you will always need to define the event name in camelCase format:
 
 ```handlebars
-<Input @type="checkbox" @keypress={{action "updateName"}} />
+<Input @type="checkbox" @keyPress={{action "updateName"}} />
 ```
 
 


### PR DESCRIPTION
I think checkbox event names should be defined in camelCase format.