### PR TITLE
Add a dummy workflow to the master branch

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -1,0 +1,12 @@
+name: Dummy Workflow
+
+on:
+  push:
+    branches:
+      - dummy
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Have a nice day!"


### PR DESCRIPTION
This is needed, because if we didn't have any workflow on the master branch, GitHub thinks that we are not using the feature and will not run any workflows on this repo (that may exists on other branches).

Based on my testing, this seems to be sufficient. This workflow will probably never run in practice, but that seems to be sufficient.

Replaces #1017