### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,27 +92,27 @@ In code samples:
 
 \`\`\`
 
-* All fenced code blocks should begin with a language code supported by [prism.js](http://prismjs.com/) so that they get highlighted properly when rendered. Here are some frequently used language codes,
+* All fenced code blocks should begin with a language code supported by [prism.js](http://prismjs.com/) so that they get highlighted properly when rendered. Here are some frequently used language codes:
   * bash
   * javascript
   * css
   * handlebars
 
-When linking to topics from guide md files:
+When linking to topics from guide `.md` files:
 
 * use relative links when referencing a topic.
   * Incorrect: `https://guides.emberjs.com/release/routing/query-params/`
   * Correct: `../routing/query-params`
 
-* to reference a topic when you are in `index.md`, you only have to go up one level to reference another topics md file, `../main-topic/sub-topic`.
+* to reference a topic when you are in `index.md`, you only have to go up one level to reference another topics `.md` file, `../main-topic/sub-topic`.
   * example from `index.md` to `routing/query-params.md`:
     * `../routing/query-params`
 
-* to reference a md file in a different main topic to the one you are in, you need to go two levels up, `../../main-topic/sub-topic`.
+* to reference a `.md` file in a different main topic to the one you are in, you need to go two levels up, `../../main-topic/sub-topic`.
   * example from `routing/query-params.md` to `components/block-params.md`:
     * `../../components/block-params`
 
-* to reference a md file within the topic you are currently in, you need to go up one level, `../sub-topic`.
+* to reference a `.md` file within the topic you are currently in, you need to go up one level, `../sub-topic`.
   * example from `routing/query-params.md` to `routing/redirection.md`:
     * `../redirection`
 

--- a/guides/release/tutorial/ember-data.md
+++ b/guides/release/tutorial/ember-data.md
@@ -37,7 +37,7 @@ _title_, _owner_, _city_, _category_, _image_, _bedrooms_ and _description_.
 Define attributes by giving them the result of the function [`DS.attr()`](https://api.emberjs.com/ember-data/3.10/classes/DS/methods/attr?anchor=attr).
 For more information on Ember Data Attributes, read the section called [Defining Attributes](../../models/defining-models/#toc_defining-attributes) in the guides.
 
-```javascript {data-filename="app/models/rental.js" data-diff="+4,+5,+6,+7,+8,+9,+10"}
+```javascript {data-filename="app/models/rental.js" data-diff="+5,+6,+7,+8,+9,+10,+11"}
 import DS from 'ember-data';
 const { Model } = DS;
 
@@ -128,7 +128,7 @@ import {
   click,
   currentURL,
   visit
-} from '@ember/test-helpers'
+} from '@ember/test-helpers';
 
 ```
 

--- a/guides/release/tutorial/hbs-helper.md
+++ b/guides/release/tutorial/hbs-helper.md
@@ -65,12 +65,12 @@ Instead, our default template helper is returning back our `rental.category` val
 Let's update our helper to look if a property exists in an array of `communityPropertyTypes`,
 if so, we'll return either `'Community'` or `'Standalone'`:
 
-```javascript {data-filename="app/helpers/rental-property-type.js" data-diff="-3,-4,-5,+7,+8,+9,+10,+11,+13,+14,+15,+16,+18,+19"}
+```javascript {data-filename="app/helpers/rental-property-type.js" data-diff="-3,-4,-5,+7,+8,+9,+10,+11,+13,+14,+15,+16,+18,+19,+21"}
 import { helper } from '@ember/component/helper';
 
-export function rentalPropertyType(params/*, hash*/) {
+export default helper(function rentalPropertyType(params/*, hash*/) {
   return params;
-}
+});
 
 const communityPropertyTypes = [
   'Condo',

--- a/guides/release/tutorial/routes-and-templates.md
+++ b/guides/release/tutorial/routes-and-templates.md
@@ -313,7 +313,7 @@ You can also run our specific test by selecting the entry called "Acceptance | l
 in the drop down input labeled "Module" on the test UI.
 
 You can also toggle "Hide passed tests" to show your passing test case along with the tests that are still
-failing (because we haven't yet built them/).
+failing (because we haven't built them yet).
 
 ![6_fail](/images/routes-and-templates/routes-and-templates.gif)
 

--- a/guides/release/tutorial/simple-component.md
+++ b/guides/release/tutorial/simple-component.md
@@ -276,17 +276,18 @@ For the test we'll pass the component a fake object that has all the properties 
 We'll give the variable the name `rental`, and in each test we'll set `rental` to our local scope, represented by the `this` object.
 The render template can access values in local scope.
 
-```javascript {data-filename="tests/integration/components/rental-listing-test.js" data-diff="+9,+10,+11,+12,+13,+14,+15,+16,+17,+18"}
+```javascript {data-filename="tests/integration/components/rental-listing-test.js" data-diff="+5,+10,+11,+12,+13,+14,+15,+16,+17,+18,+19"}
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
 
 module('Integration | Component | rental listing', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.rental = {
+    this.rental = EmberObject.create({
       image: 'fake.png',
       title: 'test-title',
       owner: 'test-owner',
@@ -310,17 +311,18 @@ Now let's render our component using the `render` function.
 The `render` function allows us to pass a template string, so that we can declare the component in the same way we do in our templates.
 Since we set the `rental` variable to our local scope in the `beforeEach` hook, we can access it as part of our render string.
 
-```javascript {data-filename="tests/integration/components/rental-listing-test.js" data-diff="+21,+25"}
+```javascript {data-filename="tests/integration/components/rental-listing-test.js" data-diff="+22,+26"}
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
 
 module('Integration | Component | rental listing', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.rental = {
+    this.rental = EmberObject.create({
       image: 'fake.png',
       title: 'test-title',
       owner: 'test-owner',
@@ -374,6 +376,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
 ```
 The final test should look as follows:
 


### PR DESCRIPTION
# Description

* Fixes general typos
* Fixes code inconsistency in examples
* Clarifies `.md` files in contributing guidelines