### PR TITLE
Fix wrong filename in "Specifying a Route's Model" page

### DIFF
--- a/guides/release/routing/specifying-a-routes-model.md
+++ b/guides/release/routing/specifying-a-routes-model.md
@@ -173,7 +173,7 @@ Router.map(function() {
 
 Whatever shows up in the URL at the `:post_id`, the dynamic segment, will be available in the params for the route's `model` hook:
 
-```javascript {data-filename=app/routes/photo.js}
+```javascript {data-filename=app/routes/post.js}
 import Route from '@ember/routing/route';
 
 export default Route.extend({


### PR DESCRIPTION
Easily missable typo I think! The section after that one _does_ use a `photo` route.