### PR TITLE
Fix code blocks diff rendering

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -127,3 +127,21 @@ a.edit-page, #search-input {
   position: relative;
   z-index: 10;
 }
+
+/* Fix diff formatting */
+
+code[data-diff] > .diff-deletion,
+code[data-diff] > .diff-insertion {
+  position: relative;
+  left: -1ch;
+}
+code[data-diff] .diff-deletion > .diff-operator,
+code[data-diff] .diff-insertion > .diff-operator {
+  display: none;
+}
+code[data-diff] .diff-deletion::before {
+  content: "-";
+}
+code[data-diff] .diff-insertion::before {
+  content: "+";
+}


### PR DESCRIPTION
1. Make lines with "+"/"-" align with other lines by shifting them to the left by one character to compensate.

2. Make the "+"/"-" non-selectable and non-copyable with CSS pseudo elements.

Before:

<img width="768" alt="Before" src="https://user-images.githubusercontent.com/55829/64484076-13597080-d1c2-11e9-87e9-e9e494462db4.png">

After:

<img width="757" alt="After" src="https://user-images.githubusercontent.com/55829/64484082-1b191500-d1c2-11e9-92a0-f3c0a97ce132.png">

This may want to be upstreamed to guidemaker? It could also have avoided generating those `.diff-operators` to begin with.