### PR TITLE
Fix diff format (take 2)

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -130,18 +130,17 @@ a.edit-page, #search-input {
 
 /* Fix diff formatting */
 
-code[data-diff] > .diff-deletion,
-code[data-diff] > .diff-insertion {
-  position: relative;
-  left: -1ch;
-}
 code[data-diff] .diff-deletion > .diff-operator,
 code[data-diff] .diff-insertion > .diff-operator {
   display: none;
 }
 code[data-diff] .diff-deletion::before {
   content: "-";
+  margin-left: -1ch;
+  background-color: rgba(144,84,84,.7);
 }
 code[data-diff] .diff-insertion::before {
   content: "+";
+  margin-left: -1ch;
+  background-color: rgba(93,125,93,.5)
 }


### PR DESCRIPTION
Using `position: relative; left: -1ch;` had a very mild side effect that when you make text selection, the browser seems a tad confused bout how to draw the highlight color.

It doesn't affect the selection/copy/paste functionality, as far as I can tell, just looks a bit odd visually. It occured to me there may be another way to pull the text to the left without that problem so here it is.

It seems to work the same, but does not have the selection rendering issue.

Before (Safari on OS X):

<img width="754" alt="Screen Shot 2019-09-08 at 3 48 27 PM" src="https://user-images.githubusercontent.com/55829/64495544-60842380-d250-11e9-9aa7-ad3e3711131a.png">

Before (Chrome on OS X):

<img width="756" alt="Screen Shot 2019-09-08 at 3 49 27 PM" src="https://user-images.githubusercontent.com/55829/64495546-6548d780-d250-11e9-84c9-94132a2a45aa.png">

After (Safari on OS X):

<img width="749" alt="Screen Shot 2019-09-08 at 5 30 38 PM" src="https://user-images.githubusercontent.com/55829/64496906-a1833480-d25e-11e9-909f-6c8b88058b26.png">

After (Chrome on OS X):

<img width="752" alt="Screen Shot 2019-09-08 at 5 31 09 PM" src="https://user-images.githubusercontent.com/55829/64496911-ac3dc980-d25e-11e9-9051-4bb2ca9fb5e0.png">
