### PR TITLE
fix(quick-start): use props instead of args in route template code example

### DIFF
--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -153,7 +153,7 @@ Open the `scientists` template and add the following code to loop through the ar
 <h2>List of Scientists</h2>
 
 <ul>
-  {{#each @model as |scientist|}}
+  {{#each this.model as |scientist|}}
     <li>{{scientist}}</li>
   {{/each}}
 </ul>
@@ -211,17 +211,17 @@ We're going to tell our component:
 
 1. What title to use, via the `@title` argument.
 2. What array of people to use, via the `@people` argument. We'll
-   provide this route's `@model` as the list of people.
+   provide this route's `this.model` as the list of people.
 
 ```handlebars {data-filename="app/templates/scientists.hbs" data-diff="-1,-2,-3,-4,-5,-6,-7,+8"}
 <h2>List of Scientists</h2>
 
 <ul>
-  {{#each @model as |scientist|}}
+  {{#each this.model as |scientist|}}
     <li>{{scientist}}</li>
   {{/each}}
 </ul>
-<PeopleList @title="List of Scientists" @people={{@model}} />
+<PeopleList @title="List of Scientists" @people={{this.model}} />
 ```
 
 Go back to your browser and you should see that the UI looks identical.


### PR DESCRIPTION
This updates the code example in the Quick Start section, explaining how to pass properties to a component to use the `this.` syntax instead of argument syntax `@`.

As far as I'm aware, properties are only prefixed with an `@` when they refer to arguments passed into a component. In this code example the property `model` is used in a route's template though, therefore `this.model` should be used instead of `@model`.