### PR TITLE
Corrections to content in Tutorial

### DIFF
--- a/guides/release/tutorial/autocomplete-component.md
+++ b/guides/release/tutorial/autocomplete-component.md
@@ -412,9 +412,10 @@ module('Integration | Component | list-filter', function(hooks) {
 
 Finally, we'll assert that the locations are listed upon render completion.
 
-```javascript {data-filename="tests/integration/components/list-filter-test.js" data-diff="+31,+32,+33,+34"}
+```javascript {data-filename="tests/integration/components/list-filter-test.js" data-diff="-3,+4,+32,+33,+34,+35"}
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -464,7 +465,7 @@ First add `triggerKeyEvent` and `fillIn` to the list of imports.  The [`fillIn`]
 ```javascript {data-filename="tests/integration/components/list-filter-test.js" data-diff="-3,+4"}
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, settled } from '@ember/test-helpers';
 import { render, settled, triggerKeyEvent, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 ```

--- a/guides/release/tutorial/hbs-helper.md
+++ b/guides/release/tutorial/hbs-helper.md
@@ -105,7 +105,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Helper | my-helper', function(hooks) {
+module('Integration | Helper | rental-property-type', function(hooks) {
   setupRenderingTest(hooks);
 
   // Replace this with your real tests.


### PR DESCRIPTION
This changes two pieces of content in the Ember Tutorial which confused me in their respective sections. First, one of the examples in `hbs-test.md` uses an arbitrary example name `my-helper` in a test name, while Ember actually generates the test with the proper name `rental-property-type`. Second, there was a mistake in the `autocomplete-component.md` section where the `settled` function is imported without a diff marker at the place where it's used, getting rolled into the diff marker for the next section.

To test this change, I verified that `npm run lint:md` passes. 

Let me know if you'd like any more detail!