### PR TITLE
increase travis wait time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,10 @@ jobs:
       name: 'Ember test suite'
     - script:
         - npm run build -- --prod
-        - travis_wait 40 netlify deploy
+        - travis_wait 50 netlify deploy
       if: type = pull_request
     - stage: deploy to prod
       script:
         - npm run build -- --prod
-        - travis_wait 40 netlify deploy --prod
+        - travis_wait 50 netlify deploy --prod
       if: type IN (push) AND branch = master


### PR DESCRIPTION
Our preview deploys started timing out. This fixes it, I think?

We have run out of Percy requests for the month, which is unfortunate but will be fine.