### PR TITLE
Remove duplicated paragraph in tutorial

### DIFF
--- a/guides/release/tutorial/07-reusable-components.md
+++ b/guides/release/tutorial/07-reusable-components.md
@@ -166,8 +166,6 @@ _The ordering is important here!_ Ember applies the attributes in the order that
 
 Since the passed-in `alt` attribute (if any exists) will appear _after_ ours, it will override the value we specified. On the other hand, it is important that we assign `src`, `width`, and `height` after `...attributes`, so that they don't get accidentally overwritten by the invoker.
 
-Since the passed-in `alt` attribute (if any) will appear _after_ ours, it will override the value we specified. On the other hand, it is important that we assign `src`, `width`, and `height` after `...attributes`. That way, the invoker can't accidentally overwrite them — those attributes should always be specified by the component.
-
 The `src` attribute interpolates all the required parameters into the URL format for Mapbox's [static map image API](https://docs.mapbox.com/api/maps/#static-images), including the URL-escaped access token from `this.token`.
 
 Finally, since we are using the `@2x` "retina" image, we should specify the `width` and `height` attributes. Otherwise, the `<img>` will be rendered at twice the size than what we expected!


### PR DESCRIPTION
I was reading chapter 7 of super rental tutorial when I saw a duplicated paragraph. I choose to remove the second one because it seems to me that it was the least complete