### PR TITLE
Updated alt img tag for a11y (#1056)

### DIFF
--- a/guides/release/tutorial/service.md
+++ b/guides/release/tutorial/service.md
@@ -173,7 +173,7 @@ Finally open the template file for our `rental-listing` component and add the ne
     onclick={{action "toggleImageSize"}}
     role="button"
   >
-    <img src={{this.rental.image}} alt="">
+    <img src={{this.rental.image}} alt={{this.location.title}}>
     <small>View Larger</small>
   </a>
   <div class="details">


### PR DESCRIPTION
alt tag should be descriptive and not just a static generic string such as 'image'.

Using `this.location.title`

src: https://a11yproject.com/posts/alt-text/