### PR TITLE
Removed alternate texts for Zoey & Tomster images in the release version

### DIFF
--- a/guides/release/components/glimmer-components-dom.md
+++ b/guides/release/components/glimmer-components-dom.md
@@ -69,7 +69,7 @@ Think of this as evaluating the template from scratch, substituting in the new v
         and other state won't change for no reason.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 
@@ -212,7 +212,7 @@ export default class Counter extends Component {
         the results of an element modifier into HTML.</p>
       </div>
     </div>
-    <img src="/images/mascots/tomster.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/tomster.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/release/models/defining-models.md
+++ b/guides/release/models/defining-models.md
@@ -33,7 +33,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
         Ember Data models are normally setup using the singular form (which is why we use `person` instead of `people` here)
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/release/models/index.md
+++ b/guides/release/models/index.md
@@ -189,7 +189,7 @@ first ask the store for it.
         so you can access it as `this.store`!
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/release/object-model/enumerables.md
+++ b/guides/release/object-model/enumerables.md
@@ -33,7 +33,7 @@ where available.
         </a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/release/templates/actions.md
+++ b/guides/release/templates/actions.md
@@ -64,7 +64,7 @@ the action name with a string in the template.
 For more examples of that syntax see <a href="https://guides.emberjs.com/v3.6.0/templates/actions/">previous version of this Guide entry</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/release/testing/index.md
+++ b/guides/release/testing/index.md
@@ -59,7 +59,7 @@ test('should allow disabling the button', async function(assert) {
         All examples in this guide follow QUnit. Rest assured, the best practices for testing that we present in this guide are independent of your choice of testing framework. Keep in mind, the setup functions from <a href="https://github.com/emberjs/ember-qunit" target="_blank" rel="noopener noreferrer">ember-qunit</a>—<code>setupTest</code>, <code>setupRenderingTest</code>, and <code>setupApplicationTest</code>—need to be replaced with those from <a href="https://github.com/emberjs/ember-mocha" target="_blank" rel="noopener noreferrer">ember-mocha</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 
@@ -89,7 +89,7 @@ You want to be able to grab DOM elements in your tests. Since Ember is just Java
         While you can use CSS classes as selectors, a best practice for testing is to <strong>separate the concerns between styling and testing</strong>. Class names and DOM structure change over time—for the better—by you, your team, and addon developers. If you rely on CSS classes, your tests will break and need a significant rewrite.
       </div>
     </div>
-    <img src="/images/mascots/tomster.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/tomster.png" role="presentation" alt="">
   </div>
 </div>
 


### PR DESCRIPTION
Fix for issue #1124 .

The remaining non-empty `alt` instances happen in `release/tutorial` (will be fixed separately) and in pre-Octane Guides.

![after_changes](https://user-images.githubusercontent.com/16869656/65998337-b9666680-e460-11e9-9b72-4c8671290a59.png)
