### PR TITLE
use <button> elements instead of <a> + role='button' (#938)

### DIFF
--- a/guides/release/tutorial/hbs-helper.md
+++ b/guides/release/tutorial/hbs-helper.md
@@ -34,13 +34,13 @@ Let's update our `rental-listing` component template to use our new helper and p
 
 ```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-15,+16"}
 <article class="listing">
-  <a
+  <button
     onclick={{action 'toggleImageSize'}}
     class="image {{if this.isWide "wide"}}"
   >
     <img src={{this.rental.image}} alt="">
     <small>View Larger</small>
-  </a>
+  </button>
   <div class="details">
     <h3>{{this.rental.title}}</h3>
     <div class="detail owner">

--- a/guides/release/tutorial/service.md
+++ b/guides/release/tutorial/service.md
@@ -166,16 +166,15 @@ This property will be passed in to the component by its parent template below.
 
 Finally open the template file for our `rental-listing` component and add the new `LocationMap` component.
 
-```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="+25"}
+```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="+24"}
 <article class="listing">
-  <a
+  <button
     class="image {{if this.isWide "wide"}}"
     onclick={{action "toggleImageSize"}}
-    role="button"
   >
     <img src={{this.rental.image}} alt="">
     <small>View Larger</small>
-  </a>
+  </button>
   <div class="details">
     <h3>{{this.rental.title}}</h3>
     <div class="detail owner">

--- a/guides/release/tutorial/simple-component.md
+++ b/guides/release/tutorial/simple-component.md
@@ -119,13 +119,12 @@ We'll also add some text to indicate that the image can be clicked on,
 and wrap both with an anchor element,
 giving it the `image` class name so that our test can find it.
 
-```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="+2,+3,+5,+6"}
+```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="+2,+4,+5"}
 <article class="listing">
-  <a class="image {{if this.isWide "wide"}}"
-    role="button">
+  <button class="image {{if this.isWide "wide"}}">
     <img src={{this.rental.image}} alt="">
     <small>View Larger</small>
-  </a>
+  </button>
   <div class="details">
     <h3>{{this.rental.title}}</h3>
     <div class="detail owner">
@@ -176,18 +175,16 @@ export default Component.extend({
 In order to trigger this action, we need to use the `{{action}}` helper in our
 template:
 
-```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-2,+3,+4,+5,+6,+7"}
+```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-2,+3,+4,+5,+6"}
 <article class="listing">
-  <a class="image {{if this.isWide "wide"}}"
-    role="button">
-  <a
+  <button class="image {{if this.isWide "wide"}}">
+  <button
     onclick={{action "toggleImageSize"}}
     class="image {{if this.isWide "wide"}}"
-    role="button"
   >
     <img src={{this.rental.image}} alt="">
     <small>View Larger</small>
-  </a>
+  </button>
   <div class="details">
     <h3>{{this.rental.title}}</h3>
     <div class="detail owner">

--- a/guides/release/tutorial/subroutes.md
+++ b/guides/release/tutorial/subroutes.md
@@ -354,16 +354,15 @@ Notice also that we are providing `rental.id` as the class attribute on the `lin
 
 Clicking on the title will load the detail page for that rental.
 
-```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-11,+12"}
+```handlebars {data-filename="app/templates/components/rental-listing.hbs" data-diff="-10,+11"}
 <article class="listing">
-  <a
+  <button
     class="image {{if this.isWide "wide"}}">
     onclick={{action 'toggleImageSize'}}
-    role="button"
   >
     <img src="{{this.rental.image}}" alt=""
     <small>View Larger</small>
-  </a>
+  </button>
   <div class="details">
     <h3>{{this.rental.title}}</h3>
     <h3>{{#link-to "rentals.show" rental class=rental.id}}{{this.rental.title}}{{/link-to}}</h3>


### PR DESCRIPTION
🚨 This is my first PR to this project. I've read the CONTRIBUTING.md and tried my best to follow the guidelines, but I'm very open to feedback If I missed something.

This change updates the markup in the guide to use the more semantic `<button>` element instead of applying `role="button"` to `<a>`. Because this change removes that attribute, the diffs for each section needed to be adjusted as well. This change should fix the issue in #938.

Here are some screenshots of it rendered out:

**Simple Component**
<img width="759" alt="Screen Shot 2019-10-02 at 10 33 42 PM" src="https://user-images.githubusercontent.com/587702/66095299-0af81980-e565-11e9-9590-ac4a57e69bb2.png">

**Template Helper**
<img width="753" alt="Screen Shot 2019-10-02 at 10 33 26 PM" src="https://user-images.githubusercontent.com/587702/66095317-1e0ae980-e565-11e9-809e-e781c810eb96.png">

**Services**
<img width="759" alt="Screen Shot 2019-10-02 at 10 34 03 PM" src="https://user-images.githubusercontent.com/587702/66095340-35e26d80-e565-11e9-943a-b52ec6ecc237.png">

**Nested Routes**
<img width="759" alt="Screen Shot 2019-10-02 at 10 34 23 PM" src="https://user-images.githubusercontent.com/587702/66095361-48f53d80-e565-11e9-8ebf-35088309da71.png">
