### PR TITLE
update guidemaker, fix bug in #1137

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8293,9 +8293,9 @@
       }
     },
     "ember-body-class": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ember-body-class/-/ember-body-class-1.1.3.tgz",
-      "integrity": "sha512-JCyepyKWapbrd/Rym6C+0ficGvERnH5PUo0dBdeoxZG4wa8dJ6K2YfU90l9EbMy3kk0lXkEhPRxhclqW4Cru/Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/ember-body-class/-/ember-body-class-1.1.4.tgz",
+      "integrity": "sha512-tZAA2HDpxbY9VKsnARzA2tqJ3+SfaMCpgYmsNTKuphj7BwZxKmmUKK6AsJ0+Ak2JgP3qHkwvTqSSdo6f9Y3FMA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^6.16.0"
@@ -14762,9 +14762,9 @@
       "dev": true
     },
     "guidemaker": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/guidemaker/-/guidemaker-2.0.1.tgz",
-      "integrity": "sha512-vq7ovbqqSzvlnO3KUiyVEEDtgGDavPj/sdVyDwvx3LTyw+HfCnhGpYISgHY+zJa8Xmsxm8/ZjV0DF5b2ig7k7A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/guidemaker/-/guidemaker-2.0.2.tgz",
+      "integrity": "sha512-/V/9+WpfVuw1Ygbx7BM/oO9PZbh9iEdOwR4T5xS2zGN1A877sqpsVspiDXaIL5s7UiEEW70VwipzyAc9CWWW1A==",
       "dev": true,
       "requires": {
         "broccoli-file-creator": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-ember": "^6.7.1",
     "eslint-plugin-import": "^2.18.2",
     "gfm-code-blocks": "^1.0.0",
-    "guidemaker": "^2.0.1",
+    "guidemaker": "^2.0.2",
     "guidemaker-ember-template": "ember-learn/guidemaker-ember-template#8863b3df25f9b9425c2b33525273a74213b71db7",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.15",


### PR DESCRIPTION
Closes #1137 

We were seeing old table of contents entries showing up in newer versions, if you switched between versions! See https://github.com/empress/guidemaker/pull/26