### PR TITLE
Possible typo: missing self-close?

### DIFF
--- a/guides/release/components-update/extracting-a-component.md
+++ b/guides/release/components-update/extracting-a-component.md
@@ -418,7 +418,7 @@ And finally, the signature.
 
 <StartingDates />
 <Subjects />
-<ToDo>
+<ToDo />
 
 <p>Yours sincerely,</p>
 


### PR DESCRIPTION
There isn't a `</ToDo>` and it hasn't talked about yielding yet, so this looked like a typo to me.