### PR TITLE
Fix broken markdown on REST Adapter page

### DIFF
--- a/guides/v1.10.0/models/the-rest-adapter.md
+++ b/guides/v1.10.0/models/the-rest-adapter.md
@@ -207,7 +207,7 @@ the `keyForRelationship` method.
       return key + 'Ids';
    }
  });
- ```
+```
 
 #### Sideloaded Relationships
 


### PR DESCRIPTION
There's a bug on the REST Adapter page that has to do with rendering markdown on the page. There was an extra space before the backticks that close out the last code block in the relationships section of that page (link [here](https://guides.emberjs.com/release/models/the-rest-adapter/#toc_relationships)), which messes up the formatting on the rest of the page.