### PR TITLE
[FEAT] Adds ToC Headings

### DIFF
--- a/app/helpers/includes.js
+++ b/app/helpers/includes.js
@@ -1,0 +1,5 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(([string = '', match]) => {
+  return string.indexOf(match) !== -1;
+});

--- a/app/initializers/patch-page-service.js
+++ b/app/initializers/patch-page-service.js
@@ -1,0 +1,17 @@
+import PageService from '../services/page';
+
+Object.defineProperty(PageService.prototype, 'pages', {
+  get() {
+    return this._pages;
+  },
+
+  set(pages) {
+    if (pages) {
+      this._pages = pages.filter(page => page.id.indexOf('toc-heading') === -1);
+    }
+  }
+});
+
+export default {
+  initialize() {}
+};

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -206,3 +206,21 @@ code[data-diff] .diff-insertion::before {
   display: inline-block;
   margin-left: 0.05em;
 }
+
+/* ToC heading styles */
+
+li.toc-heading.toc-level-0 {
+  font-size: 0.8em;
+  text-transform: uppercase;
+  color: rgb(155, 41, 24, 0.76);
+  font-weight: bold;
+  margin: 2em 0 1em;
+}
+
+li.toc-heading.toc-level-0:first-of-type {
+  margin-top: 0;
+}
+
+li.toc-group.toc-level-0 {
+  padding-left: 1em;
+}

--- a/app/templates/components/table-of-contents.hbs
+++ b/app/templates/components/table-of-contents.hbs
@@ -1,0 +1,32 @@
+{{#each data as |page|}}
+  {{! template-lint-disable simple-unless }}
+  {{#unless (or page.skipToc (get page "skip-toc"))}}
+    {{#if (includes page.id "toc-heading")}}
+      <li class="toc-heading {{tocLevel}}">{{page.title}}</li>
+    {{else if page.pages}}
+      <li class="toc-group {{tocLevel}}">
+        {{#cp-panel open=(eq currentSection.id page.id) as |p|}}
+          {{#if fastboot.isFastBoot}}
+            {{#link-to "version.show" page.id activeClass="selected" class="cp-Panel-toggle" data-test-toc-link=page.title}}
+              {{page.title}}
+            {{/link-to}}
+          {{else}}
+            {{#p.toggle data-test-toc-title=page.title}}
+              {{page.title}}
+            {{/p.toggle}}
+          {{/if}}
+
+          {{#p.body}}
+            {{table-of-contents data=page.pages currentPage=currentPage level=(inc level)}}
+          {{/p.body}}
+        {{/cp-panel}}
+      </li>
+    {{else}}
+      <li class="toc-link {{tocLevel}} {{if (eq currentPage.url page.url) "selected"}}">
+        {{#link-to "version.show" page.url activeClass="selected" data-test-toc-link=page.title}}
+          {{page.title}}
+        {{/link-to}}
+      </li>
+    {{/if}}
+  {{/unless}}
+{{/each}}

--- a/guides/release/pages.yml
+++ b/guides/release/pages.yml
@@ -1,7 +1,11 @@
 - title: "Introduction"
+  url: "toc-heading_introduction"
+  is_heading: true
+- title: "Guides and Tutorials"
   url: "index"
+  skip_toc: true
   pages:
-    - title: "What Is Ember"
+    - title: "Ember.js Guides"
       url: ""
 - title: "Getting Started"
   url: "getting-started"
@@ -51,6 +55,10 @@
       url: "14-provider-components"
     - title: "Part 2: Recap"
       url: "15-part-2-recap"
+
+- title: "Core Concepts"
+  url: "toc-heading_core-concepts"
+  is_heading: true
 - title: "Components"
   url: components
   pages:
@@ -143,11 +151,10 @@
       url: "making-api-requests"
     - title: "Native Classes In-Depth"
       url: "native-classes-in-depth"
-- title: "Addons and Dependencies"
-  url: "addons-and-dependencies"
-  pages:
-    - title: "Managing Dependencies"
-      url: "index"
+
+- title: "Application Development"
+  url: "toc-heading_application-development"
+  is_heading: true
 - title: "Testing"
   url: "testing"
   pages:
@@ -194,30 +201,26 @@
       url: "build-targets"
     - title: "Debugging"
       url: "debugging"
-- title: "Upgrading"
-  url: "upgrading"
+- title: Accessibility
+  url: accessibility
   pages:
-    - title: "How to upgrade"
+    - title: Intro to Accessibility
+      url: index
+    - title: Application Considerations
+      url: application-considerations
+    - title: Page Template Considerations
+      url: page-template-considerations
+    - title: Component Considerations
+      url: components
+    - title: Testing Considerations
+      url: testing
+    - title: Learning Resources
+      url: learning-resources
+- title: "Addons and Dependencies"
+  url: "addons-and-dependencies"
+  pages:
+    - title: "Managing Dependencies"
       url: "index"
-    - title: "Octane Upgrade Guide"
-      url: "current-edition"
-      pages:
-        - title: "Introduction"
-          url: "index"
-        - title: "Templates"
-          url: "templates"
-        - title: "Native Classes"
-          url: "native-classes"
-        - title: "Tracked Properties"
-          url: "tracked-properties"
-        - title: "@action, {{on}} and {{fn}}"
-          url: "action-on-and-fn"
-        - title: "Glimmer Components"
-          url: "glimmer-components"
-        - title: "Cheat Sheet"
-          url: "cheat-sheet"
-    # - title: "Deprecations"
-    #   url: "deprecations"
 - title: "Developer Tools"
   url: "ember-inspector"
   pages:
@@ -247,21 +250,34 @@
       url: "render-performance"
     - title: "Troubleshooting"
       url: "troubleshooting"
-- title: Accessibility
-  url: accessibility
+
+- title: "Additional Resources"
+  url: "toc-heading_additional-resources"
+  is_heading: true
+- title: "Upgrading"
+  url: "upgrading"
   pages:
-    - title: Intro to Accessibility
-      url: index
-    - title: Application Considerations
-      url: application-considerations
-    - title: Page Template Considerations
-      url: page-template-considerations
-    - title: Component Considerations
-      url: components
-    - title: Testing Considerations
-      url: testing
-    - title: Learning Resources
-      url: learning-resources
+    - title: "How to upgrade"
+      url: "index"
+    - title: "Octane Upgrade Guide"
+      url: "current-edition"
+      pages:
+        - title: "Introduction"
+          url: "index"
+        - title: "Templates"
+          url: "templates"
+        - title: "Native Classes"
+          url: "native-classes"
+        - title: "Tracked Properties"
+          url: "tracked-properties"
+        - title: "@action, {{on}} and {{fn}}"
+          url: "action-on-and-fn"
+        - title: "Glimmer Components"
+          url: "glimmer-components"
+        - title: "Cheat Sheet"
+          url: "cheat-sheet"
+    # - title: "Deprecations"
+    #   url: "deprecations"
 - title: "Contributing to Ember.js"
   url: "contributing"
   isAdvanced: true

--- a/tests/acceptance/side-bar-links-test.js
+++ b/tests/acceptance/side-bar-links-test.js
@@ -30,6 +30,6 @@ module('Acceptance | side bar links', function(hooks) {
     let store = this.owner.lookup('service:store');
     let pages = await store.peekAll('page');
 
-    await visitPages(pages.toArray(), assert);
+    await visitPages(pages.toArray().filter(page => !page.id.includes('toc-heading')), assert);
   });
 });

--- a/tests/acceptance/visual-regression-test.js
+++ b/tests/acceptance/visual-regression-test.js
@@ -17,6 +17,10 @@ module('Acceptance | visual regression', function(hooks) {
     await pages.reduce(async (prev, section) => {
       await prev;
 
+      if (section.get('id').includes('toc-heading')) {
+        return;
+      }
+
       return section.get('pages').reduce(async (prev, page) => {
         await prev;
 


### PR DESCRIPTION
Adds the ability to have ToC headings, which allows us to organize the ToC visually.

<img width="300" alt="Screen Shot 2019-12-07 at 1 18 21 PM" src="https://user-images.githubusercontent.com/685518/70380749-c25a3500-18f4-11ea-8f5f-123db01d3e75.png">

Unlike the previous nesting work, this is purely presentational. Headings do not link to any page, and they do not need to be toggled. This just allows us to bucket the main sections more clearly.

Could use help with the styling, I think I landed on something _ok_ but it could use more work.