### PR TITLE
[Octane] Slight tweaks to the new component guides

### DIFF
--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -1,7 +1,7 @@
 Component templates can leave a placeholder that users of the component can fill
 with their own HTML.
 
-To make it more concrete, let's take a look at two similar components
+To make that more concrete, let's take a look at two similar components
 representing different user's messages.
 
 ```handlebars {data-filename="app/components/received-message.hbs"}
@@ -257,7 +257,7 @@ function in JavaScript. Consider for instance a simple `BlogPost` component.
 ```
 
 We may want to give the user the ability to put extra content before or after
-the post, like for instance image or a profile. Since we don't know what the
+the post, such as an image or a profile. Since we don't know what the
 user wants to do with the body of the post, we can instead pass the body back
 to them.
 

--- a/guides/release/components/component-arguments-and-html-attributes.md
+++ b/guides/release/components/component-arguments-and-html-attributes.md
@@ -23,9 +23,9 @@ attributes).
   <div class="cta-note">
     <div class="cta-note-body">
       <div class="cta-note-message">
-        You may have noticed that the <code>is-active</code> class on the
+        You may notice that the <code>is-active</code> class on the
         received message avatar from the previous chapters is missing here.
-        We'll return to this in the next chapter on
+        We'll cover that in the next chapter on
         <a href="../conditional-content">Conditional Content</a>.
       </div>
     </div>
@@ -66,19 +66,9 @@ the _browser_ what to do, it's telling your custom tag what to do.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          You might be wondering why Ember doesn't use attribute syntax for the
-          component syntax. In the next section, we'll learn that you can put normal
-          HTML attributes on component tags, and they will end up on the HTML
-          element that the component creates.
-        </p>
-        <p>
-          So when you use a normal attribute name, you're putting a normal HTML
-          attribute on an element. When you use an argument (which starts with
-          <code>@</code>), you're providing data to a component.
-        </p>
-        <p>
-          This also means that arguments can pass any kind of data to the
-          component, even though HTML attributes are always strings
+          You might be wondering why Ember uses the `@` syntax for its
+          components instead of normal HTML attribute syntax. We'll learn why
+          in the next section.
         </p>
       </div>
     </div>
@@ -88,7 +78,7 @@ the _browser_ what to do, it's telling your custom tag what to do.
 
 ## HTML Attributes
 
-Now let's try to use our `<Avatar>` component for the sent message avatar.
+Let's try to use our `<Avatar>` component for the sent message avatar.
 
 ```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
 <Avatar @title="Zoey's avatar" @initial="Z" />
@@ -104,7 +94,7 @@ We're really, really close.
 ```
 
 We're just missing the `current-user` class on the HTML `<aside>` element. To
-make that work, we'll specify the HTML attribute `class` on the `<Address>` tag.
+make that work, we'll specify the HTML attribute `class` on the `<Avatar>` tag.
 
 ```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
 <Avatar
@@ -134,15 +124,15 @@ the avatar component now, and they will all end up on the element that has
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          <code>...attributes</code> syntax follows the same rules as
-          object-spread syntax in JavaScript. If it appears <em>after</em> an attribute,
+          In general, you should place <code>...attributes</code> after any attributes you
+          specify to give people using your component an opportunity to override your attribute.
+          If <code>...attributes</code> appears <em>after</em> an attribute,
           it overrides that attribute. If it appears <em>before</em> an attribute, it
           does not.</p>
         <p>
-          In general, you should place <code>...attributes</code> after attributes that
-          you specify to give tags an opportunity to override your attribute. Place it
+          Place <code>...attributes</code>
           <strong>before</strong> your attributes only if you want to disallow tags from
-          overriding your attributes. This should be unusual.
+          overriding your attributes. This is likely to be unusual.
         </p>
         <p>
           In addition, the <code>class</code> attribute is special, and will be

--- a/guides/release/components/conditional-content.md
+++ b/guides/release/components/conditional-content.md
@@ -15,7 +15,7 @@ Let's take a look at two similar components representing a user's username.
 ```
 
 We can use arguments to make these two components dynamic, but the first
-username has extra information in the form of the local time of the user.
+username also has extra information about the local time of the user.
 
 Let's say we tried to create a single `address` component.
 
@@ -29,8 +29,8 @@ Let's say we tried to create a single `address` component.
 If the `<Username>` tag doesn't specify a `@localTime` argument, we'll end up
 with some extra unneeded text in the output.
 
-What we need is a way to only include the local time text `@localTime` exists at
-all. We can do this with an `if`:
+What we need is a way to only include the local time text if `@localTime` exists.
+We can do this with an `if`:
 
 ```handlebars {data-filename="app/components/username.hbs"}
 <h4 class="username">
@@ -72,6 +72,17 @@ _public API_ of the component, so an argument makes sense.
 So, we want to add the `is-active` class if an argument, like say `@isActive`,
 is passed in and is truthy.
 
+```handlebars {data-filename="app/components/avatar.hbs"}
+<aside ...attributes>
+  <div
+    class="avatar {{if @isActive "is-active"}}"
+    title="{{@title}}"
+  >
+    {{@initial}}
+  </div>
+</aside>
+```
+
 <div class="cta">
   <div class="cta-note">
     <div class="cta-note-body">
@@ -88,17 +99,6 @@ is passed in and is truthy.
     <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
-
-```handlebars {data-filename="app/components/avatar.hbs"}
-<aside ...attributes>
-  <div
-    class="avatar {{if @isActive "is-active"}}"
-    title="{{@title}}"
-  >
-    {{@initial}}
-  </div>
-</aside>
-```
 
 We can then use the argument to add the active state to the received message
 avatar, and omit it from the sent message avatar.

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -41,7 +41,7 @@ By looking at how we use the `<Message>` component, we can see that some of the 
 
 Let's update the component to do that. It'll take a `@username` argument and calculate the title and initial.
 
-Since the title is just the `@username` plus some extra stuff, We can replace `@avatarTitle` by _interpolating_ the `@username` argument in a string literal passed to `<Message::Avatar>`.
+Since the title is just the `@username` plus some extra stuff, we can replace `@avatarTitle` by _interpolating_ the `@username` argument in a string literal passed to `<Message::Avatar>`.
 
 ```handlebars {data-filename="app/components/message.hbs" data-diff="-2,+3"}
 <Message::Avatar
@@ -61,7 +61,7 @@ Since the title is just the `@username` plus some extra stuff, We can replace `@
 </section>
 ```
 
-However, to get the first initial of the string, we'll need to use JavaScript. We'll write a helper function that gives us a substring from inside a string.
+However, to get the first initial of the string, we'll need to use JavaScript. To do that, we'll write a helper function.
 
 ## Writing a Helper Function
 
@@ -97,7 +97,7 @@ function substring(args) {
 export default helper(substring);
 ```
 
-**This is how we'll normally write helpers in Ember**.
+**This is how we normally write helpers in Ember**.
 
 We can then use this helper in the component's template to get the first letter of the username.
 
@@ -130,7 +130,7 @@ Using named arguments, we could make our template a lot clearer.
   @title="{{@username}}'s avatar"
   @initial={{substring @username 0 1}}
   {{! This won't work yet! We need to update the substring helper }}
-  @initial={{substring @username start=0 lenght=1}}
+  @initial={{substring @username start=0 length=1}}
   @isActive={{@userIsActive}}
   class="{{if @isCurrentUser "current-user"}}"
 />
@@ -219,8 +219,8 @@ If it returns "city", you get `this.address.city`.
 
 ### The `concat` helper
 
-In the last section it was discussed that helpers can be nested. This can be
-combined with these sorts of dynamic helpers. For example, the
+We mentioned above that helpers can be nested. This can be
+combined with different dynamic helpers. For example, the
 [`{{concat}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
 helper makes it easy to dynamically send a number of parameters to a component
 or helper as a single parameter in the format of a concatenated string.
@@ -238,7 +238,7 @@ Now let's say your template is starting to get a bit cluttered and you want
 to clean up the logic in your templates. This can be achieved with the `let`
 block helper.
 The [`{{let}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/let?anchor=let)
-helper lets you create new bindings in your template.
+helper lets you create new bindings (or temporary variables) in your template.
 
 Say your template now looks like this:
 

--- a/guides/release/components/introducing-components.md
+++ b/guides/release/components/introducing-components.md
@@ -159,7 +159,7 @@ We can include our new component into our application by using HTML tag syntax.
 </div>
 ```
 
-A _component_ is kind of like your own custom HTML tag. You can tell that a tag refers to an Ember component because it starts with a capital letter. Built-in tag start with lowercase letters (`<div>`, `<p>`, `<table>`). Our component is called `<ReceivedMessage>`, based on its name on the file system.
+A _component_ is kind of like your own custom HTML tag. You can tell that a tag refers to an Ember component because it starts with a capital letter. Built-in HTML tags start with lowercase letters (`<div>`, `<p>`, `<table>`). Our component is called `<ReceivedMessage>`, based on its name on the file system.
 
 <div class="cta">
   <div class="cta-note">
@@ -276,7 +276,7 @@ We have one last component to extract. Let's pull out the new message input.
 </form>
 ```
 
-And include it in the application.
+And include it in our `application.hbs` file.
 
 ```handlebars {data-filename="app/templates/application.hbs" data-diff="-6,-7,-8,-9,-10,-11,+12"}
 <div class="messages">


### PR DESCRIPTION
These are some very slight editorial tweaks to what otherwise reads quite nicely. My goal here was to reduce jargon and simplify the language a tad without over-simplifying the items we're teaching