### PR TITLE
Remove duplicate restriction about valid HTML elements in <body>

### DIFF
--- a/guides/release/components/index.md
+++ b/guides/release/components/index.md
@@ -213,6 +213,5 @@ template:
 
 - Only valid HTML elements in a `<body>` tag can be used
 - No `<script>` tags
-- You can only use HTML that is valid in `<body>`
 
 Other than that, go to town!


### PR DESCRIPTION
The `Restrictions` section listed 3 items:

```
- Only valid HTML elements in a `<body>` tag can be used
- No `<script>` tags
- You can only use HTML that is valid in `<body>`
```

I believe the first and third ones are identical and the list can be reduced to:

```
- Only valid HTML elements in a `<body>` tag can be used
- No `<script>` tags
```
