### PR TITLE
upd(configure:ember): add writeup on default-async-observers

### DIFF
--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -174,8 +174,8 @@ For more information, see [RFC #278](https://github.com/emberjs/rfcs/blob/master
 ### default-async-observers
 
 With this feature *enabled*, Ember will run all observers in the application
-asynchronously by default. This leads to observers running in the runloop
-_after_ the one in which the observed properties were updated.
+asynchronously by default. This leads to observers running in the run loop
+*after* the one in which the observed properties were updated.
 
 If the feature is *disabled*, observers run synchronously
 and will be invoked as soon as their observed properties update.
@@ -185,7 +185,7 @@ and can help you to manage your application state in a more predictable manner.
 This is one of the reasons, why the `default-async-observers` feature is
 **enabled by default** in newly created, modern Ember applications.
 
-The `default-async-observers` feature affects the behaviour of observers application-wide,
+The `default-async-observers` feature affects the behavior of observers application-wide,
 but you can still instruct individual observers to run synchronously or async
 manually. By using the `sync: true` option, observers who are otherwise async by default
 can be marked as synchronous manually. Similarly, observers

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -197,7 +197,7 @@ import { observer } from '@ember/object';
 
 Person.reopen({
   partOfNameChanged: observer({
-  dependentKeys: ['firstName', 'lastName'],
+    dependentKeys: ['firstName', 'lastName'],
   function() {
     // Fires async after firstName or lastName have updated
   },

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -202,6 +202,7 @@ Person.extend({
       // Fires async after firstName or lastName have updated
     },
     sync: false,
+  })
 });
 ```
 

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -200,7 +200,7 @@ Person.reopen({
     dependentKeys: ['firstName', 'lastName'],
     fn() {
       // Fires async after firstName or lastName have updated
-  },
+    },
     sync: false,
 });
 ```

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -188,7 +188,7 @@ This is one of the reasons, why the `default-async-observers` feature is
 The `default-async-observers` feature affects the behaviour of observers application-wide,
 but you can still instruct individual observers to run synchronously or async
 manually. By using the `sync: true` option, observers who are otherwise async by default
-can be marked as synchronous manually. Vice versa, otherwise synchronously running observers
+can be marked as synchronous manually. Similarly, observers
 can be set to run asynchronously using the `sync: false` option.
 
 

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -198,7 +198,7 @@ import { observer } from '@ember/object';
 Person.reopen({
   partOfNameChanged: observer({
     dependentKeys: ['firstName', 'lastName'],
-  function() {
+    fn() {
     // Fires async after firstName or lastName have updated
   },
   sync: false,

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -199,7 +199,7 @@ Person.reopen({
   partOfNameChanged: observer({
     dependentKeys: ['firstName', 'lastName'],
     fn() {
-    // Fires async after firstName or lastName have updated
+      // Fires async after firstName or lastName have updated
   },
   sync: false,
 });

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -201,7 +201,7 @@ Person.reopen({
     fn() {
       // Fires async after firstName or lastName have updated
   },
-  sync: false,
+    sync: false,
 });
 ```
 

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -211,5 +211,5 @@ you can enable this optional feature in older apps (Ember 3.13+) as follows:
 
 ```bash
 $ ember feature:enable default-async-observers
-Enable async observers application-wide. Be sure to commit config/optional-features.json to source control!
+# Enable async observers application-wide. Be sure to commit config/optional-features.json to source control!
 ```

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -187,7 +187,7 @@ This is one of the reasons, why the `default-async-observers` feature is
 
 The `default-async-observers` feature affects the behaviour of observers application-wide,
 but you can still instruct individual observers to run synchronously or async
-manually. By using the `sync: true` option, observers who are otherwise async by default,
+manually. By using the `sync: true` option, observers who are otherwise async by default
 can be marked as synchronous manually. Vice versa, otherwise synchronously running observers
 can be set to run asynchronously using the `sync: false` option.
 

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -64,7 +64,7 @@ However, you may choose to install and use it in your app!
 
 #### Including jQuery
 
-To include jQuery in your Ember app, follow the instructions above to install `@ember/optional-features`. 
+To include jQuery in your Ember app, follow the instructions above to install `@ember/optional-features`.
 Next, enable the feature:
 
 ```bash
@@ -170,3 +170,45 @@ backwards compatibility for existing templates while new template-only
 components gain the advantages of this feature.
 
 For more information, see [RFC #278](https://github.com/emberjs/rfcs/blob/master/text/0278-template-only-components.md).
+
+### default-async-observers
+
+With this feature *enabled*, Ember will run all observers in the application
+asynchronously by default. This leads to observers running in the runloop
+after the one in which the properties it observers were updated.
+
+If the feature is *disabled*, observers run synchronously
+and will then update as soon as their observed properties update.
+
+Async observers are more performant than those that run synchronously
+and can help you to manage your application state in a more predictable manner.
+This is one of the reasons, why the `default-async-observers` feature is
+**enabled by default** in newly created, modern Ember applications.
+
+The `default-async-observers` feature affects the behaviour of observers application-wide,
+but can still set single instances of observers to run synchronously or async
+manually. By using the `sync: true` option, observers who are otherwise async by default,
+can be marked as synchronous manually. Vice versa, otherwise synchronously running observers
+can be set to run asynchronously using the `sync: false` option.
+
+
+```javascript
+import { observer } from '@ember/object';
+
+Person.reopen({
+  partOfNameChanged: observer({
+  dependentKeys: ['firstName', 'lastName'],
+  function() {
+    // Fires async after firstName or lastName have updated
+  },
+  sync: false,
+});
+```
+
+While the `default-async-observers` feature is only enabled by default in modern Ember applications,
+you can enable this optional feature in older apps (Ember 3.13+) as follows:
+
+```bash
+$ ember feature:enable default-async-observers
+Enable async observers application-wide. Be sure to commit config/optional-features.json to source control!
+```

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -186,7 +186,7 @@ This is one of the reasons, why the `default-async-observers` feature is
 **enabled by default** in newly created, modern Ember applications.
 
 The `default-async-observers` feature affects the behaviour of observers application-wide,
-but can still set single instances of observers to run synchronously or async
+but you can still instruct individual observers to run synchronously or async
 manually. By using the `sync: true` option, observers who are otherwise async by default,
 can be marked as synchronous manually. Vice versa, otherwise synchronously running observers
 can be set to run asynchronously using the `sync: false` option.

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -195,7 +195,7 @@ can be set to run asynchronously using the `sync: false` option.
 ```javascript
 import { observer } from '@ember/object';
 
-Person.reopen({
+Person.extend({
   partOfNameChanged: observer({
     dependentKeys: ['firstName', 'lastName'],
     fn() {

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -175,7 +175,7 @@ For more information, see [RFC #278](https://github.com/emberjs/rfcs/blob/master
 
 With this feature *enabled*, Ember will run all observers in the application
 asynchronously by default. This leads to observers running in the runloop
-after the one in which the properties it observes were updated.
+_after_ the one in which the observed properties were updated.
 
 If the feature is *disabled*, observers run synchronously
 and will be invoked as soon as their observed properties update.

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -175,7 +175,7 @@ For more information, see [RFC #278](https://github.com/emberjs/rfcs/blob/master
 
 With this feature *enabled*, Ember will run all observers in the application
 asynchronously by default. This leads to observers running in the runloop
-after the one in which the properties it observers were updated.
+after the one in which the properties it observes were updated.
 
 If the feature is *disabled*, observers run synchronously
 and will then update as soon as their observed properties update.

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -178,7 +178,7 @@ asynchronously by default. This leads to observers running in the runloop
 after the one in which the properties it observes were updated.
 
 If the feature is *disabled*, observers run synchronously
-and will then update as soon as their observed properties update.
+and will be invoked as soon as their observed properties update.
 
 Async observers are more performant than those that run synchronously
 and can help you to manage your application state in a more predictable manner.


### PR DESCRIPTION
This should add a section documenting the use of the [default async observer optional feature](https://github.com/emberjs/ember-optional-features/blob/master/features/default-async-observers.js) as described in RFC#494: https://github.com/emberjs/rfcs/pull/494