### PR TITLE
docs: update Array method when compared to EmberArray

### DIFF
--- a/guides/release/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/release/configuring-ember/disabling-prototype-extensions.md
@@ -76,15 +76,15 @@ required interfaces using the convenience method `Ember.A`:
 import { A } from '@ember/array';
 
 let islands = ['Oahu', 'Kauai'];
-islands.includes('Oahu');
-// => TypeError: Object Oahu,Kauai has no method 'includes'
+islands.pushObject('Maui');
+// => TypeError: Object Oahu,Kauai has no method `pushObject`
 
 // Convert `islands` to an array that implements the
 // Ember enumerable and array interfaces
 A(islands);
 
-islands.includes('Oahu');
-// => true
+islands.pushObject('Maui');
+// => ['Oahu', 'Kauai', 'Maui'];
 ```
 
 ### Strings


### PR DESCRIPTION
The method `includes()` used on the native JS Array should be changed to something else, to a method that really does not exist.

1. You are trying to show that this method does not exist but at this time [native JS Array does implements the `includes()` method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes).

2. The snippet currently displayed is incorrect and should return `true`:
```js
let islands = ['Oahu', 'Kauai'];
islands.includes('Oahu');
// => true
```