### PR TITLE
Fix: Automated Test `About Us` Text

### DIFF
--- a/guides/release/tutorial/part-1/automated-testing.md
+++ b/guides/release/tutorial/part-1/automated-testing.md
@@ -171,7 +171,7 @@ module('Acceptance | super rentals', function(hooks) {
     assert.equal(currentURL(), '/getting-in-touch');
     assert.dom('h2').hasText('Contact Us');
 
-    assert.dom('a.button').hasText('About');
+    assert.dom('a.button').hasText('About Us');
     await click('.jumbo a.button');
 
     assert.equal(currentURL(), '/about');


### PR DESCRIPTION
Minor fix for failing automated test in the Octane guides.

This PR updates line 174 of the acceptance test file to fix the failing test.
This changes `assert.dom('a.button').hasText('About');` to `assert.dom('a.button').hasText('About Us');`