### PR TITLE
Try to fix missing netlify reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ jobs:
       name: 'Ember test suite'
     - script:
         - npm run build -- --prod
-        - travis_wait 50 netlify deploy --timeout=2999
+        - travis_wait 50 netlify deploy ; netlify watch
       # if: ./should-it-deploy-preview-app.js
     - stage: deploy to prod
       script:
         - npm run build -- --prod
-        - travis_wait 50 netlify deploy --prod --timeout=2999
+        - travis_wait 50 netlify deploy --prod ; netlify watch
       if: type IN (push) AND branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ jobs:
       name: 'Ember test suite'
     - script:
         - npm run build -- --prod
-        - travis_wait 50 netlify deploy ; netlify watch
+        - travis_wait 50 netlify deploy --timeout=2999
       # if: ./should-it-deploy-preview-app.js
     - stage: deploy to prod
       script:
         - npm run build -- --prod
-        - travis_wait 50 netlify deploy --prod ; netlify watch
+        - travis_wait 50 netlify deploy --prod --timeout=2999
       if: type IN (push) AND branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,13 +39,13 @@ jobs:
     - script:
         - npm run build -- --prod
         - netlify link --name ember-guides
-        - netlify watch
         - travis_wait 50 netlify deploy
+        - netlify watch
       # if: ./should-it-deploy-preview-app.js
     - stage: deploy to prod
       script:
         - npm run build -- --prod
         - netlify link --name ember-guides
-        - netlify watch
         - travis_wait 50 netlify deploy --prod
+        - netlify watch
       if: type IN (push) AND branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,10 @@ jobs:
       name: 'Ember test suite'
     - script:
         - npm run build -- --prod
-        - netlify link --name ember-guides
-        - travis_wait 50 netlify deploy
-        - netlify watch
+        - travis_wait 50 netlify deploy ; netlify watch
       # if: ./should-it-deploy-preview-app.js
     - stage: deploy to prod
       script:
         - npm run build -- --prod
-        - netlify link --name ember-guides
-        - travis_wait 50 netlify deploy --prod
-        - netlify watch
+        - travis_wait 50 netlify deploy --prod ; netlify watch
       if: type IN (push) AND branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,14 @@ jobs:
       name: 'Ember test suite'
     - script:
         - npm run build -- --prod
+        - netlify link --name ember-guides
+        - netlify watch
         - travis_wait 50 netlify deploy
-      if: ./should-it-deploy-preview-app.js
+      # if: ./should-it-deploy-preview-app.js
     - stage: deploy to prod
       script:
         - npm run build -- --prod
+        - netlify link --name ember-guides
+        - netlify watch
         - travis_wait 50 netlify deploy --prod
       if: type IN (push) AND branch = master

--- a/guides/release/applications/applications-and-instances.md
+++ b/guides/release/applications/applications-and-instances.md
@@ -1,3 +1,3 @@
 ---
-redirect: applications/index
+redirect: applications/indeeeeeex
 ---

--- a/guides/release/applications/applications-and-instances.md
+++ b/guides/release/applications/applications-and-instances.md
@@ -1,3 +1,3 @@
 ---
-redirect: applications/indeeeeeex
+redirect: applications/index
 ---


### PR DESCRIPTION
The goal of this PR is for Travis to show a failure if the build fails, but otherwise display success, even if netlify times out.

If this works, I think we can repurpose the should-deploy script to make deploys skippable.