### PR TITLE
[Autotracking In-Depth] Fix typo in Autotracking code example

### DIFF
--- a/guides/release/in-depth-topics/autotracking-in-depth.md
+++ b/guides/release/in-depth-topics/autotracking-in-depth.md
@@ -292,7 +292,7 @@ class SimpleCache {
   }
 
   get(key) {
-    return this._cache(key);
+    return this._cache[key];
   }
 }
 ```


### PR DESCRIPTION
Noticed that the getter was using `this._cache` as a method and not a POJO.