### PR TITLE
Use ember-cli-htmlbars over deprecated ember-cli-htmlbars-inline-precompile

### DIFF
--- a/.local.dic
+++ b/.local.dic
@@ -53,6 +53,7 @@ ember-cli-deprecation-workflow
 ember-cli-cjs-transform
 ember-cli-document-title
 ember-cli-head
+ember-cli-htmlbars
 ember-cli-mirage.
 ember-cli-tutorial-style
 ember-debug-handlers-polyfill

--- a/guides/release/testing/test-types.md
+++ b/guides/release/testing/test-types.md
@@ -114,7 +114,7 @@ Consider a button component. For simplicity, assume that the component keeps tra
 ```javascript {data-filename=tests/integration/components/simple-button-test.js}
 import { click, render } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 
 module('Integration | Component | simple-button', function(hooks) {
@@ -133,7 +133,7 @@ module('Integration | Component | simple-button', function(hooks) {
 });
 ```
 
-Note, we imported `render` and `click` from [@ember/test-helpers](https://github.com/emberjs/ember-test-helpers/blob/master/API.md) to show and interact with the component. We also imported `hbs` from [htmlbars-inline-precompile](https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile) to help with inline template definitions. With these methods, we can check if clicking on the component correctly updates its output to the user.
+Note, we imported `render` and `click` from [@ember/test-helpers](https://github.com/emberjs/ember-test-helpers/blob/master/API.md) to show and interact with the component. We also imported `hbs` from [ember-cli-htmlbars](https://github.com/ember-cli/ember-cli-htmlbars) to help with inline template definitions. With these methods, we can check if clicking on the component correctly updates its output to the user.
 
 Here are more examples where rendering tests are ideal:
 

--- a/guides/release/testing/testing-components.md
+++ b/guides/release/testing/testing-components.md
@@ -65,7 +65,7 @@ We can better see what this means, once we start writing out our first test case
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | pretty-color', function(hooks) {
   setupRenderingTest(hooks);
@@ -96,7 +96,7 @@ component's `style` attribute and is reflected in the rendered HTML:
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | pretty-color', function(hooks) {
   setupRenderingTest(hooks);
@@ -123,7 +123,7 @@ We might also test this component to ensure that the content of its template is 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | pretty-color', function(hooks) {
   setupRenderingTest(hooks);
@@ -182,7 +182,7 @@ And our test might look like this:
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | magic-title', function(hooks) {
   setupRenderingTest(hooks);
@@ -247,7 +247,7 @@ external action is called:
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | comment-form', function(hooks) {
   setupRenderingTest(hooks);
@@ -313,7 +313,7 @@ In this case we initially force location to "New York".
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
 //Stub location service
@@ -349,7 +349,7 @@ the test needs to check that the stub data from the service is reflected in the 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
 //Stub location service
@@ -390,7 +390,7 @@ In the next example, we'll add another test that validates that the display chan
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
 //Stub location service
@@ -492,7 +492,7 @@ In your test, use the `settled` helper to wait until your debounce timer is up a
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | delayed-typeahead', function(hooks) {
   setupRenderingTest(hooks);

--- a/guides/release/testing/testing-helpers.md
+++ b/guides/release/testing/testing-helpers.md
@@ -55,7 +55,7 @@ in [Testing Components](../testing-components/).
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Helper | format currency', function(hooks) {
   setupRenderingTest(hooks);
@@ -77,7 +77,7 @@ We can now also properly test if a helper will respond to property changes.
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Helper | format currency', function(hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
Some of the integration test docs are using the deprecated `ember-cli-htmlbars-inline-precompile` in code examples. This patch updates the docs to use the preferred `ember-cli-htmlbars` instead.