### PR TITLE
Fix all release links to release API

### DIFF
--- a/guides/release/applications/dependency-injection.md
+++ b/guides/release/applications/dependency-injection.md
@@ -11,11 +11,11 @@ guide covers the details of the system, and how to use it when needed.
 
 Applications and application instances each serve a role in Ember's DI implementation.
 
-An [`Application`](https://api.emberjs.com/ember/3.11/classes/Application) serves as a "registry" for dependency declarations.
+An [`Application`](https://api.emberjs.com/ember/release/classes/Application) serves as a "registry" for dependency declarations.
 Factories (i.e. classes) are registered with an application,
 as well as rules about "injecting" dependencies that are applied when objects are instantiated.
 
-An [`ApplicationInstance`](https://api.emberjs.com/ember/3.11/classes/ApplicationInstance) serves as the "owner" for objects that are instantiated from registered factories.
+An [`ApplicationInstance`](https://api.emberjs.com/ember/release/classes/ApplicationInstance) serves as the "owner" for objects that are instantiated from registered factories.
 Application instances provide a means to "look up" (i.e. instantiate and / or retrieve) objects.
 
 > _Note: Although an `Application` serves as the primary registry for an app,
@@ -203,7 +203,7 @@ export default Component.extend({
 ## Factory Instance Lookups
 
 To fetch an instantiated factory from the running application you can call the
-[`lookup`](https://api.emberjs.com/ember/3.11/classes/ApplicationInstance/methods/lookup?anchor=lookup) method on an application instance. This method takes a string
+[`lookup`](https://api.emberjs.com/ember/release/classes/ApplicationInstance/methods/lookup?anchor=lookup) method on an application instance. This method takes a string
 to identify a factory and returns the appropriate object.
 
 ```javascript
@@ -234,9 +234,9 @@ export default {
 
 ### Getting an Application Instance from a Factory Instance
 
-[`Ember.getOwner`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) will retrieve the application instance that "owns" an
+[`Ember.getOwner`](https://api.emberjs.com/ember/release/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) will retrieve the application instance that "owns" an
 object. This means that framework objects like components, helpers, and routes
-can use [`Ember.getOwner`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) to perform lookups through their application
+can use [`Ember.getOwner`](https://api.emberjs.com/ember/release/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) to perform lookups through their application
 instance at runtime.
 
 For example, this component plays songs with different audio services based

--- a/guides/release/applications/ember-engines.md
+++ b/guides/release/applications/ember-engines.md
@@ -1,6 +1,6 @@
 ## What are Engines?
 
-[Ember Engines](http://ember-engines.com/) allow multiple logical applications to be composed together into a single application from the user's perspective, that provide functionality to their host applications. Engines are isolated, `composable applications`, they have almost all the same features as normal Ember applications, except an [Engine](https://api.emberjs.com/ember/3.11/classes/Engine) requires a host application to boot it and provide a Router instance.
+[Ember Engines](http://ember-engines.com/) allow multiple logical applications to be composed together into a single application from the user's perspective, that provide functionality to their host applications. Engines are isolated, `composable applications`, they have almost all the same features as normal Ember applications, except an [Engine](https://api.emberjs.com/ember/release/classes/Engine) requires a host application to boot it and provide a Router instance.
 
 ## Why use Engines?
 

--- a/guides/release/applications/index.md
+++ b/guides/release/applications/index.md
@@ -1,8 +1,8 @@
-Every Ember application is represented by a class that extends [`Application`](https://api.emberjs.com/ember/3.11/classes/Application).
+Every Ember application is represented by a class that extends [`Application`](https://api.emberjs.com/ember/release/classes/Application).
 This class is used to declare and configure the many objects that make up your app.
 
 As your application boots,
-it creates an [`ApplicationInstance`](https://api.emberjs.com/ember/3.11/classes/ApplicationInstance) that is used to manage its stateful aspects.
+it creates an [`ApplicationInstance`](https://api.emberjs.com/ember/release/classes/ApplicationInstance) that is used to manage its stateful aspects.
 This instance acts as the "owner" of objects instantiated for your app.
 
 Essentially, the `Application` *defines your application*

--- a/guides/release/applications/run-loop.md
+++ b/guides/release/applications/run-loop.md
@@ -199,9 +199,9 @@ $('a').click(() => {
 });
 ```
 
-The run loop API calls that _schedule_ work, i.e. [`run.schedule`](https://api.emberjs.com/ember/3.11/classes/@ember%2Frunloop/methods/schedule?anchor=schedule),
-[`run.scheduleOnce`](https://api.emberjs.com/ember/3.11/classes/@ember%2Frunloop/methods/scheduleOnce?anchor=scheduleOnce),
-[`run.once`](https://api.emberjs.com/ember/3.11/classes/@ember%2Frunloop/methods/once?anchor=once) have the property that they will approximate a run loop for you if one does not already exist.
+The run loop API calls that _schedule_ work, i.e. [`run.schedule`](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop/methods/schedule?anchor=schedule),
+[`run.scheduleOnce`](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop/methods/scheduleOnce?anchor=scheduleOnce),
+[`run.once`](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop/methods/once?anchor=once) have the property that they will approximate a run loop for you if one does not already exist.
 These automatically created run loops we call _autoruns_.
 
 Here is some pseudocode to describe what happens using the example above:
@@ -242,5 +242,5 @@ $('a').click(() => {
 
 ## Where can I find more information?
 
-Check out the [Ember.run](https://api.emberjs.com/ember/3.11/classes/@ember%2Frunloop) API documentation,
+Check out the [Ember.run](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop) API documentation,
 as well as the [Backburner library](https://github.com/ebryn/backburner.js/) that powers the run loop.

--- a/guides/release/components/built-in-components.md
+++ b/guides/release/components/built-in-components.md
@@ -71,7 +71,7 @@ The following event types are supported (dasherized format):
 * `key-up`
 
 
-More [events types](https://api.emberjs.com/ember/3.11/classes/Component#event-names) are also supported but these events need to be written in camelCase format, such `mouseEnter`. Note, there are events of the same type in both the list above and linked. Event names listed above must be dasherized. Additional work is performed on these events.
+More [events types](https://api.emberjs.com/ember/release/classes/Component#event-names) are also supported but these events need to be written in camelCase format, such `mouseEnter`. Note, there are events of the same type in both the list above and linked. Event names listed above must be dasherized. Additional work is performed on these events.
 
 ### Checkboxes
 
@@ -98,7 +98,7 @@ Checkboxes support the following properties:
 Which can be bound or set as described in the previous section.
 
 
-Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.11/classes/Component#event-handler-methods), you will always need to define the event name in camelCase format:
+Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/release/classes/Component#event-handler-methods), you will always need to define the event name in camelCase format:
 
 ```handlebars
 <label for="firstname">First Name</label>
@@ -115,7 +115,7 @@ Checkboxes are a special input type. If you want to dispatch an action on a cert
 
 Will bind the value of the text area to `name` on the current context.
 
-[`<Textarea>`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea) supports binding and/or setting the following properties:
+[`<Textarea>`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea) supports binding and/or setting the following properties:
 
 * `value`
 * `name`
@@ -139,8 +139,8 @@ Will bind the value of the text area to `name` on the current context.
 
 You might need to bind a property dynamically to an input if you're building a
 flexible form, for example. To achieve this you need to use the
-[`{{get}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/get?anchor=get)
-and [`{{mut}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/mut?anchor=mut)
+[`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
+and [`{{mut}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/mut?anchor=mut)
 in conjunction like shown in the following example:
 
 ```handlebars
@@ -151,5 +151,5 @@ in conjunction like shown in the following example:
 The `{{get}}` helper allows you to dynamically specify which property to bind,
 while the `{{mut}}` helper allows the binding to be updated from the input. See
 the respective helper documentation for more detail:
-[`{{get}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/get?anchor=get)
-and [`{{mut}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/mut?anchor=mut).
+[`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
+and [`{{mut}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/mut?anchor=mut).

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -274,7 +274,7 @@ capitalized first name and last name as `firstName` and `lastName` instead of
 
 ### The `array` helper
 
-Using the [`{{array}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
+Using the [`{{array}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
 you can pass arrays directly from the template as an argument to your components.
 
 ```handlebars

--- a/guides/release/components/looping-through-lists.md
+++ b/guides/release/components/looping-through-lists.md
@@ -1,6 +1,6 @@
 Oftentimes we'll need to repeat a component multiple times in a row, with
 different data for each usage of the component. We can use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/if?anchor=each)
 helper to loop through lists of items like this, repeating a section of template
 for each item in the list.
 
@@ -370,7 +370,7 @@ export default class extends Component {
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/if?anchor=each)
 helper can also have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/release/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/release/configuring-ember/disabling-prototype-extensions.md
@@ -9,7 +9,7 @@ objects in the following ways:
 
 * `String` is extended to add convenience methods, such as
   `camelize()` and `w()`. You can find a list of these methods with the
-  [Ember.String documentation](https://api.emberjs.com/ember/3.11/classes/String).
+  [Ember.String documentation](https://api.emberjs.com/ember/release/classes/String).
 
 * `Function` is extended with methods to annotate functions as
   computed properties, via the `property()` method, and as observers,
@@ -90,7 +90,7 @@ islands.includes('Oahu');
 ### Strings
 
 Strings will no longer have the convenience methods described in the
-[`Ember.String` API reference](https://api.emberjs.com/ember/3.11/classes/String).
+[`Ember.String` API reference](https://api.emberjs.com/ember/release/classes/String).
 Instead,
 you can use the similarly-named methods of the `Ember.String` object and
 pass the string to use as the first parameter:

--- a/guides/release/configuring-ember/handling-deprecations.md
+++ b/guides/release/configuring-ember/handling-deprecations.md
@@ -10,7 +10,7 @@ Fortunately, Ember provides a way for projects to deal with deprecations in an o
 ## Filtering Deprecations
 
 When your project has a lot of deprecations, you can start by filtering out deprecations that do not have to be addressed right away.
-You can use the [deprecation handlers](https://api.emberjs.com/ember/3.11/functions/@ember%2Fdebug/registerDeprecationHandler) API to check for what release a deprecated feature will be removed.
+You can use the [deprecation handlers](https://api.emberjs.com/ember/release/functions/@ember%2Fdebug/registerDeprecationHandler) API to check for what release a deprecated feature will be removed.
 An example handler is shown below that filters out all deprecations that are not going away in release 2.0.0.
 
 ```javascript {data-filename= app/initializers/main.js}

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -102,7 +102,7 @@ Now your app will be about 30KB lighter!
 
 Without jQuery, any code that still relies on it will break, especially the following usages:
 
-- [`this.$()`](https://api.emberjs.com/ember/3.11/classes/Component/methods/$?anchor=%24) in components
+- [`this.$()`](https://api.emberjs.com/ember/release/classes/Component/methods/$?anchor=%24) in components
 - `jQuery` or `$` directly as a global, through `Ember.$()` or by importing it (`import jQuery from jquery;`)
 - global acceptance test helpers like `find()` or `click()`
 - `this.$()` in component tests

--- a/guides/release/ember-inspector/data.md
+++ b/guides/release/ember-inspector/data.md
@@ -30,4 +30,4 @@ You can also filter records by entering a query in the search box.
 ### Building a Data Custom Adapter
 
 You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter and [DataAdapter](https://api.emberjs.com/ember/3.11/classes/DataAdapter) documentation.
+using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter and [DataAdapter](https://api.emberjs.com/ember/release/classes/DataAdapter) documentation.

--- a/guides/release/models/finding-records.md
+++ b/guides/release/models/finding-records.md
@@ -40,7 +40,7 @@ let blogPosts = this.store.peekAll('blog-post'); // => no network request
 
 `store.findAll()` returns a `DS.PromiseArray` that fulfills to a `DS.RecordArray` and `store.peekAll` directly returns a `DS.RecordArray`.
 
-It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`MutableArray`](https://api.emberjs.com/ember/3.11/classes/MutableArray).
+It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`MutableArray`](https://api.emberjs.com/ember/release/classes/MutableArray).
 This is important because, for example, if you want to retrieve records by index,
 the `[]` notation will not work--you'll have to use `objectAt(index)` instead.
 

--- a/guides/release/object-model/bindings.md
+++ b/guides/release/object-model/bindings.md
@@ -1,7 +1,7 @@
 *__Note:__ Unlike most other frameworks that include some sort of binding implementation, bindings in Ember.js can be used with any object. That said, bindings are most often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.*
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
 that specifies the path to another object.
 
 ```javascript
@@ -35,7 +35,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/release/object-model/classes-and-instances.md
+++ b/guides/release/object-model/classes-and-instances.md
@@ -4,8 +4,8 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
-[`EmberObject`](https://api.emberjs.com/ember/3.11/modules/@ember%2Fobject):
+To define a new Ember _class_, call the [`extend()`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://api.emberjs.com/ember/release/modules/@ember%2Fobject):
 
 
 ```javascript
@@ -22,7 +22,7 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`](https://api.emberjs.com/ember/3.11/classes/Component) class:
+of Ember's built-in [`Component`](https://api.emberjs.com/ember/release/classes/Component) class:
 
 ```javascript {data-filename=app/components/todo-item.js}
 import Component from '@ember/component';
@@ -83,7 +83,7 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
+class by calling its [`create()`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
 
@@ -133,7 +133,7 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`](https://api.emberjs.com/ember/3.11/classes/EmberObject/methods/init?anchor=init) method is invoked automatically. This is the ideal place to implement setup required on new instances:
+When a new instance is created, its [`init()`](https://api.emberjs.com/ember/release/classes/EmberObject/methods/init?anchor=init) method is invoked automatically. This is the ideal place to implement setup required on new instances:
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -218,7 +218,7 @@ Person.create({
 
 When reading a property value of an object, you can in most cases use the common JavaScript dot notation, e.g. `myObject.myProperty`.
 
-[Ember proxy objects](https://api.emberjs.com/ember/3.3/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
+[Ember proxy objects](https://api.emberjs.com/ember/release/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
 
 Let's look at the following `blogPost` Ember Data model:
 
@@ -236,7 +236,7 @@ export default Model.extend({
 
 To access the blog post's title you can simply write `blogPost.title`, whereas only the syntax `blogPost.get('comments')` will return the post's comments.
 
-Always use Ember's [`set()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject/methods/set?anchor=set) method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
+Always use Ember's [`set()`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject/methods/set?anchor=set) method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
 
 ```javascript
 import EmberObject from '@ember/object';

--- a/guides/release/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/release/object-model/computed-properties-and-aggregate-data.md
@@ -108,7 +108,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}
@@ -200,10 +200,10 @@ export default Component.extend({
 Here, `indexOfSelectedTodo` depends on `todos.[]`, so it will update if we add an item
 to `todos`, but won't update if the value of `isDone` on a `todo` changes.
 
-Several of the [Ember.computed](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed) macros
+Several of the [Ember.computed](https://api.emberjs.com/ember/release/classes/@ember%2Fobject%2Fcomputed) macros
 utilize the `[]` key to implement common use-cases. For instance, to
 create a computed property that mapped properties from an array, you could use
-[Ember.computed.map](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/map?anchor=map)
+[Ember.computed.map](https://api.emberjs.com/ember/release/classes/@ember%2Fobject%2Fcomputed/methods/map?anchor=map)
 or build the computed property yourself:
 
 ```javascript

--- a/guides/release/object-model/computed-properties.md
+++ b/guides/release/object-model/computed-properties.md
@@ -259,4 +259,4 @@ class Person extends EmberObject {
 ```
 
 To see the full list of computed property macros, have a look at
-[the API documentation](https://api.emberjs.com/ember/3.11/modules/@ember%2Fobject)
+[the API documentation](https://api.emberjs.com/ember/release/modules/@ember%2Fobject)

--- a/guides/release/object-model/enumerables.md
+++ b/guides/release/object-model/enumerables.md
@@ -1,6 +1,6 @@
 In Ember.js, an enumerable is any object that contains a number of child
 objects, and which allows you to work with those children using the
-[`MutableArray`](https://api.emberjs.com/ember/3.11/classes/MutableArray) API. The most common
+[`MutableArray`](https://api.emberjs.com/ember/release/classes/MutableArray) API. The most common
 enumerable in the majority of apps is the native JavaScript array, which
 Ember.js extends to conform to the enumerable interface.
 
@@ -69,11 +69,11 @@ in an observable fashion, you should use `myArray.get('firstObject')` and
 
 In the rest of this guide, we'll explore some of the most common enumerable
 conveniences. For the full list, please see the [`MutableArray API
-reference documentation`](https://api.emberjs.com/ember/3.11/classes/MutableArray).
+reference documentation`](https://api.emberjs.com/ember/release/classes/MutableArray).
 
 ### Iterating Over an Enumerable
 
-To enumerate all the values of an enumerable object, use the [`forEach()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/forEach?anchor=forEach)
+To enumerate all the values of an enumerable object, use the [`forEach()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/forEach?anchor=forEach)
 method:
 
 
@@ -91,7 +91,7 @@ food.forEach((item, index) => {
 
 ### First and Last Objects
 
-All enumerables expose [`firstObject`](https://api.emberjs.com/ember/3.11/classes/MutableArray/properties/firstObject?anchor=firstObject) and [`lastObject`](https://api.emberjs.com/ember/3.11/classes/MutableArray/properties/lastObject?anchor=lastObject) properties
+All enumerables expose [`firstObject`](https://api.emberjs.com/ember/release/classes/MutableArray/properties/firstObject?anchor=firstObject) and [`lastObject`](https://api.emberjs.com/ember/release/classes/MutableArray/properties/lastObject?anchor=lastObject) properties
 that you can bind to.
 
 
@@ -113,7 +113,7 @@ animals.get('lastObject');
 ### Map
 
 You can easily transform each item in an enumerable using the
-[`map()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/map?anchor=map) method, which creates a new array with results of calling a
+[`map()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/map?anchor=map) method, which creates a new array with results of calling a
 function on each item in the enumerable.
 
 
@@ -124,7 +124,7 @@ let emphaticWords = words.map(item => `${item}!`);
 //=> ["goodbye!", "cruel!", "world!"]
 ```
 
-If your enumerable is composed of objects, there is a [`mapBy()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/mapBy?anchor=mapBy)
+If your enumerable is composed of objects, there is a [`mapBy()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/mapBy?anchor=mapBy)
 method that will extract the named property from each of those objects
 in turn and return a new array:
 
@@ -153,7 +153,7 @@ Another common task to perform on an enumerable is to take the
 enumerable as input, and return an Array after filtering it based on
 some criteria.
 
-For arbitrary filtering, use the [`filter()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/filter?anchor=filter) method.  The filter method
+For arbitrary filtering, use the [`filter()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/filter?anchor=filter) method.  The filter method
 expects the callback to return `true` if Ember should include it in the
 final Array, and `false` or `undefined` if Ember should not.
 
@@ -166,7 +166,7 @@ arr.filter((item, index, self) => item < 4);
 //=> [1, 2, 3]
 ```
 
-When working with a collection of Ember objects, you will often want to filter a set of objects based upon the value of some property. The [`filterBy()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/filterBy?anchor=filterBy) method provides a shortcut.
+When working with a collection of Ember objects, you will often want to filter a set of objects based upon the value of some property. The [`filterBy()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/filterBy?anchor=filterBy) method provides a shortcut.
 
 
 ```javascript
@@ -189,14 +189,14 @@ todos.filterBy('isDone', true);
 ```
 
 If you only want to return the first matched value, rather than an Array
-containing all of the matched values, you can use [`find()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/find?anchor=find) and [`findBy()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/findBy?anchor=findBy),
+containing all of the matched values, you can use [`find()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/find?anchor=find) and [`findBy()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/findBy?anchor=findBy),
 which work like `filter()` and `filterBy()`, but return only one item.
 
 
 ### Aggregate Information (Every or Any)
 
 To find out whether every item in an enumerable matches some condition, you can
-use the [`every()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/every?anchor=every) method:
+use the [`every()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/every?anchor=every) method:
 
 
 ```javascript
@@ -219,7 +219,7 @@ people.every((person, index, self) => person.get('isHappy'));
 ```
 
 To find out whether at least one item in an enumerable matches some condition,
-you can use the [`any()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/any?anchor=any) method:
+you can use the [`any()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/any?anchor=any) method:
 
 
 ```javascript

--- a/guides/release/object-model/index.md
+++ b/guides/release/object-model/index.md
@@ -2,20 +2,20 @@ One of the first things you'll notice when you generate JavaScript files in Embe
 
 ### Introducing: Ember Objects
 
-The [Ember Object](https://api.emberjs.com/ember/3.11/classes/EmberObject) class extends plain JavaScript objects to provide core framework functions such as participating in Ember's [binding system](../object-model/bindings/) or how changes to an object automatically trigger updates to the user interface.
+The [Ember Object](https://api.emberjs.com/ember/release/classes/EmberObject) class extends plain JavaScript objects to provide core framework functions such as participating in Ember's [binding system](../object-model/bindings/) or how changes to an object automatically trigger updates to the user interface.
 
 Most objects in Ember, including Routes, Models, Services, Mixins, Controllers, and Components extend the `EmberObject` class.
 
 ### Why Ember Objects?
 
-The most important reason is that an Ember Object can be watched for changes – or _observed_. For example, being [observable](https://api.emberjs.com/ember/3.11/classes/Observable) is important for [computed properties](../object-model/computed-properties/). It is one of the fundamental ways that models, controllers and views communicate with each other in an Ember application.
+The most important reason is that an Ember Object can be watched for changes – or _observed_. For example, being [observable](https://api.emberjs.com/ember/release/classes/Observable) is important for [computed properties](../object-model/computed-properties/). It is one of the fundamental ways that models, controllers and views communicate with each other in an Ember application.
 
 ### More on Ember Objects
 
-The [@ember/object](https://api.emberjs.com/ember/3.11/modules/@ember%2Fobject) package also provides a class system, supporting features like mixins and constructor methods, and being observable.
+The [@ember/object](https://api.emberjs.com/ember/release/modules/@ember%2Fobject) package also provides a class system, supporting features like mixins and constructor methods, and being observable.
 
 Some features in Ember's object model are not present in JavaScript classes or common patterns, but all are aligned as much as possible with the language and proposed additions.
 
-Ember also extends the JavaScript `Array` prototype with its [@ember/enumerable](https://api.emberjs.com/ember/3.11/classes/Enumerable) interface to provide change observation for arrays.
+Ember also extends the JavaScript `Array` prototype with its [@ember/enumerable](https://api.emberjs.com/ember/release/classes/Enumerable) interface to provide change observation for arrays.
 
-Finally, Ember extends the `String` prototype with a few [formatting and localization methods](https://api.emberjs.com/ember/3.11/classes/String).
+Finally, Ember extends the `String` prototype with a few [formatting and localization methods](https://api.emberjs.com/ember/release/classes/String).

--- a/guides/release/object-model/observers.md
+++ b/guides/release/object-model/observers.md
@@ -79,7 +79,7 @@ person.set('firstName', 'John');
 person.set('lastName', 'Smith');
 ```
 
-To get around these problems, you should make use of [`Ember.run.once()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Frunloop/methods/once?anchor=once).
+To get around these problems, you should make use of [`Ember.run.once()`](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop/methods/once?anchor=once).
 This will ensure that any processing you need to do only happens once, and
 happens in the next run loop once all bindings are synchronized:
 
@@ -145,7 +145,7 @@ get it in your `init()` method.
 ### Outside of class definitions
 
 You can also add observers to an object outside of a class definition
-using [`addObserver()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fobservers/methods/addObserver?anchor=addObserver):
+using [`addObserver()`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject%2Fobservers/methods/addObserver?anchor=addObserver):
 
 
 ```javascript

--- a/guides/release/routing/asynchronous-routing.md
+++ b/guides/release/routing/asynchronous-routing.md
@@ -71,7 +71,7 @@ defined on it to be a promise.
 If the promise fulfills, the transition will pick up where it left off and
 begin resolving the next (child) route's model, pausing if it too is a
 promise, and so on, until all destination route models have been
-resolved. The values passed to the [`setupController()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/setupController?anchor=setupController) hook for each route
+resolved. The values passed to the [`setupController()`](https://api.emberjs.com/ember/release/classes/Route/methods/setupController?anchor=setupController) hook for each route
 will be the fulfilled values from the promises.
 
 

--- a/guides/release/routing/defining-your-routes.md
+++ b/guides/release/routing/defining-your-routes.md
@@ -14,7 +14,7 @@ It also adds the route to the router.
 
 ## Basic Routes
 
-The [`map()`](https://api.emberjs.com/ember/3.11/classes/EmberRouter/methods/map?anchor=map) method
+The [`map()`](https://api.emberjs.com/ember/release/classes/EmberRouter/methods/map?anchor=map) method
 of your Ember application's router can be invoked to define URL mappings. When
 calling `map()`, you should pass a function that will be invoked with the value
 `this` set to an object which you can use to create routes.
@@ -350,8 +350,8 @@ export default class SomeRouteRoute extends Route {
 To have your route do something beyond render a template with the same name, you'll
 need to create a route handler. The following guides will explore the different
 features of route handlers. For more information on routes, see the API documentation
-for [the router](https://api.emberjs.com/ember/3.11/classes/EmberRouter) and for [route
-handlers](https://api.emberjs.com/ember/3.11/classes/Route).
+for [the router](https://api.emberjs.com/ember/release/classes/EmberRouter) and for [route
+handlers](https://api.emberjs.com/ember/release/classes/Route).
 
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:

--- a/guides/release/routing/loading-and-error-substates.md
+++ b/guides/release/routing/loading-and-error-substates.md
@@ -102,7 +102,7 @@ within the route hierarchy where loading feedback is important.
 ### The `loading` event
 
 If the various `beforeModel`/`model`/`afterModel` hooks
-don't immediately resolve, a [`loading`](https://api.emberjs.com/ember/3.11/classes/Route/events/loading?anchor=loading) event will be fired on that route.
+don't immediately resolve, a [`loading`](https://api.emberjs.com/ember/release/classes/Route/events/loading?anchor=loading) event will be fired on that route.
 
 ```javascript {data-filename=app/routes/user-slow-model.js}
 import Route from '@ember/routing/route';
@@ -215,7 +215,7 @@ logged.
 
 If the `articles.overview` route's `model` hook returns a promise that rejects
 (for instance the server returned an error, the user isn't logged in,
-etc.), an [`error`](https://api.emberjs.com/ember/3.11/classes/Route/events/error?anchor=error) event will fire from that route and bubble upward.
+etc.), an [`error`](https://api.emberjs.com/ember/release/classes/Route/events/error?anchor=error) event will fire from that route and bubble upward.
 This `error` event can be handled and used to display an error message,
 redirect to a login page, etc.
 

--- a/guides/release/routing/redirection.md
+++ b/guides/release/routing/redirection.md
@@ -7,12 +7,12 @@ Usually you want to redirect them to the login page, and after they have success
 There are many other reasons you probably want to have the last word on whether a user can or cannot access a certain page.
 Ember allows you to control that access with a combination of hooks and methods in your route.
 
-One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=transitionTo).
+One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://www.emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [`LinkTo`](../../templates/links/) helper.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/release/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/release/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/release/classes/Route/methods/transitionTo?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/release/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/release/routing/rendering-a-template.md
+++ b/guides/release/routing/rendering-a-template.md
@@ -19,7 +19,7 @@ template. For example, the `posts.new` route will render its template into the
 `posts.hbs`'s `{{outlet}}`, and the `posts` route will render its template into
 the `application.hbs`'s `{{outlet}}`.
 
-If you want to render a template other than the default one, set the route's [`templateName`](https://api.emberjs.com/ember/3.11/classes/Route/properties/templateName?anchor=templateName) property to the name of
+If you want to render a template other than the default one, set the route's [`templateName`](https://api.emberjs.com/ember/release/classes/Route/properties/templateName?anchor=templateName) property to the name of
 the template you want to render instead.
 
 ```javascript {data-filename=app/routes/posts.js}
@@ -30,5 +30,5 @@ export default class PostsRoute extends Route {
 }
 ```
 
-You can override the [`renderTemplate()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/renderTemplate?anchor=renderTemplate) hook if you want finer control over template rendering.
+You can override the [`renderTemplate()`](https://api.emberjs.com/ember/release/classes/Route/methods/renderTemplate?anchor=renderTemplate) hook if you want finer control over template rendering.
 Among other things, it allows you to choose the controller used to configure the template and specific outlet to render it into.

--- a/guides/release/routing/specifying-a-routes-model.md
+++ b/guides/release/routing/specifying-a-routes-model.md
@@ -1,6 +1,6 @@
 A route's JavaScript file is one of the best places in an app to make requests to an API.
 In this section of the guides, you'll learn how to use the
-[`model`](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=model)
+[`model`](https://api.emberjs.com/ember/release/classes/Route/methods/model?anchor=model)
 method to fetch data by making a HTTP request, and render it in a route's `hbs` template, or pass it down to a component.
 
 For example, take this router:
@@ -63,7 +63,7 @@ Now that data can be used in the `favorite-posts` template:
 {{/each}}
 ```
 
-Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=setupController) receives the results of the model hook, and Ember makes the model hook results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
+Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/release/classes/Route/methods/model?anchor=setupController) receives the results of the model hook, and Ember makes the model hook results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
 
 Let's compare some examples using the model hook to make asynchronous HTTP requests to a server somewhere.
 
@@ -125,7 +125,7 @@ identifier, instead):
 Ember Data is a powerful (but optional) library included by default in new Ember apps.
 In the next example, we will use Ember Data's [`findAll`](https://api.emberjs.com/ember-data/release/classes/Store/methods/findAll?anchor=findAll) method, which returns a Promise, and resolves with an array of [Ember Data records](../../models/).
 
-_Note that Ember Data also has a feature called a [`Model`](https://api.emberjs.com/ember-data/release/classes/Model), but it's a separate concept from a route's [`model`](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=model) hook._
+_Note that Ember Data also has a feature called a [`Model`](https://api.emberjs.com/ember-data/release/classes/Model), but it's a separate concept from a route's [`model`](https://api.emberjs.com/ember/release/classes/Route/methods/model?anchor=model) hook._
 
 ```javascript {data-filename=app/routes/favorite-posts.js}
 import Route from '@ember/routing/route';
@@ -144,7 +144,7 @@ export default class FavoritePostsRoute extends Route {
 What should you do if you need the `model` to return the results of multiple API requests?
 
 Multiple models can be returned through an
-[RSVP.hash](https://api.emberjs.com/ember/3.11/classes/rsvp/methods/hash?anchor=hash).
+[RSVP.hash](https://api.emberjs.com/ember/release/classes/rsvp/methods/hash?anchor=hash).
 The `RSVP.hash` method takes an object containing multiple promises.
 If all of the promises resolve, the returned promise will resolve to an object that contains the results of each request. For example:
 
@@ -232,7 +232,7 @@ method.
 There are two ways to link to a dynamic segment from an `.hbs` template using [`<LinkTo>`](../../templates/links/).
 Depending on which approach you use, it will affect whether that route's `model` hook is run.
 To learn how to link to a dynamic segment from within the JavaScript file, see the API documentation on
-[`transitionTo`](https://api.emberjs.com/ember/3.11/classes/RouterService/methods/transitionTo?anchor=transitionTo)
+[`transitionTo`](https://api.emberjs.com/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo)
 instead.
 
 When you provide a string or number to the `<LinkTo>`, the dynamic segment's `model` hook will run when the app transitions to the new route.

--- a/guides/release/services/index.md
+++ b/guides/release/services/index.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.11/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/release/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.11/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/release/modules/@ember%2Fservice) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';
@@ -88,7 +88,7 @@ This injects the shopping cart service into the component and makes it available
 
 Sometimes a service may or may not exist, like when an initializer conditionally registers a service.
 Since normal injection will throw an error if the service doesn't exist,
-you must look up the service using Ember's [`getOwner`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) instead.
+you must look up the service using Ember's [`getOwner`](https://api.emberjs.com/ember/release/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) instead.
 
 ```javascript {data-filename=app/components/cart-contents.js}
 import Component from '@glimmer/component';

--- a/guides/release/testing/testing-components.md
+++ b/guides/release/testing/testing-components.md
@@ -457,7 +457,7 @@ The `settled` function itself returns a Promise that resolves once all async ope
 
 You can use `settled` as a helper in your tests directly and `await` it for all async behavior to settle deliberately.
 
-Imagine you have a typeahead component that uses [`Ember.run.debounce`](https://api.emberjs.com/ember/3.11/classes/@ember%2Frunloop/methods/debounce?anchor=debounce) to limit requests to the server, and you want to verify that results are displayed after typing a character.
+Imagine you have a typeahead component that uses [`Ember.run.debounce`](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop/methods/debounce?anchor=debounce) to limit requests to the server, and you want to verify that results are displayed after typing a character.
 
 > You can follow along by generating your own component with `ember generate
 > component delayed-typeahead`.

--- a/guides/release/upgrading/current-edition/native-classes.md
+++ b/guides/release/upgrading/current-edition/native-classes.md
@@ -469,7 +469,7 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
   const Actress = Person.extend({});
   ```
 
-[1]: https://emberjs.com/api/ember/3.7/functions/@ember%2Fobject/extend
+[1]: https://emberjs.com/api/ember/release/functions/@ember%2Fobject/extend
 [2]: https://www.emberjs.com/api/ember/release/classes/EmberObject
 
 ### Instantiation
@@ -523,7 +523,7 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `init` method instead of the `constructor`.
 
-[3]: https://emberjs.com/api/ember/3.7/functions/@ember%2Fobject/create
+[3]: https://emberjs.com/api/ember/release/functions/@ember%2Fobject/create
 
 ### Methods
 


### PR DESCRIPTION
I noticed the links didn't all go to the latest api docs, so I corrected them mechanically in the release guides via the snippet below

```sh
git grep -l ember\/3 guides/release | xargs perl -pi -w -e 's/ember\/3\.\d+/ember\/release/g;'
```