### PR TITLE
A number of copy fixes in the release (Octane) guides

### DIFF
--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -21,7 +21,7 @@ representing different user's messages.
 </section>
 ```
 
-```handlebars {data-filename="app/components/sent-address.hbs"}
+```handlebars {data-filename="app/components/sent-message.hbs"}
 <aside class="current-user">
   <div class="avatar" title="Zoey's avatar">Z</div>
 </aside>
@@ -201,7 +201,7 @@ yields to the block once the block is passed into the component.
 
 ### Conditional Blocks
 
-Sometimes, we may want provide some default content if the user of a component
+Sometimes, we may want to provide some default content if the user of a component
 hasn't provided a block. For instance, consider an error message dialog that has
 a default message in cases where we don't know what error occurred. We could show
 the default message using the `(has-block)` syntax.

--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -204,7 +204,7 @@ yields to the block once the block is passed into the component.
 Sometimes, we may want to provide some default content if the user of a component
 hasn't provided a block. For instance, consider an error message dialog that has
 a default message in cases where we don't know what error occurred. We could show
-the default message using the `(has-block)` syntax.
+the default message using the `(has-block)` syntax in an `ErrorDialog` component.
 
 ```handlebars {data-filename=app/templates/components/error-dialog.hbs}
 <dialog>

--- a/guides/release/components/conditional-content.md
+++ b/guides/release/components/conditional-content.md
@@ -17,7 +17,7 @@ Let's take a look at two similar components representing a user's username.
 We can use arguments to make these two components dynamic, but the first
 username also has extra information about the local time of the user.
 
-Let's say we tried to create a single `address` component.
+Let's say we tried to create a single `username` component.
 
 ```handlebars {data-filename="app/components/username.hbs"}
 <h4 class="username">

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -243,11 +243,11 @@ helper lets you create new bindings (or temporary variables) in your template.
 Say your template now looks like this:
 
 ```handlebars
-Welcome back {{concat this.person.firstName ' ' this.person.lastName}}
+Welcome back {{concat (capitalize this.person.firstName) ' ' (capitalize this.person.lastName)}}
 
 Account Details:
-First Name: {{this.person.firstName}}
-Last Name: {{this.person.lastName}}
+First Name: {{capitalize this.person.firstName}}
+Last Name: {{capitalize this.person.lastName}}
 ```
 
 As mentioned in the previous section, we use the `concat` helper to render both
@@ -257,14 +257,14 @@ sure that the names are capitalized. It gets a bit repetitive to keep writing
 can use the `{{let}}` helper to fix this:
 
 ```handlebars
-{{#let (concat this.person.firstName this.person.lastName)
-  as |fullName|
+{{#let (capitalize this.person.firstName) (capitalize this.person.lastName)
+  as |firstName lastName|
 }}
-  Welcome back {{fullName}}
+  Welcome back {{concat firstName ' ' lastName}}
 
   Account Details:
-  First Name: {{this.person.firstName}}
-  Last Name: {{this.person.lastName}}
+  First Name: {{firstName}}
+  Last Name: {{lastName}}
 {{/let}}
 ```
 

--- a/guides/release/components/looping-through-lists.md
+++ b/guides/release/components/looping-through-lists.md
@@ -65,7 +65,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
-export default class Messages extends Component {
+export default class MessagesComponent extends Component {
   messages = [
     {
       username: 'Tomster',
@@ -279,7 +279,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { A } from '@ember/array';
 
-export default class Messages extends Component {
+export default class MessagesComponent extends Component {
   username = 'Zoey';
 
   @action
@@ -392,7 +392,7 @@ helper to do this:
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@glimmer/component';
 
-export default class StoreCategories extends Component {
+export default class StoreCategoriesComponent extends Component {
   // Set the "categories" property to a JavaScript object
   // with the category name as the key and the value a list
   // of products.

--- a/guides/release/components/looping-through-lists.md
+++ b/guides/release/components/looping-through-lists.md
@@ -65,7 +65,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
-export default class extends Component {
+export default class Messages extends Component {
   messages = [
     {
       username: 'Tomster',
@@ -214,7 +214,7 @@ add an action for creating the new message. We'll add this to the
 ```
 
 We're using the `submit` event on the form itself here rather than adding a
-`click` event handler to the button since is about submitting the form as a
+`click` event handler to the button since it is about submitting the form as a
 whole. We also updated the `input` tag to instead use the built in `<Input>`
 component, which automatically updates the value we pass to `@value`. Next, lets
 add the component class:
@@ -248,7 +248,7 @@ getting the new message input.
 
 Next, we'll update the parent component to use this new argument.
 
-```handlebars {data-filename="app/components/messages.hbs" data-diff=""}
+```handlebars {data-filename="app/components/messages.hbs" data-diff="-12,+13"}
 <div class="messages">
   {{#each this.messages as |message|}}
     <Message
@@ -279,7 +279,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { A } from '@ember/array';
 
-export default class extends Component {
+export default class Messages extends Component {
   username = 'Zoey';
 
   @action
@@ -351,7 +351,7 @@ print positions in a queue
 ```javascript
 import Component from '@glimmer/component';
 
-export default class extends Component {
+export default class SomeComponent extends Component {
   queue = [
     { name: 'Yehuda' },
     { name: 'Jen' },
@@ -392,7 +392,7 @@ helper to do this:
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@glimmer/component';
 
-export default class extends Component {
+export default class StoreCategories extends Component {
   // Set the "categories" property to a JavaScript object
   // with the category name as the key and the value a list
   // of products.

--- a/guides/release/routing/linking-between-routes.md
+++ b/guides/release/routing/linking-between-routes.md
@@ -67,7 +67,7 @@ segment directly, bypassing the `serialize` hook entirely:
 <a href="/photos/1">First Photo Ever</a>
 ```
 
-When the use click on the link, Ember will run the `PhotoEditRoute`'s `model`
+When the user click on the link, Ember will run the `PhotoEditRoute`'s `model`
 hook with `params.photo_id = 1`. On the other hand, if a model object was
 passed instead of the `id`, the model hook will _not_ run.
 

--- a/guides/release/tutorial/part-2/ember-data.md
+++ b/guides/release/tutorial/part-2/ember-data.md
@@ -173,7 +173,7 @@ installing model-test
   </div>
 </div>
 
-The generator created some boilerplate code for us, which servers as a pretty good starting point for writing our test:
+The generator created some boilerplate code for us, which serves as a pretty good starting point for writing our test:
 
 ```js { data-filename="tests/unit/models/rental-test.js" data-diff="-7,-8,+9,-11,-12,+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,+26,+27,+28,+29,+30,+31,+32,+33,+34,+35,+36,+37,+38,+39,+40" }
 import { module, test } from 'qunit';

--- a/guides/release/tutorial/part-2/ember-data.md
+++ b/guides/release/tutorial/part-2/ember-data.md
@@ -173,7 +173,7 @@ installing model-test
   </div>
 </div>
 
-The generator created some boilerplate code for us, which serves as a pretty good starting point for writing our test:
+The generator created some boilerplate code for us, which servers as a pretty good starting point for writing our test:
 
 ```js { data-filename="tests/unit/models/rental-test.js" data-diff="-7,-8,+9,-11,-12,+13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,+26,+27,+28,+29,+30,+31,+32,+33,+34,+35,+36,+37,+38,+39,+40" }
 import { module, test } from 'qunit';


### PR DESCRIPTION
Each is individually applicable

- Typo in guides/release/routing/linking-between-routes.md
- Fix typos guides/release/components/looping-through-lists.md
- Correct examples from copy; guides/v3.9.0/templates/built-in-helpers.md
- Consider clarifying guides/release/components/block-content.md

   On first read I didn't catch that the error dialog component was being
   called `ErrorDialog`
- Typo in guides/release/components/block-content.md
- Typo in guides/release/components/conditional-content.md
- ~~Typo in guides/release/tutorial/part-2/ember-data.md~~  moved to https://github.com/ember-learn/super-rentals-tutorial/pull/122