### PR TITLE
Clarify unclear checkbox event example

### DIFF
--- a/guides/release/components/built-in-components.md
+++ b/guides/release/components/built-in-components.md
@@ -98,11 +98,16 @@ Checkboxes support the following properties:
 Which can be bound or set as described in the previous section.
 
 
-Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input), you will always need to define the event name in camelCase format:
+Checkboxes are a special input type.  If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/release/classes/Component#event-handler-methods), you will always need to define the event name in [Web-API format](https://developer.mozilla.org/en-US/docs/Web/API/Document/keypress_event):
 
 ```handlebars
 <label for="firstname">First Name</label>
-<Input @type="checkbox" @keyPress={{this.updateName}} id="firstname" />
+{{!-- This does not work --}}
+<Input @type="checkbox" @key-press={{this.updateName}} id="firstname" />
+{{!-- Instead do this --}}
+<Input @type="checkbox" @keypress={{action "updateName"}} />
+{{!-- or do this --}}
+<Input @type="checkbox" {{on 'keypress' this.updateName}} id="firstname" />
 ```
 
 

--- a/guides/release/components/built-in-components.md
+++ b/guides/release/components/built-in-components.md
@@ -98,11 +98,11 @@ Checkboxes support the following properties:
 Which can be bound or set as described in the previous section.
 
 
-Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/release/classes/Component#event-handler-methods), you will always need to define the event name in camelCase format:
+Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input), you will always need to define the event name in camelCase format:
 
 ```handlebars
 <label for="firstname">First Name</label>
-<Input @type="checkbox" @key-press={{this.updateName}} id="firstname" />
+<Input @type="checkbox" @keyPress={{this.updateName}} id="firstname" />
 ```
 
 

--- a/guides/release/components/built-in-components.md
+++ b/guides/release/components/built-in-components.md
@@ -116,6 +116,8 @@ use an `on` helper with the [Web-API event name](https://developer.mozilla.org/e
 ```
 
 
+Internally, `<Input @type="checkbox" />` creates an instance of Checkbox. Do *not* use `Checkbox` directly.
+
 ## `<Textarea />`
 
 ```handlebars

--- a/guides/release/components/built-in-components.md
+++ b/guides/release/components/built-in-components.md
@@ -105,14 +105,14 @@ use an `on` helper with the [Web-API event name](https://developer.mozilla.org/e
 
 ```handlebars
 <label for="firstname">First Name</label>
+{{!-- This works: uses camelCase event name --}}
+<Input @type="checkbox" @keyDown={{this.updateName}} id="firstname" />
+{{!-- This works: uses 'on' with actual event name --}}
+<Input @type="checkbox" {{on "keydown" this.updateName}} id="firstname" />
 {{!-- This does not work: uses dasherized event name --}}
 <Input @type="checkbox" @key-down={{this.updateName}} id="firstname" />
 {{!-- This does not work: uses actual event name --}}
 <Input @type="checkbox" @keydown={{this.updateName}} id="firstname" />
-{{!-- This works: uses camelCase event name--}}
-<Input @type="checkbox" @keyDown={{this.updateName}} id="firstname" />
-{{!-- This works: uses 'on' with actual event name--}}
-<Input @type="checkbox" {{on 'keydown' this.updateName}} id="firstname" />
 ```
 
 Internally, `<Input @type="checkbox" />` creates an instance of Checkbox. Do *not* use `Checkbox` directly.

--- a/guides/release/components/built-in-components.md
+++ b/guides/release/components/built-in-components.md
@@ -100,7 +100,7 @@ Which can be bound or set as described in the previous section.
 
 
 Checkboxes are a special input type.  If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/release/classes/Component#event-handler-methods),
-you will always need to either define the event name in camelCase format (e.g. `@keyDown`, see Application.customEvents), or
+you will always need to either define the event name in camelCase format (e.g. `@keyDown`), or
 use an `on` helper with the [Web-API event name](https://developer.mozilla.org/en-US/docs/Web/API/Document/keydown_event) (e.g. `on 'keydown'`):
 
 ```handlebars
@@ -114,7 +114,6 @@ use an `on` helper with the [Web-API event name](https://developer.mozilla.org/e
 {{!-- This works: uses 'on' with actual event name--}}
 <Input @type="checkbox" {{on 'keydown' this.updateName}} id="firstname" />
 ```
-
 
 Internally, `<Input @type="checkbox" />` creates an instance of Checkbox. Do *not* use `Checkbox` directly.
 

--- a/guides/release/components/built-in-components.md
+++ b/guides/release/components/built-in-components.md
@@ -99,17 +99,20 @@ Checkboxes support the following properties:
 Which can be bound or set as described in the previous section.
 
 
-Checkboxes are a special input type.  If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/release/classes/Component#event-handler-methods), you will always need to define the event name in [Web-API format](https://developer.mozilla.org/en-US/docs/Web/API/Document/keydown_event):
-Or per the camelCase mapping in Application.customEvents in packages/@ember/-internals/views/lib/system/event_dispatcher.js
+Checkboxes are a special input type.  If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/release/classes/Component#event-handler-methods),
+you will always need to either define the event name in camelCase format (e.g. `@keyDown`, see Application.customEvents), or
+use an `on` helper with the [Web-API event name](https://developer.mozilla.org/en-US/docs/Web/API/Document/keydown_event) (e.g. `on 'keydown'`):
 
 ```handlebars
 <label for="firstname">First Name</label>
-{{!-- This does not work --}}
-<Input @type="checkbox" @key-press={{this.updateName}} id="firstname" />
-{{!-- Instead do this --}}
-<Input @type="checkbox" @keypress={{action "updateName"}} />
-{{!-- or do this --}}
-<Input @type="checkbox" {{on 'keypress' this.updateName}} id="firstname" />
+{{!-- This does not work: uses dasherized event name --}}
+<Input @type="checkbox" @key-down={{this.updateName}} id="firstname" />
+{{!-- This does not work: uses actual event name --}}
+<Input @type="checkbox" @keydown={{this.updateName}} id="firstname" />
+{{!-- This works: uses camelCase event name--}}
+<Input @type="checkbox" @keyDown={{this.updateName}} id="firstname" />
+{{!-- This works: uses 'on' with actual event name--}}
+<Input @type="checkbox" {{on 'keydown' this.updateName}} id="firstname" />
 ```
 
 

--- a/guides/release/components/built-in-components.md
+++ b/guides/release/components/built-in-components.md
@@ -53,11 +53,11 @@ current context.
 
 ### Actions
 
-To dispatch an action on specific events such as `key-press`, use the following
+To dispatch an action on specific events such as `key-down`, use the following
 
 ```handlebars
 <label for="firstname">First Name</label>
-<Input @value={{this.firstName}} @key-press={{this.updateFirstName}} id="firstname" />
+<Input @value={{this.firstName}} @key-down={{this.updateFirstName}} id="firstname" />
 ```
 
 The following event types are supported (dasherized format):
@@ -67,7 +67,8 @@ The following event types are supported (dasherized format):
 * `escape-press`
 * `focus-in`
 * `focus-out`
-* `key-press`
+* `key-down`
+* `key-press` ([Deprecated Web API](https://developer.mozilla.org/en-US/docs/Web/API/Document/keypress_event))
 * `key-up`
 
 
@@ -98,7 +99,8 @@ Checkboxes support the following properties:
 Which can be bound or set as described in the previous section.
 
 
-Checkboxes are a special input type.  If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/release/classes/Component#event-handler-methods), you will always need to define the event name in [Web-API format](https://developer.mozilla.org/en-US/docs/Web/API/Document/keypress_event):
+Checkboxes are a special input type.  If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/release/classes/Component#event-handler-methods), you will always need to define the event name in [Web-API format](https://developer.mozilla.org/en-US/docs/Web/API/Document/keydown_event):
+Or per the camelCase mapping in Application.customEvents in packages/@ember/-internals/views/lib/system/event_dispatcher.js
 
 ```handlebars
 <label for="firstname">First Name</label>


### PR DESCRIPTION
I ended up just testing this in the browser.

Reading through the api docs, old guides, and glimmer code I wasn't exactly
sure what this example is trying to say or if it's just wrong.