### PR TITLE
Add link to full list of void HTML elements

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -155,6 +155,10 @@ code[data-diff] .diff-insertion::before {
   line-height: 1.75em;
   margin: 0.5em 0;
 }
+.chapter .cta-note-body code {
+  padding: 0;
+  background-color: transparent;
+}
 @media screen and (min-width: 768px) {
   .chapter .cta .cta-note img {
     padding-bottom: 10px;

--- a/guides/release/components/index.md
+++ b/guides/release/components/index.md
@@ -186,10 +186,10 @@ In addition to normal HTML syntax, Ember allows you to use self-closing syntax
     <div class="cta-note-body">
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
-        You don't <strong>need</strong> to use this syntax for "void" HTML tags
-        such as `img` or `br`, which are already defined as self-closing by the
-        HTML spec, but you <strong>can</strong> use this syntax as a shorthand
-        for tags that are not self-closing.
+        You don't <strong>need</strong> to use this syntax for <a href="https://html.spec.whatwg.org/multipage/syntax.html#void-elements">"void" HTML
+        tags</a> such as <code>img</code> or <code>br</code>, which are already
+        defined as self-closing by the HTML specification, but you <strong>can</strong> use this syntax
+        as a shorthand for tags that are not self-closing.
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">


### PR DESCRIPTION
Adds a link to the HTML5 specification with the full list of void elements.

Also fixes a syntax bug where Markdown backticks were used (and not rendered as intended) inside the HTML block, replacing them with `code` tags. Additionally, fixes the CSS to remove the incorrect orange background styling of `code` elements inside the red background of the Zoey CTA.