### PR TITLE
fix namespace example

### DIFF
--- a/guides/v3.3.0/models/customizing-adapters.md
+++ b/guides/v3.3.0/models/customizing-adapters.md
@@ -155,7 +155,7 @@ export default DS.JSONAPIAdapter.extend({
 });
 ```
 
-Requests for `person` would now target `https://api.emberjs.com/1/people/1`.
+Requests for `person` would now target `https://api.emberjs.com/api/1/people/1`.
 
 
 #### Host Customization


### PR DESCRIPTION
The url would actually be `https://api.emberjs.com/api/1/people/1`.