### PR TITLE
Add a code comment to every file that ends in a code block

### DIFF
--- a/guides/release/addons-and-dependencies/index.md
+++ b/guides/release/addons-and-dependencies/index.md
@@ -169,3 +169,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/applications/dependency-injection.md
+++ b/guides/release/applications/dependency-injection.md
@@ -268,3 +268,5 @@ export default class PlayAudioComponent extends Component {
   }
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -298,3 +298,5 @@ We can yield back multiple values as well, separated by spaces.
   <AuthorBio @author={{author}} />
 </BlogPost>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/components/component-state-and-actions.md
+++ b/guides/release/components/component-state-and-actions.md
@@ -416,3 +416,5 @@ export default class DoubleIt extends Component {
   }
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -317,3 +317,5 @@ In the component's template, you can then use the `person` object:
 ```handlebars {data-filename=app/components/greeting/template.hbs}
 Hello, {{@person.firstName}} {{@person.lastName}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/components/looping-through-lists.md
+++ b/guides/release/components/looping-through-lists.md
@@ -462,3 +462,5 @@ the object is empty, null, or undefined:
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/configuring-ember/configuring-your-app.md
+++ b/guides/release/configuring-ember/configuring-your-app.md
@@ -18,3 +18,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/release/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/configuring-ember/embedding-applications.md
+++ b/guides/release/configuring-ember/embedding-applications.md
@@ -99,3 +99,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/configuring-ember/index.md
+++ b/guides/release/configuring-ember/index.md
@@ -18,3 +18,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -213,3 +213,5 @@ you can enable this optional feature in older apps (Ember 3.13+) as follows:
 $ ember feature:enable default-async-observers
 # Enable async observers application-wide. Be sure to commit config/optional-features.json to source control!
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/ember-inspector/promises.md
+++ b/guides/release/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -360,3 +360,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/in-depth-topics/autotracking-in-depth.md
+++ b/guides/release/in-depth-topics/autotracking-in-depth.md
@@ -320,3 +320,5 @@ class ShoppingList {
   }
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/models/creating-updating-and-deleting-records.md
+++ b/guides/release/models/creating-updating-and-deleting-records.md
@@ -157,3 +157,5 @@ the [`destroyRecord`](https://api.emberjs.com/ember-data/release/classes/Model/m
   post.destroyRecord(); // => DELETE to /posts/2
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/models/defining-models.md
+++ b/guides/release/models/defining-models.md
@@ -190,3 +190,5 @@ and accessing them within a template:
 ```handlebars
 {{@model.location.latitude}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/models/finding-records.md
+++ b/guides/release/models/finding-records.md
@@ -122,3 +122,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/object-model/bindings.md
+++ b/guides/release/object-model/bindings.md
@@ -69,3 +69,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/object-model/classes-and-instances.md
+++ b/guides/release/object-model/classes-and-instances.md
@@ -251,3 +251,5 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/object-model/enumerables.md
+++ b/guides/release/object-model/enumerables.md
@@ -235,3 +235,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/object-model/observers.md
+++ b/guides/release/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/object-model/reopening-classes-and-instances.md
+++ b/guides/release/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/routing/asynchronous-routing.md
+++ b/guides/release/routing/asynchronous-routing.md
@@ -166,3 +166,5 @@ export default class FunkyRoute extends Route {
   }
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/routing/linking-between-routes.md
+++ b/guides/release/routing/linking-between-routes.md
@@ -223,3 +223,5 @@ option:
   Top comment for the current photo
 </Link>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/routing/loading-and-error-substates.md
+++ b/guides/release/routing/loading-and-error-substates.md
@@ -262,3 +262,5 @@ export default class ArticlesOverviewRoute extends Route {
   }
 };
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/routing/preventing-and-retrying-transitions.md
+++ b/guides/release/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default class LoginController extends Controller {
   }
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/routing/query-params.md
+++ b/guides/release/routing/query-params.md
@@ -352,3 +352,5 @@ export default class ArticlesController extends Controller {
   ]
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/routing/redirection.md
+++ b/guides/release/routing/redirection.md
@@ -112,3 +112,5 @@ export default class PostsRoute extends Route {
   }
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/services/index.md
+++ b/guides/release/services/index.md
@@ -135,3 +135,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/testing/testing-components.md
+++ b/guides/release/testing/testing-components.md
@@ -521,3 +521,5 @@ module('Integration | Component | delayed-typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/testing/testing-controllers.md
+++ b/guides/release/testing/testing-controllers.md
@@ -86,3 +86,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/testing/testing-helpers.md
+++ b/guides/release/testing/testing-helpers.md
@@ -96,3 +96,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/testing/testing-routes.md
+++ b/guides/release/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/testing/unit-testing-basics.md
+++ b/guides/release/testing/unit-testing-basics.md
@@ -245,3 +245,5 @@ module('Unit | Service | employees', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/upgrading/current-edition/action-on-and-fn.md
+++ b/guides/release/upgrading/current-edition/action-on-and-fn.md
@@ -219,3 +219,5 @@ helper:
 <button {{on "click" (fn this.handleClick 123)}}>Click Me!</button>
 <MyComponent @onClick={{fn this.handleClick 123}} />
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/upgrading/current-edition/glimmer-components.md
+++ b/guides/release/upgrading/current-edition/glimmer-components.md
@@ -869,3 +869,5 @@ Additionally, the `mut` helper generally can't be used for the same reason:
   onkeyup={{action (mut this.value) target="value"}}
 />
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/upgrading/current-edition/tracked-properties.md
+++ b/guides/release/upgrading/current-edition/tracked-properties.md
@@ -384,3 +384,5 @@ still use Ember's `get` and `set` functions:
 get(maybeProxy, 'firstName');
 set(maybeProxy, 'firstName', 'Amy');
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/configuring-ember/embedding-applications.md
+++ b/guides/v1.10.0/configuring-ember/embedding-applications.md
@@ -31,3 +31,5 @@ App.Router = Ember.Router.extend({
   location: 'none'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/controllers/representing-a-single-model-with-objectcontroller.md
+++ b/guides/v1.10.0/controllers/representing-a-single-model-with-objectcontroller.md
@@ -104,3 +104,5 @@ Now, the output of our template is a lot friendlier:
   <strong>Duration</strong>: 4:17
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/controllers/representing-multiple-models-with-arraycontroller.md
+++ b/guides/v1.10.0/controllers/representing-multiple-models-with-arraycontroller.md
@@ -110,3 +110,5 @@ App.SongsController = Ember.ArrayController.extend({
   <li>{{item.fullName}}</li>
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/enumerables/index.md
+++ b/guides/v1.10.0/enumerables/index.md
@@ -230,3 +230,5 @@ Just like the filtering methods, the `every` and `some` methods have analogous `
 people.isEvery('isHappy', true) // false
 people.isAny('isHappy', true)  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/models/connecting-to-an-http-server.md
+++ b/guides/v1.10.0/models/connecting-to-an-http-server.md
@@ -174,3 +174,5 @@ Requests for any resource will include the following HTTP headers.
 ANOTHER_HEADER: Some header value
 API_KEY: secret key
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/models/creating-and-deleting-records.md
+++ b/guides/v1.10.0/models/creating-and-deleting-records.md
@@ -59,3 +59,5 @@ store.find('post', 2).then(function (post) {
   post.destroyRecord(); // => DELETE to /posts/2
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/models/defining-models.md
+++ b/guides/v1.10.0/models/defining-models.md
@@ -232,3 +232,5 @@ App.Folder = DS.Model.extend({
   parent: belongsTo('folder', {inverse: null})
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/models/finding-records.md
+++ b/guides/v1.10.0/models/finding-records.md
@@ -85,3 +85,5 @@ App.PostRoute = Ember.Route.extend({
   }
 })
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/models/frequently-asked-questions.md
+++ b/guides/v1.10.0/models/frequently-asked-questions.md
@@ -136,3 +136,5 @@ socket.on('message', function (message) {
   store.pushPayload(message.model, message.data);
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/models/handling-metadata.md
+++ b/guides/v1.10.0/models/handling-metadata.md
@@ -68,3 +68,5 @@ App.ApplicationSerializer = DS.RESTSerializer.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/models/persisting-records.md
+++ b/guides/v1.10.0/models/persisting-records.md
@@ -97,3 +97,5 @@ retry(function() {
   return post.save();
 }, 5);
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/models/pushing-records-into-the-store.md
+++ b/guides/v1.10.0/models/pushing-records-into-the-store.md
@@ -55,3 +55,5 @@ App.ApplicationRoute = Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/models/working-with-records.md
+++ b/guides/v1.10.0/models/working-with-records.md
@@ -48,3 +48,5 @@ person.get('isDirty');      //=> false
 person.get('isAdmin');      //=> false
 person.changedAttributes(); //=> {}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/object-model/bindings.md
+++ b/guides/v1.10.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', "Krang Gates");
 userView.set('userName', "Truckasaurus Gates");
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/object-model/observers.md
+++ b/guides/v1.10.0/object-model/observers.md
@@ -142,3 +142,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v1.10.0/object-model/reopening-classes-and-instances.md
@@ -36,3 +36,5 @@ Person.reopenClass({
 
 Person.createMan().get('isMan') // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/routing/index.md
+++ b/guides/v1.10.0/routing/index.md
@@ -53,3 +53,5 @@ App.Router.reopen({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v1.10.0/routing/preventing-and-retrying-transitions.md
@@ -96,3 +96,5 @@ App.LoginController = Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/routing/rendering-a-template.md
+++ b/guides/v1.10.0/routing/rendering-a-template.md
@@ -90,3 +90,5 @@ App.PostRoute = App.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/routing/setting-up-a-controller.md
+++ b/guides/v1.10.0/routing/setting-up-a-controller.md
@@ -60,3 +60,5 @@ App.PostRoute = Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/routing/specifying-the-location-api.md
+++ b/guides/v1.10.0/routing/specifying-the-location-api.md
@@ -36,3 +36,5 @@ App.Router.reopen({
   location: 'none'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/templates/actions.md
+++ b/guides/v1.10.0/templates/actions.md
@@ -248,3 +248,5 @@ a parent view, use the following:
   {{post.title}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/templates/development-helpers.md
+++ b/guides/v1.10.0/templates/development-helpers.md
@@ -39,3 +39,5 @@ hit, you can use the `templateContext` in your console to lookup properties:
 > templateContext.get('name')
 "Bruce Lee"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/templates/displaying-a-list-of-items.md
+++ b/guides/v1.10.0/templates/displaying-a-list-of-items.md
@@ -35,3 +35,5 @@ The contents of this block will render if the collection is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/templates/links.md
+++ b/guides/v1.10.0/templates/links.md
@@ -142,3 +142,5 @@ the browser's history you can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/templates/writing-helpers.md
+++ b/guides/v1.10.0/templates/writing-helpers.md
@@ -78,3 +78,5 @@ arguments as:
 ```handlebars
 {{view "calendar"}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/understanding-ember/debugging.md
+++ b/guides/v1.10.0/understanding-ember/debugging.md
@@ -217,3 +217,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/understanding-ember/keeping-templates-up-to-date.md
+++ b/guides/v1.10.0/understanding-ember/keeping-templates-up-to-date.md
@@ -25,3 +25,5 @@ Your output will be free of markers, but be careful, because the output won't be
 ```html
 My new car is blue.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/views/adding-layouts-to-views.md
+++ b/guides/v1.10.0/views/adding-layouts-to-views.md
@@ -42,3 +42,5 @@ This will result in view instances containing the following HTML
   Hello, <b>Teddy</b>!
 </div>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/views/customizing-a-views-element.md
+++ b/guides/v1.10.0/views/customizing-a-views-element.md
@@ -176,3 +176,5 @@ This yields a view wrapper that will look something like this:
 ```html
 <div id="ember420" class="ember-view is-urgent p4"></div>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.10.0/views/defining-a-view.md
+++ b/guides/v1.10.0/views/defining-a-view.md
@@ -40,3 +40,5 @@ To remove a view from the document, call `remove`:
 ```javascript
 view.remove();
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/components/index.md
+++ b/guides/v1.11.0/components/index.md
@@ -72,3 +72,5 @@ export default Ember.Component.extend({
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/configuring-ember/embedding-applications.md
+++ b/guides/v1.11.0/configuring-ember/embedding-applications.md
@@ -34,3 +34,5 @@ var ENV = {
 };
 export default ENV;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/controllers/representing-a-single-model-with-objectcontroller.md
+++ b/guides/v1.11.0/controllers/representing-a-single-model-with-objectcontroller.md
@@ -104,3 +104,5 @@ Now, the output of our template is a lot friendlier:
   <strong>Duration</strong>: 4:17
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/controllers/representing-multiple-models-with-arraycontroller.md
+++ b/guides/v1.11.0/controllers/representing-multiple-models-with-arraycontroller.md
@@ -110,3 +110,5 @@ export default Ember.ArrayController.extend({
   <li>{{item.fullName}}</li>
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/enumerables/index.md
+++ b/guides/v1.11.0/enumerables/index.md
@@ -230,3 +230,5 @@ Just like the filtering methods, the `every` and `some` methods have analogous `
 people.isEvery('isHappy', true) // false
 people.isAny('isHappy', true)  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/models/connecting-to-an-http-server.md
+++ b/guides/v1.11.0/models/connecting-to-an-http-server.md
@@ -188,3 +188,5 @@ Requests for any resource will include the following HTTP headers.
 ANOTHER_HEADER: Some header value
 API_KEY: secret key
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/models/creating-and-deleting-records.md
+++ b/guides/v1.11.0/models/creating-and-deleting-records.md
@@ -59,3 +59,5 @@ store.find('post', 2).then(function (post) {
   post.destroyRecord(); // => DELETE to /posts/2
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/models/defining-models.md
+++ b/guides/v1.11.0/models/defining-models.md
@@ -225,3 +225,5 @@ export default DS.Model.extend({
   parent: belongsTo('folder', {inverse: null})
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/models/finding-records.md
+++ b/guides/v1.11.0/models/finding-records.md
@@ -93,3 +93,5 @@ export default Ember.Route.extend({
   }
 })
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/models/frequently-asked-questions.md
+++ b/guides/v1.11.0/models/frequently-asked-questions.md
@@ -136,3 +136,5 @@ socket.on('message', function (message) {
   store.pushPayload(message.model, message.data);
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/models/handling-metadata.md
+++ b/guides/v1.11.0/models/handling-metadata.md
@@ -68,3 +68,5 @@ export default DS.RESTSerializer.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/models/persisting-records.md
+++ b/guides/v1.11.0/models/persisting-records.md
@@ -97,3 +97,5 @@ retry(function() {
   return post.save();
 }, 5);
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/models/pushing-records-into-the-store.md
+++ b/guides/v1.11.0/models/pushing-records-into-the-store.md
@@ -55,3 +55,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/models/working-with-records.md
+++ b/guides/v1.11.0/models/working-with-records.md
@@ -48,3 +48,5 @@ person.get('isDirty');      //=> false
 person.get('isAdmin');      //=> false
 person.changedAttributes(); //=> {}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/object-model/bindings.md
+++ b/guides/v1.11.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', "Krang Gates");
 userView.set('userName', "Truckasaurus Gates");
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/object-model/observers.md
+++ b/guides/v1.11.0/object-model/observers.md
@@ -142,3 +142,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v1.11.0/object-model/reopening-classes-and-instances.md
@@ -36,3 +36,5 @@ Person.reopenClass({
 
 Person.createMan().get('isMan') // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/routing/generated-objects.md
+++ b/guides/v1.11.0/routing/generated-objects.md
@@ -35,3 +35,5 @@ as an `outlet` so that nested routes can be seamlessly inserted.  It is equivale
 ```handlebars
 {{outlet}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/routing/index.md
+++ b/guides/v1.11.0/routing/index.md
@@ -51,3 +51,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/routing/loading-and-error-substates.md
+++ b/guides/v1.11.0/routing/loading-and-error-substates.md
@@ -288,3 +288,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v1.11.0/routing/preventing-and-retrying-transitions.md
@@ -98,3 +98,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/routing/rendering-a-template.md
+++ b/guides/v1.11.0/routing/rendering-a-template.md
@@ -92,3 +92,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/routing/setting-up-a-controller.md
+++ b/guides/v1.11.0/routing/setting-up-a-controller.md
@@ -60,3 +60,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/routing/specifying-the-location-api.md
+++ b/guides/v1.11.0/routing/specifying-the-location-api.md
@@ -37,3 +37,5 @@ Ember.Router.extend({
   location: 'none'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/templates/actions.md
+++ b/guides/v1.11.0/templates/actions.md
@@ -244,3 +244,5 @@ a parent view, use the following:
   {{post.title}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/templates/conditionals.md
+++ b/guides/v1.11.0/templates/conditionals.md
@@ -55,3 +55,5 @@ The inline-if syntax also support the inverse syntax using an inline-unless:
 ```handlebars
 This message is {{unless isImportant 'unimportant' 'important'}}.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/templates/development-helpers.md
+++ b/guides/v1.11.0/templates/development-helpers.md
@@ -38,3 +38,5 @@ hit, you can use the `templateContext` in your console to lookup properties:
 > templateContext.get('name')
 "Bruce Lee"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/templates/displaying-a-list-of-items.md
+++ b/guides/v1.11.0/templates/displaying-a-list-of-items.md
@@ -35,3 +35,5 @@ The contents of this block will render if the collection is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/templates/links.md
+++ b/guides/v1.11.0/templates/links.md
@@ -136,3 +136,5 @@ the browser's history you can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/templates/writing-helpers.md
+++ b/guides/v1.11.0/templates/writing-helpers.md
@@ -80,3 +80,5 @@ arguments as:
 ```handlebars
 {{view "calendar"}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/testing/test-helpers.md
+++ b/guides/v1.11.0/testing/test-helpers.md
@@ -204,3 +204,5 @@ import addContact from './add-contact';
 // addContact("Bob");
 // addContact("Dan");
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/testing/testing-user-interaction.md
+++ b/guides/v1.11.0/testing/testing-user-interaction.md
@@ -81,3 +81,5 @@ test('visiting /transitions', function(assert) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/understanding-ember/debugging.md
+++ b/guides/v1.11.0/understanding-ember/debugging.md
@@ -143,3 +143,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/views/adding-layouts-to-views.md
+++ b/guides/v1.11.0/views/adding-layouts-to-views.md
@@ -38,3 +38,5 @@ This will result in view instances containing the following HTML
   Hello, <b>Teddy</b>!
 </div>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/views/customizing-a-views-element.md
+++ b/guides/v1.11.0/views/customizing-a-views-element.md
@@ -177,3 +177,5 @@ This yields a view wrapper that will look something like this:
 ```html
 <div id="ember420" class="ember-view is-urgent p4"></div>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.11.0/views/defining-a-view.md
+++ b/guides/v1.11.0/views/defining-a-view.md
@@ -35,3 +35,5 @@ To remove a view from the document, call `remove`:
 ```javascript
 view.remove();
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/components/index.md
+++ b/guides/v1.12.0/components/index.md
@@ -69,3 +69,5 @@ export default Ember.Route.extend({
 export default Ember.Component.extend({
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/configuring-ember/embedding-applications.md
+++ b/guides/v1.12.0/configuring-ember/embedding-applications.md
@@ -34,3 +34,5 @@ var ENV = {
 };
 export default ENV;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/configuring-ember/index.md
+++ b/guides/v1.12.0/configuring-ember/index.md
@@ -148,3 +148,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/controllers/representing-multiple-models-with-arraycontroller.md
+++ b/guides/v1.12.0/controllers/representing-multiple-models-with-arraycontroller.md
@@ -112,3 +112,5 @@ export default Ember.ArrayController.extend({
   <li>{{item.fullName}}</li>
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/enumerables/index.md
+++ b/guides/v1.12.0/enumerables/index.md
@@ -225,3 +225,5 @@ Just like the filtering methods, the `every` and `some` methods have analogous `
 people.isEvery('isHappy', true) // false
 people.isAny('isHappy', true)  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/models/connecting-to-an-http-server.md
+++ b/guides/v1.12.0/models/connecting-to-an-http-server.md
@@ -188,3 +188,5 @@ Requests for any resource will include the following HTTP headers.
 ANOTHER_HEADER: Some header value
 API_KEY: secret key
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/models/creating-and-deleting-records.md
+++ b/guides/v1.12.0/models/creating-and-deleting-records.md
@@ -59,3 +59,5 @@ store.find('post', 2).then(function (post) {
   post.destroyRecord(); // => DELETE to /posts/2
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/models/defining-models.md
+++ b/guides/v1.12.0/models/defining-models.md
@@ -226,3 +226,5 @@ export default DS.Model.extend({
   parent: belongsTo('folder', { inverse: null })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/models/finding-records.md
+++ b/guides/v1.12.0/models/finding-records.md
@@ -93,3 +93,5 @@ export default Ember.Route.extend({
   }
 })
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/models/frequently-asked-questions.md
+++ b/guides/v1.12.0/models/frequently-asked-questions.md
@@ -136,3 +136,5 @@ socket.on('message', function (message) {
   store.pushPayload(message.model, message.data);
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/models/handling-metadata.md
+++ b/guides/v1.12.0/models/handling-metadata.md
@@ -68,3 +68,5 @@ export default DS.RESTSerializer.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/models/persisting-records.md
+++ b/guides/v1.12.0/models/persisting-records.md
@@ -97,3 +97,5 @@ retry(function() {
   return post.save();
 }, 5);
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/models/pushing-records-into-the-store.md
+++ b/guides/v1.12.0/models/pushing-records-into-the-store.md
@@ -55,3 +55,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/models/working-with-records.md
+++ b/guides/v1.12.0/models/working-with-records.md
@@ -48,3 +48,5 @@ person.get('isDirty');      //=> false
 person.get('isAdmin');      //=> false
 person.changedAttributes(); //=> {}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/object-model/bindings.md
+++ b/guides/v1.12.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', "Krang Gates");
 userView.set('userName', "Truckasaurus Gates");
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/object-model/observers.md
+++ b/guides/v1.12.0/object-model/observers.md
@@ -142,3 +142,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v1.12.0/object-model/reopening-classes-and-instances.md
@@ -40,3 +40,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get("isPerson"); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/routing/index.md
+++ b/guides/v1.12.0/routing/index.md
@@ -51,3 +51,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/routing/loading-and-error-substates.md
+++ b/guides/v1.12.0/routing/loading-and-error-substates.md
@@ -288,3 +288,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v1.12.0/routing/preventing-and-retrying-transitions.md
@@ -98,3 +98,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/routing/rendering-a-template.md
+++ b/guides/v1.12.0/routing/rendering-a-template.md
@@ -92,3 +92,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/routing/setting-up-a-controller.md
+++ b/guides/v1.12.0/routing/setting-up-a-controller.md
@@ -59,3 +59,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/routing/specifying-the-location-api.md
+++ b/guides/v1.12.0/routing/specifying-the-location-api.md
@@ -36,3 +36,5 @@ Ember.Router.extend({
   location: 'none'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/templates/actions.md
+++ b/guides/v1.12.0/templates/actions.md
@@ -247,3 +247,5 @@ a parent view, use the following:
   {{post.title}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/templates/development-helpers.md
+++ b/guides/v1.12.0/templates/development-helpers.md
@@ -38,3 +38,5 @@ hit, you can use the `templateContext` in your console to lookup properties:
 > templateContext.get('name')
 "Bruce Lee"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/templates/displaying-a-list-of-items.md
+++ b/guides/v1.12.0/templates/displaying-a-list-of-items.md
@@ -35,3 +35,5 @@ The contents of this block will render if the collection is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/templates/links.md
+++ b/guides/v1.12.0/templates/links.md
@@ -144,3 +144,5 @@ the browser's history you can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/templates/writing-helpers.md
+++ b/guides/v1.12.0/templates/writing-helpers.md
@@ -80,3 +80,5 @@ arguments as:
 ```handlebars
 {{view "calendar"}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/testing/test-helpers.md
+++ b/guides/v1.12.0/testing/test-helpers.md
@@ -202,3 +202,5 @@ import shouldHaveElementWithCount from './should-have-element-with-count';
 import dblclick from './dblclick';
 import addContact from './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/testing/testing-user-interaction.md
+++ b/guides/v1.12.0/testing/testing-user-interaction.md
@@ -81,3 +81,5 @@ test('visiting /profile', function(assert) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/understanding-ember/debugging.md
+++ b/guides/v1.12.0/understanding-ember/debugging.md
@@ -143,3 +143,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/views/adding-layouts-to-views.md
+++ b/guides/v1.12.0/views/adding-layouts-to-views.md
@@ -38,3 +38,5 @@ This will result in view instances containing the following HTML
   Hello, <b>Teddy</b>!
 </div>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/views/customizing-a-views-element.md
+++ b/guides/v1.12.0/views/customizing-a-views-element.md
@@ -177,3 +177,5 @@ This yields a view wrapper that will look something like this:
 ```html
 <div id="ember420" class="ember-view is-urgent p4"></div>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.12.0/views/defining-a-view.md
+++ b/guides/v1.12.0/views/defining-a-view.md
@@ -35,3 +35,5 @@ To remove a view from the document, call `remove`:
 ```javascript
 view.remove();
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/components/index.md
+++ b/guides/v1.13.0/components/index.md
@@ -69,3 +69,5 @@ export default Ember.Route.extend({
 export default Ember.Component.extend({
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/configuring-ember/embedding-applications.md
+++ b/guides/v1.13.0/configuring-ember/embedding-applications.md
@@ -34,3 +34,5 @@ var ENV = {
 };
 export default ENV;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/configuring-ember/index.md
+++ b/guides/v1.13.0/configuring-ember/index.md
@@ -148,3 +148,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/controllers/representing-multiple-models.md
+++ b/guides/v1.13.0/controllers/representing-multiple-models.md
@@ -50,3 +50,5 @@ Now we can use this property in our template:
 
 {{longSongCount}} songs over 30 seconds.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/models/connecting-to-an-http-server.md
+++ b/guides/v1.13.0/models/connecting-to-an-http-server.md
@@ -188,3 +188,5 @@ Requests for any resource will include the following HTTP headers.
 ANOTHER_HEADER: Some header value
 API_KEY: secret key
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/models/creating-and-deleting-records.md
+++ b/guides/v1.13.0/models/creating-and-deleting-records.md
@@ -59,3 +59,5 @@ store.findRecord('post', 2).then(function(post) {
   post.destroyRecord(); // => DELETE to /posts/2
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/models/defining-models.md
+++ b/guides/v1.13.0/models/defining-models.md
@@ -226,3 +226,5 @@ export default DS.Model.extend({
   parent: DS.belongsTo('folder', { inverse: null })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/models/finding-records.md
+++ b/guides/v1.13.0/models/finding-records.md
@@ -98,3 +98,5 @@ export default Ember.Route.extend({
   }
 })
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/models/frequently-asked-questions.md
+++ b/guides/v1.13.0/models/frequently-asked-questions.md
@@ -136,3 +136,5 @@ socket.on('message', function (message) {
   store.pushPayload(message.model, message.data);
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/models/persisting-records.md
+++ b/guides/v1.13.0/models/persisting-records.md
@@ -97,3 +97,5 @@ retry(function() {
   return post.save();
 }, 5);
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/models/pushing-records-into-the-store.md
+++ b/guides/v1.13.0/models/pushing-records-into-the-store.md
@@ -55,3 +55,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/models/working-with-records.md
+++ b/guides/v1.13.0/models/working-with-records.md
@@ -48,3 +48,5 @@ person.get('isDirty');      //=> false
 person.get('isAdmin');      //=> false
 person.changedAttributes(); //=> {}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/object-model/bindings.md
+++ b/guides/v1.13.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', "Krang Gates");
 userView.set('userName', "Truckasaurus Gates");
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/object-model/enumerables.md
+++ b/guides/v1.13.0/object-model/enumerables.md
@@ -223,3 +223,5 @@ Just like the filtering methods, the `every` and `some` methods have analogous `
 people.isEvery('isHappy', true) // false
 people.isAny('isHappy', true)  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/object-model/observers.md
+++ b/guides/v1.13.0/object-model/observers.md
@@ -126,3 +126,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v1.13.0/object-model/reopening-classes-and-instances.md
@@ -40,3 +40,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get("isPerson"); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/routing/generated-objects.md
+++ b/guides/v1.13.0/routing/generated-objects.md
@@ -35,3 +35,5 @@ template.
 ```handlebars
 {{outlet}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/routing/index.md
+++ b/guides/v1.13.0/routing/index.md
@@ -51,3 +51,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/routing/loading-and-error-substates.md
+++ b/guides/v1.13.0/routing/loading-and-error-substates.md
@@ -291,3 +291,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v1.13.0/routing/preventing-and-retrying-transitions.md
@@ -98,3 +98,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/routing/rendering-a-template.md
+++ b/guides/v1.13.0/routing/rendering-a-template.md
@@ -92,3 +92,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/routing/setting-up-a-controller.md
+++ b/guides/v1.13.0/routing/setting-up-a-controller.md
@@ -56,3 +56,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/routing/specifying-the-location-api.md
+++ b/guides/v1.13.0/routing/specifying-the-location-api.md
@@ -40,3 +40,5 @@ Ember.Router.extend({
   location: 'none'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/templates/development-helpers.md
+++ b/guides/v1.13.0/templates/development-helpers.md
@@ -55,3 +55,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/templates/displaying-a-list-of-items.md
+++ b/guides/v1.13.0/templates/displaying-a-list-of-items.md
@@ -60,3 +60,5 @@ The contents of this block will render if the collection is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/templates/links.md
+++ b/guides/v1.13.0/templates/links.md
@@ -144,3 +144,5 @@ the browser's history you can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/templates/writing-helpers.md
+++ b/guides/v1.13.0/templates/writing-helpers.md
@@ -376,3 +376,5 @@ would just see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/testing/test-helpers.md
+++ b/guides/v1.13.0/testing/test-helpers.md
@@ -202,3 +202,5 @@ import shouldHaveElementWithCount from './should-have-element-with-count';
 import dblclick from './dblclick';
 import addContact from './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/testing/testing-user-interaction.md
+++ b/guides/v1.13.0/testing/testing-user-interaction.md
@@ -81,3 +81,5 @@ test('visiting /profile', function(assert) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/testing/unit-testing-basics.md
+++ b/guides/v1.13.0/testing/unit-testing-basics.md
@@ -134,3 +134,5 @@ test('doSomething observer sets other prop', function() {
   equal(someThing.get('other'), 'yes');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v1.13.0/understanding-ember/index.md
+++ b/guides/v1.13.0/understanding-ember/index.md
@@ -143,3 +143,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/addons-and-dependencies/index.md
+++ b/guides/v2.0.0/addons-and-dependencies/index.md
@@ -127,3 +127,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/applications/dependency-injection.md
+++ b/guides/v2.0.0/applications/dependency-injection.md
@@ -206,3 +206,5 @@ export default {
   initialize: initialize
 };
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/components/customizing-a-components-element.md
+++ b/guides/v2.0.0/components/customizing-a-components-element.md
@@ -152,3 +152,5 @@ export default Ember.Component.extend({
   customHref: 'http://emberjs.com'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.0.0/components/passing-properties-to-a-component.md
@@ -103,3 +103,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/configuring-ember/debugging.md
+++ b/guides/v2.0.0/configuring-ember/debugging.md
@@ -131,3 +131,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.0.0/configuring-ember/disabling-prototype-extensions.md
@@ -155,3 +155,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.0.0/configuring-ember/embedding-applications.md
@@ -48,3 +48,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/configuring-ember/index.md
+++ b/guides/v2.0.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/controllers/index.md
+++ b/guides/v2.0.0/controllers/index.md
@@ -87,3 +87,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/ember-inspector/promises.md
+++ b/guides/v2.0.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/models/finding-records.md
+++ b/guides/v2.0.0/models/finding-records.md
@@ -75,3 +75,5 @@ this.store.queryRecord('person', { filter: { email: 'tomster@example.com' } }).t
   // do something with `tomster`
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/models/pushing-records-into-the-store.md
+++ b/guides/v2.0.0/models/pushing-records-into-the-store.md
@@ -129,3 +129,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/object-model/bindings.md
+++ b/guides/v2.0.0/object-model/bindings.md
@@ -63,3 +63,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/object-model/computed-properties.md
+++ b/guides/v2.0.0/object-model/computed-properties.md
@@ -103,3 +103,5 @@ captainAmerica.set('fullName', 'William Burnside');
 captainAmerica.get('firstName'); // William
 captainAmerica.get('lastName'); // Burnside
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/object-model/enumerables.md
+++ b/guides/v2.0.0/object-model/enumerables.md
@@ -193,3 +193,5 @@ Just like the filtering methods, the `every` and `any` methods have analogous `i
 people.isEvery('isHappy', true) // false
 people.isAny('isHappy', true)  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/object-model/observers.md
+++ b/guides/v2.0.0/object-model/observers.md
@@ -132,3 +132,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.0.0/object-model/reopening-classes-and-instances.md
@@ -40,3 +40,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/routing/asynchronous-routing.md
+++ b/guides/v2.0.0/routing/asynchronous-routing.md
@@ -160,3 +160,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.0.0/routing/preventing-and-retrying-transitions.md
@@ -98,3 +98,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/routing/query-params.md
+++ b/guides/v2.0.0/routing/query-params.md
@@ -322,3 +322,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/routing/redirection.md
+++ b/guides/v2.0.0/routing/redirection.md
@@ -86,3 +86,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/routing/rendering-a-template.md
+++ b/guides/v2.0.0/routing/rendering-a-template.md
@@ -30,3 +30,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.0.0/routing/specifying-a-routes-model.md
@@ -126,3 +126,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/templates/actions.md
+++ b/guides/v2.0.0/templates/actions.md
@@ -154,3 +154,5 @@ For example:
   cursor: pointer;
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/templates/binding-element-attributes.md
+++ b/guides/v2.0.0/templates/binding-element-attributes.md
@@ -79,3 +79,5 @@ Now the same handlebars code above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/templates/conditionals.md
+++ b/guides/v2.0.0/templates/conditionals.md
@@ -85,3 +85,5 @@ user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/templates/development-helpers.md
+++ b/guides/v2.0.0/templates/development-helpers.md
@@ -55,3 +55,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.0.0/templates/displaying-a-list-of-items.md
@@ -71,3 +71,5 @@ is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.0.0/templates/displaying-the-keys-in-an-object.md
@@ -127,3 +127,5 @@ undefined:
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/templates/links.md
+++ b/guides/v2.0.0/templates/links.md
@@ -144,3 +144,5 @@ the browser's history you can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/templates/writing-helpers.md
+++ b/guides/v2.0.0/templates/writing-helpers.md
@@ -356,3 +356,5 @@ would just see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/testing/acceptance.md
+++ b/guides/v2.0.0/testing/acceptance.md
@@ -238,3 +238,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/testing/testing-components.md
+++ b/guides/v2.0.0/testing/testing-components.md
@@ -270,3 +270,5 @@ test('should change displayed location when current location changes', function 
   assert.equal(this.$().text().trim(), 'You currently are located in Beijing, China', 'location display should change');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.0.0/testing/unit-testing-basics.md
+++ b/guides/v2.0.0/testing/unit-testing-basics.md
@@ -125,3 +125,5 @@ test('should set other prop to yes when foo changes', function(assert) {
   assert.equal(someThing.get('other'), 'yes');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/addons-and-dependencies/index.md
+++ b/guides/v2.1.0/addons-and-dependencies/index.md
@@ -127,3 +127,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/applications/dependency-injection.md
+++ b/guides/v2.1.0/applications/dependency-injection.md
@@ -206,3 +206,5 @@ export default {
   initialize: initialize
 };
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/components/customizing-a-components-element.md
+++ b/guides/v2.1.0/components/customizing-a-components-element.md
@@ -152,3 +152,5 @@ export default Ember.Component.extend({
   customHref: 'http://emberjs.com'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.1.0/components/passing-properties-to-a-component.md
@@ -103,3 +103,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/configuring-ember/debugging.md
+++ b/guides/v2.1.0/configuring-ember/debugging.md
@@ -131,3 +131,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.1.0/configuring-ember/disabling-prototype-extensions.md
@@ -155,3 +155,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.1.0/configuring-ember/embedding-applications.md
@@ -48,3 +48,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/configuring-ember/index.md
+++ b/guides/v2.1.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/controllers/index.md
+++ b/guides/v2.1.0/controllers/index.md
@@ -87,3 +87,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/ember-inspector/promises.md
+++ b/guides/v2.1.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/models/finding-records.md
+++ b/guides/v2.1.0/models/finding-records.md
@@ -75,3 +75,5 @@ this.store.queryRecord('person', { filter: { email: 'tomster@example.com' } }).t
   // do something with `tomster`
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/models/pushing-records-into-the-store.md
+++ b/guides/v2.1.0/models/pushing-records-into-the-store.md
@@ -129,3 +129,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/object-model/bindings.md
+++ b/guides/v2.1.0/object-model/bindings.md
@@ -63,3 +63,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/object-model/computed-properties.md
+++ b/guides/v2.1.0/object-model/computed-properties.md
@@ -103,3 +103,5 @@ captainAmerica.set('fullName', 'William Burnside');
 captainAmerica.get('firstName'); // William
 captainAmerica.get('lastName'); // Burnside
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/object-model/enumerables.md
+++ b/guides/v2.1.0/object-model/enumerables.md
@@ -193,3 +193,5 @@ Just like the filtering methods, the `every` and `any` methods have analogous `i
 people.isEvery('isHappy', true) // false
 people.isAny('isHappy', true)  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/object-model/observers.md
+++ b/guides/v2.1.0/object-model/observers.md
@@ -132,3 +132,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.1.0/object-model/reopening-classes-and-instances.md
@@ -40,3 +40,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/routing/asynchronous-routing.md
+++ b/guides/v2.1.0/routing/asynchronous-routing.md
@@ -160,3 +160,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.1.0/routing/preventing-and-retrying-transitions.md
@@ -98,3 +98,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/routing/query-params.md
+++ b/guides/v2.1.0/routing/query-params.md
@@ -322,3 +322,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/routing/redirection.md
+++ b/guides/v2.1.0/routing/redirection.md
@@ -86,3 +86,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/routing/rendering-a-template.md
+++ b/guides/v2.1.0/routing/rendering-a-template.md
@@ -30,3 +30,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.1.0/routing/specifying-a-routes-model.md
@@ -126,3 +126,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/templates/actions.md
+++ b/guides/v2.1.0/templates/actions.md
@@ -154,3 +154,5 @@ For example:
   cursor: pointer;
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/templates/binding-element-attributes.md
+++ b/guides/v2.1.0/templates/binding-element-attributes.md
@@ -79,3 +79,5 @@ Now the same handlebars code above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/templates/conditionals.md
+++ b/guides/v2.1.0/templates/conditionals.md
@@ -85,3 +85,5 @@ user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/templates/development-helpers.md
+++ b/guides/v2.1.0/templates/development-helpers.md
@@ -55,3 +55,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.1.0/templates/displaying-a-list-of-items.md
@@ -71,3 +71,5 @@ is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.1.0/templates/displaying-the-keys-in-an-object.md
@@ -127,3 +127,5 @@ undefined:
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/templates/links.md
+++ b/guides/v2.1.0/templates/links.md
@@ -144,3 +144,5 @@ the browser's history you can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/templates/writing-helpers.md
+++ b/guides/v2.1.0/templates/writing-helpers.md
@@ -356,3 +356,5 @@ would just see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/testing/acceptance.md
+++ b/guides/v2.1.0/testing/acceptance.md
@@ -238,3 +238,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/testing/testing-components.md
+++ b/guides/v2.1.0/testing/testing-components.md
@@ -270,3 +270,5 @@ test('should change displayed location when current location changes', function 
   assert.equal(this.$().text().trim(), 'You currently are located in Beijing, China', 'location display should change');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.1.0/testing/unit-testing-basics.md
+++ b/guides/v2.1.0/testing/unit-testing-basics.md
@@ -125,3 +125,5 @@ test('should set other prop to yes when foo changes', function(assert) {
   assert.equal(someThing.get('other'), 'yes');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/addons-and-dependencies/index.md
+++ b/guides/v2.10.0/addons-and-dependencies/index.md
@@ -146,3 +146,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/applications/services.md
+++ b/guides/v2.10.0/applications/services.md
@@ -126,3 +126,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/components/customizing-a-components-element.md
+++ b/guides/v2.10.0/components/customizing-a-components-element.md
@@ -200,3 +200,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.10.0/components/passing-properties-to-a-component.md
@@ -111,3 +111,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/configuring-ember/debugging.md
+++ b/guides/v2.10.0/configuring-ember/debugging.md
@@ -138,3 +138,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.10.0/configuring-ember/disabling-prototype-extensions.md
@@ -156,3 +156,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.10.0/configuring-ember/embedding-applications.md
@@ -50,3 +50,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/configuring-ember/index.md
+++ b/guides/v2.10.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/controllers/index.md
+++ b/guides/v2.10.0/controllers/index.md
@@ -89,3 +89,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/ember-inspector/promises.md
+++ b/guides/v2.10.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/getting-started/quick-start.md
+++ b/guides/v2.10.0/getting-started/quick-start.md
@@ -276,3 +276,5 @@ add the following directive to the application's virtual host configuration
 ```
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/models/defining-models.md
+++ b/guides/v2.10.0/models/defining-models.md
@@ -157,3 +157,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/models/finding-records.md
+++ b/guides/v2.10.0/models/finding-records.md
@@ -114,3 +114,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/object-model/bindings.md
+++ b/guides/v2.10.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/object-model/enumerables.md
+++ b/guides/v2.10.0/object-model/enumerables.md
@@ -201,3 +201,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/object-model/observers.md
+++ b/guides/v2.10.0/object-model/observers.md
@@ -138,3 +138,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.10.0/object-model/reopening-classes-and-instances.md
@@ -46,3 +46,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/routing/asynchronous-routing.md
+++ b/guides/v2.10.0/routing/asynchronous-routing.md
@@ -170,3 +170,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.10.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/routing/query-params.md
+++ b/guides/v2.10.0/routing/query-params.md
@@ -346,3 +346,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/routing/redirection.md
+++ b/guides/v2.10.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.10.0/routing/specifying-a-routes-model.md
@@ -163,3 +163,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/templates/binding-element-attributes.md
+++ b/guides/v2.10.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/templates/conditionals.md
+++ b/guides/v2.10.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/templates/development-helpers.md
+++ b/guides/v2.10.0/templates/development-helpers.md
@@ -60,3 +60,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.10.0/templates/displaying-a-list-of-items.md
@@ -75,3 +75,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.10.0/templates/displaying-the-keys-in-an-object.md
@@ -137,3 +137,5 @@ helper can have a matching `{{else}}`. The contents of this block will render
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/templates/links.md
+++ b/guides/v2.10.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/testing/acceptance.md
+++ b/guides/v2.10.0/testing/acceptance.md
@@ -254,3 +254,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/testing/testing-components.md
+++ b/guides/v2.10.0/testing/testing-components.md
@@ -353,3 +353,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/testing/unit-testing-basics.md
+++ b/guides/v2.10.0/testing/unit-testing-basics.md
@@ -135,3 +135,5 @@ test('should set other prop to yes when foo changes', function(assert) {
   assert.equal(someThing.get('other'), 'yes');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.10.0/tutorial/installing-addons.md
+++ b/guides/v2.10.0/tutorial/installing-addons.md
@@ -107,3 +107,5 @@ export default DS.JSONAPIAdapter.extend({
 });
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/addons-and-dependencies/index.md
+++ b/guides/v2.11.0/addons-and-dependencies/index.md
@@ -146,3 +146,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/applications/services.md
+++ b/guides/v2.11.0/applications/services.md
@@ -126,3 +126,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/components/customizing-a-components-element.md
+++ b/guides/v2.11.0/components/customizing-a-components-element.md
@@ -200,3 +200,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.11.0/components/passing-properties-to-a-component.md
@@ -111,3 +111,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/configuring-ember/debugging.md
+++ b/guides/v2.11.0/configuring-ember/debugging.md
@@ -138,3 +138,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.11.0/configuring-ember/disabling-prototype-extensions.md
@@ -156,3 +156,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.11.0/configuring-ember/embedding-applications.md
@@ -50,3 +50,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/configuring-ember/index.md
+++ b/guides/v2.11.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/ember-inspector/promises.md
+++ b/guides/v2.11.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/getting-started/quick-start.md
+++ b/guides/v2.11.0/getting-started/quick-start.md
@@ -276,3 +276,5 @@ add the following directive to the application's virtual host configuration
 ```
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/models/defining-models.md
+++ b/guides/v2.11.0/models/defining-models.md
@@ -157,3 +157,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/models/finding-records.md
+++ b/guides/v2.11.0/models/finding-records.md
@@ -114,3 +114,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/object-model/bindings.md
+++ b/guides/v2.11.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/object-model/enumerables.md
+++ b/guides/v2.11.0/object-model/enumerables.md
@@ -201,3 +201,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/object-model/observers.md
+++ b/guides/v2.11.0/object-model/observers.md
@@ -138,3 +138,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.11.0/object-model/reopening-classes-and-instances.md
@@ -46,3 +46,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/routing/asynchronous-routing.md
+++ b/guides/v2.11.0/routing/asynchronous-routing.md
@@ -170,3 +170,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.11.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/routing/query-params.md
+++ b/guides/v2.11.0/routing/query-params.md
@@ -346,3 +346,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/routing/redirection.md
+++ b/guides/v2.11.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.11.0/routing/specifying-a-routes-model.md
@@ -163,3 +163,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/templates/binding-element-attributes.md
+++ b/guides/v2.11.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/templates/conditionals.md
+++ b/guides/v2.11.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/templates/development-helpers.md
+++ b/guides/v2.11.0/templates/development-helpers.md
@@ -60,3 +60,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.11.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.11.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/templates/links.md
+++ b/guides/v2.11.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/testing/acceptance.md
+++ b/guides/v2.11.0/testing/acceptance.md
@@ -254,3 +254,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/testing/testing-components.md
+++ b/guides/v2.11.0/testing/testing-components.md
@@ -353,3 +353,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/testing/unit-testing-basics.md
+++ b/guides/v2.11.0/testing/unit-testing-basics.md
@@ -135,3 +135,5 @@ test('should set other prop to yes when foo changes', function(assert) {
   assert.equal(someThing.get('other'), 'yes');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.11.0/tutorial/installing-addons.md
+++ b/guides/v2.11.0/tutorial/installing-addons.md
@@ -107,3 +107,5 @@ export default DS.JSONAPIAdapter.extend({
 });
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/addons-and-dependencies/index.md
+++ b/guides/v2.12.0/addons-and-dependencies/index.md
@@ -146,3 +146,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/applications/services.md
+++ b/guides/v2.12.0/applications/services.md
@@ -126,3 +126,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/components/customizing-a-components-element.md
+++ b/guides/v2.12.0/components/customizing-a-components-element.md
@@ -200,3 +200,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.12.0/components/passing-properties-to-a-component.md
@@ -111,3 +111,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/configuring-ember/debugging.md
+++ b/guides/v2.12.0/configuring-ember/debugging.md
@@ -138,3 +138,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.12.0/configuring-ember/disabling-prototype-extensions.md
@@ -156,3 +156,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.12.0/configuring-ember/embedding-applications.md
@@ -50,3 +50,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/configuring-ember/index.md
+++ b/guides/v2.12.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/ember-inspector/promises.md
+++ b/guides/v2.12.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/getting-started/quick-start.md
+++ b/guides/v2.12.0/getting-started/quick-start.md
@@ -276,3 +276,5 @@ add the following directive to the application's virtual host configuration
 ```
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/models/defining-models.md
+++ b/guides/v2.12.0/models/defining-models.md
@@ -157,3 +157,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/models/finding-records.md
+++ b/guides/v2.12.0/models/finding-records.md
@@ -114,3 +114,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/object-model/bindings.md
+++ b/guides/v2.12.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/object-model/enumerables.md
+++ b/guides/v2.12.0/object-model/enumerables.md
@@ -201,3 +201,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/object-model/observers.md
+++ b/guides/v2.12.0/object-model/observers.md
@@ -138,3 +138,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.12.0/object-model/reopening-classes-and-instances.md
@@ -46,3 +46,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/routing/asynchronous-routing.md
+++ b/guides/v2.12.0/routing/asynchronous-routing.md
@@ -170,3 +170,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.12.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/routing/query-params.md
+++ b/guides/v2.12.0/routing/query-params.md
@@ -334,3 +334,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/routing/redirection.md
+++ b/guides/v2.12.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.12.0/routing/specifying-a-routes-model.md
@@ -163,3 +163,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/templates/binding-element-attributes.md
+++ b/guides/v2.12.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/templates/conditionals.md
+++ b/guides/v2.12.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/templates/development-helpers.md
+++ b/guides/v2.12.0/templates/development-helpers.md
@@ -60,3 +60,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.12.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.12.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/templates/links.md
+++ b/guides/v2.12.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/testing/acceptance.md
+++ b/guides/v2.12.0/testing/acceptance.md
@@ -254,3 +254,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/testing/testing-components.md
+++ b/guides/v2.12.0/testing/testing-components.md
@@ -353,3 +353,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/testing/unit-testing-basics.md
+++ b/guides/v2.12.0/testing/unit-testing-basics.md
@@ -135,3 +135,5 @@ test('should set other prop to yes when foo changes', function(assert) {
   assert.equal(someThing.get('other'), 'yes');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.12.0/tutorial/index.md
+++ b/guides/v2.12.0/tutorial/index.md
@@ -148,3 +148,5 @@ The application should now be a completely blank canvas to build our application
 {{outlet}}
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/addons-and-dependencies/index.md
+++ b/guides/v2.13.0/addons-and-dependencies/index.md
@@ -134,3 +134,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/applications/services.md
+++ b/guides/v2.13.0/applications/services.md
@@ -141,3 +141,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/components/customizing-a-components-element.md
+++ b/guides/v2.13.0/components/customizing-a-components-element.md
@@ -200,3 +200,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.13.0/components/passing-properties-to-a-component.md
@@ -111,3 +111,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/configuring-ember/debugging.md
+++ b/guides/v2.13.0/configuring-ember/debugging.md
@@ -138,3 +138,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.13.0/configuring-ember/disabling-prototype-extensions.md
@@ -156,3 +156,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.13.0/configuring-ember/embedding-applications.md
@@ -50,3 +50,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/configuring-ember/index.md
+++ b/guides/v2.13.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/ember-inspector/promises.md
+++ b/guides/v2.13.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/getting-started/quick-start.md
+++ b/guides/v2.13.0/getting-started/quick-start.md
@@ -322,3 +322,5 @@ add the following directive to the application's virtual host configuration
 ```
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/models/defining-models.md
+++ b/guides/v2.13.0/models/defining-models.md
@@ -157,3 +157,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/models/finding-records.md
+++ b/guides/v2.13.0/models/finding-records.md
@@ -114,3 +114,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/object-model/bindings.md
+++ b/guides/v2.13.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/object-model/enumerables.md
+++ b/guides/v2.13.0/object-model/enumerables.md
@@ -201,3 +201,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/object-model/observers.md
+++ b/guides/v2.13.0/object-model/observers.md
@@ -138,3 +138,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.13.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/routing/asynchronous-routing.md
+++ b/guides/v2.13.0/routing/asynchronous-routing.md
@@ -170,3 +170,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.13.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/routing/query-params.md
+++ b/guides/v2.13.0/routing/query-params.md
@@ -335,3 +335,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/routing/redirection.md
+++ b/guides/v2.13.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.13.0/routing/specifying-a-routes-model.md
@@ -163,3 +163,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/templates/binding-element-attributes.md
+++ b/guides/v2.13.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/templates/conditionals.md
+++ b/guides/v2.13.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/templates/development-helpers.md
+++ b/guides/v2.13.0/templates/development-helpers.md
@@ -60,3 +60,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.13.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.13.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/templates/links.md
+++ b/guides/v2.13.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/testing/acceptance.md
+++ b/guides/v2.13.0/testing/acceptance.md
@@ -254,3 +254,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/testing/testing-components.md
+++ b/guides/v2.13.0/testing/testing-components.md
@@ -353,3 +353,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/testing/unit-testing-basics.md
+++ b/guides/v2.13.0/testing/unit-testing-basics.md
@@ -152,3 +152,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.13.0/tutorial/index.md
+++ b/guides/v2.13.0/tutorial/index.md
@@ -140,3 +140,5 @@ The application should now be a completely blank canvas to build our application
 {{outlet}}
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/addons-and-dependencies/index.md
+++ b/guides/v2.14.0/addons-and-dependencies/index.md
@@ -134,3 +134,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/applications/services.md
+++ b/guides/v2.14.0/applications/services.md
@@ -141,3 +141,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/components/customizing-a-components-element.md
+++ b/guides/v2.14.0/components/customizing-a-components-element.md
@@ -200,3 +200,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.14.0/components/passing-properties-to-a-component.md
@@ -111,3 +111,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/configuring-ember/debugging.md
+++ b/guides/v2.14.0/configuring-ember/debugging.md
@@ -138,3 +138,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.14.0/configuring-ember/disabling-prototype-extensions.md
@@ -156,3 +156,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.14.0/configuring-ember/embedding-applications.md
@@ -94,3 +94,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/configuring-ember/index.md
+++ b/guides/v2.14.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/ember-inspector/promises.md
+++ b/guides/v2.14.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/getting-started/quick-start.md
+++ b/guides/v2.14.0/getting-started/quick-start.md
@@ -322,3 +322,5 @@ add the following directive to the application's virtual host configuration
 ```
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/models/defining-models.md
+++ b/guides/v2.14.0/models/defining-models.md
@@ -157,3 +157,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/models/finding-records.md
+++ b/guides/v2.14.0/models/finding-records.md
@@ -113,3 +113,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/object-model/bindings.md
+++ b/guides/v2.14.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/object-model/enumerables.md
+++ b/guides/v2.14.0/object-model/enumerables.md
@@ -201,3 +201,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/object-model/observers.md
+++ b/guides/v2.14.0/object-model/observers.md
@@ -138,3 +138,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.14.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/routing/asynchronous-routing.md
+++ b/guides/v2.14.0/routing/asynchronous-routing.md
@@ -170,3 +170,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.14.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/routing/query-params.md
+++ b/guides/v2.14.0/routing/query-params.md
@@ -335,3 +335,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/routing/redirection.md
+++ b/guides/v2.14.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.14.0/routing/specifying-a-routes-model.md
@@ -163,3 +163,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/templates/binding-element-attributes.md
+++ b/guides/v2.14.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/templates/conditionals.md
+++ b/guides/v2.14.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/templates/development-helpers.md
+++ b/guides/v2.14.0/templates/development-helpers.md
@@ -60,3 +60,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.14.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.14.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/templates/links.md
+++ b/guides/v2.14.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/testing/acceptance.md
+++ b/guides/v2.14.0/testing/acceptance.md
@@ -254,3 +254,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/testing/testing-components.md
+++ b/guides/v2.14.0/testing/testing-components.md
@@ -353,3 +353,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/testing/unit-testing-basics.md
+++ b/guides/v2.14.0/testing/unit-testing-basics.md
@@ -152,3 +152,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/tutorial/hbs-helper.md
+++ b/guides/v2.14.0/tutorial/hbs-helper.md
@@ -111,3 +111,5 @@ test('it renders', function(assert) {
 });
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.14.0/tutorial/index.md
+++ b/guides/v2.14.0/tutorial/index.md
@@ -140,3 +140,5 @@ The application should now be a completely blank canvas to build our application
 {{outlet}}
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/addons-and-dependencies/index.md
+++ b/guides/v2.15.0/addons-and-dependencies/index.md
@@ -134,3 +134,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/applications/services.md
+++ b/guides/v2.15.0/applications/services.md
@@ -141,3 +141,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/components/customizing-a-components-element.md
+++ b/guides/v2.15.0/components/customizing-a-components-element.md
@@ -200,3 +200,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.15.0/components/passing-properties-to-a-component.md
@@ -111,3 +111,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.15.0/configuring-ember/disabling-prototype-extensions.md
@@ -156,3 +156,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.15.0/configuring-ember/embedding-applications.md
@@ -94,3 +94,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/configuring-ember/index.md
+++ b/guides/v2.15.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/ember-inspector/promises.md
+++ b/guides/v2.15.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/getting-started/quick-start.md
+++ b/guides/v2.15.0/getting-started/quick-start.md
@@ -299,3 +299,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/models/defining-models.md
+++ b/guides/v2.15.0/models/defining-models.md
@@ -158,3 +158,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/models/finding-records.md
+++ b/guides/v2.15.0/models/finding-records.md
@@ -113,3 +113,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/object-model/bindings.md
+++ b/guides/v2.15.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/object-model/enumerables.md
+++ b/guides/v2.15.0/object-model/enumerables.md
@@ -201,3 +201,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/object-model/observers.md
+++ b/guides/v2.15.0/object-model/observers.md
@@ -138,3 +138,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.15.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/routing/asynchronous-routing.md
+++ b/guides/v2.15.0/routing/asynchronous-routing.md
@@ -170,3 +170,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/routing/loading-and-error-substates.md
+++ b/guides/v2.15.0/routing/loading-and-error-substates.md
@@ -246,3 +246,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.15.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/routing/query-params.md
+++ b/guides/v2.15.0/routing/query-params.md
@@ -335,3 +335,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/routing/redirection.md
+++ b/guides/v2.15.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/templates/binding-element-attributes.md
+++ b/guides/v2.15.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/templates/conditionals.md
+++ b/guides/v2.15.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/templates/development-helpers.md
+++ b/guides/v2.15.0/templates/development-helpers.md
@@ -60,3 +60,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.15.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.15.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/templates/links.md
+++ b/guides/v2.15.0/templates/links.md
@@ -162,3 +162,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/testing/acceptance.md
+++ b/guides/v2.15.0/testing/acceptance.md
@@ -253,3 +253,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/testing/testing-components.md
+++ b/guides/v2.15.0/testing/testing-components.md
@@ -353,3 +353,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/testing/unit-testing-basics.md
+++ b/guides/v2.15.0/testing/unit-testing-basics.md
@@ -152,3 +152,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/tutorial/hbs-helper.md
+++ b/guides/v2.15.0/tutorial/hbs-helper.md
@@ -115,3 +115,5 @@ test('it renders', function(assert) {
 });
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.15.0/tutorial/index.md
+++ b/guides/v2.15.0/tutorial/index.md
@@ -140,3 +140,5 @@ The application should now be a completely blank canvas to build our application
 {{outlet}}
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/addons-and-dependencies/index.md
+++ b/guides/v2.16.0/addons-and-dependencies/index.md
@@ -134,3 +134,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/applications/dependency-injection.md
+++ b/guides/v2.16.0/applications/dependency-injection.md
@@ -255,3 +255,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/applications/services.md
+++ b/guides/v2.16.0/applications/services.md
@@ -142,3 +142,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/components/customizing-a-components-element.md
+++ b/guides/v2.16.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.16.0/components/passing-properties-to-a-component.md
@@ -110,3 +110,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/components/the-component-lifecycle.md
+++ b/guides/v2.16.0/components/the-component-lifecycle.md
@@ -279,3 +279,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.16.0/configuring-ember/disabling-prototype-extensions.md
@@ -166,3 +166,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.16.0/configuring-ember/embedding-applications.md
@@ -94,3 +94,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/configuring-ember/index.md
+++ b/guides/v2.16.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/ember-inspector/promises.md
+++ b/guides/v2.16.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/getting-started/quick-start.md
+++ b/guides/v2.16.0/getting-started/quick-start.md
@@ -295,3 +295,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/models/defining-models.md
+++ b/guides/v2.16.0/models/defining-models.md
@@ -158,3 +158,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/models/finding-records.md
+++ b/guides/v2.16.0/models/finding-records.md
@@ -114,3 +114,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/object-model/bindings.md
+++ b/guides/v2.16.0/object-model/bindings.md
@@ -71,3 +71,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/object-model/enumerables.md
+++ b/guides/v2.16.0/object-model/enumerables.md
@@ -207,3 +207,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/object-model/observers.md
+++ b/guides/v2.16.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.16.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/routing/asynchronous-routing.md
+++ b/guides/v2.16.0/routing/asynchronous-routing.md
@@ -170,3 +170,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/routing/loading-and-error-substates.md
+++ b/guides/v2.16.0/routing/loading-and-error-substates.md
@@ -246,3 +246,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.16.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/routing/query-params.md
+++ b/guides/v2.16.0/routing/query-params.md
@@ -338,3 +338,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/routing/redirection.md
+++ b/guides/v2.16.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/templates/binding-element-attributes.md
+++ b/guides/v2.16.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/templates/conditionals.md
+++ b/guides/v2.16.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/templates/development-helpers.md
+++ b/guides/v2.16.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.16.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.16.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/templates/links.md
+++ b/guides/v2.16.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/testing/acceptance.md
+++ b/guides/v2.16.0/testing/acceptance.md
@@ -263,3 +263,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/testing/testing-components.md
+++ b/guides/v2.16.0/testing/testing-components.md
@@ -460,3 +460,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/testing/unit-testing-basics.md
+++ b/guides/v2.16.0/testing/unit-testing-basics.md
@@ -175,3 +175,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/tutorial/hbs-helper.md
+++ b/guides/v2.16.0/tutorial/hbs-helper.md
@@ -115,3 +115,5 @@ test('it renders', function(assert) {
 });
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.16.0/tutorial/index.md
+++ b/guides/v2.16.0/tutorial/index.md
@@ -140,3 +140,5 @@ The application should now be a completely blank canvas to build our application
 {{outlet}}
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/addons-and-dependencies/index.md
+++ b/guides/v2.17.0/addons-and-dependencies/index.md
@@ -134,3 +134,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/applications/dependency-injection.md
+++ b/guides/v2.17.0/applications/dependency-injection.md
@@ -255,3 +255,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/applications/services.md
+++ b/guides/v2.17.0/applications/services.md
@@ -142,3 +142,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/components/customizing-a-components-element.md
+++ b/guides/v2.17.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.17.0/components/passing-properties-to-a-component.md
@@ -110,3 +110,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/components/the-component-lifecycle.md
+++ b/guides/v2.17.0/components/the-component-lifecycle.md
@@ -279,3 +279,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.17.0/configuring-ember/disabling-prototype-extensions.md
@@ -166,3 +166,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.17.0/configuring-ember/embedding-applications.md
@@ -94,3 +94,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/configuring-ember/index.md
+++ b/guides/v2.17.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/ember-inspector/promises.md
+++ b/guides/v2.17.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/getting-started/quick-start.md
+++ b/guides/v2.17.0/getting-started/quick-start.md
@@ -295,3 +295,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/models/defining-models.md
+++ b/guides/v2.17.0/models/defining-models.md
@@ -158,3 +158,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/models/finding-records.md
+++ b/guides/v2.17.0/models/finding-records.md
@@ -114,3 +114,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/object-model/bindings.md
+++ b/guides/v2.17.0/object-model/bindings.md
@@ -71,3 +71,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/object-model/enumerables.md
+++ b/guides/v2.17.0/object-model/enumerables.md
@@ -207,3 +207,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/object-model/observers.md
+++ b/guides/v2.17.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.17.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/routing/asynchronous-routing.md
+++ b/guides/v2.17.0/routing/asynchronous-routing.md
@@ -170,3 +170,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/routing/loading-and-error-substates.md
+++ b/guides/v2.17.0/routing/loading-and-error-substates.md
@@ -246,3 +246,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.17.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/routing/query-params.md
+++ b/guides/v2.17.0/routing/query-params.md
@@ -338,3 +338,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/routing/redirection.md
+++ b/guides/v2.17.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/templates/binding-element-attributes.md
+++ b/guides/v2.17.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/templates/conditionals.md
+++ b/guides/v2.17.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/templates/development-helpers.md
+++ b/guides/v2.17.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.17.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.17.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/templates/links.md
+++ b/guides/v2.17.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/testing/acceptance.md
+++ b/guides/v2.17.0/testing/acceptance.md
@@ -263,3 +263,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/testing/testing-components.md
+++ b/guides/v2.17.0/testing/testing-components.md
@@ -460,3 +460,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/testing/unit-testing-basics.md
+++ b/guides/v2.17.0/testing/unit-testing-basics.md
@@ -175,3 +175,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/tutorial/hbs-helper.md
+++ b/guides/v2.17.0/tutorial/hbs-helper.md
@@ -115,3 +115,5 @@ test('it renders', function(assert) {
 });
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.17.0/tutorial/index.md
+++ b/guides/v2.17.0/tutorial/index.md
@@ -140,3 +140,5 @@ The application should now be a completely blank canvas to build our application
 {{outlet}}
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/addons-and-dependencies/index.md
+++ b/guides/v2.18.0/addons-and-dependencies/index.md
@@ -134,3 +134,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/applications/dependency-injection.md
+++ b/guides/v2.18.0/applications/dependency-injection.md
@@ -255,3 +255,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/applications/services.md
+++ b/guides/v2.18.0/applications/services.md
@@ -142,3 +142,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/components/customizing-a-components-element.md
+++ b/guides/v2.18.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.18.0/components/passing-properties-to-a-component.md
@@ -102,3 +102,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/components/the-component-lifecycle.md
+++ b/guides/v2.18.0/components/the-component-lifecycle.md
@@ -279,3 +279,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.18.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.18.0/configuring-ember/embedding-applications.md
@@ -94,3 +94,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/configuring-ember/index.md
+++ b/guides/v2.18.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/ember-inspector/promises.md
+++ b/guides/v2.18.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/getting-started/quick-start.md
+++ b/guides/v2.18.0/getting-started/quick-start.md
@@ -295,3 +295,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/models/defining-models.md
+++ b/guides/v2.18.0/models/defining-models.md
@@ -158,3 +158,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/models/finding-records.md
+++ b/guides/v2.18.0/models/finding-records.md
@@ -114,3 +114,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/object-model/bindings.md
+++ b/guides/v2.18.0/object-model/bindings.md
@@ -71,3 +71,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/object-model/enumerables.md
+++ b/guides/v2.18.0/object-model/enumerables.md
@@ -207,3 +207,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/object-model/observers.md
+++ b/guides/v2.18.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.18.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/routing/asynchronous-routing.md
+++ b/guides/v2.18.0/routing/asynchronous-routing.md
@@ -171,3 +171,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/routing/loading-and-error-substates.md
+++ b/guides/v2.18.0/routing/loading-and-error-substates.md
@@ -250,3 +250,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.18.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/routing/query-params.md
+++ b/guides/v2.18.0/routing/query-params.md
@@ -338,3 +338,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/routing/redirection.md
+++ b/guides/v2.18.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/templates/binding-element-attributes.md
+++ b/guides/v2.18.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/templates/conditionals.md
+++ b/guides/v2.18.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/templates/development-helpers.md
+++ b/guides/v2.18.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.18.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.18.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/templates/links.md
+++ b/guides/v2.18.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/testing/acceptance.md
+++ b/guides/v2.18.0/testing/acceptance.md
@@ -263,3 +263,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/testing/testing-components.md
+++ b/guides/v2.18.0/testing/testing-components.md
@@ -460,3 +460,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/testing/unit-testing-basics.md
+++ b/guides/v2.18.0/testing/unit-testing-basics.md
@@ -175,3 +175,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/tutorial/hbs-helper.md
+++ b/guides/v2.18.0/tutorial/hbs-helper.md
@@ -124,3 +124,5 @@ test('it renders correctly for a Community rental', function(assert) {
   assert.equal(this.$().text().trim(), 'Community');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.18.0/tutorial/index.md
+++ b/guides/v2.18.0/tutorial/index.md
@@ -140,3 +140,5 @@ The application should now be a completely blank canvas to build our application
 {{outlet}}
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/addons-and-dependencies/index.md
+++ b/guides/v2.2.0/addons-and-dependencies/index.md
@@ -137,3 +137,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/applications/dependency-injection.md
+++ b/guides/v2.2.0/applications/dependency-injection.md
@@ -200,3 +200,5 @@ export default {
   initialize: initialize
 };
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/components/customizing-a-components-element.md
+++ b/guides/v2.2.0/components/customizing-a-components-element.md
@@ -152,3 +152,5 @@ export default Ember.Component.extend({
   customHref: 'http://emberjs.com'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.2.0/components/passing-properties-to-a-component.md
@@ -105,3 +105,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/configuring-ember/debugging.md
+++ b/guides/v2.2.0/configuring-ember/debugging.md
@@ -131,3 +131,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.2.0/configuring-ember/disabling-prototype-extensions.md
@@ -155,3 +155,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.2.0/configuring-ember/embedding-applications.md
@@ -48,3 +48,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/configuring-ember/index.md
+++ b/guides/v2.2.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/controllers/index.md
+++ b/guides/v2.2.0/controllers/index.md
@@ -87,3 +87,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/ember-inspector/promises.md
+++ b/guides/v2.2.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/models/finding-records.md
+++ b/guides/v2.2.0/models/finding-records.md
@@ -80,3 +80,5 @@ this.store.queryRecord('person', { filter: { email: 'tomster@example.com' } }).t
   // do something with `tomster`
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/models/pushing-records-into-the-store.md
+++ b/guides/v2.2.0/models/pushing-records-into-the-store.md
@@ -135,3 +135,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/object-model/bindings.md
+++ b/guides/v2.2.0/object-model/bindings.md
@@ -68,3 +68,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/object-model/computed-properties.md
+++ b/guides/v2.2.0/object-model/computed-properties.md
@@ -103,3 +103,5 @@ captainAmerica.set('fullName', 'William Burnside');
 captainAmerica.get('firstName'); // William
 captainAmerica.get('lastName'); // Burnside
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/object-model/enumerables.md
+++ b/guides/v2.2.0/object-model/enumerables.md
@@ -219,3 +219,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true) // false
 people.isAny('isHappy', true)  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/object-model/observers.md
+++ b/guides/v2.2.0/object-model/observers.md
@@ -141,3 +141,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.2.0/object-model/reopening-classes-and-instances.md
@@ -46,3 +46,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/routing/asynchronous-routing.md
+++ b/guides/v2.2.0/routing/asynchronous-routing.md
@@ -164,3 +164,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.2.0/routing/preventing-and-retrying-transitions.md
@@ -98,3 +98,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/routing/query-params.md
+++ b/guides/v2.2.0/routing/query-params.md
@@ -322,3 +322,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/routing/redirection.md
+++ b/guides/v2.2.0/routing/redirection.md
@@ -96,3 +96,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/routing/rendering-a-template.md
+++ b/guides/v2.2.0/routing/rendering-a-template.md
@@ -32,3 +32,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.2.0/routing/specifying-a-routes-model.md
@@ -128,3 +128,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/templates/actions.md
+++ b/guides/v2.2.0/templates/actions.md
@@ -158,3 +158,5 @@ For example:
   cursor: pointer;
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/templates/binding-element-attributes.md
+++ b/guides/v2.2.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same handlebars code above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/templates/conditionals.md
+++ b/guides/v2.2.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/templates/development-helpers.md
+++ b/guides/v2.2.0/templates/development-helpers.md
@@ -60,3 +60,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.2.0/templates/displaying-a-list-of-items.md
@@ -72,3 +72,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.2.0/templates/displaying-the-keys-in-an-object.md
@@ -131,3 +131,5 @@ helper can have a matching `{{else}}`. The contents of this block will render
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/templates/links.md
+++ b/guides/v2.2.0/templates/links.md
@@ -149,3 +149,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/testing/acceptance.md
+++ b/guides/v2.2.0/testing/acceptance.md
@@ -243,3 +243,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/testing/testing-components.md
+++ b/guides/v2.2.0/testing/testing-components.md
@@ -341,3 +341,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/testing/unit-testing-basics.md
+++ b/guides/v2.2.0/testing/unit-testing-basics.md
@@ -127,3 +127,5 @@ test('should set other prop to yes when foo changes', function(assert) {
   assert.equal(someThing.get('other'), 'yes');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.2.0/tutorial/index.md
+++ b/guides/v2.2.0/tutorial/index.md
@@ -194,3 +194,5 @@ Let's update our `index.hbs` with some HTML for our home page and our links to t
 {{#link-to "about"}}About{{/link-to}}
 {{#link-to "contact"}}Click here to contact us.{{/link-to}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/addons-and-dependencies/index.md
+++ b/guides/v2.3.0/addons-and-dependencies/index.md
@@ -138,3 +138,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/applications/services.md
+++ b/guides/v2.3.0/applications/services.md
@@ -117,3 +117,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/components/customizing-a-components-element.md
+++ b/guides/v2.3.0/components/customizing-a-components-element.md
@@ -180,3 +180,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.3.0/components/passing-properties-to-a-component.md
@@ -105,3 +105,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.3.0/components/triggering-changes-with-actions.md
@@ -426,3 +426,5 @@ export default Ember.Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/configuring-ember/debugging.md
+++ b/guides/v2.3.0/configuring-ember/debugging.md
@@ -131,3 +131,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.3.0/configuring-ember/disabling-prototype-extensions.md
@@ -155,3 +155,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.3.0/configuring-ember/embedding-applications.md
@@ -48,3 +48,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/configuring-ember/index.md
+++ b/guides/v2.3.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/controllers/index.md
+++ b/guides/v2.3.0/controllers/index.md
@@ -87,3 +87,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/ember-inspector/promises.md
+++ b/guides/v2.3.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/getting-started/quick-start.md
+++ b/guides/v2.3.0/getting-started/quick-start.md
@@ -264,3 +264,5 @@ add the following directive to the application's virtual host configuration
 ```
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v2.3.0/models/creating-updating-and-deleting-records.md
@@ -162,3 +162,5 @@ store.findRecord('post', 2).then(function(post) {
   post.destroyRecord(); // => DELETE to /posts/2
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/models/defining-models.md
+++ b/guides/v2.3.0/models/defining-models.md
@@ -162,3 +162,5 @@ export default Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/models/finding-records.md
+++ b/guides/v2.3.0/models/finding-records.md
@@ -80,3 +80,5 @@ this.store.queryRecord('person', { filter: { email: 'tomster@example.com' } }).t
   // do something with `tomster`
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/models/pushing-records-into-the-store.md
+++ b/guides/v2.3.0/models/pushing-records-into-the-store.md
@@ -140,3 +140,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/object-model/bindings.md
+++ b/guides/v2.3.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/object-model/enumerables.md
+++ b/guides/v2.3.0/object-model/enumerables.md
@@ -209,3 +209,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/object-model/observers.md
+++ b/guides/v2.3.0/object-model/observers.md
@@ -138,3 +138,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.3.0/object-model/reopening-classes-and-instances.md
@@ -46,3 +46,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/routing/asynchronous-routing.md
+++ b/guides/v2.3.0/routing/asynchronous-routing.md
@@ -162,3 +162,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.3.0/routing/preventing-and-retrying-transitions.md
@@ -98,3 +98,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/routing/query-params.md
+++ b/guides/v2.3.0/routing/query-params.md
@@ -322,3 +322,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/routing/redirection.md
+++ b/guides/v2.3.0/routing/redirection.md
@@ -96,3 +96,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/routing/rendering-a-template.md
+++ b/guides/v2.3.0/routing/rendering-a-template.md
@@ -32,3 +32,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.3.0/routing/specifying-a-routes-model.md
@@ -128,3 +128,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/templates/binding-element-attributes.md
+++ b/guides/v2.3.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/templates/conditionals.md
+++ b/guides/v2.3.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/templates/development-helpers.md
+++ b/guides/v2.3.0/templates/development-helpers.md
@@ -60,3 +60,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.3.0/templates/displaying-a-list-of-items.md
@@ -75,3 +75,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.3.0/templates/displaying-the-keys-in-an-object.md
@@ -131,3 +131,5 @@ helper can have a matching `{{else}}`. The contents of this block will render
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/templates/links.md
+++ b/guides/v2.3.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/testing/acceptance.md
+++ b/guides/v2.3.0/testing/acceptance.md
@@ -246,3 +246,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/testing/testing-components.md
+++ b/guides/v2.3.0/testing/testing-components.md
@@ -341,3 +341,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.3.0/testing/unit-testing-basics.md
+++ b/guides/v2.3.0/testing/unit-testing-basics.md
@@ -127,3 +127,5 @@ test('should set other prop to yes when foo changes', function(assert) {
   assert.equal(someThing.get('other'), 'yes');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/addons-and-dependencies/index.md
+++ b/guides/v2.4.0/addons-and-dependencies/index.md
@@ -138,3 +138,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/applications/services.md
+++ b/guides/v2.4.0/applications/services.md
@@ -117,3 +117,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/components/customizing-a-components-element.md
+++ b/guides/v2.4.0/components/customizing-a-components-element.md
@@ -180,3 +180,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.4.0/components/passing-properties-to-a-component.md
@@ -105,3 +105,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.4.0/components/triggering-changes-with-actions.md
@@ -426,3 +426,5 @@ export default Ember.Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/configuring-ember/debugging.md
+++ b/guides/v2.4.0/configuring-ember/debugging.md
@@ -131,3 +131,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.4.0/configuring-ember/disabling-prototype-extensions.md
@@ -155,3 +155,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.4.0/configuring-ember/embedding-applications.md
@@ -48,3 +48,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/configuring-ember/index.md
+++ b/guides/v2.4.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/controllers/index.md
+++ b/guides/v2.4.0/controllers/index.md
@@ -87,3 +87,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/ember-inspector/promises.md
+++ b/guides/v2.4.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/getting-started/quick-start.md
+++ b/guides/v2.4.0/getting-started/quick-start.md
@@ -264,3 +264,5 @@ add the following directive to the application's virtual host configuration
 ```
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v2.4.0/models/creating-updating-and-deleting-records.md
@@ -162,3 +162,5 @@ store.findRecord('post', 2).then(function(post) {
   post.destroyRecord(); // => DELETE to /posts/2
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/models/defining-models.md
+++ b/guides/v2.4.0/models/defining-models.md
@@ -143,3 +143,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/models/finding-records.md
+++ b/guides/v2.4.0/models/finding-records.md
@@ -80,3 +80,5 @@ this.store.queryRecord('person', { filter: { email: 'tomster@example.com' } }).t
   // do something with `tomster`
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/models/pushing-records-into-the-store.md
+++ b/guides/v2.4.0/models/pushing-records-into-the-store.md
@@ -135,3 +135,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/object-model/bindings.md
+++ b/guides/v2.4.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/object-model/enumerables.md
+++ b/guides/v2.4.0/object-model/enumerables.md
@@ -209,3 +209,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/object-model/observers.md
+++ b/guides/v2.4.0/object-model/observers.md
@@ -138,3 +138,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.4.0/object-model/reopening-classes-and-instances.md
@@ -46,3 +46,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/routing/asynchronous-routing.md
+++ b/guides/v2.4.0/routing/asynchronous-routing.md
@@ -162,3 +162,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.4.0/routing/preventing-and-retrying-transitions.md
@@ -98,3 +98,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/routing/query-params.md
+++ b/guides/v2.4.0/routing/query-params.md
@@ -322,3 +322,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/routing/redirection.md
+++ b/guides/v2.4.0/routing/redirection.md
@@ -96,3 +96,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/routing/rendering-a-template.md
+++ b/guides/v2.4.0/routing/rendering-a-template.md
@@ -32,3 +32,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.4.0/routing/specifying-a-routes-model.md
@@ -128,3 +128,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/templates/binding-element-attributes.md
+++ b/guides/v2.4.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/templates/conditionals.md
+++ b/guides/v2.4.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/templates/development-helpers.md
+++ b/guides/v2.4.0/templates/development-helpers.md
@@ -60,3 +60,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.4.0/templates/displaying-a-list-of-items.md
@@ -75,3 +75,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.4.0/templates/displaying-the-keys-in-an-object.md
@@ -131,3 +131,5 @@ helper can have a matching `{{else}}`. The contents of this block will render
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/templates/links.md
+++ b/guides/v2.4.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/testing/acceptance.md
+++ b/guides/v2.4.0/testing/acceptance.md
@@ -246,3 +246,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/testing/testing-components.md
+++ b/guides/v2.4.0/testing/testing-components.md
@@ -341,3 +341,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.4.0/testing/unit-testing-basics.md
+++ b/guides/v2.4.0/testing/unit-testing-basics.md
@@ -127,3 +127,5 @@ test('should set other prop to yes when foo changes', function(assert) {
   assert.equal(someThing.get('other'), 'yes');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/addons-and-dependencies/index.md
+++ b/guides/v2.5.0/addons-and-dependencies/index.md
@@ -138,3 +138,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/applications/services.md
+++ b/guides/v2.5.0/applications/services.md
@@ -117,3 +117,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/components/customizing-a-components-element.md
+++ b/guides/v2.5.0/components/customizing-a-components-element.md
@@ -180,3 +180,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.5.0/components/passing-properties-to-a-component.md
@@ -105,3 +105,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.5.0/components/triggering-changes-with-actions.md
@@ -426,3 +426,5 @@ export default Ember.Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/configuring-ember/debugging.md
+++ b/guides/v2.5.0/configuring-ember/debugging.md
@@ -131,3 +131,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.5.0/configuring-ember/disabling-prototype-extensions.md
@@ -155,3 +155,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.5.0/configuring-ember/embedding-applications.md
@@ -48,3 +48,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/configuring-ember/index.md
+++ b/guides/v2.5.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/controllers/index.md
+++ b/guides/v2.5.0/controllers/index.md
@@ -87,3 +87,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/ember-inspector/promises.md
+++ b/guides/v2.5.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/getting-started/quick-start.md
+++ b/guides/v2.5.0/getting-started/quick-start.md
@@ -264,3 +264,5 @@ add the following directive to the application's virtual host configuration
 ```
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v2.5.0/models/creating-updating-and-deleting-records.md
@@ -162,3 +162,5 @@ store.findRecord('post', 2).then(function(post) {
   post.destroyRecord(); // => DELETE to /posts/2
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/models/defining-models.md
+++ b/guides/v2.5.0/models/defining-models.md
@@ -143,3 +143,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/models/finding-records.md
+++ b/guides/v2.5.0/models/finding-records.md
@@ -80,3 +80,5 @@ this.store.queryRecord('person', { filter: { email: 'tomster@example.com' } }).t
   // do something with `tomster`
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/models/pushing-records-into-the-store.md
+++ b/guides/v2.5.0/models/pushing-records-into-the-store.md
@@ -135,3 +135,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/object-model/bindings.md
+++ b/guides/v2.5.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/object-model/enumerables.md
+++ b/guides/v2.5.0/object-model/enumerables.md
@@ -209,3 +209,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/object-model/observers.md
+++ b/guides/v2.5.0/object-model/observers.md
@@ -138,3 +138,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.5.0/object-model/reopening-classes-and-instances.md
@@ -46,3 +46,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/routing/asynchronous-routing.md
+++ b/guides/v2.5.0/routing/asynchronous-routing.md
@@ -162,3 +162,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.5.0/routing/preventing-and-retrying-transitions.md
@@ -98,3 +98,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/routing/query-params.md
+++ b/guides/v2.5.0/routing/query-params.md
@@ -322,3 +322,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/routing/redirection.md
+++ b/guides/v2.5.0/routing/redirection.md
@@ -96,3 +96,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/routing/rendering-a-template.md
+++ b/guides/v2.5.0/routing/rendering-a-template.md
@@ -32,3 +32,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.5.0/routing/specifying-a-routes-model.md
@@ -128,3 +128,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/templates/binding-element-attributes.md
+++ b/guides/v2.5.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/templates/conditionals.md
+++ b/guides/v2.5.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/templates/development-helpers.md
+++ b/guides/v2.5.0/templates/development-helpers.md
@@ -60,3 +60,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.5.0/templates/displaying-a-list-of-items.md
@@ -75,3 +75,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.5.0/templates/displaying-the-keys-in-an-object.md
@@ -131,3 +131,5 @@ helper can have a matching `{{else}}`. The contents of this block will render
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/templates/links.md
+++ b/guides/v2.5.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/testing/acceptance.md
+++ b/guides/v2.5.0/testing/acceptance.md
@@ -246,3 +246,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/testing/testing-components.md
+++ b/guides/v2.5.0/testing/testing-components.md
@@ -341,3 +341,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.5.0/testing/unit-testing-basics.md
+++ b/guides/v2.5.0/testing/unit-testing-basics.md
@@ -127,3 +127,5 @@ test('should set other prop to yes when foo changes', function(assert) {
   assert.equal(someThing.get('other'), 'yes');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/addons-and-dependencies/index.md
+++ b/guides/v2.6.0/addons-and-dependencies/index.md
@@ -146,3 +146,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/applications/services.md
+++ b/guides/v2.6.0/applications/services.md
@@ -117,3 +117,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/components/customizing-a-components-element.md
+++ b/guides/v2.6.0/components/customizing-a-components-element.md
@@ -180,3 +180,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.6.0/components/passing-properties-to-a-component.md
@@ -105,3 +105,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.6.0/components/triggering-changes-with-actions.md
@@ -426,3 +426,5 @@ export default Ember.Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/configuring-ember/debugging.md
+++ b/guides/v2.6.0/configuring-ember/debugging.md
@@ -131,3 +131,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.6.0/configuring-ember/disabling-prototype-extensions.md
@@ -155,3 +155,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.6.0/configuring-ember/embedding-applications.md
@@ -48,3 +48,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/configuring-ember/index.md
+++ b/guides/v2.6.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/controllers/index.md
+++ b/guides/v2.6.0/controllers/index.md
@@ -87,3 +87,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/ember-inspector/promises.md
+++ b/guides/v2.6.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/getting-started/quick-start.md
+++ b/guides/v2.6.0/getting-started/quick-start.md
@@ -275,3 +275,5 @@ add the following directive to the application's virtual host configuration
 ```
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v2.6.0/models/creating-updating-and-deleting-records.md
@@ -162,3 +162,5 @@ store.findRecord('post', 2).then(function(post) {
   post.destroyRecord(); // => DELETE to /posts/2
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/models/defining-models.md
+++ b/guides/v2.6.0/models/defining-models.md
@@ -143,3 +143,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/models/finding-records.md
+++ b/guides/v2.6.0/models/finding-records.md
@@ -88,3 +88,5 @@ this.get('store').queryRecord('person', {
   // do something with `tomster`
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/models/pushing-records-into-the-store.md
+++ b/guides/v2.6.0/models/pushing-records-into-the-store.md
@@ -135,3 +135,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/object-model/bindings.md
+++ b/guides/v2.6.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/object-model/enumerables.md
+++ b/guides/v2.6.0/object-model/enumerables.md
@@ -209,3 +209,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/object-model/observers.md
+++ b/guides/v2.6.0/object-model/observers.md
@@ -138,3 +138,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.6.0/object-model/reopening-classes-and-instances.md
@@ -46,3 +46,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/routing/asynchronous-routing.md
+++ b/guides/v2.6.0/routing/asynchronous-routing.md
@@ -162,3 +162,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.6.0/routing/preventing-and-retrying-transitions.md
@@ -98,3 +98,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/routing/query-params.md
+++ b/guides/v2.6.0/routing/query-params.md
@@ -322,3 +322,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/routing/redirection.md
+++ b/guides/v2.6.0/routing/redirection.md
@@ -96,3 +96,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/routing/rendering-a-template.md
+++ b/guides/v2.6.0/routing/rendering-a-template.md
@@ -32,3 +32,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.6.0/routing/specifying-a-routes-model.md
@@ -128,3 +128,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/templates/binding-element-attributes.md
+++ b/guides/v2.6.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/templates/conditionals.md
+++ b/guides/v2.6.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/templates/development-helpers.md
+++ b/guides/v2.6.0/templates/development-helpers.md
@@ -60,3 +60,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.6.0/templates/displaying-a-list-of-items.md
@@ -75,3 +75,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.6.0/templates/displaying-the-keys-in-an-object.md
@@ -131,3 +131,5 @@ helper can have a matching `{{else}}`. The contents of this block will render
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/templates/links.md
+++ b/guides/v2.6.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/testing/acceptance.md
+++ b/guides/v2.6.0/testing/acceptance.md
@@ -246,3 +246,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/testing/testing-components.md
+++ b/guides/v2.6.0/testing/testing-components.md
@@ -341,3 +341,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.6.0/testing/unit-testing-basics.md
+++ b/guides/v2.6.0/testing/unit-testing-basics.md
@@ -127,3 +127,5 @@ test('should set other prop to yes when foo changes', function(assert) {
   assert.equal(someThing.get('other'), 'yes');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/addons-and-dependencies/index.md
+++ b/guides/v2.7.0/addons-and-dependencies/index.md
@@ -146,3 +146,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/applications/services.md
+++ b/guides/v2.7.0/applications/services.md
@@ -126,3 +126,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/components/customizing-a-components-element.md
+++ b/guides/v2.7.0/components/customizing-a-components-element.md
@@ -200,3 +200,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.7.0/components/passing-properties-to-a-component.md
@@ -111,3 +111,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/components/triggering-changes-with-actions.md
+++ b/guides/v2.7.0/components/triggering-changes-with-actions.md
@@ -446,3 +446,5 @@ export default Ember.Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/configuring-ember/debugging.md
+++ b/guides/v2.7.0/configuring-ember/debugging.md
@@ -138,3 +138,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.7.0/configuring-ember/disabling-prototype-extensions.md
@@ -155,3 +155,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.7.0/configuring-ember/embedding-applications.md
@@ -50,3 +50,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/configuring-ember/index.md
+++ b/guides/v2.7.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/controllers/index.md
+++ b/guides/v2.7.0/controllers/index.md
@@ -89,3 +89,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/ember-inspector/promises.md
+++ b/guides/v2.7.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/getting-started/quick-start.md
+++ b/guides/v2.7.0/getting-started/quick-start.md
@@ -276,3 +276,5 @@ add the following directive to the application's virtual host configuration
 ```
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/models/defining-models.md
+++ b/guides/v2.7.0/models/defining-models.md
@@ -157,3 +157,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/models/finding-records.md
+++ b/guides/v2.7.0/models/finding-records.md
@@ -88,3 +88,5 @@ this.get('store').queryRecord('person', {
   // do something with `tomster`
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/models/pushing-records-into-the-store.md
+++ b/guides/v2.7.0/models/pushing-records-into-the-store.md
@@ -145,3 +145,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/object-model/bindings.md
+++ b/guides/v2.7.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/object-model/enumerables.md
+++ b/guides/v2.7.0/object-model/enumerables.md
@@ -201,3 +201,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/object-model/observers.md
+++ b/guides/v2.7.0/object-model/observers.md
@@ -138,3 +138,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.7.0/object-model/reopening-classes-and-instances.md
@@ -46,3 +46,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/routing/asynchronous-routing.md
+++ b/guides/v2.7.0/routing/asynchronous-routing.md
@@ -170,3 +170,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.7.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/routing/query-params.md
+++ b/guides/v2.7.0/routing/query-params.md
@@ -344,3 +344,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/routing/redirection.md
+++ b/guides/v2.7.0/routing/redirection.md
@@ -102,3 +102,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.7.0/routing/specifying-a-routes-model.md
@@ -163,3 +163,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/templates/binding-element-attributes.md
+++ b/guides/v2.7.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/templates/conditionals.md
+++ b/guides/v2.7.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/templates/development-helpers.md
+++ b/guides/v2.7.0/templates/development-helpers.md
@@ -60,3 +60,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.7.0/templates/displaying-a-list-of-items.md
@@ -75,3 +75,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.7.0/templates/displaying-the-keys-in-an-object.md
@@ -137,3 +137,5 @@ helper can have a matching `{{else}}`. The contents of this block will render
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/templates/links.md
+++ b/guides/v2.7.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/testing/acceptance.md
+++ b/guides/v2.7.0/testing/acceptance.md
@@ -254,3 +254,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/testing/testing-components.md
+++ b/guides/v2.7.0/testing/testing-components.md
@@ -351,3 +351,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/testing/unit-testing-basics.md
+++ b/guides/v2.7.0/testing/unit-testing-basics.md
@@ -135,3 +135,5 @@ test('should set other prop to yes when foo changes', function(assert) {
   assert.equal(someThing.get('other'), 'yes');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.7.0/tutorial/installing-addons.md
+++ b/guides/v2.7.0/tutorial/installing-addons.md
@@ -107,3 +107,5 @@ export default DS.JSONAPIAdapter.extend({
 });
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/addons-and-dependencies/index.md
+++ b/guides/v2.8.0/addons-and-dependencies/index.md
@@ -146,3 +146,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/applications/services.md
+++ b/guides/v2.8.0/applications/services.md
@@ -126,3 +126,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/components/customizing-a-components-element.md
+++ b/guides/v2.8.0/components/customizing-a-components-element.md
@@ -200,3 +200,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.8.0/components/passing-properties-to-a-component.md
@@ -111,3 +111,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/configuring-ember/debugging.md
+++ b/guides/v2.8.0/configuring-ember/debugging.md
@@ -138,3 +138,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.8.0/configuring-ember/disabling-prototype-extensions.md
@@ -156,3 +156,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.8.0/configuring-ember/embedding-applications.md
@@ -50,3 +50,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/configuring-ember/index.md
+++ b/guides/v2.8.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/controllers/index.md
+++ b/guides/v2.8.0/controllers/index.md
@@ -89,3 +89,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/ember-inspector/promises.md
+++ b/guides/v2.8.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/getting-started/quick-start.md
+++ b/guides/v2.8.0/getting-started/quick-start.md
@@ -276,3 +276,5 @@ add the following directive to the application's virtual host configuration
 ```
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/models/defining-models.md
+++ b/guides/v2.8.0/models/defining-models.md
@@ -157,3 +157,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/models/finding-records.md
+++ b/guides/v2.8.0/models/finding-records.md
@@ -114,3 +114,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/models/pushing-records-into-the-store.md
+++ b/guides/v2.8.0/models/pushing-records-into-the-store.md
@@ -145,3 +145,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/object-model/bindings.md
+++ b/guides/v2.8.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/object-model/enumerables.md
+++ b/guides/v2.8.0/object-model/enumerables.md
@@ -201,3 +201,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/object-model/observers.md
+++ b/guides/v2.8.0/object-model/observers.md
@@ -138,3 +138,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.8.0/object-model/reopening-classes-and-instances.md
@@ -46,3 +46,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/routing/asynchronous-routing.md
+++ b/guides/v2.8.0/routing/asynchronous-routing.md
@@ -170,3 +170,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.8.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/routing/query-params.md
+++ b/guides/v2.8.0/routing/query-params.md
@@ -346,3 +346,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/routing/redirection.md
+++ b/guides/v2.8.0/routing/redirection.md
@@ -102,3 +102,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.8.0/routing/specifying-a-routes-model.md
@@ -163,3 +163,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/templates/binding-element-attributes.md
+++ b/guides/v2.8.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/templates/conditionals.md
+++ b/guides/v2.8.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/templates/development-helpers.md
+++ b/guides/v2.8.0/templates/development-helpers.md
@@ -60,3 +60,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.8.0/templates/displaying-a-list-of-items.md
@@ -75,3 +75,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.8.0/templates/displaying-the-keys-in-an-object.md
@@ -137,3 +137,5 @@ helper can have a matching `{{else}}`. The contents of this block will render
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/templates/links.md
+++ b/guides/v2.8.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/testing/acceptance.md
+++ b/guides/v2.8.0/testing/acceptance.md
@@ -254,3 +254,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/testing/testing-components.md
+++ b/guides/v2.8.0/testing/testing-components.md
@@ -353,3 +353,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/testing/unit-testing-basics.md
+++ b/guides/v2.8.0/testing/unit-testing-basics.md
@@ -135,3 +135,5 @@ test('should set other prop to yes when foo changes', function(assert) {
   assert.equal(someThing.get('other'), 'yes');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.8.0/tutorial/installing-addons.md
+++ b/guides/v2.8.0/tutorial/installing-addons.md
@@ -107,3 +107,5 @@ export default DS.JSONAPIAdapter.extend({
 });
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/addons-and-dependencies/index.md
+++ b/guides/v2.9.0/addons-and-dependencies/index.md
@@ -146,3 +146,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/applications/services.md
+++ b/guides/v2.9.0/applications/services.md
@@ -126,3 +126,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/components/customizing-a-components-element.md
+++ b/guides/v2.9.0/components/customizing-a-components-element.md
@@ -200,3 +200,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.9.0/components/passing-properties-to-a-component.md
@@ -111,3 +111,5 @@ BlogPostComponent.reopenClass({
 
 export default BlogPostComponent;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/configuring-ember/debugging.md
+++ b/guides/v2.9.0/configuring-ember/debugging.md
@@ -138,3 +138,5 @@ To enable this mode you can set:
 ```javascript
 Ember.run.backburner.DEBUG = true;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.9.0/configuring-ember/disabling-prototype-extensions.md
@@ -156,3 +156,5 @@ doStuffWhenInserted: Ember.on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/configuring-ember/embedding-applications.md
+++ b/guides/v2.9.0/configuring-ember/embedding-applications.md
@@ -50,3 +50,5 @@ Ember.Router.extend({
   rootURL: '/blog/'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/configuring-ember/index.md
+++ b/guides/v2.9.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/controllers/index.md
+++ b/guides/v2.9.0/controllers/index.md
@@ -89,3 +89,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/ember-inspector/promises.md
+++ b/guides/v2.9.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/getting-started/quick-start.md
+++ b/guides/v2.9.0/getting-started/quick-start.md
@@ -276,3 +276,5 @@ add the following directive to the application's virtual host configuration
 ```
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/models/defining-models.md
+++ b/guides/v2.9.0/models/defining-models.md
@@ -157,3 +157,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/models/finding-records.md
+++ b/guides/v2.9.0/models/finding-records.md
@@ -114,3 +114,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/object-model/bindings.md
+++ b/guides/v2.9.0/object-model/bindings.md
@@ -64,3 +64,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/object-model/enumerables.md
+++ b/guides/v2.9.0/object-model/enumerables.md
@@ -201,3 +201,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/object-model/observers.md
+++ b/guides/v2.9.0/object-model/observers.md
@@ -138,3 +138,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v2.9.0/object-model/reopening-classes-and-instances.md
@@ -46,3 +46,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/routing/asynchronous-routing.md
+++ b/guides/v2.9.0/routing/asynchronous-routing.md
@@ -170,3 +170,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v2.9.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Ember.Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/routing/query-params.md
+++ b/guides/v2.9.0/routing/query-params.md
@@ -346,3 +346,5 @@ export default Ember.Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/routing/redirection.md
+++ b/guides/v2.9.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Ember.Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.9.0/routing/specifying-a-routes-model.md
@@ -163,3 +163,5 @@ each record in the song model and album model:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/templates/binding-element-attributes.md
+++ b/guides/v2.9.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/templates/conditionals.md
+++ b/guides/v2.9.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/templates/development-helpers.md
+++ b/guides/v2.9.0/templates/development-helpers.md
@@ -60,3 +60,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.9.0/templates/displaying-a-list-of-items.md
@@ -75,3 +75,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.9.0/templates/displaying-the-keys-in-an-object.md
@@ -137,3 +137,5 @@ helper can have a matching `{{else}}`. The contents of this block will render
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/templates/links.md
+++ b/guides/v2.9.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/testing/acceptance.md
+++ b/guides/v2.9.0/testing/acceptance.md
@@ -254,3 +254,5 @@ import './should-have-element-with-count';
 import './dblclick';
 import './add-contact';
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/testing/testing-components.md
+++ b/guides/v2.9.0/testing/testing-components.md
@@ -353,3 +353,5 @@ test('should render results after typing a term', function(assert) {
 
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/testing/unit-testing-basics.md
+++ b/guides/v2.9.0/testing/unit-testing-basics.md
@@ -135,3 +135,5 @@ test('should set other prop to yes when foo changes', function(assert) {
   assert.equal(someThing.get('other'), 'yes');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v2.9.0/tutorial/installing-addons.md
+++ b/guides/v2.9.0/tutorial/installing-addons.md
@@ -107,3 +107,5 @@ export default DS.JSONAPIAdapter.extend({
 });
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/addons-and-dependencies/managing-dependencies.md
+++ b/guides/v3.0.0/addons-and-dependencies/managing-dependencies.md
@@ -134,3 +134,5 @@ app.import('bower_components/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/applications/dependency-injection.md
+++ b/guides/v3.0.0/applications/dependency-injection.md
@@ -255,3 +255,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/applications/services.md
+++ b/guides/v3.0.0/applications/services.md
@@ -142,3 +142,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/components/customizing-a-components-element.md
+++ b/guides/v3.0.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.0.0/components/passing-properties-to-a-component.md
@@ -102,3 +102,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/components/the-component-lifecycle.md
+++ b/guides/v3.0.0/components/the-component-lifecycle.md
@@ -275,3 +275,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/configuring-ember/configuring-your-app.md
+++ b/guides/v3.0.0/configuring-ember/configuring-your-app.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.0.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.0.0/configuring-ember/embedding-applications.md
@@ -94,3 +94,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/ember-inspector/promises.md
+++ b/guides/v3.0.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/getting-started/quick-start.md
+++ b/guides/v3.0.0/getting-started/quick-start.md
@@ -295,3 +295,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/models/defining-models.md
+++ b/guides/v3.0.0/models/defining-models.md
@@ -158,3 +158,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/models/finding-records.md
+++ b/guides/v3.0.0/models/finding-records.md
@@ -114,3 +114,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/object-model/bindings.md
+++ b/guides/v3.0.0/object-model/bindings.md
@@ -71,3 +71,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/object-model/enumerables.md
+++ b/guides/v3.0.0/object-model/enumerables.md
@@ -207,3 +207,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/object-model/observers.md
+++ b/guides/v3.0.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.0.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/routing/asynchronous-routing.md
+++ b/guides/v3.0.0/routing/asynchronous-routing.md
@@ -171,3 +171,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/routing/loading-and-error-substates.md
+++ b/guides/v3.0.0/routing/loading-and-error-substates.md
@@ -250,3 +250,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.0.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/routing/query-params.md
+++ b/guides/v3.0.0/routing/query-params.md
@@ -338,3 +338,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/routing/redirection.md
+++ b/guides/v3.0.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/templates/binding-element-attributes.md
+++ b/guides/v3.0.0/templates/binding-element-attributes.md
@@ -81,3 +81,5 @@ Now the same template above renders the following HTML:
 <input id="ember259" class="ember-view ember-text-field"
        type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/templates/conditionals.md
+++ b/guides/v3.0.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/templates/development-helpers.md
+++ b/guides/v3.0.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.0.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.0.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/templates/links.md
+++ b/guides/v3.0.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/templates/writing-helpers.md
+++ b/guides/v3.0.0/templates/writing-helpers.md
@@ -392,3 +392,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/testing/testing-components.md
+++ b/guides/v3.0.0/testing/testing-components.md
@@ -522,3 +522,5 @@ module('Integration | Component | delayed typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/testing/testing-controllers.md
+++ b/guides/v3.0.0/testing/testing-controllers.md
@@ -145,3 +145,5 @@ module('Unit | Controller | comments', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/testing/testing-helpers.md
+++ b/guides/v3.0.0/testing/testing-helpers.md
@@ -94,3 +94,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/testing/testing-routes.md
+++ b/guides/v3.0.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/testing/unit-testing-basics.md
+++ b/guides/v3.0.0/testing/unit-testing-basics.md
@@ -186,3 +186,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/tutorial/ember-cli.md
+++ b/guides/v3.0.0/tutorial/ember-cli.md
@@ -140,3 +140,5 @@ The application should now be a completely blank canvas to build our application
 {{outlet}}
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.0.0/tutorial/hbs-helper.md
+++ b/guides/v3.0.0/tutorial/hbs-helper.md
@@ -124,3 +124,5 @@ test('it renders correctly for a Community rental', function(assert) {
   assert.equal(this.$().text().trim(), 'Community');
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/addons-and-dependencies/managing-dependencies.md
+++ b/guides/v3.1.0/addons-and-dependencies/managing-dependencies.md
@@ -149,3 +149,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/applications/dependency-injection.md
+++ b/guides/v3.1.0/applications/dependency-injection.md
@@ -255,3 +255,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/applications/services.md
+++ b/guides/v3.1.0/applications/services.md
@@ -142,3 +142,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/components/customizing-a-components-element.md
+++ b/guides/v3.1.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.1.0/components/passing-properties-to-a-component.md
@@ -102,3 +102,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/components/the-component-lifecycle.md
+++ b/guides/v3.1.0/components/the-component-lifecycle.md
@@ -276,3 +276,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/configuring-ember/configuring-your-app.md
+++ b/guides/v3.1.0/configuring-ember/configuring-your-app.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.1.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.1.0/configuring-ember/embedding-applications.md
@@ -94,3 +94,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/ember-inspector/promises.md
+++ b/guides/v3.1.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/getting-started/core-concepts.md
+++ b/guides/v3.1.0/getting-started/core-concepts.md
@@ -81,3 +81,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/getting-started/quick-start.md
+++ b/guides/v3.1.0/getting-started/quick-start.md
@@ -295,3 +295,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/models/defining-models.md
+++ b/guides/v3.1.0/models/defining-models.md
@@ -158,3 +158,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/models/finding-records.md
+++ b/guides/v3.1.0/models/finding-records.md
@@ -114,3 +114,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/object-model/bindings.md
+++ b/guides/v3.1.0/object-model/bindings.md
@@ -72,3 +72,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/object-model/enumerables.md
+++ b/guides/v3.1.0/object-model/enumerables.md
@@ -207,3 +207,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/object-model/observers.md
+++ b/guides/v3.1.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.1.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/routing/asynchronous-routing.md
+++ b/guides/v3.1.0/routing/asynchronous-routing.md
@@ -171,3 +171,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/routing/loading-and-error-substates.md
+++ b/guides/v3.1.0/routing/loading-and-error-substates.md
@@ -250,3 +250,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.1.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/routing/query-params.md
+++ b/guides/v3.1.0/routing/query-params.md
@@ -338,3 +338,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/routing/redirection.md
+++ b/guides/v3.1.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/templates/binding-element-attributes.md
+++ b/guides/v3.1.0/templates/binding-element-attributes.md
@@ -74,3 +74,5 @@ Now the same template above renders the following HTML:
 ```html
 <a id="ember239" class="ember-view" href="#/photos" data-toggle="dropdown" lang="es">Fotos</a>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/templates/conditionals.md
+++ b/guides/v3.1.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/templates/development-helpers.md
+++ b/guides/v3.1.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.1.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.1.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/templates/links.md
+++ b/guides/v3.1.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/templates/writing-helpers.md
+++ b/guides/v3.1.0/templates/writing-helpers.md
@@ -392,3 +392,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/testing/testing-components.md
+++ b/guides/v3.1.0/testing/testing-components.md
@@ -522,3 +522,5 @@ module('Integration | Component | delayed typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/testing/testing-controllers.md
+++ b/guides/v3.1.0/testing/testing-controllers.md
@@ -79,3 +79,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/testing/testing-helpers.md
+++ b/guides/v3.1.0/testing/testing-helpers.md
@@ -94,3 +94,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/testing/testing-routes.md
+++ b/guides/v3.1.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/testing/unit-testing-basics.md
+++ b/guides/v3.1.0/testing/unit-testing-basics.md
@@ -187,3 +187,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/tutorial/ember-cli.md
+++ b/guides/v3.1.0/tutorial/ember-cli.md
@@ -140,3 +140,5 @@ The application should now be a completely blank canvas to build our application
 {{outlet}}
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.1.0/tutorial/hbs-helper.md
+++ b/guides/v3.1.0/tutorial/hbs-helper.md
@@ -125,3 +125,5 @@ module('Integration | Helper | my-helper', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/addons-and-dependencies/managing-dependencies.md
+++ b/guides/v3.10.0/addons-and-dependencies/managing-dependencies.md
@@ -169,3 +169,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/applications/dependency-injection.md
+++ b/guides/v3.10.0/applications/dependency-injection.md
@@ -260,3 +260,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/applications/services.md
+++ b/guides/v3.10.0/applications/services.md
@@ -141,3 +141,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/components/customizing-a-components-element.md
+++ b/guides/v3.10.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.10.0/components/passing-properties-to-a-component.md
@@ -119,3 +119,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/components/the-component-lifecycle.md
+++ b/guides/v3.10.0/components/the-component-lifecycle.md
@@ -281,3 +281,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/configuring-ember/configuring-your-app.md
+++ b/guides/v3.10.0/configuring-ember/configuring-your-app.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.10.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.10.0/configuring-ember/embedding-applications.md
@@ -99,3 +99,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/ember-inspector/promises.md
+++ b/guides/v3.10.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/getting-started/core-concepts.md
+++ b/guides/v3.10.0/getting-started/core-concepts.md
@@ -81,3 +81,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/getting-started/quick-start.md
+++ b/guides/v3.10.0/getting-started/quick-start.md
@@ -289,3 +289,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/models/defining-models.md
+++ b/guides/v3.10.0/models/defining-models.md
@@ -178,3 +178,5 @@ tags: DS.attr() // a read-only array
 ```handlebars
 {{this.model.location.latitude}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/models/finding-records.md
+++ b/guides/v3.10.0/models/finding-records.md
@@ -122,3 +122,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/object-model/bindings.md
+++ b/guides/v3.10.0/object-model/bindings.md
@@ -69,3 +69,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/object-model/classes-and-instances.md
+++ b/guides/v3.10.0/object-model/classes-and-instances.md
@@ -251,3 +251,5 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/object-model/enumerables.md
+++ b/guides/v3.10.0/object-model/enumerables.md
@@ -235,3 +235,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/object-model/observers.md
+++ b/guides/v3.10.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.10.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/reference/syntax-conversion-guide.md
+++ b/guides/v3.10.0/reference/syntax-conversion-guide.md
@@ -113,3 +113,5 @@ When you need direct support for positional arguments, you should still reach fo
 ```handlebars
 {{some-component param1 param2}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/routing/asynchronous-routing.md
+++ b/guides/v3.10.0/routing/asynchronous-routing.md
@@ -166,3 +166,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/routing/loading-and-error-substates.md
+++ b/guides/v3.10.0/routing/loading-and-error-substates.md
@@ -264,3 +264,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.10.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/routing/query-params.md
+++ b/guides/v3.10.0/routing/query-params.md
@@ -349,3 +349,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/routing/redirection.md
+++ b/guides/v3.10.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/templates/built-in-helpers.md
+++ b/guides/v3.10.0/templates/built-in-helpers.md
@@ -87,3 +87,5 @@ In the component's template, you can then use the `people` argument as an array:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/templates/conditionals.md
+++ b/guides/v3.10.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{this.total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/templates/development-helpers.md
+++ b/guides/v3.10.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.10.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.10.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/templates/links.md
+++ b/guides/v3.10.0/templates/links.md
@@ -144,3 +144,5 @@ can use the `replace=true` option:
   </LinkTo>
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/templates/writing-helpers.md
+++ b/guides/v3.10.0/templates/writing-helpers.md
@@ -393,3 +393,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/testing/testing-components.md
+++ b/guides/v3.10.0/testing/testing-components.md
@@ -524,3 +524,5 @@ module('Integration | Component | delayed-typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/testing/testing-controllers.md
+++ b/guides/v3.10.0/testing/testing-controllers.md
@@ -79,3 +79,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/testing/testing-helpers.md
+++ b/guides/v3.10.0/testing/testing-helpers.md
@@ -96,3 +96,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/testing/testing-routes.md
+++ b/guides/v3.10.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/testing/unit-testing-basics.md
+++ b/guides/v3.10.0/testing/unit-testing-basics.md
@@ -183,3 +183,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.10.0/tutorial/hbs-helper.md
+++ b/guides/v3.10.0/tutorial/hbs-helper.md
@@ -129,3 +129,5 @@ module('Integration | Helper | my-helper', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/addons-and-dependencies/index.md
+++ b/guides/v3.11.0/addons-and-dependencies/index.md
@@ -169,3 +169,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/applications/dependency-injection.md
+++ b/guides/v3.11.0/applications/dependency-injection.md
@@ -260,3 +260,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/applications/services.md
+++ b/guides/v3.11.0/applications/services.md
@@ -141,3 +141,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/components/customizing-a-components-element.md
+++ b/guides/v3.11.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.11.0/components/passing-properties-to-a-component.md
@@ -119,3 +119,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/components/the-component-lifecycle.md
+++ b/guides/v3.11.0/components/the-component-lifecycle.md
@@ -281,3 +281,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.11.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.11.0/configuring-ember/embedding-applications.md
@@ -99,3 +99,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/configuring-ember/index.md
+++ b/guides/v3.11.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/ember-inspector/promises.md
+++ b/guides/v3.11.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/getting-started/core-concepts.md
+++ b/guides/v3.11.0/getting-started/core-concepts.md
@@ -81,3 +81,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/getting-started/quick-start.md
+++ b/guides/v3.11.0/getting-started/quick-start.md
@@ -289,3 +289,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/models/defining-models.md
+++ b/guides/v3.11.0/models/defining-models.md
@@ -178,3 +178,5 @@ tags: DS.attr() // a read-only array
 ```handlebars
 {{this.model.location.latitude}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/models/finding-records.md
+++ b/guides/v3.11.0/models/finding-records.md
@@ -122,3 +122,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/object-model/bindings.md
+++ b/guides/v3.11.0/object-model/bindings.md
@@ -69,3 +69,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/object-model/classes-and-instances.md
+++ b/guides/v3.11.0/object-model/classes-and-instances.md
@@ -251,3 +251,5 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/object-model/enumerables.md
+++ b/guides/v3.11.0/object-model/enumerables.md
@@ -235,3 +235,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/object-model/observers.md
+++ b/guides/v3.11.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.11.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/reference/index.md
+++ b/guides/v3.11.0/reference/index.md
@@ -113,3 +113,5 @@ When you need direct support for positional arguments, you should still reach fo
 ```handlebars
 {{some-component param1 param2}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/routing/asynchronous-routing.md
+++ b/guides/v3.11.0/routing/asynchronous-routing.md
@@ -166,3 +166,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/routing/loading-and-error-substates.md
+++ b/guides/v3.11.0/routing/loading-and-error-substates.md
@@ -264,3 +264,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.11.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/routing/query-params.md
+++ b/guides/v3.11.0/routing/query-params.md
@@ -349,3 +349,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/routing/redirection.md
+++ b/guides/v3.11.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/templates/built-in-helpers.md
+++ b/guides/v3.11.0/templates/built-in-helpers.md
@@ -87,3 +87,5 @@ In the component's template, you can then use the `people` argument as an array:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/templates/conditionals.md
+++ b/guides/v3.11.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{this.total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/templates/development-helpers.md
+++ b/guides/v3.11.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.11.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.11.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/templates/links.md
+++ b/guides/v3.11.0/templates/links.md
@@ -144,3 +144,5 @@ can use the `replace=true` option:
   </LinkTo>
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/templates/writing-helpers.md
+++ b/guides/v3.11.0/templates/writing-helpers.md
@@ -393,3 +393,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/testing/testing-components.md
+++ b/guides/v3.11.0/testing/testing-components.md
@@ -524,3 +524,5 @@ module('Integration | Component | delayed-typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/testing/testing-controllers.md
+++ b/guides/v3.11.0/testing/testing-controllers.md
@@ -79,3 +79,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/testing/testing-helpers.md
+++ b/guides/v3.11.0/testing/testing-helpers.md
@@ -96,3 +96,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/testing/testing-routes.md
+++ b/guides/v3.11.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/testing/unit-testing-basics.md
+++ b/guides/v3.11.0/testing/unit-testing-basics.md
@@ -183,3 +183,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.11.0/tutorial/hbs-helper.md
+++ b/guides/v3.11.0/tutorial/hbs-helper.md
@@ -129,3 +129,5 @@ module('Integration | Helper | my-helper', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/addons-and-dependencies/index.md
+++ b/guides/v3.12.0/addons-and-dependencies/index.md
@@ -169,3 +169,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/applications/dependency-injection.md
+++ b/guides/v3.12.0/applications/dependency-injection.md
@@ -260,3 +260,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/applications/services.md
+++ b/guides/v3.12.0/applications/services.md
@@ -141,3 +141,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/components/customizing-a-components-element.md
+++ b/guides/v3.12.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.12.0/components/passing-properties-to-a-component.md
@@ -119,3 +119,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/components/the-component-lifecycle.md
+++ b/guides/v3.12.0/components/the-component-lifecycle.md
@@ -281,3 +281,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.12.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.12.0/configuring-ember/embedding-applications.md
@@ -99,3 +99,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/configuring-ember/index.md
+++ b/guides/v3.12.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/ember-inspector/promises.md
+++ b/guides/v3.12.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/getting-started/core-concepts.md
+++ b/guides/v3.12.0/getting-started/core-concepts.md
@@ -81,3 +81,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/getting-started/quick-start.md
+++ b/guides/v3.12.0/getting-started/quick-start.md
@@ -289,3 +289,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/models/defining-models.md
+++ b/guides/v3.12.0/models/defining-models.md
@@ -189,3 +189,5 @@ tags: DS.attr() // a read-only array
 ```handlebars
 {{this.model.location.latitude}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/models/finding-records.md
+++ b/guides/v3.12.0/models/finding-records.md
@@ -122,3 +122,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/object-model/bindings.md
+++ b/guides/v3.12.0/object-model/bindings.md
@@ -69,3 +69,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/object-model/classes-and-instances.md
+++ b/guides/v3.12.0/object-model/classes-and-instances.md
@@ -251,3 +251,5 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/object-model/enumerables.md
+++ b/guides/v3.12.0/object-model/enumerables.md
@@ -235,3 +235,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/object-model/observers.md
+++ b/guides/v3.12.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.12.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/reference/index.md
+++ b/guides/v3.12.0/reference/index.md
@@ -113,3 +113,5 @@ When you need direct support for positional arguments, you should still reach fo
 ```handlebars
 {{some-component param1 param2}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/routing/asynchronous-routing.md
+++ b/guides/v3.12.0/routing/asynchronous-routing.md
@@ -166,3 +166,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/routing/loading-and-error-substates.md
+++ b/guides/v3.12.0/routing/loading-and-error-substates.md
@@ -264,3 +264,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.12.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/routing/query-params.md
+++ b/guides/v3.12.0/routing/query-params.md
@@ -349,3 +349,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/routing/redirection.md
+++ b/guides/v3.12.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/templates/built-in-helpers.md
+++ b/guides/v3.12.0/templates/built-in-helpers.md
@@ -87,3 +87,5 @@ In the component's template, you can then use the `people` argument as an array:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/templates/conditionals.md
+++ b/guides/v3.12.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{this.total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/templates/development-helpers.md
+++ b/guides/v3.12.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.12.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.12.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/templates/links.md
+++ b/guides/v3.12.0/templates/links.md
@@ -144,3 +144,5 @@ can use the `replace=true` option:
   </LinkTo>
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/templates/writing-helpers.md
+++ b/guides/v3.12.0/templates/writing-helpers.md
@@ -393,3 +393,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/testing/testing-components.md
+++ b/guides/v3.12.0/testing/testing-components.md
@@ -524,3 +524,5 @@ module('Integration | Component | delayed-typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/testing/testing-controllers.md
+++ b/guides/v3.12.0/testing/testing-controllers.md
@@ -79,3 +79,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/testing/testing-helpers.md
+++ b/guides/v3.12.0/testing/testing-helpers.md
@@ -96,3 +96,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/testing/testing-routes.md
+++ b/guides/v3.12.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/testing/unit-testing-basics.md
+++ b/guides/v3.12.0/testing/unit-testing-basics.md
@@ -183,3 +183,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.12.0/tutorial/hbs-helper.md
+++ b/guides/v3.12.0/tutorial/hbs-helper.md
@@ -129,3 +129,5 @@ module('Integration | Helper | rental-property-type', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/addons-and-dependencies/index.md
+++ b/guides/v3.13.0/addons-and-dependencies/index.md
@@ -169,3 +169,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/applications/dependency-injection.md
+++ b/guides/v3.13.0/applications/dependency-injection.md
@@ -260,3 +260,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/applications/services.md
+++ b/guides/v3.13.0/applications/services.md
@@ -141,3 +141,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/components/customizing-a-components-element.md
+++ b/guides/v3.13.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.13.0/components/passing-properties-to-a-component.md
@@ -119,3 +119,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/components/the-component-lifecycle.md
+++ b/guides/v3.13.0/components/the-component-lifecycle.md
@@ -281,3 +281,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.13.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.13.0/configuring-ember/embedding-applications.md
@@ -99,3 +99,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/configuring-ember/index.md
+++ b/guides/v3.13.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/ember-inspector/promises.md
+++ b/guides/v3.13.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/getting-started/core-concepts.md
+++ b/guides/v3.13.0/getting-started/core-concepts.md
@@ -81,3 +81,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/getting-started/quick-start.md
+++ b/guides/v3.13.0/getting-started/quick-start.md
@@ -289,3 +289,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/models/defining-models.md
+++ b/guides/v3.13.0/models/defining-models.md
@@ -189,3 +189,5 @@ tags: DS.attr() // a read-only array
 ```handlebars
 {{this.model.location.latitude}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/models/finding-records.md
+++ b/guides/v3.13.0/models/finding-records.md
@@ -122,3 +122,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/object-model/bindings.md
+++ b/guides/v3.13.0/object-model/bindings.md
@@ -69,3 +69,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/object-model/classes-and-instances.md
+++ b/guides/v3.13.0/object-model/classes-and-instances.md
@@ -251,3 +251,5 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/object-model/enumerables.md
+++ b/guides/v3.13.0/object-model/enumerables.md
@@ -235,3 +235,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/object-model/observers.md
+++ b/guides/v3.13.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.13.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/reference/index.md
+++ b/guides/v3.13.0/reference/index.md
@@ -113,3 +113,5 @@ When you need direct support for positional arguments, you should still reach fo
 ```handlebars
 {{some-component param1 param2}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/routing/asynchronous-routing.md
+++ b/guides/v3.13.0/routing/asynchronous-routing.md
@@ -166,3 +166,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/routing/loading-and-error-substates.md
+++ b/guides/v3.13.0/routing/loading-and-error-substates.md
@@ -264,3 +264,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.13.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/routing/query-params.md
+++ b/guides/v3.13.0/routing/query-params.md
@@ -349,3 +349,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/routing/redirection.md
+++ b/guides/v3.13.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/templates/built-in-helpers.md
+++ b/guides/v3.13.0/templates/built-in-helpers.md
@@ -87,3 +87,5 @@ In the component's template, you can then use the `people` argument as an array:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/templates/conditionals.md
+++ b/guides/v3.13.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{this.total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/templates/development-helpers.md
+++ b/guides/v3.13.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.13.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.13.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/templates/links.md
+++ b/guides/v3.13.0/templates/links.md
@@ -144,3 +144,5 @@ can use the `replace=true` option:
   </LinkTo>
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/templates/writing-helpers.md
+++ b/guides/v3.13.0/templates/writing-helpers.md
@@ -393,3 +393,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/testing/testing-components.md
+++ b/guides/v3.13.0/testing/testing-components.md
@@ -524,3 +524,5 @@ module('Integration | Component | delayed-typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/testing/testing-controllers.md
+++ b/guides/v3.13.0/testing/testing-controllers.md
@@ -79,3 +79,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/testing/testing-helpers.md
+++ b/guides/v3.13.0/testing/testing-helpers.md
@@ -96,3 +96,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/testing/testing-routes.md
+++ b/guides/v3.13.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/testing/unit-testing-basics.md
+++ b/guides/v3.13.0/testing/unit-testing-basics.md
@@ -183,3 +183,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.13.0/tutorial/hbs-helper.md
+++ b/guides/v3.13.0/tutorial/hbs-helper.md
@@ -129,3 +129,5 @@ module('Integration | Helper | rental-property-type', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/addons-and-dependencies/index.md
+++ b/guides/v3.14.0/addons-and-dependencies/index.md
@@ -169,3 +169,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/applications/dependency-injection.md
+++ b/guides/v3.14.0/applications/dependency-injection.md
@@ -260,3 +260,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/applications/services.md
+++ b/guides/v3.14.0/applications/services.md
@@ -141,3 +141,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/components/customizing-a-components-element.md
+++ b/guides/v3.14.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.14.0/components/passing-properties-to-a-component.md
@@ -119,3 +119,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/components/the-component-lifecycle.md
+++ b/guides/v3.14.0/components/the-component-lifecycle.md
@@ -281,3 +281,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.14.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.14.0/configuring-ember/embedding-applications.md
@@ -99,3 +99,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/configuring-ember/index.md
+++ b/guides/v3.14.0/configuring-ember/index.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/ember-inspector/promises.md
+++ b/guides/v3.14.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/getting-started/core-concepts.md
+++ b/guides/v3.14.0/getting-started/core-concepts.md
@@ -81,3 +81,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/getting-started/quick-start.md
+++ b/guides/v3.14.0/getting-started/quick-start.md
@@ -289,3 +289,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/models/defining-models.md
+++ b/guides/v3.14.0/models/defining-models.md
@@ -189,3 +189,5 @@ tags: DS.attr() // a read-only array
 ```handlebars
 {{this.model.location.latitude}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/models/finding-records.md
+++ b/guides/v3.14.0/models/finding-records.md
@@ -122,3 +122,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/object-model/bindings.md
+++ b/guides/v3.14.0/object-model/bindings.md
@@ -69,3 +69,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/object-model/classes-and-instances.md
+++ b/guides/v3.14.0/object-model/classes-and-instances.md
@@ -251,3 +251,5 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/object-model/enumerables.md
+++ b/guides/v3.14.0/object-model/enumerables.md
@@ -235,3 +235,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/object-model/observers.md
+++ b/guides/v3.14.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.14.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/reference/index.md
+++ b/guides/v3.14.0/reference/index.md
@@ -113,3 +113,5 @@ When you need direct support for positional arguments, you should still reach fo
 ```handlebars
 {{some-component param1 param2}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/routing/asynchronous-routing.md
+++ b/guides/v3.14.0/routing/asynchronous-routing.md
@@ -166,3 +166,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/routing/loading-and-error-substates.md
+++ b/guides/v3.14.0/routing/loading-and-error-substates.md
@@ -264,3 +264,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.14.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/routing/query-params.md
+++ b/guides/v3.14.0/routing/query-params.md
@@ -349,3 +349,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/routing/redirection.md
+++ b/guides/v3.14.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/templates/built-in-helpers.md
+++ b/guides/v3.14.0/templates/built-in-helpers.md
@@ -87,3 +87,5 @@ In the component's template, you can then use the `people` argument as an array:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/templates/conditionals.md
+++ b/guides/v3.14.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{this.total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/templates/development-helpers.md
+++ b/guides/v3.14.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.14.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.14.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/templates/links.md
+++ b/guides/v3.14.0/templates/links.md
@@ -144,3 +144,5 @@ can use the `replace=true` option:
   </LinkTo>
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/templates/writing-helpers.md
+++ b/guides/v3.14.0/templates/writing-helpers.md
@@ -393,3 +393,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/testing/testing-components.md
+++ b/guides/v3.14.0/testing/testing-components.md
@@ -524,3 +524,5 @@ module('Integration | Component | delayed-typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/testing/testing-controllers.md
+++ b/guides/v3.14.0/testing/testing-controllers.md
@@ -79,3 +79,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/testing/testing-helpers.md
+++ b/guides/v3.14.0/testing/testing-helpers.md
@@ -96,3 +96,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/testing/testing-routes.md
+++ b/guides/v3.14.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/testing/unit-testing-basics.md
+++ b/guides/v3.14.0/testing/unit-testing-basics.md
@@ -183,3 +183,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.14.0/tutorial/hbs-helper.md
+++ b/guides/v3.14.0/tutorial/hbs-helper.md
@@ -129,3 +129,5 @@ module('Integration | Helper | rental-property-type', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/addons-and-dependencies/managing-dependencies.md
+++ b/guides/v3.2.0/addons-and-dependencies/managing-dependencies.md
@@ -149,3 +149,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/applications/dependency-injection.md
+++ b/guides/v3.2.0/applications/dependency-injection.md
@@ -258,3 +258,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/applications/services.md
+++ b/guides/v3.2.0/applications/services.md
@@ -140,3 +140,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/components/customizing-a-components-element.md
+++ b/guides/v3.2.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.2.0/components/passing-properties-to-a-component.md
@@ -102,3 +102,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/components/the-component-lifecycle.md
+++ b/guides/v3.2.0/components/the-component-lifecycle.md
@@ -275,3 +275,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/configuring-ember/configuring-your-app.md
+++ b/guides/v3.2.0/configuring-ember/configuring-your-app.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.2.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.2.0/configuring-ember/embedding-applications.md
@@ -94,3 +94,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/ember-inspector/promises.md
+++ b/guides/v3.2.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/getting-started/core-concepts.md
+++ b/guides/v3.2.0/getting-started/core-concepts.md
@@ -81,3 +81,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/getting-started/quick-start.md
+++ b/guides/v3.2.0/getting-started/quick-start.md
@@ -295,3 +295,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/models/defining-models.md
+++ b/guides/v3.2.0/models/defining-models.md
@@ -158,3 +158,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/models/finding-records.md
+++ b/guides/v3.2.0/models/finding-records.md
@@ -114,3 +114,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/object-model/bindings.md
+++ b/guides/v3.2.0/object-model/bindings.md
@@ -72,3 +72,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/object-model/enumerables.md
+++ b/guides/v3.2.0/object-model/enumerables.md
@@ -207,3 +207,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/object-model/observers.md
+++ b/guides/v3.2.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.2.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/routing/asynchronous-routing.md
+++ b/guides/v3.2.0/routing/asynchronous-routing.md
@@ -171,3 +171,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/routing/loading-and-error-substates.md
+++ b/guides/v3.2.0/routing/loading-and-error-substates.md
@@ -250,3 +250,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.2.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/routing/query-params.md
+++ b/guides/v3.2.0/routing/query-params.md
@@ -338,3 +338,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/routing/redirection.md
+++ b/guides/v3.2.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/templates/binding-element-attributes.md
+++ b/guides/v3.2.0/templates/binding-element-attributes.md
@@ -74,3 +74,5 @@ Now the same template above renders the following HTML:
 ```html
 <a id="ember239" class="ember-view" href="#/photos" data-toggle="dropdown" lang="es">Fotos</a>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/templates/conditionals.md
+++ b/guides/v3.2.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/templates/development-helpers.md
+++ b/guides/v3.2.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.2.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.2.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/templates/links.md
+++ b/guides/v3.2.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/templates/writing-helpers.md
+++ b/guides/v3.2.0/templates/writing-helpers.md
@@ -392,3 +392,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/testing/testing-components.md
+++ b/guides/v3.2.0/testing/testing-components.md
@@ -521,3 +521,5 @@ module('Integration | Component | delayed typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/testing/testing-controllers.md
+++ b/guides/v3.2.0/testing/testing-controllers.md
@@ -79,3 +79,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/testing/testing-helpers.md
+++ b/guides/v3.2.0/testing/testing-helpers.md
@@ -94,3 +94,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/testing/testing-routes.md
+++ b/guides/v3.2.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/testing/unit-testing-basics.md
+++ b/guides/v3.2.0/testing/unit-testing-basics.md
@@ -183,3 +183,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/tutorial/ember-cli.md
+++ b/guides/v3.2.0/tutorial/ember-cli.md
@@ -140,3 +140,5 @@ The application should now be a completely blank canvas to build our application
 {{outlet}}
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.2.0/tutorial/hbs-helper.md
+++ b/guides/v3.2.0/tutorial/hbs-helper.md
@@ -125,3 +125,5 @@ module('Integration | Helper | my-helper', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/addons-and-dependencies/managing-dependencies.md
+++ b/guides/v3.3.0/addons-and-dependencies/managing-dependencies.md
@@ -149,3 +149,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/applications/dependency-injection.md
+++ b/guides/v3.3.0/applications/dependency-injection.md
@@ -258,3 +258,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/applications/services.md
+++ b/guides/v3.3.0/applications/services.md
@@ -140,3 +140,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/components/customizing-a-components-element.md
+++ b/guides/v3.3.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.3.0/components/passing-properties-to-a-component.md
@@ -102,3 +102,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/components/the-component-lifecycle.md
+++ b/guides/v3.3.0/components/the-component-lifecycle.md
@@ -275,3 +275,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/configuring-ember/configuring-your-app.md
+++ b/guides/v3.3.0/configuring-ember/configuring-your-app.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.3.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.3.0/configuring-ember/embedding-applications.md
@@ -94,3 +94,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/ember-inspector/promises.md
+++ b/guides/v3.3.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/getting-started/core-concepts.md
+++ b/guides/v3.3.0/getting-started/core-concepts.md
@@ -81,3 +81,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/getting-started/quick-start.md
+++ b/guides/v3.3.0/getting-started/quick-start.md
@@ -295,3 +295,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/models/defining-models.md
+++ b/guides/v3.3.0/models/defining-models.md
@@ -158,3 +158,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/models/finding-records.md
+++ b/guides/v3.3.0/models/finding-records.md
@@ -122,3 +122,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/object-model/bindings.md
+++ b/guides/v3.3.0/object-model/bindings.md
@@ -72,3 +72,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/object-model/classes-and-instances.md
+++ b/guides/v3.3.0/object-model/classes-and-instances.md
@@ -253,3 +253,5 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/object-model/enumerables.md
+++ b/guides/v3.3.0/object-model/enumerables.md
@@ -207,3 +207,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/object-model/observers.md
+++ b/guides/v3.3.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.3.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/routing/asynchronous-routing.md
+++ b/guides/v3.3.0/routing/asynchronous-routing.md
@@ -171,3 +171,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/routing/loading-and-error-substates.md
+++ b/guides/v3.3.0/routing/loading-and-error-substates.md
@@ -250,3 +250,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.3.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/routing/query-params.md
+++ b/guides/v3.3.0/routing/query-params.md
@@ -338,3 +338,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/routing/redirection.md
+++ b/guides/v3.3.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/templates/binding-element-attributes.md
+++ b/guides/v3.3.0/templates/binding-element-attributes.md
@@ -74,3 +74,5 @@ Now the same template above renders the following HTML:
 ```html
 <a id="ember239" class="ember-view" href="#/photos" data-toggle="dropdown" lang="es">Fotos</a>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/templates/conditionals.md
+++ b/guides/v3.3.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/templates/development-helpers.md
+++ b/guides/v3.3.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.3.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.3.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/templates/links.md
+++ b/guides/v3.3.0/templates/links.md
@@ -162,3 +162,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/templates/writing-helpers.md
+++ b/guides/v3.3.0/templates/writing-helpers.md
@@ -392,3 +392,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/testing/testing-components.md
+++ b/guides/v3.3.0/testing/testing-components.md
@@ -521,3 +521,5 @@ module('Integration | Component | delayed typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/testing/testing-controllers.md
+++ b/guides/v3.3.0/testing/testing-controllers.md
@@ -79,3 +79,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/testing/testing-helpers.md
+++ b/guides/v3.3.0/testing/testing-helpers.md
@@ -94,3 +94,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/testing/testing-routes.md
+++ b/guides/v3.3.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/testing/unit-testing-basics.md
+++ b/guides/v3.3.0/testing/unit-testing-basics.md
@@ -183,3 +183,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/tutorial/ember-cli.md
+++ b/guides/v3.3.0/tutorial/ember-cli.md
@@ -140,3 +140,5 @@ The application should now be a completely blank canvas to build our application
 {{outlet}}
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.3.0/tutorial/hbs-helper.md
+++ b/guides/v3.3.0/tutorial/hbs-helper.md
@@ -125,3 +125,5 @@ module('Integration | Helper | my-helper', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/addons-and-dependencies/managing-dependencies.md
+++ b/guides/v3.4.0/addons-and-dependencies/managing-dependencies.md
@@ -157,3 +157,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/applications/dependency-injection.md
+++ b/guides/v3.4.0/applications/dependency-injection.md
@@ -258,3 +258,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/applications/services.md
+++ b/guides/v3.4.0/applications/services.md
@@ -140,3 +140,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/components/customizing-a-components-element.md
+++ b/guides/v3.4.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.4.0/components/passing-properties-to-a-component.md
@@ -117,3 +117,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/components/the-component-lifecycle.md
+++ b/guides/v3.4.0/components/the-component-lifecycle.md
@@ -277,3 +277,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/configuring-ember/configuring-your-app.md
+++ b/guides/v3.4.0/configuring-ember/configuring-your-app.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.4.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.4.0/configuring-ember/embedding-applications.md
@@ -94,3 +94,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/ember-inspector/promises.md
+++ b/guides/v3.4.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/getting-started/core-concepts.md
+++ b/guides/v3.4.0/getting-started/core-concepts.md
@@ -81,3 +81,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/getting-started/quick-start.md
+++ b/guides/v3.4.0/getting-started/quick-start.md
@@ -295,3 +295,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/models/defining-models.md
+++ b/guides/v3.4.0/models/defining-models.md
@@ -158,3 +158,5 @@ export default DS.Model.extend({
   })
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/models/finding-records.md
+++ b/guides/v3.4.0/models/finding-records.md
@@ -122,3 +122,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/object-model/bindings.md
+++ b/guides/v3.4.0/object-model/bindings.md
@@ -72,3 +72,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/object-model/classes-and-instances.md
+++ b/guides/v3.4.0/object-model/classes-and-instances.md
@@ -253,3 +253,5 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/object-model/enumerables.md
+++ b/guides/v3.4.0/object-model/enumerables.md
@@ -207,3 +207,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/object-model/observers.md
+++ b/guides/v3.4.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.4.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/routing/asynchronous-routing.md
+++ b/guides/v3.4.0/routing/asynchronous-routing.md
@@ -171,3 +171,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/routing/loading-and-error-substates.md
+++ b/guides/v3.4.0/routing/loading-and-error-substates.md
@@ -250,3 +250,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.4.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/routing/query-params.md
+++ b/guides/v3.4.0/routing/query-params.md
@@ -343,3 +343,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/routing/redirection.md
+++ b/guides/v3.4.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/templates/binding-element-attributes.md
+++ b/guides/v3.4.0/templates/binding-element-attributes.md
@@ -74,3 +74,5 @@ Now the same template above renders the following HTML:
 ```html
 <a id="ember239" class="ember-view" href="#/photos" data-toggle="dropdown" lang="es">Fotos</a>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/templates/conditionals.md
+++ b/guides/v3.4.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/templates/development-helpers.md
+++ b/guides/v3.4.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.4.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.4.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/templates/links.md
+++ b/guides/v3.4.0/templates/links.md
@@ -162,3 +162,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/templates/writing-helpers.md
+++ b/guides/v3.4.0/templates/writing-helpers.md
@@ -392,3 +392,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/testing/testing-components.md
+++ b/guides/v3.4.0/testing/testing-components.md
@@ -522,3 +522,5 @@ module('Integration | Component | delayed typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/testing/testing-controllers.md
+++ b/guides/v3.4.0/testing/testing-controllers.md
@@ -79,3 +79,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/testing/testing-helpers.md
+++ b/guides/v3.4.0/testing/testing-helpers.md
@@ -94,3 +94,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/testing/testing-routes.md
+++ b/guides/v3.4.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/testing/unit-testing-basics.md
+++ b/guides/v3.4.0/testing/unit-testing-basics.md
@@ -183,3 +183,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/tutorial/ember-cli.md
+++ b/guides/v3.4.0/tutorial/ember-cli.md
@@ -140,3 +140,5 @@ The application should now be a completely blank canvas to build our application
 {{outlet}}
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.4.0/tutorial/hbs-helper.md
+++ b/guides/v3.4.0/tutorial/hbs-helper.md
@@ -125,3 +125,5 @@ module('Integration | Helper | my-helper', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/addons-and-dependencies/managing-dependencies.md
+++ b/guides/v3.5.0/addons-and-dependencies/managing-dependencies.md
@@ -157,3 +157,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/applications/dependency-injection.md
+++ b/guides/v3.5.0/applications/dependency-injection.md
@@ -260,3 +260,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/applications/services.md
+++ b/guides/v3.5.0/applications/services.md
@@ -140,3 +140,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/components/customizing-a-components-element.md
+++ b/guides/v3.5.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.5.0/components/passing-properties-to-a-component.md
@@ -117,3 +117,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/components/the-component-lifecycle.md
+++ b/guides/v3.5.0/components/the-component-lifecycle.md
@@ -277,3 +277,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/configuring-ember/configuring-your-app.md
+++ b/guides/v3.5.0/configuring-ember/configuring-your-app.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.5.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.5.0/configuring-ember/embedding-applications.md
@@ -96,3 +96,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/ember-inspector/promises.md
+++ b/guides/v3.5.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/getting-started/core-concepts.md
+++ b/guides/v3.5.0/getting-started/core-concepts.md
@@ -81,3 +81,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/getting-started/quick-start.md
+++ b/guides/v3.5.0/getting-started/quick-start.md
@@ -295,3 +295,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/models/defining-models.md
+++ b/guides/v3.5.0/models/defining-models.md
@@ -178,3 +178,5 @@ tags: DS.attr() // a read-only array
 ```handlebars
 {{model.location.latitude}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/models/finding-records.md
+++ b/guides/v3.5.0/models/finding-records.md
@@ -122,3 +122,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/object-model/bindings.md
+++ b/guides/v3.5.0/object-model/bindings.md
@@ -72,3 +72,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/object-model/classes-and-instances.md
+++ b/guides/v3.5.0/object-model/classes-and-instances.md
@@ -253,3 +253,5 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/object-model/enumerables.md
+++ b/guides/v3.5.0/object-model/enumerables.md
@@ -207,3 +207,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/object-model/observers.md
+++ b/guides/v3.5.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.5.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/routing/asynchronous-routing.md
+++ b/guides/v3.5.0/routing/asynchronous-routing.md
@@ -171,3 +171,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/routing/loading-and-error-substates.md
+++ b/guides/v3.5.0/routing/loading-and-error-substates.md
@@ -264,3 +264,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.5.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/routing/query-params.md
+++ b/guides/v3.5.0/routing/query-params.md
@@ -350,3 +350,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/routing/redirection.md
+++ b/guides/v3.5.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/templates/binding-element-attributes.md
+++ b/guides/v3.5.0/templates/binding-element-attributes.md
@@ -74,3 +74,5 @@ Now the same template above renders the following HTML:
 ```html
 <a id="ember239" class="ember-view" href="#/photos" data-toggle="dropdown" lang="es">Fotos</a>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/templates/conditionals.md
+++ b/guides/v3.5.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/templates/development-helpers.md
+++ b/guides/v3.5.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.5.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.5.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/templates/links.md
+++ b/guides/v3.5.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/templates/writing-helpers.md
+++ b/guides/v3.5.0/templates/writing-helpers.md
@@ -392,3 +392,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/testing/testing-components.md
+++ b/guides/v3.5.0/testing/testing-components.md
@@ -522,3 +522,5 @@ module('Integration | Component | delayed typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/testing/testing-controllers.md
+++ b/guides/v3.5.0/testing/testing-controllers.md
@@ -79,3 +79,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/testing/testing-helpers.md
+++ b/guides/v3.5.0/testing/testing-helpers.md
@@ -94,3 +94,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/testing/testing-routes.md
+++ b/guides/v3.5.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/testing/unit-testing-basics.md
+++ b/guides/v3.5.0/testing/unit-testing-basics.md
@@ -183,3 +183,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.5.0/tutorial/hbs-helper.md
+++ b/guides/v3.5.0/tutorial/hbs-helper.md
@@ -129,3 +129,5 @@ module('Integration | Helper | my-helper', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/addons-and-dependencies/managing-dependencies.md
+++ b/guides/v3.6.0/addons-and-dependencies/managing-dependencies.md
@@ -169,3 +169,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/applications/dependency-injection.md
+++ b/guides/v3.6.0/applications/dependency-injection.md
@@ -260,3 +260,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/applications/services.md
+++ b/guides/v3.6.0/applications/services.md
@@ -140,3 +140,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/components/customizing-a-components-element.md
+++ b/guides/v3.6.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.6.0/components/passing-properties-to-a-component.md
@@ -117,3 +117,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/components/the-component-lifecycle.md
+++ b/guides/v3.6.0/components/the-component-lifecycle.md
@@ -277,3 +277,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/configuring-ember/configuring-your-app.md
+++ b/guides/v3.6.0/configuring-ember/configuring-your-app.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.6.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.6.0/configuring-ember/embedding-applications.md
@@ -99,3 +99,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/ember-inspector/promises.md
+++ b/guides/v3.6.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/getting-started/core-concepts.md
+++ b/guides/v3.6.0/getting-started/core-concepts.md
@@ -81,3 +81,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/getting-started/quick-start.md
+++ b/guides/v3.6.0/getting-started/quick-start.md
@@ -295,3 +295,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/models/defining-models.md
+++ b/guides/v3.6.0/models/defining-models.md
@@ -178,3 +178,5 @@ tags: DS.attr() // a read-only array
 ```handlebars
 {{this.model.location.latitude}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/models/finding-records.md
+++ b/guides/v3.6.0/models/finding-records.md
@@ -122,3 +122,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/object-model/bindings.md
+++ b/guides/v3.6.0/object-model/bindings.md
@@ -72,3 +72,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/object-model/classes-and-instances.md
+++ b/guides/v3.6.0/object-model/classes-and-instances.md
@@ -253,3 +253,5 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/object-model/enumerables.md
+++ b/guides/v3.6.0/object-model/enumerables.md
@@ -207,3 +207,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/object-model/observers.md
+++ b/guides/v3.6.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.6.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/routing/asynchronous-routing.md
+++ b/guides/v3.6.0/routing/asynchronous-routing.md
@@ -171,3 +171,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/routing/loading-and-error-substates.md
+++ b/guides/v3.6.0/routing/loading-and-error-substates.md
@@ -264,3 +264,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.6.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/routing/query-params.md
+++ b/guides/v3.6.0/routing/query-params.md
@@ -350,3 +350,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/routing/redirection.md
+++ b/guides/v3.6.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/templates/binding-element-attributes.md
+++ b/guides/v3.6.0/templates/binding-element-attributes.md
@@ -74,3 +74,5 @@ Now the same template above renders the following HTML:
 ```html
 <a id="ember239" class="ember-view" href="#/photos" data-toggle="dropdown" lang="es">Fotos</a>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/templates/conditionals.md
+++ b/guides/v3.6.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{this.total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/templates/development-helpers.md
+++ b/guides/v3.6.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.6.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.6.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/templates/links.md
+++ b/guides/v3.6.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/templates/writing-helpers.md
+++ b/guides/v3.6.0/templates/writing-helpers.md
@@ -392,3 +392,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/testing/testing-components.md
+++ b/guides/v3.6.0/testing/testing-components.md
@@ -522,3 +522,5 @@ module('Integration | Component | delayed typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/testing/testing-controllers.md
+++ b/guides/v3.6.0/testing/testing-controllers.md
@@ -79,3 +79,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/testing/testing-helpers.md
+++ b/guides/v3.6.0/testing/testing-helpers.md
@@ -94,3 +94,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/testing/testing-routes.md
+++ b/guides/v3.6.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/testing/unit-testing-basics.md
+++ b/guides/v3.6.0/testing/unit-testing-basics.md
@@ -183,3 +183,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.6.0/tutorial/hbs-helper.md
+++ b/guides/v3.6.0/tutorial/hbs-helper.md
@@ -129,3 +129,5 @@ module('Integration | Helper | my-helper', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/addons-and-dependencies/managing-dependencies.md
+++ b/guides/v3.7.0/addons-and-dependencies/managing-dependencies.md
@@ -169,3 +169,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/applications/dependency-injection.md
+++ b/guides/v3.7.0/applications/dependency-injection.md
@@ -260,3 +260,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/applications/services.md
+++ b/guides/v3.7.0/applications/services.md
@@ -140,3 +140,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/components/customizing-a-components-element.md
+++ b/guides/v3.7.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.7.0/components/passing-properties-to-a-component.md
@@ -119,3 +119,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/components/the-component-lifecycle.md
+++ b/guides/v3.7.0/components/the-component-lifecycle.md
@@ -277,3 +277,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/configuring-ember/configuring-your-app.md
+++ b/guides/v3.7.0/configuring-ember/configuring-your-app.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.7.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.7.0/configuring-ember/embedding-applications.md
@@ -99,3 +99,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/ember-inspector/promises.md
+++ b/guides/v3.7.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/getting-started/core-concepts.md
+++ b/guides/v3.7.0/getting-started/core-concepts.md
@@ -81,3 +81,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/getting-started/quick-start.md
+++ b/guides/v3.7.0/getting-started/quick-start.md
@@ -294,3 +294,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/models/defining-models.md
+++ b/guides/v3.7.0/models/defining-models.md
@@ -178,3 +178,5 @@ tags: DS.attr() // a read-only array
 ```handlebars
 {{this.model.location.latitude}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/models/finding-records.md
+++ b/guides/v3.7.0/models/finding-records.md
@@ -122,3 +122,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/object-model/bindings.md
+++ b/guides/v3.7.0/object-model/bindings.md
@@ -72,3 +72,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/object-model/classes-and-instances.md
+++ b/guides/v3.7.0/object-model/classes-and-instances.md
@@ -253,3 +253,5 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/object-model/enumerables.md
+++ b/guides/v3.7.0/object-model/enumerables.md
@@ -207,3 +207,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/object-model/observers.md
+++ b/guides/v3.7.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.7.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/reference/syntax-conversion-guide.md
+++ b/guides/v3.7.0/reference/syntax-conversion-guide.md
@@ -112,3 +112,5 @@ When you need direct support for positional arguments or if your components are 
 {{some-component param1 param2}}
 {{ui/foo-bar}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/routing/asynchronous-routing.md
+++ b/guides/v3.7.0/routing/asynchronous-routing.md
@@ -171,3 +171,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/routing/loading-and-error-substates.md
+++ b/guides/v3.7.0/routing/loading-and-error-substates.md
@@ -264,3 +264,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.7.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/routing/query-params.md
+++ b/guides/v3.7.0/routing/query-params.md
@@ -350,3 +350,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/routing/redirection.md
+++ b/guides/v3.7.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/templates/binding-element-attributes.md
+++ b/guides/v3.7.0/templates/binding-element-attributes.md
@@ -74,3 +74,5 @@ Now the same template above renders the following HTML:
 ```html
 <a id="ember239" class="ember-view" href="#/photos" data-toggle="dropdown" lang="es">Fotos</a>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/templates/built-in-helpers.md
+++ b/guides/v3.7.0/templates/built-in-helpers.md
@@ -90,3 +90,5 @@ In the component's template, you can then use the `people` argument as an array:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/templates/conditionals.md
+++ b/guides/v3.7.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{this.total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/templates/development-helpers.md
+++ b/guides/v3.7.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.7.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.7.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/templates/links.md
+++ b/guides/v3.7.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/templates/writing-helpers.md
+++ b/guides/v3.7.0/templates/writing-helpers.md
@@ -392,3 +392,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/testing/testing-components.md
+++ b/guides/v3.7.0/testing/testing-components.md
@@ -522,3 +522,5 @@ module('Integration | Component | delayed-typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/testing/testing-controllers.md
+++ b/guides/v3.7.0/testing/testing-controllers.md
@@ -79,3 +79,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/testing/testing-helpers.md
+++ b/guides/v3.7.0/testing/testing-helpers.md
@@ -94,3 +94,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/testing/testing-routes.md
+++ b/guides/v3.7.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/testing/unit-testing-basics.md
+++ b/guides/v3.7.0/testing/unit-testing-basics.md
@@ -183,3 +183,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.7.0/tutorial/hbs-helper.md
+++ b/guides/v3.7.0/tutorial/hbs-helper.md
@@ -129,3 +129,5 @@ module('Integration | Helper | my-helper', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/addons-and-dependencies/managing-dependencies.md
+++ b/guides/v3.8.0/addons-and-dependencies/managing-dependencies.md
@@ -169,3 +169,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/applications/dependency-injection.md
+++ b/guides/v3.8.0/applications/dependency-injection.md
@@ -260,3 +260,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/applications/services.md
+++ b/guides/v3.8.0/applications/services.md
@@ -141,3 +141,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/components/customizing-a-components-element.md
+++ b/guides/v3.8.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.8.0/components/passing-properties-to-a-component.md
@@ -119,3 +119,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/components/the-component-lifecycle.md
+++ b/guides/v3.8.0/components/the-component-lifecycle.md
@@ -279,3 +279,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/configuring-ember/configuring-your-app.md
+++ b/guides/v3.8.0/configuring-ember/configuring-your-app.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.8.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.8.0/configuring-ember/embedding-applications.md
@@ -99,3 +99,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/ember-inspector/promises.md
+++ b/guides/v3.8.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/getting-started/core-concepts.md
+++ b/guides/v3.8.0/getting-started/core-concepts.md
@@ -81,3 +81,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/getting-started/quick-start.md
+++ b/guides/v3.8.0/getting-started/quick-start.md
@@ -294,3 +294,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/models/defining-models.md
+++ b/guides/v3.8.0/models/defining-models.md
@@ -178,3 +178,5 @@ tags: DS.attr() // a read-only array
 ```handlebars
 {{this.model.location.latitude}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/models/finding-records.md
+++ b/guides/v3.8.0/models/finding-records.md
@@ -122,3 +122,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/object-model/bindings.md
+++ b/guides/v3.8.0/object-model/bindings.md
@@ -72,3 +72,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/object-model/classes-and-instances.md
+++ b/guides/v3.8.0/object-model/classes-and-instances.md
@@ -252,3 +252,5 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/object-model/enumerables.md
+++ b/guides/v3.8.0/object-model/enumerables.md
@@ -235,3 +235,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/object-model/observers.md
+++ b/guides/v3.8.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.8.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/reference/syntax-conversion-guide.md
+++ b/guides/v3.8.0/reference/syntax-conversion-guide.md
@@ -112,3 +112,5 @@ When you need direct support for positional arguments or if your components are 
 {{some-component param1 param2}}
 {{ui/foo-bar}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/routing/asynchronous-routing.md
+++ b/guides/v3.8.0/routing/asynchronous-routing.md
@@ -164,3 +164,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/routing/loading-and-error-substates.md
+++ b/guides/v3.8.0/routing/loading-and-error-substates.md
@@ -264,3 +264,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.8.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/routing/query-params.md
+++ b/guides/v3.8.0/routing/query-params.md
@@ -350,3 +350,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/routing/redirection.md
+++ b/guides/v3.8.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/templates/binding-element-attributes.md
+++ b/guides/v3.8.0/templates/binding-element-attributes.md
@@ -74,3 +74,5 @@ Now the same template above renders the following HTML:
 ```html
 <a id="ember239" class="ember-view" href="#/photos" data-toggle="dropdown" lang="es">Fotos</a>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/templates/built-in-helpers.md
+++ b/guides/v3.8.0/templates/built-in-helpers.md
@@ -90,3 +90,5 @@ In the component's template, you can then use the `people` argument as an array:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/templates/conditionals.md
+++ b/guides/v3.8.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{this.total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/templates/development-helpers.md
+++ b/guides/v3.8.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.8.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.8.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/templates/links.md
+++ b/guides/v3.8.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/templates/writing-helpers.md
+++ b/guides/v3.8.0/templates/writing-helpers.md
@@ -392,3 +392,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/testing/testing-components.md
+++ b/guides/v3.8.0/testing/testing-components.md
@@ -522,3 +522,5 @@ module('Integration | Component | delayed-typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/testing/testing-controllers.md
+++ b/guides/v3.8.0/testing/testing-controllers.md
@@ -79,3 +79,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/testing/testing-helpers.md
+++ b/guides/v3.8.0/testing/testing-helpers.md
@@ -94,3 +94,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/testing/testing-routes.md
+++ b/guides/v3.8.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/testing/unit-testing-basics.md
+++ b/guides/v3.8.0/testing/unit-testing-basics.md
@@ -183,3 +183,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.8.0/tutorial/hbs-helper.md
+++ b/guides/v3.8.0/tutorial/hbs-helper.md
@@ -129,3 +129,5 @@ module('Integration | Helper | my-helper', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/addons-and-dependencies/managing-dependencies.md
+++ b/guides/v3.9.0/addons-and-dependencies/managing-dependencies.md
@@ -169,3 +169,5 @@ app.import('node_modules/es5-shim/es5-shim.js', {
   prepend: true
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/applications/dependency-injection.md
+++ b/guides/v3.9.0/applications/dependency-injection.md
@@ -260,3 +260,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/applications/services.md
+++ b/guides/v3.9.0/applications/services.md
@@ -141,3 +141,5 @@ Note `cart` being used below to get data from the cart.
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/components/customizing-a-components-element.md
+++ b/guides/v3.9.0/components/customizing-a-components-element.md
@@ -203,3 +203,5 @@ This would render this HTML when no title is passed to the component:
 ```html
 <span class="ember-view" title="Ember JS">
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.9.0/components/passing-properties-to-a-component.md
@@ -119,3 +119,5 @@ export default Component.extend({
   positionalParams: 'params'
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/components/the-component-lifecycle.md
+++ b/guides/v3.9.0/components/the-component-lifecycle.md
@@ -279,3 +279,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/configuring-ember/configuring-your-app.md
+++ b/guides/v3.9.0/configuring-ember/configuring-your-app.md
@@ -17,3 +17,5 @@ if (ENV.environment === 'development') {
   // ...
 }
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.9.0/configuring-ember/disabling-prototype-extensions.md
@@ -162,3 +162,5 @@ doStuffWhenInserted: on('didInsertElement', function() {
   /* awesome sauce */
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/configuring-ember/embedding-applications.md
+++ b/guides/v3.9.0/configuring-ember/embedding-applications.md
@@ -99,3 +99,5 @@ Router.map(function() {
 
 export default Router;
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/ember-inspector/promises.md
+++ b/guides/v3.9.0/ember-inspector/promises.md
@@ -84,3 +84,5 @@ promise.catch(callback, label);
 promise.finally(callback, label);
 
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/getting-started/core-concepts.md
+++ b/guides/v3.9.0/getting-started/core-concepts.md
@@ -81,3 +81,5 @@ export default Component.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/getting-started/quick-start.md
+++ b/guides/v3.9.0/getting-started/quick-start.md
@@ -294,3 +294,5 @@ add the following directive to the application's virtual host configuration:
 ```apacheconf
 FallbackResource index.html
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/models/defining-models.md
+++ b/guides/v3.9.0/models/defining-models.md
@@ -178,3 +178,5 @@ tags: DS.attr() // a read-only array
 ```handlebars
 {{this.model.location.latitude}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/models/finding-records.md
+++ b/guides/v3.9.0/models/finding-records.md
@@ -122,3 +122,5 @@ tom = store.query('user', {
   return users.get("firstObject");
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/object-model/bindings.md
+++ b/guides/v3.9.0/object-model/bindings.md
@@ -72,3 +72,5 @@ user.set('fullName', 'Krang Gates');
 userComponent.set('userName', 'Truckasaurus Gates');
 user.get('fullName'); // "Krang Gates"
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/object-model/classes-and-instances.md
+++ b/guides/v3.9.0/object-model/classes-and-instances.md
@@ -252,3 +252,5 @@ person.name; // 'Robert Jackson'
 person.set('name', 'Tobias Fünke');
 person.name; // 'Tobias Fünke'
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/object-model/enumerables.md
+++ b/guides/v3.9.0/object-model/enumerables.md
@@ -235,3 +235,5 @@ analogous `isEvery()` and `isAny()` methods.
 people.isEvery('isHappy', true); // false
 people.isAny('isHappy', true);  // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/object-model/observers.md
+++ b/guides/v3.9.0/object-model/observers.md
@@ -153,3 +153,5 @@ person.addObserver('fullName', function() {
   // deal with the change
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.9.0/object-model/reopening-classes-and-instances.md
@@ -44,3 +44,5 @@ Person.reopen({
 Person.isPerson; // false - because it is static property created by `reopenClass`
 Person.create().get('isPerson'); // true
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/reference/syntax-conversion-guide.md
+++ b/guides/v3.9.0/reference/syntax-conversion-guide.md
@@ -112,3 +112,5 @@ When you need direct support for positional arguments or if your components are 
 {{some-component param1 param2}}
 {{ui/foo-bar}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/routing/asynchronous-routing.md
+++ b/guides/v3.9.0/routing/asynchronous-routing.md
@@ -164,3 +164,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/routing/loading-and-error-substates.md
+++ b/guides/v3.9.0/routing/loading-and-error-substates.md
@@ -264,3 +264,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/routing/preventing-and-retrying-transitions.md
+++ b/guides/v3.9.0/routing/preventing-and-retrying-transitions.md
@@ -106,3 +106,5 @@ export default Controller.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/routing/query-params.md
+++ b/guides/v3.9.0/routing/query-params.md
@@ -350,3 +350,5 @@ export default Controller.extend({
   ]
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/routing/redirection.md
+++ b/guides/v3.9.0/routing/redirection.md
@@ -112,3 +112,5 @@ export default Route.extend({
   }
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/templates/binding-element-attributes.md
+++ b/guides/v3.9.0/templates/binding-element-attributes.md
@@ -74,3 +74,5 @@ Now the same template above renders the following HTML:
 ```html
 <a id="ember239" class="ember-view" href="#/photos" data-toggle="dropdown" lang="es">Fotos</a>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/templates/built-in-helpers.md
+++ b/guides/v3.9.0/templates/built-in-helpers.md
@@ -90,3 +90,5 @@ In the component's template, you can then use the `people` argument as an array:
   {{/each}}
 </ul>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/templates/conditionals.md
+++ b/guides/v3.9.0/templates/conditionals.md
@@ -90,3 +90,5 @@ template only shows an amount due when the user has not paid:
   You owe: ${{this.total}}
 {{/unless}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/templates/development-helpers.md
+++ b/guides/v3.9.0/templates/development-helpers.md
@@ -57,3 +57,5 @@ you expect:
 ```javascript
 > context
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.9.0/templates/displaying-a-list-of-items.md
@@ -77,3 +77,5 @@ render if the array passed to `{{#each}}` is empty:
   Sorry, nobody is here.
 {{/each}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.9.0/templates/displaying-the-keys-in-an-object.md
@@ -74,3 +74,5 @@ The contents of this block will render if the object is empty, null, or undefine
   Sorry, nobody is here.
 {{/each-in}}
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/templates/links.md
+++ b/guides/v3.9.0/templates/links.md
@@ -163,3 +163,5 @@ can use the `replace=true` option:
   {{/link-to}}
 </p>
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/templates/writing-helpers.md
+++ b/guides/v3.9.0/templates/writing-helpers.md
@@ -392,3 +392,5 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/testing/testing-components.md
+++ b/guides/v3.9.0/testing/testing-components.md
@@ -522,3 +522,5 @@ module('Integration | Component | delayed-typeahead', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/testing/testing-controllers.md
+++ b/guides/v3.9.0/testing/testing-controllers.md
@@ -79,3 +79,5 @@ module('Unit | Controller | posts', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/testing/testing-helpers.md
+++ b/guides/v3.9.0/testing/testing-helpers.md
@@ -94,3 +94,5 @@ module('Integration | Helper | format currency', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/testing/testing-routes.md
+++ b/guides/v3.9.0/testing/testing-routes.md
@@ -86,3 +86,5 @@ module('Unit | Route | application', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/testing/unit-testing-basics.md
+++ b/guides/v3.9.0/testing/unit-testing-basics.md
@@ -183,3 +183,5 @@ skip('skip this test', function(assert) {
     assert.ok(true)
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.9.0/tutorial/hbs-helper.md
+++ b/guides/v3.9.0/tutorial/hbs-helper.md
@@ -129,3 +129,5 @@ module('Integration | Helper | my-helper', function(hooks) {
   });
 });
 ```
+
+<!-- eof - needed for pages that end in a code block  -->


### PR DESCRIPTION
This is needed due to an interaction between our parisng tools and the glimmer renderer. Part of the work for #1264

Without this, upgrading our dependencies results in parsing failures that manifest like this in our tests and in the console:

```
Source: | TypeError: Cannot read property 'nextSibling' of null     at clear (http://localhost:7357/assets/vendor.js:51012:26)     at UpdatableBlockTracker.reset
```

This PR helps to unblock an infinite rendering issue noted by contributors in the past: https://github.com/empress/guidemaker/issues/27