### PR TITLE
Adds Model suffix

### DIFF
--- a/guides/release/models/defining-models.md
+++ b/guides/release/models/defining-models.md
@@ -84,7 +84,7 @@ which coerce the value to the JavaScript type that matches its name.
 ```javascript {data-filename=app/models/person.js}
 import Model, { attr } from '@ember-data/model';
 
-export default class Person extends Model {
+export default class PersonModel extends Model {
   @attr('string') name;
   @attr('number') age;
   @attr('boolean') admin;


### PR DESCRIPTION
The example above uses `PersonModel`. Figured this example should be consistent.