### PR TITLE
Simplify remark ignore file

### DIFF
--- a/.remarkignore
+++ b/.remarkignore
@@ -1,29 +1,12 @@
 CONTRIBUTING.*
 README.*
 MAINTAINERS.md
-guides/v1.10.0/**/*.md
-guides/v1.11.0/**/*.md
-guides/v1.12.0/**/*.md
-guides/v1.13.0/**/*.md
-guides/v2.0.0/**/*.md
-guides/v2.1.0/**/*.md
-guides/v2.2.0/**/*.md
-guides/v2.3.0/**/*.md
-guides/v2.4.0/**/*.md
-guides/v2.5.0/**/*.md
-guides/v2.6.0/**/*.md
-guides/v2.7.0/**/*.md
-guides/v2.8.0/**/*.md
-guides/v2.9.0/**/*.md
-guides/v2.10.0/**/*.md
-guides/v2.11.0/**/*.md
-guides/v2.12.0/**/*.md
-guides/v2.13.0/**/*.md
-guides/v2.14.0/**/*.md
-guides/v2.15.0/**/*.md
-guides/v2.16.0/**/*.md
-guides/v2.17.0/**/*.md
-guides/v2.18.0/**/*.md
+
+# old major versions
+guides/v1*/**/*.md
+guides/v2*/**/*.md
+
+# current major version
 guides/v3.0.0/**/*.md
 guides/v3.1.0/**/*.md
 guides/v3.2.0/**/*.md


### PR DESCRIPTION
Reduced the number of entires by globing old major versions vs individual releases.  This will make it easier to maintain the file over the long term.