### PR TITLE
Clean up services

### DIFF
--- a/guides/release/services/index.md
+++ b/guides/release/services/index.md
@@ -26,7 +26,7 @@ Services must extend the [`Service`](https://api.emberjs.com/ember/release/modul
 import Service from '@ember/service';
 
 export default class ShoppingCartService extends Service {
-};
+}
 ```
 
 Like any Ember object, a service is initialized and can have properties and methods of its own.
@@ -50,7 +50,7 @@ export default class ShoppingCartService extends Service {
   empty() {
     this.items.clear();
   }
-};
+}
 ```
 
 ### Accessing Services
@@ -69,7 +69,7 @@ import { inject as service } from '@ember/service';
 export default class CartContentsComponent extends Component {
   //will load the service in file /app/services/shopping-cart.js
   @service shoppingCart;
-};
+}
 ```
 
 Another way to inject a service is to provide the name of the service as the argument.
@@ -81,7 +81,7 @@ import { inject as service } from '@ember/service';
 export default class CartContentsComponent extends Component {
   //will load the service in file /app/services/shopping-cart.js
   @service('shopping-cart') cart;
-};
+}
 ```
 
 This injects the shopping cart service into the component and makes it available as the `cart` property.
@@ -99,7 +99,7 @@ export default class CartContentsComponent extends Component {
   get cart() {
     return getOwner(this).lookup('service:shopping-cart');
   }
-};
+}
 ```
 
 Injected properties are lazy loaded; meaning the service will not be instantiated until the property is explicitly called.
@@ -120,7 +120,7 @@ export default class CartContentsComponent extends Component {
 	remove(item) {
 		this.cart.remove(item);
 	}
-};
+}
 ```
 Once injected into a component, a service can also be used in the template.
 Note `cart` being used below to get data from the cart.

--- a/guides/release/services/index.md
+++ b/guides/release/services/index.md
@@ -56,10 +56,11 @@ export default class ShoppingCartService extends Service {
 ### Accessing Services
 
 To access a service,
-you can inject it in any container-resolved object such as a component or another service using the `inject` function from the `@ember/service` module.
-There are two ways to use this function.
+you can inject it in any container-resolved object such as a component or another service using the `inject` decorator from the `@ember/service` module.
+Standard practice is to alias `inject` as `service` to make it more clear that it is performing service injection.
+There are two ways to use this decorator.
 You can either invoke it with no arguments, or you can pass it the registered name of the service.
-When no arguments are passed, the service is loaded based on the name of the variable key.
+When no arguments are passed, the service is loaded based on the name of the decorated property.
 You can load the shopping cart service with no arguments like below.
 
 ```javascript {data-filename=app/components/cart-contents.js}
@@ -67,19 +68,21 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 
 export default class CartContentsComponent extends Component {
-  //will load the service in file /app/services/shopping-cart.js
+  // Will load the service defined in: app/services/shopping-cart.js
   @service shoppingCart;
 }
 ```
 
-Another way to inject a service is to provide the name of the service as the argument.
+This injects the shopping cart service into the component and makes it available as the `shoppingCart` property.
+
+Another way to inject a service is to provide the name of the service as an argument to the decorator.
 
 ```javascript {data-filename=app/components/cart-contents.js}
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 
 export default class CartContentsComponent extends Component {
-  //will load the service in file /app/services/shopping-cart.js
+  // Will load the service defined in: app/services/shopping-cart.js
   @service('shopping-cart') cart;
 }
 ```
@@ -95,7 +98,7 @@ import Component from '@glimmer/component';
 import { getOwner } from '@ember/application';
 
 export default class CartContentsComponent extends Component {
-  //will load the service in file /app/services/shopping-cart.js
+  // Will load the service defined in: app/services/shopping-cart.js
   get cart() {
     return getOwner(this).lookup('service:shopping-cart');
   }
@@ -122,6 +125,7 @@ export default class CartContentsComponent extends Component {
 	}
 }
 ```
+
 Once injected into a component, a service can also be used in the template.
 Note `cart` being used below to get data from the cart.
 

--- a/guides/release/services/index.md
+++ b/guides/release/services/index.md
@@ -119,10 +119,10 @@ import { action } from '@ember/object';
 export default class CartContentsComponent extends Component {
   @service('shopping-cart') cart;
 
-	@action
-	remove(item) {
-		this.cart.remove(item);
-	}
+  @action
+  remove(item) {
+    this.cart.remove(item);
+  }
 }
 ```
 

--- a/guides/release/services/index.md
+++ b/guides/release/services/index.md
@@ -37,7 +37,7 @@ import { A } from '@ember/array';
 import Service from '@ember/service';
 
 export default class ShoppingCartService extends Service {
-  items = [];
+  items = A([]);
 
   add(item) {
     this.items.pushObject(item);


### PR DESCRIPTION
This cleans up the services guide a bit and includes one fix.

Changes:
* fix: use `A()` to initialize items in shopping-cart service (it's currently imported, but never used)
* make improvements to verbiage for clarity and correctness including:
  * more specificity (decorator vs. function)
  * more correctness (decorated property vs. variable key)
  * a note explaining `inject as service`
* remove extraneous semicolons after class definitions
* replace tabs with spaces in one code example so it indents properly when rendered