### PR TITLE
Fixed "Endpoint Path Customization" example

### DIFF
--- a/guides/release/models/customizing-adapters.md
+++ b/guides/release/models/customizing-adapters.md
@@ -152,7 +152,7 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
 }
 ```
 
-Requests for `person` would now target `https://api.emberjs.com/1/people/1`.
+Requests for `person` would now target `https://api.emberjs.com/api/1/people/1`.
 
 
 #### Host Customization


### PR DESCRIPTION
The section "Endpoint Path Customization" contains an example of how to costumize the JSONAPIAdapter adapter namespace used.

The URL shown is missing part of the namespace specified in the example.