### PR TITLE
Update query-params.md

### DIFF
--- a/guides/release/routing/query-params.md
+++ b/guides/release/routing/query-params.md
@@ -32,6 +32,7 @@ import Controller from '@ember/controller';
 
 export default class ArticlesController extends Controller {
   queryParams = ['category'];
+  
   category = null;
 }
 ```
@@ -52,6 +53,7 @@ import Controller from '@ember/controller';
 
 export default class ArticlesController extends Controller {
   queryParams = ['category'];
+  
   @tracked category = null;
 
   @tracked model;
@@ -145,7 +147,7 @@ export default class ArticlesRoute extends Route {
     category: {
       refreshModel: true
     }
-  }
+  };
 
   model(params) {
     // This gets called upon entering 'articles' route
@@ -164,6 +166,7 @@ import Controller from '@ember/controller';
 
 export default class ArticlesController extends Controller {
   queryParams = ['category'];
+  
   category = null;
 });
 ```
@@ -184,7 +187,7 @@ export default class ArticlesRoute extends Route {
     category: {
       replace: true
     }
-  }
+  };
 }
 ```
 
@@ -201,11 +204,11 @@ You can also map a controller property to a different query param key using the 
 import Controller from '@ember/controller';
 
 export default class ArticlesController extends Controller {
-  queryParams = {
+  queryParams = [{
     category: 'articles_category'
-  }
+  }];
 
-  category = null
+  category = null;
 }
 ```
 
@@ -221,7 +224,7 @@ import Controller from '@ember/controller';
 export default class ArticlesController extends Controller {
   queryParams = ['page', 'filter', {
     category: 'articles_category'
-  }]
+  }];
 
   category = null;
   page = 1;
@@ -238,7 +241,8 @@ the controller query param property `page` is considered to have a default value
 import Controller from '@ember/controller';
 
 export default class ArticlesController extends Controller {
-  queryParams = 'page';
+  queryParams = ['page'];
+  
   page = 1;
 }
 ```
@@ -332,7 +336,7 @@ export default class ArticlesController extends Controller {
     showMagnifyingGlass: {
       scope: 'controller'
     }
-  }]
+  }];
 }
 ```
 
@@ -342,14 +346,12 @@ The following demonstrates how you can override both the scope and the query par
 import Controller from '@ember/controller';
 
 export default class ArticlesController extends Controller {
-  queryParams = ['page', 'filter',
-    {
-      showMagnifyingGlass: {
-        scope: 'controller',
-        as: 'glass'
-      }
+  queryParams = ['page', 'filter', {
+    showMagnifyingGlass: {
+      scope: 'controller',
+      as: 'glass'
     }
-  ]
+  }];
 }
 ```
 


### PR DESCRIPTION
Primarily I'd like to update this example:

```javascript
import Controller from '@ember/controller';

export default class ArticlesController extends Controller {
  queryParams = {
    category: 'articles_category'
  };

  category = null;
}
```

This doesn't work, and it hasn't worked in quite some time. (Shame on me for not submitting a PR the first time I figured it out.) The correct syntax is:

```javascript
import Controller from '@ember/controller';

export default class ArticlesController extends Controller {
  queryParams = [{
    category: 'articles_category'
  }];

  category = null;
}
```

While I was here, I went through and made the examples consistent with each other.