### PR TITLE
Update tracked-properties.md

### DIFF
--- a/guides/release/upgrading/current-edition/tracked-properties.md
+++ b/guides/release/upgrading/current-edition/tracked-properties.md
@@ -305,6 +305,7 @@ However, there still are two cases where you _will_ need to use them:
 
 Additionally, you will have to continue using _accessor_ functions for arrays if
 you want arrays to update as expected.
+
 Importantly, you do _not_ have to use `get` or `set` when reading or updating
 computed properties, as was noted in the computed property section.
 

--- a/guides/release/upgrading/current-edition/tracked-properties.md
+++ b/guides/release/upgrading/current-edition/tracked-properties.md
@@ -304,9 +304,7 @@ However, there still are two cases where you _will_ need to use them:
   `unknownProperty` function (which allows objects to intercept `get` calls)
 
 Additionally, you will have to continue using _accessor_ functions for arrays if
-you want arrays to update as expected. These functions are covered in more
-detail in the guide on arrays (LINK TO ARRAY GUIDES HERE).
-
+you want arrays to update as expected.
 Importantly, you do _not_ have to use `get` or `set` when reading or updating
 computed properties, as was noted in the computed property section.
 


### PR DESCRIPTION
A community member pointed out that we still have the placeholder text instead of linking to "array guides". As I'm not sure what it's supposed to link to, I removed the relevant prose for now.