### PR TITLE
Fix a tiny typo in getting-started/quick-start.md

### DIFF
--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -327,7 +327,7 @@ the button in the template.
 
 There is a problem with this though – if you tried this in the browser, you
 will quickly discovered that clicking on the buttons will bring up an alert
-dialog that said "The person's name is `[Object Mousevent]`!" – eek!
+dialog that said "The person's name is `[Object MouseEvent]`!" – eek!
 
 The cause of this bug is that we wrote our action to take an argument – the
 person's name – and we forgot to pass it. The fix is easy enough:


### PR DESCRIPTION
Changed `Mousevent` to correct `MouseEvent`