### PR TITLE
Update helper-functions.md

### DIFF
--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -76,8 +76,8 @@ arguments, which we'll discuss next.
 import { helper } from "@ember/component/helper";
 
 function substring(args) {
-  let [string, start, length] = args;
-  return string.substr(start, length);
+  let [string, start, end] = args;
+  return string.substring(start, end);
 }
 
 export default helper(substring);
@@ -88,10 +88,10 @@ We can tighten up the implementation by moving the [destructuring](https://devel
 ```js {data-filename="app/helpers/substring.js" data-diff="+3,-4,-5"}
 import { helper } from "@ember/component/helper";
 
-function substring([string, start, length]) {
+function substring([string, start, end]) {
 function substring(args) {
-  let [string, start, length] = args;
-  return string.substr(start, length);
+  let [string, start, end] = args;
+  return string.substring(start, length);
 }
 
 export default helper(substring);


### PR DESCRIPTION
According to MDN as of String.prototype.substr:
Warning: Although String.prototype.substr(…) is not strictly deprecated (as in "removed from the Web standards"), it is considered a legacy function and should be avoided when possible. It is not part of the core JavaScript language and may be removed in the future. If at all possible, use the substring() method instead.