### PR TITLE
Update helper-functions.md

### DIFF
--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -76,8 +76,8 @@ arguments, which we'll discuss next.
 import { helper } from "@ember/component/helper";
 
 function substring(args) {
-  let [string, start, length] = args;
-  return string.substr(start, length);
+  let [string, start, end] = args;
+  return string.substring(start, end);
 }
 
 export default helper(substring);
@@ -88,10 +88,10 @@ We can tighten up the implementation by moving the [destructuring](https://devel
 ```js {data-filename="app/helpers/substring.js" data-diff="+3,-4,-5"}
 import { helper } from "@ember/component/helper";
 
-function substring([string, start, length]) {
+function substring([string, start, end]) {
 function substring(args) {
-  let [string, start, length] = args;
-  return string.substr(start, length);
+  let [string, start, end] = args;
+  return string.substring(start, length);
 }
 
 export default helper(substring);

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -91,7 +91,7 @@ import { helper } from "@ember/component/helper";
 function substring([string, start, end]) {
 function substring(args) {
   let [string, start, end] = args;
-  return string.substring(start, length);
+  return string.substring(start, end);
 }
 
 export default helper(substring);
@@ -149,8 +149,8 @@ In addition to taking _positional arguments_ as an array, helpers take _named ar
 ```js {data-filename="app/helpers/substring.js"}
 import { helper } from "@ember/component/helper";
 
-function substring([string], { start, length }) {
-  return string.substr(start || 0, length);
+function substring([string], { start, end }) {
+  return string.substring(start || 0, end);
 }
 
 export default helper(substring);
@@ -191,8 +191,8 @@ import Helper from "@ember/component/helper";
 
 function substring([string], { start, length }) {
 export default class Substring extends Helper {
-  compute([string], { start, length }) {
-    return string.substr(start || 0, length);
+  compute([string], { start, end }) {
+    return string.substring(start || 0, end);
   }
 }
 ```


### PR DESCRIPTION
According to MDN as of String.prototype.substr:
Warning: Although String.prototype.substr(…) is not strictly deprecated (as in "removed from the Web standards"), it is considered a legacy function and should be avoided when possible. It is not part of the core JavaScript language and may be removed in the future. If at all possible, use the substring() method instead.