### PR TITLE
update LTS versions to account for 3.16

### DIFF
--- a/guides/versions.yml
+++ b/guides/versions.yml
@@ -42,7 +42,5 @@ allVersions:
   - "v3.17.0"
 currentVersion: "v3.17.0"
 ltsVersions:
-  - "v2.18.0"
-  - "v3.4.0"
-  - "v3.8.0"
   - "v3.12.0"
+  - "v3.16.0"


### PR DESCRIPTION
I opted to list only the current active LTS. Should we keep every version?

Fixes https://github.com/ember-learn/guides-source/issues/1362.