### PR TITLE
fix:  Set `PERCY_BRANCH` for forked CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,7 @@ script:
   - npm run lint:hbs
   - npm run lint:js
   - npm run lint:md
+  # if there's a forked PR with the `branch` set to `master`, we want to unset that for Percy
+  # to avoid resetting the Percy projects baseline
+  - [ "$TRAVIS_PULL_REQUEST_SLUG" != "ember-learn/guides-source" ] && [ "$TRAVIS_PULL_REQUEST_BRANCH" == "master" ] && export PERCY_BRANCH="fork-${TRAVIS_BUILD_NUMBER}"
   - npm test


### PR DESCRIPTION
## What is this?

This will prevent forked `master` builds from resetting the Percy projects baseline. 