### PR TITLE
`on` does not prevent default like `action` did

### DIFF
--- a/guides/release/upgrading/current-edition/action-on-and-fn.md
+++ b/guides/release/upgrading/current-edition/action-on-and-fn.md
@@ -133,6 +133,8 @@ export default class ExampleComponent extends Component {
 }
 ```
 
+Note that the `{{action}}` modifier called `event.preventDefault()` under the hood, but the `{{on}}` modifier does not, so if you need to do anything other than the default action for a particular event, you must call `event.preventDefault` within the action. 
+
 This is a replacement for `{{action}}` when it is used as a modifier:
 
 ```handlebars

--- a/guides/release/upgrading/current-edition/action-on-and-fn.md
+++ b/guides/release/upgrading/current-edition/action-on-and-fn.md
@@ -138,7 +138,7 @@ export default class ExampleComponent extends Component {
     <div class="cta-note-body">
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
-        The `{{action}}` modifier called `event.preventDefault()` under the hood, but the `{{on}}` modifier does not, so if you need to do anything other than the default action for a particular event, you must call `event.preventDefault` within the action.
+        The <code>{{action}}</code> modifier called <code>event.preventDefault()</code> under the hood, but the <code>{{on}}</code> modifier does not, so if you need to do anything other than the default action for a particular event, you must call <code>event.preventDefault</code> within the action.
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">

--- a/guides/release/upgrading/current-edition/action-on-and-fn.md
+++ b/guides/release/upgrading/current-edition/action-on-and-fn.md
@@ -133,7 +133,17 @@ export default class ExampleComponent extends Component {
 }
 ```
 
-Note that the `{{action}}` modifier called `event.preventDefault()` under the hood, but the `{{on}}` modifier does not, so if you need to do anything other than the default action for a particular event, you must call `event.preventDefault` within the action. 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        The `{{action}}` modifier called `event.preventDefault()` under the hood, but the `{{on}}` modifier does not, so if you need to do anything other than the default action for a particular event, you must call `event.preventDefault` within the action.
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+  </div>
+</div> 
 
 This is a replacement for `{{action}}` when it is used as a modifier:
 


### PR DESCRIPTION
I think it would be helpful to point out this difference in the `action` and `on` modifiers. I encountered this issue when I tried to convert a component to Octane and it took a very long time to figure out the problem.