### PR TITLE
fix: Correct Travis config for forked branch parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ script:
   - npm run lint:md
   # if there's a forked PR with the `branch` set to `master`, we want to unset that for Percy
   # to avoid resetting the Percy projects baseline
-  - [ "$TRAVIS_PULL_REQUEST_SLUG" != "ember-learn/guides-source" ] && [ "$TRAVIS_PULL_REQUEST_BRANCH" == "master" ] && export PERCY_BRANCH="fork-${TRAVIS_BUILD_NUMBER}"
+  - '[ "$TRAVIS_PULL_REQUEST_SLUG" != "ember-learn/guides-source" ] && [ "$TRAVIS_PULL_REQUEST_BRANCH" == "master" ] && export PERCY_BRANCH="fork-${TRAVIS_BUILD_NUMBER}"'
   - npm test


### PR DESCRIPTION
It looks like starting a bash command with `[` breaks the travis config
parser. Using their parser (https://config.travis-ci.com/explore) as a debugger
it looks like adding single quotes around the command will parse correctly

Sorry about that! Lets not merge until we know CI works :) (I assumed it didn't run due to concurrency issues or something like that) 

[edit: locks] Closes https://github.com/ember-learn/guides-source/pull/1387.