### PR TITLE
Fixes broken link in Quick Start

### DIFF
--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -390,7 +390,7 @@ Now that your app is deployed, what should you do next?
 ### Advance to the next level
 
 There is an official, free tutorial here in the Guides that delves deeper into some of the features you used today.
-[Give it a try!](./tutorial)
+[Give it a try!](../../tutorial/)
 
 ### Explore the ecosystem
 

--- a/guides/v3.16.0/getting-started/quick-start.md
+++ b/guides/v3.16.0/getting-started/quick-start.md
@@ -390,7 +390,7 @@ Now that your app is deployed, what should you do next?
 ### Advance to the next level
 
 There is an official, free tutorial here in the Guides that delves deeper into some of the features you used today.
-[Give it a try!](./tutorial)
+[Give it a try!](../../tutorial/)
 
 ### Explore the ecosystem
 


### PR DESCRIPTION
On https://guides.emberjs.com/release/getting-started/quick-start/#toc_advance-to-the-next-level there is a bad link pointing to the tutorial. Fixed it by pointing to `release/tutorial/part-1/`