### PR TITLE
Add developer tools heading and rename Ember Inspector guide

### DIFF
--- a/guides/release/pages.yml
+++ b/guides/release/pages.yml
@@ -246,6 +246,9 @@
     - title: "Managing Dependencies"
       url: "index"
 - title: "Developer Tools"
+  url: "toc-heading_developer-tools"
+  is_heading: true
+- title: "Ember Inspector"
   url: "ember-inspector"
   pages:
     - title: "Introduction"


### PR DESCRIPTION
I found it a bit confusing that "Developer Tools" was a guide for Ember Inspector. Now that we have headings, I have added one for Developer Tools so that we can document other tools than Ember Inspector (we could have a page linking to Ember CLI, for example?) and renamed "Developer Tools" back to Ember Inspector.
Since the url was still `/ember-inspector`, I only needed to rename the text on the table of content.