### PR TITLE
Fix formatting

### DIFF
--- a/guides/release/upgrading/current-edition/action-on-and-fn.md
+++ b/guides/release/upgrading/current-edition/action-on-and-fn.md
@@ -23,7 +23,7 @@ export default class TodoComponent extends Component {
 ```handlebars
 <button {{on "click" (fn this.toggleCompleted true)}}>Complete</button>
 ```
-
+<br>
 ## Benefits of `@action`, `{{on}}`, and `{{fn}}`
 
 `{{action}}` has a number of functions, including:


### PR DESCRIPTION
Add manual line break between closing ``` and ## header. Not sure if this is the best solution, but wanted to send in a fix, let me know!

WAS:
![image](https://user-images.githubusercontent.com/1372946/80556888-f14b7300-8989-11ea-9698-dfe593e338bd.png)

IS:
![image](https://user-images.githubusercontent.com/1372946/80556859-d842c200-8989-11ea-9a04-da3b892f03a4.png)
