### PR TITLE
Remove documentation of deprecated defaultSerializer functionality

### DIFF
--- a/guides/release/models/customizing-adapters.md
+++ b/guides/release/models/customizing-adapters.md
@@ -252,26 +252,6 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
 }
 ```
 
-#### Authoring Adapters
-
-The `defaultSerializer` property can be used to specify the serializer
-that will be used by this adapter. This is only used when a model
-specific serializer or `serializer:application` are not defined.
-
-In an application, it is often easier to specify an
-`serializer:application`. However, if you are the author of a
-community adapter it is important to remember to set this property to
-ensure Ember does the right thing in the case a user of your adapter
-does not specify an `serializer:application`.
-
-```javascript {data-filename=app/adapters/my-custom-adapter.js}
-import JSONAPIAdapter from '@ember-data/adapter/json-api';
-
-export default class MyCustomAdapter extends JSONAPIAdapter {
-  defaultSerializer = '-default';
-}
-```
-
 ## Community Adapters
 
 If none of the built-in Ember Data Adapters work for your backend,

--- a/guides/v3.12.0/models/customizing-adapters.md
+++ b/guides/v3.12.0/models/customizing-adapters.md
@@ -263,26 +263,6 @@ export default DS.JSONAPIAdapter.extend({
 });
 ```
 
-#### Authoring Adapters
-
-The `defaultSerializer` property can be used to specify the serializer
-that will be used by this adapter. This is only used when a model
-specific serializer or `serializer:application` are not defined.
-
-In an application, it is often easier to specify an
-`serializer:application`. However, if you are the author of a
-community adapter it is important to remember to set this property to
-ensure Ember does the right thing in the case a user of your adapter
-does not specify an `serializer:application`.
-
-```javascript {data-filename=app/adapters/my-custom-adapter.js}
-import DS from 'ember-data';
-
-export default DS.JSONAPIAdapter.extend({
-  defaultSerializer: '-default'
-});
-```
-
 ## Community Adapters
 
 If none of the built-in Ember Data Adapters work for your backend,

--- a/guides/v3.13.0/models/customizing-adapters.md
+++ b/guides/v3.13.0/models/customizing-adapters.md
@@ -263,26 +263,6 @@ export default DS.JSONAPIAdapter.extend({
 });
 ```
 
-#### Authoring Adapters
-
-The `defaultSerializer` property can be used to specify the serializer
-that will be used by this adapter. This is only used when a model
-specific serializer or `serializer:application` are not defined.
-
-In an application, it is often easier to specify an
-`serializer:application`. However, if you are the author of a
-community adapter it is important to remember to set this property to
-ensure Ember does the right thing in the case a user of your adapter
-does not specify an `serializer:application`.
-
-```javascript {data-filename=app/adapters/my-custom-adapter.js}
-import DS from 'ember-data';
-
-export default DS.JSONAPIAdapter.extend({
-  defaultSerializer: '-default'
-});
-```
-
 ## Community Adapters
 
 If none of the built-in Ember Data Adapters work for your backend,

--- a/guides/v3.14.0/models/customizing-adapters.md
+++ b/guides/v3.14.0/models/customizing-adapters.md
@@ -263,26 +263,6 @@ export default DS.JSONAPIAdapter.extend({
 });
 ```
 
-#### Authoring Adapters
-
-The `defaultSerializer` property can be used to specify the serializer
-that will be used by this adapter. This is only used when a model
-specific serializer or `serializer:application` are not defined.
-
-In an application, it is often easier to specify an
-`serializer:application`. However, if you are the author of a
-community adapter it is important to remember to set this property to
-ensure Ember does the right thing in the case a user of your adapter
-does not specify an `serializer:application`.
-
-```javascript {data-filename=app/adapters/my-custom-adapter.js}
-import DS from 'ember-data';
-
-export default DS.JSONAPIAdapter.extend({
-  defaultSerializer: '-default'
-});
-```
-
 ## Community Adapters
 
 If none of the built-in Ember Data Adapters work for your backend,

--- a/guides/v3.15.0/models/customizing-adapters.md
+++ b/guides/v3.15.0/models/customizing-adapters.md
@@ -252,26 +252,6 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
 }
 ```
 
-#### Authoring Adapters
-
-The `defaultSerializer` property can be used to specify the serializer
-that will be used by this adapter. This is only used when a model
-specific serializer or `serializer:application` are not defined.
-
-In an application, it is often easier to specify an
-`serializer:application`. However, if you are the author of a
-community adapter it is important to remember to set this property to
-ensure Ember does the right thing in the case a user of your adapter
-does not specify an `serializer:application`.
-
-```javascript {data-filename=app/adapters/my-custom-adapter.js}
-import JSONAPIAdapter from '@ember-data/adapter/json-api';
-
-export default class MyCustomAdapter extends JSONAPIAdapter {
-  defaultSerializer = '-default';
-}
-```
-
 ## Community Adapters
 
 If none of the built-in Ember Data Adapters work for your backend,

--- a/guides/v3.16.0/models/customizing-adapters.md
+++ b/guides/v3.16.0/models/customizing-adapters.md
@@ -252,26 +252,6 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
 }
 ```
 
-#### Authoring Adapters
-
-The `defaultSerializer` property can be used to specify the serializer
-that will be used by this adapter. This is only used when a model
-specific serializer or `serializer:application` are not defined.
-
-In an application, it is often easier to specify an
-`serializer:application`. However, if you are the author of a
-community adapter it is important to remember to set this property to
-ensure Ember does the right thing in the case a user of your adapter
-does not specify an `serializer:application`.
-
-```javascript {data-filename=app/adapters/my-custom-adapter.js}
-import JSONAPIAdapter from '@ember-data/adapter/json-api';
-
-export default class MyCustomAdapter extends JSONAPIAdapter {
-  defaultSerializer = '-default';
-}
-```
-
 ## Community Adapters
 
 If none of the built-in Ember Data Adapters work for your backend,


### PR DESCRIPTION
Fixes https://github.com/ember-learn/guides-source/issues/1411.

Removed documentation relative to the deprecated `defaultSerializer` property of Ember Data's Adapter.
I have also backported the changes to the affected versions in a separate commit, in case the team decides it should not be applied. I added that commit because I consider a bug to recommend code that will result in deprecation warnings.