### PR TITLE
link to Handling Deprecations guide from debugging section regarding deprecations

### DIFF
--- a/guides/release/configuring-ember/debugging.md
+++ b/guides/release/configuring-ember/debugging.md
@@ -68,6 +68,9 @@ export default class App extends Application {
 ```
 ### Dealing with deprecations
 
+In addition to what is described in the [Handling Deprecations guide](../handling-deprecations),
+you can turn on the following settings:
+
 ```javascript
 Ember.ENV.RAISE_ON_DEPRECATION = true;
 Ember.ENV.LOG_STACKTRACE_ON_DEPRECATION = true;

--- a/guides/release/configuring-ember/debugging.md
+++ b/guides/release/configuring-ember/debugging.md
@@ -68,7 +68,7 @@ export default class App extends Application {
 ```
 ### Dealing with deprecations
 
-In addition to what is described in the [Handling Deprecations guide](../handling-deprecations),
+In addition to what is described in the [Handling Deprecations guide](./handling-deprecations),
 you can turn on the following settings:
 
 ```javascript


### PR DESCRIPTION
Fixes https://github.com/ember-learn/guides-source/issues/475.

Since we actually have a section dedicated to handling deprecations, we should link to it.