### PR TITLE
Change spelling of Mac OSX to macOS in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ ember serve
 
 Visit [http://localhost:4200](http://localhost:4200)
 
-Note: If you get an error on Mac OSX mentioning `"Error: EMFILE: too many open files, watch"`, try installing Watchman. Install [Homebrew](https://brew.sh/) if you don't have it. Then in you terminal `brew install watchman`.
+Note: If you get an error on macOS mentioning `"Error: EMFILE: too many open files, watch"`, try installing Watchman. Install [Homebrew](https://brew.sh/) if you don't have it. Then in you terminal `brew install watchman`.
 
 ## Running tests
 


### PR DESCRIPTION
## Current

Readme has a reference to "Mac OSX"

## Expected

The official spelling of the OS is ["macOS"](https://en.wikipedia.org/wiki/MacOS)

## Change

Updates the spelling to "macOS"