### PR TITLE
Correct reference to counter button labels

### DIFF
--- a/guides/release/components/component-state-and-actions.md
+++ b/guides/release/components/component-state-and-actions.md
@@ -2,7 +2,7 @@ While you can accomplish a lot in Ember using HTML templating, you'll need
 JavaScript to make your application interactive.
 
 Let's start with a small example, a counter component. When the user presses
-the `+` button, the count will increase by 1. When the user presses the `-`
+the `+1` button, the count will increase by 1. When the user presses the `-1`
 button, the count will decrease by 1.
 
 First, let's start with the HTML.


### PR DESCRIPTION
## Current

In Components > Component State and Actions, the text refers to "When the user presses the `+` button" and "When the user presses the `-` button". But the buttons are not labeled `+` and `-`, but rather `+1` and `-1`

## Expected

I would expect the buttons to be referred to as "the `+1` button and the `-1` button." They are referred to as such elsewhere on this page.

## Change

Updated these references to say "the `+1` button" and "the `-1` button" to match the rest of the page.