### PR TITLE
Fix: Tests fails in 'Integration | Component | rental/image clicking on the component toggles its size' due to incorrect asset location

### DIFF
--- a/guides/release/tutorial/part-1/interactive-components.md
+++ b/guides/release/tutorial/part-1/interactive-components.md
@@ -232,7 +232,7 @@ module('Integration | Component | rental/image', function(hooks) {
   test('clicking on the component toggles its size', async function(assert) {
     await render(hbs`
       <Rental::Image
-        src="/assets/teaching-tomster.png"
+        src="/assets/images/teaching-tomster.png"
         alt="Teaching Tomster"
       />
     `);


### PR DESCRIPTION
The location passed into the component in its test file does not match the location in the project (`assets/images/` instead of `assets/`). 

This causes the test to fail sometimes and it's hard to debug the source of the bug.