### PR TITLE
Fix action name in handlebars to match component

### DIFF
--- a/guides/release/in-depth-topics/patterns-for-actions.md
+++ b/guides/release/in-depth-topics/patterns-for-actions.md
@@ -63,7 +63,7 @@ export default class ButtonWithConfirmationComponent extends Component {
 ```
 
 ```handlebars
-<button type="button" {{on "click" this.launchConfirmationDialog}}>
+<button type="button" {{on "click" this.launchConfirmDialog}}>
   {{@text}}
 </button>
 
@@ -109,7 +109,7 @@ export default class ButtonWithConfirmationComponent extends Component {
 ```
 
 ```handlebars
-<button type="button" {{on "click" this.launchConfirmationDialog}}>
+<button type="button" {{on "click" this.launchConfirmDialog}}>
   {{@text}}
 </button>
 


### PR DESCRIPTION
Use `launchConfirmDialog` as both action function name and the reference in the template.