### PR TITLE
small clarification on implementing Ember.onerror

### DIFF
--- a/guides/release/configuring-ember/debugging.md
+++ b/guides/release/configuring-ember/debugging.md
@@ -78,7 +78,8 @@ Ember.ENV.LOG_STACKTRACE_ON_DEPRECATION = true;
 
 ### Implement an Ember.onerror hook to log all errors in production
 
-```javascript
+```javascript {data-filename=app/app.js}
+import Ember from 'ember';
 import fetch from 'fetch';
 
 Ember.onerror = function(error) {

--- a/guides/release/configuring-ember/debugging.md
+++ b/guides/release/configuring-ember/debugging.md
@@ -81,7 +81,7 @@ Ember.ENV.LOG_STACKTRACE_ON_DEPRECATION = true;
 ```javascript {data-filename=app/app.js}
 import Ember from 'ember';
 import fetch from 'fetch';
-
+// ...
 Ember.onerror = function(error) {
   fetch('/error-notification', {
     method: 'POST',


### PR DESCRIPTION
In modern apps it's required to import ember now, and it's not an import new users will be used to, so it seems logical to add it here. I also suggested to add it in app/app.js, but if there is a better place let me know and I'll update it :).