### PR TITLE
Explained how to write if-else statement in templates

### DIFF
--- a/guides/release/components/conditional-content.md
+++ b/guides/release/components/conditional-content.md
@@ -1,6 +1,4 @@
-You can conditionally include some content in the output of a template by using
-Ember's `if` syntax in templates.
-There are two styles of `if`, block and inline:
+In a template, you can use `if` to conditionally render content. There are 2 styles of `if`: **block** and **inline**.
 
 ```handlebars
 {{#if this.thingIsTrue}}
@@ -11,6 +9,7 @@ There are two styles of `if`, block and inline:
   This div used the inline "if" to calculate the class to use.
 </div>
 ```
+
 
 ## Block `if`
 

--- a/guides/release/components/conditional-content.md
+++ b/guides/release/components/conditional-content.md
@@ -195,4 +195,6 @@ Ember also allows you to write an `if-else` statement in inline form. It looks s
 ```
 
 
-Refer the [API documentation of the `if` helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.
+## Learn More
+
+Please see the [API documentation of the `if` helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.

--- a/guides/release/components/conditional-content.md
+++ b/guides/release/components/conditional-content.md
@@ -13,7 +13,9 @@ In a template, you can use `if` to conditionally render content. There are 2 sty
 
 ## Block `if`
 
-Let's take a look at two similar components representing a user's username.
+### Motivation
+
+Let's take a look at two components that display a person's username.
 
 ```handlebars {data-filename="app/components/received-message/username.hbs"}
 <h4 class="username">
@@ -23,11 +25,12 @@ Let's take a look at two similar components representing a user's username.
 ```
 
 ```handlebars {data-filename="app/components/sent-message/username.hbs"}
-<h4 class="username">Zoey</h4>
+<h4 class="username">
+  Zoey
+</h4>
 ```
 
-We can use arguments to make these two components dynamic, but the first
-username also has extra information about the local time of the user.
+The components look similar, don't they? The first component shows extra information about the user's local time.
 
 Let's say we tried to create a single `username` component.
 
@@ -38,11 +41,9 @@ Let's say we tried to create a single `username` component.
 </h4>
 ```
 
-If the `<Username>` tag doesn't specify a `@localTime` argument, we'll end up
-with some extra unneeded text in the output.
+If the `<Username>` tag doesn't specify a `@localTime` argument, we will see an extra, incomplete text, `their local time is `, on the screen.
 
-What we need is a way to only include the local time text if `@localTime` exists.
-We can do this with an `if`:
+What we need is a way to display the local time if `@localTime` exists. We can do this with an `if`.
 
 ```handlebars {data-filename="app/components/username.hbs"}
 <h4 class="username">
@@ -53,26 +54,50 @@ We can do this with an `if`:
 </h4>
 ```
 
-This is the syntax for conditionals in an Ember template. The `#if` means that the
-part after the `{{#if ...}}` is nested inside of the conditional. Just like HTML
-tags continue until closed (`<div>` continues until `</div>`), the content
-nested inside an `#if` continues until `{{/if}}`.
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          Just like in JavaScript, <code>0</code>, <code>false</code>, <code>null</code>, <code>undefined</code>, and the empty string are falsy in Ember templates. Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
 
-In our case, if the `@localTime` property exists with truthy value then, the markup (`<span class="local-time">their local time is {{@localTime}}</span>`) will be rendered.
+### Usage
 
-If a value passed to `{{#if}}` evaluates to falsy, the `{{else}}` block
-of that invocation is rendered:
-
-```handlebars
-<h4 class="username">
-  {{@name}}
-  {{#if @localTime}}
-    <span class="local-time">their local time is {{@localTime}}</span>
-  {{else}}
-    Unable to fetch local time!
-  {{/if}}
-</h4>
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{#if condition}}
+  {{!-- some content --}}
+{{/if}}
 ```
+
+This is the syntax for an `if` statement in block form. If the `condition` is true, Ember will render the content that is inside the block.
+
+Like any programming language, Ember also allows you to write `if-else` and `if-else if` statements in a template.
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{#if condition}}
+  {{!-- some content --}}
+{{else}}
+  {{!-- some other content --}}
+{{/if}}
+
+{{#if condition1}}
+  ...
+{{else if condition2}}
+  ...
+{{else if condition3}}
+  ...
+{{else}}
+  ...
+{{/if}}
+```
+
 
 ## Inline `if`
 
@@ -110,23 +135,6 @@ is passed in and is truthy.
   </div>
 </aside>
 ```
-
-<div class="cta">
-  <div class="cta-note">
-    <div class="cta-note-body">
-      <div class="cta-note-heading">Zoey says...</div>
-      <div class="cta-note-message">
-        <p>
-          In Ember templates, the values <code>0</code>, <code>false</code>,
-          <code>null</code>, <code>undefined</code>, and the empty string are
-          falsy, just like in JavaScript. In addition, the empty array is also
-          considered falsy in Ember templates.
-        </p>
-      </div>
-    </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="">
-  </div>
-</div>
 
 We can then use the argument to add the active state to the received message
 avatar, and omit it from the sent message avatar.

--- a/guides/release/components/conditional-content.md
+++ b/guides/release/components/conditional-content.md
@@ -101,29 +101,41 @@ Like any programming language, Ember also allows you to write `if-else` and `if-
 
 ## Inline `if`
 
-Sometimes, you need to place conditional content inside an argument or
-attribute. You can do this with _inline_ `if`. For instance, consider these two
-avatar components, for received messages and for sent messages respectively:
+### Motivation
+
+Sometimes, you will want to conditionally set an argument or attribute.
+
+For instance, consider two components that display a user's avatar. One is for a recipient and the other for a sender.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <aside>
-  <div class="avatar is-active" title="Tomster's avatar">T</div>
+  <div
+    class="avatar is-active"
+    title="Tomster's avatar"
+  >
+    T
+  </div>
 </aside>
 ```
 
 ```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
 <aside class="current-user">
-  <div class="avatar" title="Zoey's avatar">Z</div>
+  <div
+    class="avatar"
+    title="Zoey's avatar"
+  >
+    Z
+  </div>
 </aside>
 ```
 
-The first component needs to have an `is-active` class applied to the avatar to
-show the active icon. That icon could also change over time, so it probably
-doesn't make sense to try to use `...attributes` to apply it. It's a part of the
-_public API_ of the component, so an argument makes sense.
+Again, the two components look similar. The first component has an `is-active` class, while the second a `current-user` class. How should we unify the components into one?
 
-So, we want to add the `is-active` class if an argument, like say `@isActive`,
-is passed in and is truthy.
+The `is-active` class is responsible for showing the active icon. _How_ that icon is rendered may change over time, so we won't use `...attributes` to apply the `is-active` class. Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
+
+As for the `current-user` class, it may have been just one of a few classes that can be applied to the `<aside>` element. Let's use `...attributes` to apply the `current-user` class.
+
+We take these API designs into account and end up with a reusable component. The component uses an inline `if` to conditionally apply the `is-active` class.
 
 ```handlebars {data-filename="app/components/avatar.hbs"}
 <aside ...attributes>
@@ -136,22 +148,21 @@ is passed in and is truthy.
 </aside>
 ```
 
-We can then use the argument to add the active state to the received message
-avatar, and omit it from the sent message avatar.
+Afterwards, we can refactor the initial components.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <Avatar
+  @isActive={{true}}
   @title="Tomster's avatar"
   @initial="T"
-  @isActive={{true}}
 />
 ```
 
 ```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
 <Avatar
+  class="current-user"
   @title="Zoey's avatar"
   @initial="Z"
-  class="current-user"
 />
 ```
 
@@ -161,15 +172,27 @@ avatar, and omit it from the sent message avatar.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          When passing literal JavaScript values to a component, we have to wrap
-          the values in double curlies (like <code>{{true}}</code>). Values that
-          are not wrapped in curlies are assigned as strings, matching the
-          behavior of HTML attributes.
+          When passing a literal JavaScript value to a component, we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>). A value that isn't wrapped in curlies is assigned as string, which matches the behavior in HTML attributes. For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
         </p>
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
+
+### Usage
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{if condition value}}
+```
+
+This is the syntax for an `if` statement in inline form. If the `condition` is true, Ember will use `value` at the invocation site.
+
+Ember also allows you to write an `if-else` statement in inline form. It looks similar to a ternary operator.
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{if condition value1 value2}}
+```
+
 
 Refer the [API documentation of the `if` helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.

--- a/guides/release/components/conditional-content.md
+++ b/guides/release/components/conditional-content.md
@@ -1,4 +1,5 @@
-In a template, you can use `if` to conditionally render content. There are 2 styles of `if`: **block** and **inline**.
+In a template, you can use `if` to conditionally render content.
+There are 2 styles of `if`: **block** and **inline**.
 
 ```handlebars
 {{#if this.thingIsTrue}}
@@ -30,7 +31,8 @@ Let's take a look at two components that display a person's username.
 </h4>
 ```
 
-The components look similar, don't they? The first component shows extra information about the user's local time.
+The components look similar, don't they?
+The first component shows extra information about the user's local time.
 
 Let's say we tried to create a single `username` component.
 
@@ -41,9 +43,11 @@ Let's say we tried to create a single `username` component.
 </h4>
 ```
 
-If the `<Username>` tag doesn't specify a `@localTime` argument, we will see an extra, incomplete text, `their local time is `, on the screen.
+If the `<Username>` tag doesn't specify a `@localTime` argument,
+we will see an extra, incomplete text, `their local time is `, on the screen.
 
-What we need is a way to display the local time if `@localTime` exists. We can do this with an `if`.
+What we need is a way to display the local time if `@localTime` exists.
+We can do this with an `if`.
 
 ```handlebars {data-filename="app/components/username.hbs"}
 <h4 class="username">
@@ -60,7 +64,10 @@ What we need is a way to display the local time if `@localTime` exists. We can d
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          Just like in JavaScript, <code>0</code>, <code>false</code>, <code>null</code>, <code>undefined</code>, and the empty string are falsy in Ember templates. Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
+          Just like in JavaScript, <code>0</code>, <code>false</code>,
+          <code>null</code>, <code>undefined</code>, and
+          the empty string are falsy in Ember templates.
+          Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
         </p>
       </div>
     </div>
@@ -76,9 +83,11 @@ What we need is a way to display the local time if `@localTime` exists. We can d
 {{/if}}
 ```
 
-This is the syntax for an `if` statement in block form. If the `condition` is true, Ember will render the content that is inside the block.
+This is the syntax for an `if` statement in block form.
+If the `condition` is true, Ember will render the content that is inside the block.
 
-Like any programming language, Ember also allows you to write `if-else` and `if-else if` statements in a template.
+Like many programming languages, Ember also allows you to write `if else` and
+`if else if` statements in a template.
 
 ```handlebars {data-filename="app/components/my-component.hbs"}
 {{#if condition}}
@@ -105,7 +114,8 @@ Like any programming language, Ember also allows you to write `if-else` and `if-
 
 Sometimes, you will want to conditionally set an argument or attribute.
 
-For instance, consider two components that display a user's avatar. One is for a recipient and the other for a sender.
+For instance, consider two components that display a user's avatar.
+One is for a recipient and the other for a sender.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <aside>
@@ -129,13 +139,21 @@ For instance, consider two components that display a user's avatar. One is for a
 </aside>
 ```
 
-Again, the two components look similar. The first component has an `is-active` class, while the second a `current-user` class. How should we unify the components into one?
+Again, the two components look similar.
+The first component has an `is-active` class, while the second a `current-user` class.
+How should we unify the components into one?
 
-The `is-active` class is responsible for showing the active icon. _How_ that icon is rendered may change over time, so we won't use `...attributes` to apply the `is-active` class. Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
+The `is-active` class is responsible for showing the active icon.
+_How_ that icon is rendered may change over time,
+so we won't use `...attributes` to apply the `is-active` class.
+Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
 
-As for the `current-user` class, it may have been just one of a few classes that can be applied to the `<aside>` element. Let's use `...attributes` to apply the `current-user` class.
+As for the `current-user` class, it may have been just one of a few classes
+that can be applied to the `<aside>` element.
+Let's use `...attributes` to apply the `current-user` class.
 
-We take these API designs into account and end up with a reusable component. The component uses an inline `if` to conditionally apply the `is-active` class.
+We take these API designs into account and end up with a reusable component.
+The component uses an inline `if` to conditionally apply the `is-active` class.
 
 ```handlebars {data-filename="app/components/avatar.hbs"}
 <aside ...attributes>
@@ -172,7 +190,11 @@ Afterwards, we can refactor the initial components.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          When passing a literal JavaScript value to a component, we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>). A value that isn't wrapped in curlies is assigned as string, which matches the behavior in HTML attributes. For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
+          When passing a literal JavaScript value to a component,
+          we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>).
+          A value that isn't wrapped in curlies is assigned as string,
+          which matches the behavior in HTML attributes.
+          For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
         </p>
       </div>
     </div>
@@ -186,9 +208,11 @@ Afterwards, we can refactor the initial components.
 {{if condition value}}
 ```
 
-This is the syntax for an `if` statement in inline form. If the `condition` is true, Ember will use `value` at the invocation site.
+This is the syntax for an `if` statement in inline form.
+If the `condition` is true, Ember will use `value` at the invocation site.
 
-Ember also allows you to write an `if-else` statement in inline form. It looks similar to a ternary operator.
+Ember also allows you to write an `if else` statement in inline form.
+It looks similar to a ternary operator.
 
 ```handlebars {data-filename="app/components/my-component.hbs"}
 {{if condition value1 value2}}

--- a/guides/v3.15.0/components/conditional-content.md
+++ b/guides/v3.15.0/components/conditional-content.md
@@ -1,5 +1,15 @@
-You can conditionally include some content in the output of a template by using
-Ember's `if` syntax in templates.
+In a template, you can use `if` to conditionally render content. There are 2 styles of `if`: **block** and **inline**.
+
+```handlebars
+{{#if this.thingIsTrue}}
+  Content for the block form of "if"
+{{/if}}
+
+<div class={{if this.thingIsTrue "value-if-true" "value-if-false"}}>
+  This div used the inline "if" to calculate the class to use.
+</div>
+```
+
 
 Let's take a look at two similar components representing a user's username.
 

--- a/guides/v3.15.0/components/conditional-content.md
+++ b/guides/v3.15.0/components/conditional-content.md
@@ -101,57 +101,68 @@ Like any programming language, Ember also allows you to write `if-else` and `if-
 
 ## Inline `if`
 
-Sometimes, you need to place conditional content inside an argument or
-attribute. You can do this with _inline_ `if`. For instance, consider these two
-avatar components, for received messages and for sent messages respectively:
+### Motivation
+
+Sometimes, you will want to conditionally set an argument or attribute.
+
+For instance, consider two components that display a user's avatar. One is for a recipient and the other for a sender.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <aside>
-  <div class="avatar is-active" title="Tomster's avatar">T</div>
+  <div
+    class="avatar is-active"
+    title="Tomster's avatar"
+  >
+    T
+  </div>
 </aside>
 ```
 
 ```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
 <aside class="current-user">
-  <div class="avatar" title="Zoey's avatar">Z</div>
+  <div
+    class="avatar"
+    title="Zoey's avatar"
+  >
+    Z
+  </div>
 </aside>
 ```
 
-The first component needs to have an `is-active` class applied to the avatar to
-show the active icon. That icon could also change over time, so it probably
-doesn't make sense to try to use `...attributes` to apply it. It's a part of the
-_public API_ of the component, so an argument makes sense.
+Again, the two components look similar. The first component has an `is-active` class, while the second a `current-user` class. How should we unify the components into one?
 
-So, we want to add the `is-active` class if an argument, like say `@isActive`,
-is passed in and is truthy.
+The `is-active` class is responsible for showing the active icon. _How_ that icon is rendered may change over time, so we won't use `...attributes` to apply the `is-active` class. Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
+
+As for the `current-user` class, it may have been just one of a few classes that can be applied to the `<aside>` element. Let's use `...attributes` to apply the `current-user` class.
+
+We take these API designs into account and end up with a reusable component. The component uses an inline `if` to conditionally apply the `is-active` class.
 
 ```handlebars {data-filename="app/components/avatar.hbs"}
 <aside ...attributes>
   <div
     class="avatar {{if @isActive "is-active"}}"
-    title="{{@title}}"
+    title={{@title}}
   >
     {{@initial}}
   </div>
 </aside>
 ```
 
-We can then use the argument to add the active state to the received message
-avatar, and omit it from the sent message avatar.
+Afterwards, we can refactor the initial components.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <Avatar
+  @isActive={{true}}
   @title="Tomster's avatar"
   @initial="T"
-  @isActive={{true}}
 />
 ```
 
 ```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
 <Avatar
+  class="current-user"
   @title="Zoey's avatar"
   @initial="Z"
-  class="current-user"
 />
 ```
 
@@ -161,13 +172,24 @@ avatar, and omit it from the sent message avatar.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          When passing literal JavaScript values to a component, we have to wrap
-          the values in double curlies (like <code>{{true}}</code>). Values that
-          are not wrapped in curlies are assigned as strings, matching the
-          behavior of HTML attributes.
+          When passing a literal JavaScript value to a component, we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>). A value that isn't wrapped in curlies is assigned as string, which matches the behavior in HTML attributes. For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
         </p>
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
+
+### Usage
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{if condition value}}
+```
+
+This is the syntax for an `if` statement in inline form. If the `condition` is true, Ember will use `value` at the invocation site.
+
+Ember also allows you to write an `if-else` statement in inline form. It looks similar to a ternary operator.
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{if condition value1 value2}}
+```

--- a/guides/v3.15.0/components/conditional-content.md
+++ b/guides/v3.15.0/components/conditional-content.md
@@ -1,4 +1,5 @@
-In a template, you can use `if` to conditionally render content. There are 2 styles of `if`: **block** and **inline**.
+In a template, you can use `if` to conditionally render content.
+There are 2 styles of `if`: **block** and **inline**.
 
 ```handlebars
 {{#if this.thingIsTrue}}
@@ -30,7 +31,8 @@ Let's take a look at two components that display a person's username.
 </h4>
 ```
 
-The components look similar, don't they? The first component shows extra information about the user's local time.
+The components look similar, don't they?
+The first component shows extra information about the user's local time.
 
 Let's say we tried to create a single `username` component.
 
@@ -41,9 +43,11 @@ Let's say we tried to create a single `username` component.
 </h4>
 ```
 
-If the `<Username>` tag doesn't specify a `@localTime` argument, we will see an extra, incomplete text, `their local time is `, on the screen.
+If the `<Username>` tag doesn't specify a `@localTime` argument,
+we will see an extra, incomplete text, `their local time is `, on the screen.
 
-What we need is a way to display the local time if `@localTime` exists. We can do this with an `if`.
+What we need is a way to display the local time if `@localTime` exists.
+We can do this with an `if`.
 
 ```handlebars {data-filename="app/components/username.hbs"}
 <h4 class="username">
@@ -60,7 +64,10 @@ What we need is a way to display the local time if `@localTime` exists. We can d
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          Just like in JavaScript, <code>0</code>, <code>false</code>, <code>null</code>, <code>undefined</code>, and the empty string are falsy in Ember templates. Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
+          Just like in JavaScript, <code>0</code>, <code>false</code>,
+          <code>null</code>, <code>undefined</code>, and
+          the empty string are falsy in Ember templates.
+          Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
         </p>
       </div>
     </div>
@@ -76,9 +83,11 @@ What we need is a way to display the local time if `@localTime` exists. We can d
 {{/if}}
 ```
 
-This is the syntax for an `if` statement in block form. If the `condition` is true, Ember will render the content that is inside the block.
+This is the syntax for an `if` statement in block form.
+If the `condition` is true, Ember will render the content that is inside the block.
 
-Like any programming language, Ember also allows you to write `if-else` and `if-else if` statements in a template.
+Like many programming languages, Ember also allows you to write `if else` and
+`if else if` statements in a template.
 
 ```handlebars {data-filename="app/components/my-component.hbs"}
 {{#if condition}}
@@ -105,7 +114,8 @@ Like any programming language, Ember also allows you to write `if-else` and `if-
 
 Sometimes, you will want to conditionally set an argument or attribute.
 
-For instance, consider two components that display a user's avatar. One is for a recipient and the other for a sender.
+For instance, consider two components that display a user's avatar.
+One is for a recipient and the other for a sender.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <aside>
@@ -129,13 +139,21 @@ For instance, consider two components that display a user's avatar. One is for a
 </aside>
 ```
 
-Again, the two components look similar. The first component has an `is-active` class, while the second a `current-user` class. How should we unify the components into one?
+Again, the two components look similar.
+The first component has an `is-active` class, while the second a `current-user` class.
+How should we unify the components into one?
 
-The `is-active` class is responsible for showing the active icon. _How_ that icon is rendered may change over time, so we won't use `...attributes` to apply the `is-active` class. Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
+The `is-active` class is responsible for showing the active icon.
+_How_ that icon is rendered may change over time,
+so we won't use `...attributes` to apply the `is-active` class.
+Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
 
-As for the `current-user` class, it may have been just one of a few classes that can be applied to the `<aside>` element. Let's use `...attributes` to apply the `current-user` class.
+As for the `current-user` class, it may have been just one of a few classes
+that can be applied to the `<aside>` element.
+Let's use `...attributes` to apply the `current-user` class.
 
-We take these API designs into account and end up with a reusable component. The component uses an inline `if` to conditionally apply the `is-active` class.
+We take these API designs into account and end up with a reusable component.
+The component uses an inline `if` to conditionally apply the `is-active` class.
 
 ```handlebars {data-filename="app/components/avatar.hbs"}
 <aside ...attributes>
@@ -172,7 +190,11 @@ Afterwards, we can refactor the initial components.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          When passing a literal JavaScript value to a component, we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>). A value that isn't wrapped in curlies is assigned as string, which matches the behavior in HTML attributes. For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
+          When passing a literal JavaScript value to a component,
+          we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>).
+          A value that isn't wrapped in curlies is assigned as string,
+          which matches the behavior in HTML attributes.
+          For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
         </p>
       </div>
     </div>
@@ -186,9 +208,11 @@ Afterwards, we can refactor the initial components.
 {{if condition value}}
 ```
 
-This is the syntax for an `if` statement in inline form. If the `condition` is true, Ember will use `value` at the invocation site.
+This is the syntax for an `if` statement in inline form.
+If the `condition` is true, Ember will use `value` at the invocation site.
 
-Ember also allows you to write an `if-else` statement in inline form. It looks similar to a ternary operator.
+Ember also allows you to write an `if else` statement in inline form.
+It looks similar to a ternary operator.
 
 ```handlebars {data-filename="app/components/my-component.hbs"}
 {{if condition value1 value2}}

--- a/guides/v3.15.0/components/conditional-content.md
+++ b/guides/v3.15.0/components/conditional-content.md
@@ -193,3 +193,8 @@ Ember also allows you to write an `if-else` statement in inline form. It looks s
 ```handlebars {data-filename="app/components/my-component.hbs"}
 {{if condition value1 value2}}
 ```
+
+
+## Learn More
+
+Please see the [API documentation of the `if` helper](https://api.emberjs.com/ember/3.15.0/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.

--- a/guides/v3.15.0/components/conditional-content.md
+++ b/guides/v3.15.0/components/conditional-content.md
@@ -11,7 +11,11 @@ In a template, you can use `if` to conditionally render content. There are 2 sty
 ```
 
 
-Let's take a look at two similar components representing a user's username.
+## Block `if`
+
+### Motivation
+
+Let's take a look at two components that display a person's username.
 
 ```handlebars {data-filename="app/components/received-message/username.hbs"}
 <h4 class="username">
@@ -21,11 +25,12 @@ Let's take a look at two similar components representing a user's username.
 ```
 
 ```handlebars {data-filename="app/components/sent-message/username.hbs"}
-<h4 class="username">Zoey</h4>
+<h4 class="username">
+  Zoey
+</h4>
 ```
 
-We can use arguments to make these two components dynamic, but the first
-username also has extra information about the local time of the user.
+The components look similar, don't they? The first component shows extra information about the user's local time.
 
 Let's say we tried to create a single `username` component.
 
@@ -36,11 +41,9 @@ Let's say we tried to create a single `username` component.
 </h4>
 ```
 
-If the `<Username>` tag doesn't specify a `@localTime` argument, we'll end up
-with some extra unneeded text in the output.
+If the `<Username>` tag doesn't specify a `@localTime` argument, we will see an extra, incomplete text, `their local time is `, on the screen.
 
-What we need is a way to only include the local time text if `@localTime` exists.
-We can do this with an `if`:
+What we need is a way to display the local time if `@localTime` exists. We can do this with an `if`.
 
 ```handlebars {data-filename="app/components/username.hbs"}
 <h4 class="username">
@@ -51,10 +54,50 @@ We can do this with an `if`:
 </h4>
 ```
 
-This is the syntax for conditionals in an Ember template. The `#if` means that the
-part after the `{{#if ...}}` is nested inside of the conditional. Just like HTML
-tags continue until closed (`<div>` continues until `</div>`), the content
-nested inside an `#if` continues until `{{/if}}`.
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          Just like in JavaScript, <code>0</code>, <code>false</code>, <code>null</code>, <code>undefined</code>, and the empty string are falsy in Ember templates. Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
+
+### Usage
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{#if condition}}
+  {{!-- some content --}}
+{{/if}}
+```
+
+This is the syntax for an `if` statement in block form. If the `condition` is true, Ember will render the content that is inside the block.
+
+Like any programming language, Ember also allows you to write `if-else` and `if-else if` statements in a template.
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{#if condition}}
+  {{!-- some content --}}
+{{else}}
+  {{!-- some other content --}}
+{{/if}}
+
+{{#if condition1}}
+  ...
+{{else if condition2}}
+  ...
+{{else if condition3}}
+  ...
+{{else}}
+  ...
+{{/if}}
+```
+
 
 ## Inline `if`
 
@@ -92,23 +135,6 @@ is passed in and is truthy.
   </div>
 </aside>
 ```
-
-<div class="cta">
-  <div class="cta-note">
-    <div class="cta-note-body">
-      <div class="cta-note-heading">Zoey says...</div>
-      <div class="cta-note-message">
-        <p>
-          In Ember templates, the values <code>0</code>, <code>false</code>,
-          <code>null</code>, <code>undefined</code>, and the empty string are
-          falsy, just like in JavaScript. In addition, the empty array is also
-          considered falsy in Ember templates.
-        </p>
-      </div>
-    </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="">
-  </div>
-</div>
 
 We can then use the argument to add the active state to the received message
 avatar, and omit it from the sent message avatar.

--- a/guides/v3.16.0/components/conditional-content.md
+++ b/guides/v3.16.0/components/conditional-content.md
@@ -13,7 +13,9 @@ In a template, you can use `if` to conditionally render content. There are 2 sty
 
 ## Block `if`
 
-Let's take a look at two similar components representing a user's username.
+### Motivation
+
+Let's take a look at two components that display a person's username.
 
 ```handlebars {data-filename="app/components/received-message/username.hbs"}
 <h4 class="username">
@@ -23,11 +25,12 @@ Let's take a look at two similar components representing a user's username.
 ```
 
 ```handlebars {data-filename="app/components/sent-message/username.hbs"}
-<h4 class="username">Zoey</h4>
+<h4 class="username">
+  Zoey
+</h4>
 ```
 
-We can use arguments to make these two components dynamic, but the first
-username also has extra information about the local time of the user.
+The components look similar, don't they? The first component shows extra information about the user's local time.
 
 Let's say we tried to create a single `username` component.
 
@@ -38,11 +41,9 @@ Let's say we tried to create a single `username` component.
 </h4>
 ```
 
-If the `<Username>` tag doesn't specify a `@localTime` argument, we'll end up
-with some extra unneeded text in the output.
+If the `<Username>` tag doesn't specify a `@localTime` argument, we will see an extra, incomplete text, `their local time is `, on the screen.
 
-What we need is a way to only include the local time text if `@localTime` exists.
-We can do this with an `if`:
+What we need is a way to display the local time if `@localTime` exists. We can do this with an `if`.
 
 ```handlebars {data-filename="app/components/username.hbs"}
 <h4 class="username">
@@ -53,26 +54,50 @@ We can do this with an `if`:
 </h4>
 ```
 
-This is the syntax for conditionals in an Ember template. The `#if` means that the
-part after the `{{#if ...}}` is nested inside of the conditional. Just like HTML
-tags continue until closed (`<div>` continues until `</div>`), the content
-nested inside an `#if` continues until `{{/if}}`.
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          Just like in JavaScript, <code>0</code>, <code>false</code>, <code>null</code>, <code>undefined</code>, and the empty string are falsy in Ember templates. Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
 
-In our case, if the `@localTime` property exists with truthy value then, the markup (`<span class="local-time">their local time is {{@localTime}}</span>`) will be rendered.
+### Usage
 
-If a value passed to `{{#if}}` evaluates to falsy, the `{{else}}` block
-of that invocation is rendered:
-
-```handlebars
-<h4 class="username">
-  {{@name}}
-  {{#if @localTime}}
-    <span class="local-time">their local time is {{@localTime}}</span>
-  {{else}}
-    Unable to fetch local time!
-  {{/if}}
-</h4>
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{#if condition}}
+  {{!-- some content --}}
+{{/if}}
 ```
+
+This is the syntax for an `if` statement in block form. If the `condition` is true, Ember will render the content that is inside the block.
+
+Like any programming language, Ember also allows you to write `if-else` and `if-else if` statements in a template.
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{#if condition}}
+  {{!-- some content --}}
+{{else}}
+  {{!-- some other content --}}
+{{/if}}
+
+{{#if condition1}}
+  ...
+{{else if condition2}}
+  ...
+{{else if condition3}}
+  ...
+{{else}}
+  ...
+{{/if}}
+```
+
 
 ## Inline `if`
 
@@ -110,23 +135,6 @@ is passed in and is truthy.
   </div>
 </aside>
 ```
-
-<div class="cta">
-  <div class="cta-note">
-    <div class="cta-note-body">
-      <div class="cta-note-heading">Zoey says...</div>
-      <div class="cta-note-message">
-        <p>
-          In Ember templates, the values <code>0</code>, <code>false</code>,
-          <code>null</code>, <code>undefined</code>, and the empty string are
-          falsy, just like in JavaScript. In addition, the empty array is also
-          considered falsy in Ember templates.
-        </p>
-      </div>
-    </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="">
-  </div>
-</div>
 
 We can then use the argument to add the active state to the received message
 avatar, and omit it from the sent message avatar.

--- a/guides/v3.16.0/components/conditional-content.md
+++ b/guides/v3.16.0/components/conditional-content.md
@@ -101,57 +101,68 @@ Like any programming language, Ember also allows you to write `if-else` and `if-
 
 ## Inline `if`
 
-Sometimes, you need to place conditional content inside an argument or
-attribute. You can do this with _inline_ `if`. For instance, consider these two
-avatar components, for received messages and for sent messages respectively:
+### Motivation
+
+Sometimes, you will want to conditionally set an argument or attribute.
+
+For instance, consider two components that display a user's avatar. One is for a recipient and the other for a sender.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <aside>
-  <div class="avatar is-active" title="Tomster's avatar">T</div>
+  <div
+    class="avatar is-active"
+    title="Tomster's avatar"
+  >
+    T
+  </div>
 </aside>
 ```
 
 ```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
 <aside class="current-user">
-  <div class="avatar" title="Zoey's avatar">Z</div>
+  <div
+    class="avatar"
+    title="Zoey's avatar"
+  >
+    Z
+  </div>
 </aside>
 ```
 
-The first component needs to have an `is-active` class applied to the avatar to
-show the active icon. That icon could also change over time, so it probably
-doesn't make sense to try to use `...attributes` to apply it. It's a part of the
-_public API_ of the component, so an argument makes sense.
+Again, the two components look similar. The first component has an `is-active` class, while the second a `current-user` class. How should we unify the components into one?
 
-So, we want to add the `is-active` class if an argument, like say `@isActive`,
-is passed in and is truthy.
+The `is-active` class is responsible for showing the active icon. _How_ that icon is rendered may change over time, so we won't use `...attributes` to apply the `is-active` class. Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
+
+As for the `current-user` class, it may have been just one of a few classes that can be applied to the `<aside>` element. Let's use `...attributes` to apply the `current-user` class.
+
+We take these API designs into account and end up with a reusable component. The component uses an inline `if` to conditionally apply the `is-active` class.
 
 ```handlebars {data-filename="app/components/avatar.hbs"}
 <aside ...attributes>
   <div
     class="avatar {{if @isActive "is-active"}}"
-    title="{{@title}}"
+    title={{@title}}
   >
     {{@initial}}
   </div>
 </aside>
 ```
 
-We can then use the argument to add the active state to the received message
-avatar, and omit it from the sent message avatar.
+Afterwards, we can refactor the initial components.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <Avatar
+  @isActive={{true}}
   @title="Tomster's avatar"
   @initial="T"
-  @isActive={{true}}
 />
 ```
 
 ```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
 <Avatar
+  class="current-user"
   @title="Zoey's avatar"
   @initial="Z"
-  class="current-user"
 />
 ```
 
@@ -161,15 +172,27 @@ avatar, and omit it from the sent message avatar.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          When passing literal JavaScript values to a component, we have to wrap
-          the values in double curlies (like <code>{{true}}</code>). Values that
-          are not wrapped in curlies are assigned as strings, matching the
-          behavior of HTML attributes.
+          When passing a literal JavaScript value to a component, we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>). A value that isn't wrapped in curlies is assigned as string, which matches the behavior in HTML attributes. For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
         </p>
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
+
+### Usage
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{if condition value}}
+```
+
+This is the syntax for an `if` statement in inline form. If the `condition` is true, Ember will use `value` at the invocation site.
+
+Ember also allows you to write an `if-else` statement in inline form. It looks similar to a ternary operator.
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{if condition value1 value2}}
+```
+
 
 Refer the [API documentation of the `if` helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.

--- a/guides/v3.16.0/components/conditional-content.md
+++ b/guides/v3.16.0/components/conditional-content.md
@@ -1,4 +1,5 @@
-In a template, you can use `if` to conditionally render content. There are 2 styles of `if`: **block** and **inline**.
+In a template, you can use `if` to conditionally render content.
+There are 2 styles of `if`: **block** and **inline**.
 
 ```handlebars
 {{#if this.thingIsTrue}}
@@ -30,7 +31,8 @@ Let's take a look at two components that display a person's username.
 </h4>
 ```
 
-The components look similar, don't they? The first component shows extra information about the user's local time.
+The components look similar, don't they?
+The first component shows extra information about the user's local time.
 
 Let's say we tried to create a single `username` component.
 
@@ -41,9 +43,11 @@ Let's say we tried to create a single `username` component.
 </h4>
 ```
 
-If the `<Username>` tag doesn't specify a `@localTime` argument, we will see an extra, incomplete text, `their local time is `, on the screen.
+If the `<Username>` tag doesn't specify a `@localTime` argument,
+we will see an extra, incomplete text, `their local time is `, on the screen.
 
-What we need is a way to display the local time if `@localTime` exists. We can do this with an `if`.
+What we need is a way to display the local time if `@localTime` exists.
+We can do this with an `if`.
 
 ```handlebars {data-filename="app/components/username.hbs"}
 <h4 class="username">
@@ -60,7 +64,10 @@ What we need is a way to display the local time if `@localTime` exists. We can d
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          Just like in JavaScript, <code>0</code>, <code>false</code>, <code>null</code>, <code>undefined</code>, and the empty string are falsy in Ember templates. Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
+          Just like in JavaScript, <code>0</code>, <code>false</code>,
+          <code>null</code>, <code>undefined</code>, and
+          the empty string are falsy in Ember templates.
+          Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
         </p>
       </div>
     </div>
@@ -76,9 +83,11 @@ What we need is a way to display the local time if `@localTime` exists. We can d
 {{/if}}
 ```
 
-This is the syntax for an `if` statement in block form. If the `condition` is true, Ember will render the content that is inside the block.
+This is the syntax for an `if` statement in block form.
+If the `condition` is true, Ember will render the content that is inside the block.
 
-Like any programming language, Ember also allows you to write `if-else` and `if-else if` statements in a template.
+Like many programming languages, Ember also allows you to write `if else` and
+`if else if` statements in a template.
 
 ```handlebars {data-filename="app/components/my-component.hbs"}
 {{#if condition}}
@@ -105,7 +114,8 @@ Like any programming language, Ember also allows you to write `if-else` and `if-
 
 Sometimes, you will want to conditionally set an argument or attribute.
 
-For instance, consider two components that display a user's avatar. One is for a recipient and the other for a sender.
+For instance, consider two components that display a user's avatar.
+One is for a recipient and the other for a sender.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <aside>
@@ -129,13 +139,21 @@ For instance, consider two components that display a user's avatar. One is for a
 </aside>
 ```
 
-Again, the two components look similar. The first component has an `is-active` class, while the second a `current-user` class. How should we unify the components into one?
+Again, the two components look similar.
+The first component has an `is-active` class, while the second a `current-user` class.
+How should we unify the components into one?
 
-The `is-active` class is responsible for showing the active icon. _How_ that icon is rendered may change over time, so we won't use `...attributes` to apply the `is-active` class. Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
+The `is-active` class is responsible for showing the active icon.
+_How_ that icon is rendered may change over time,
+so we won't use `...attributes` to apply the `is-active` class.
+Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
 
-As for the `current-user` class, it may have been just one of a few classes that can be applied to the `<aside>` element. Let's use `...attributes` to apply the `current-user` class.
+As for the `current-user` class, it may have been just one of a few classes
+that can be applied to the `<aside>` element.
+Let's use `...attributes` to apply the `current-user` class.
 
-We take these API designs into account and end up with a reusable component. The component uses an inline `if` to conditionally apply the `is-active` class.
+We take these API designs into account and end up with a reusable component.
+The component uses an inline `if` to conditionally apply the `is-active` class.
 
 ```handlebars {data-filename="app/components/avatar.hbs"}
 <aside ...attributes>
@@ -172,7 +190,11 @@ Afterwards, we can refactor the initial components.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          When passing a literal JavaScript value to a component, we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>). A value that isn't wrapped in curlies is assigned as string, which matches the behavior in HTML attributes. For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
+          When passing a literal JavaScript value to a component,
+          we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>).
+          A value that isn't wrapped in curlies is assigned as string,
+          which matches the behavior in HTML attributes.
+          For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
         </p>
       </div>
     </div>
@@ -186,9 +208,11 @@ Afterwards, we can refactor the initial components.
 {{if condition value}}
 ```
 
-This is the syntax for an `if` statement in inline form. If the `condition` is true, Ember will use `value` at the invocation site.
+This is the syntax for an `if` statement in inline form.
+If the `condition` is true, Ember will use `value` at the invocation site.
 
-Ember also allows you to write an `if-else` statement in inline form. It looks similar to a ternary operator.
+Ember also allows you to write an `if else` statement in inline form.
+It looks similar to a ternary operator.
 
 ```handlebars {data-filename="app/components/my-component.hbs"}
 {{if condition value1 value2}}

--- a/guides/v3.16.0/components/conditional-content.md
+++ b/guides/v3.16.0/components/conditional-content.md
@@ -1,16 +1,15 @@
-You can conditionally include some content in the output of a template by using
-Ember's `if` syntax in templates.
-There are two styles of `if`, block and inline:
+In a template, you can use `if` to conditionally render content. There are 2 styles of `if`: **block** and **inline**.
 
 ```handlebars
 {{#if this.thingIsTrue}}
-   Content for the block form of "if"
+  Content for the block form of "if"
 {{/if}}
 
 <div class={{if this.thingIsTrue "value-if-true" "value-if-false"}}>
-    This div used the inline "if" to calculate the class to use.
+  This div used the inline "if" to calculate the class to use.
 </div>
 ```
+
 
 ## Block `if`
 

--- a/guides/v3.16.0/components/conditional-content.md
+++ b/guides/v3.16.0/components/conditional-content.md
@@ -195,4 +195,6 @@ Ember also allows you to write an `if-else` statement in inline form. It looks s
 ```
 
 
-Refer the [API documentation of the `if` helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.
+## Learn More
+
+Please see the [API documentation of the `if` helper](https://api.emberjs.com/ember/3.16.0/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.

--- a/guides/v3.17.0/components/conditional-content.md
+++ b/guides/v3.17.0/components/conditional-content.md
@@ -1,6 +1,4 @@
-You can conditionally include some content in the output of a template by using
-Ember's `if` syntax in templates.
-There are two styles of `if`, block and inline:
+In a template, you can use `if` to conditionally render content. There are 2 styles of `if`: **block** and **inline**.
 
 ```handlebars
 {{#if this.thingIsTrue}}
@@ -11,6 +9,7 @@ There are two styles of `if`, block and inline:
   This div used the inline "if" to calculate the class to use.
 </div>
 ```
+
 
 ## Block `if`
 

--- a/guides/v3.17.0/components/conditional-content.md
+++ b/guides/v3.17.0/components/conditional-content.md
@@ -13,7 +13,9 @@ In a template, you can use `if` to conditionally render content. There are 2 sty
 
 ## Block `if`
 
-Let's take a look at two similar components representing a user's username.
+### Motivation
+
+Let's take a look at two components that display a person's username.
 
 ```handlebars {data-filename="app/components/received-message/username.hbs"}
 <h4 class="username">
@@ -23,11 +25,12 @@ Let's take a look at two similar components representing a user's username.
 ```
 
 ```handlebars {data-filename="app/components/sent-message/username.hbs"}
-<h4 class="username">Zoey</h4>
+<h4 class="username">
+  Zoey
+</h4>
 ```
 
-We can use arguments to make these two components dynamic, but the first
-username also has extra information about the local time of the user.
+The components look similar, don't they? The first component shows extra information about the user's local time.
 
 Let's say we tried to create a single `username` component.
 
@@ -38,11 +41,9 @@ Let's say we tried to create a single `username` component.
 </h4>
 ```
 
-If the `<Username>` tag doesn't specify a `@localTime` argument, we'll end up
-with some extra unneeded text in the output.
+If the `<Username>` tag doesn't specify a `@localTime` argument, we will see an extra, incomplete text, `their local time is `, on the screen.
 
-What we need is a way to only include the local time text if `@localTime` exists.
-We can do this with an `if`:
+What we need is a way to display the local time if `@localTime` exists. We can do this with an `if`.
 
 ```handlebars {data-filename="app/components/username.hbs"}
 <h4 class="username">
@@ -53,26 +54,50 @@ We can do this with an `if`:
 </h4>
 ```
 
-This is the syntax for conditionals in an Ember template. The `#if` means that the
-part after the `{{#if ...}}` is nested inside of the conditional. Just like HTML
-tags continue until closed (`<div>` continues until `</div>`), the content
-nested inside an `#if` continues until `{{/if}}`.
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          Just like in JavaScript, <code>0</code>, <code>false</code>, <code>null</code>, <code>undefined</code>, and the empty string are falsy in Ember templates. Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
 
-In our case, if the `@localTime` property exists with truthy value then, the markup (`<span class="local-time">their local time is {{@localTime}}</span>`) will be rendered.
+### Usage
 
-If a value passed to `{{#if}}` evaluates to falsy, the `{{else}}` block
-of that invocation is rendered:
-
-```handlebars
-<h4 class="username">
-  {{@name}}
-  {{#if @localTime}}
-    <span class="local-time">their local time is {{@localTime}}</span>
-  {{else}}
-    Unable to fetch local time!
-  {{/if}}
-</h4>
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{#if condition}}
+  {{!-- some content --}}
+{{/if}}
 ```
+
+This is the syntax for an `if` statement in block form. If the `condition` is true, Ember will render the content that is inside the block.
+
+Like any programming language, Ember also allows you to write `if-else` and `if-else if` statements in a template.
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{#if condition}}
+  {{!-- some content --}}
+{{else}}
+  {{!-- some other content --}}
+{{/if}}
+
+{{#if condition1}}
+  ...
+{{else if condition2}}
+  ...
+{{else if condition3}}
+  ...
+{{else}}
+  ...
+{{/if}}
+```
+
 
 ## Inline `if`
 
@@ -110,23 +135,6 @@ is passed in and is truthy.
   </div>
 </aside>
 ```
-
-<div class="cta">
-  <div class="cta-note">
-    <div class="cta-note-body">
-      <div class="cta-note-heading">Zoey says...</div>
-      <div class="cta-note-message">
-        <p>
-          In Ember templates, the values <code>0</code>, <code>false</code>,
-          <code>null</code>, <code>undefined</code>, and the empty string are
-          falsy, just like in JavaScript. In addition, the empty array is also
-          considered falsy in Ember templates.
-        </p>
-      </div>
-    </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="">
-  </div>
-</div>
 
 We can then use the argument to add the active state to the received message
 avatar, and omit it from the sent message avatar.

--- a/guides/v3.17.0/components/conditional-content.md
+++ b/guides/v3.17.0/components/conditional-content.md
@@ -195,4 +195,6 @@ Ember also allows you to write an `if-else` statement in inline form. It looks s
 ```
 
 
-Refer the [API documentation of the `if` helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.
+## Learn More
+
+Please see the [API documentation of the `if` helper](https://api.emberjs.com/ember/3.17.0/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.

--- a/guides/v3.17.0/components/conditional-content.md
+++ b/guides/v3.17.0/components/conditional-content.md
@@ -101,29 +101,41 @@ Like any programming language, Ember also allows you to write `if-else` and `if-
 
 ## Inline `if`
 
-Sometimes, you need to place conditional content inside an argument or
-attribute. You can do this with _inline_ `if`. For instance, consider these two
-avatar components, for received messages and for sent messages respectively:
+### Motivation
+
+Sometimes, you will want to conditionally set an argument or attribute.
+
+For instance, consider two components that display a user's avatar. One is for a recipient and the other for a sender.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <aside>
-  <div class="avatar is-active" title="Tomster's avatar">T</div>
+  <div
+    class="avatar is-active"
+    title="Tomster's avatar"
+  >
+    T
+  </div>
 </aside>
 ```
 
 ```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
 <aside class="current-user">
-  <div class="avatar" title="Zoey's avatar">Z</div>
+  <div
+    class="avatar"
+    title="Zoey's avatar"
+  >
+    Z
+  </div>
 </aside>
 ```
 
-The first component needs to have an `is-active` class applied to the avatar to
-show the active icon. That icon could also change over time, so it probably
-doesn't make sense to try to use `...attributes` to apply it. It's a part of the
-_public API_ of the component, so an argument makes sense.
+Again, the two components look similar. The first component has an `is-active` class, while the second a `current-user` class. How should we unify the components into one?
 
-So, we want to add the `is-active` class if an argument, like say `@isActive`,
-is passed in and is truthy.
+The `is-active` class is responsible for showing the active icon. _How_ that icon is rendered may change over time, so we won't use `...attributes` to apply the `is-active` class. Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
+
+As for the `current-user` class, it may have been just one of a few classes that can be applied to the `<aside>` element. Let's use `...attributes` to apply the `current-user` class.
+
+We take these API designs into account and end up with a reusable component. The component uses an inline `if` to conditionally apply the `is-active` class.
 
 ```handlebars {data-filename="app/components/avatar.hbs"}
 <aside ...attributes>
@@ -136,22 +148,21 @@ is passed in and is truthy.
 </aside>
 ```
 
-We can then use the argument to add the active state to the received message
-avatar, and omit it from the sent message avatar.
+Afterwards, we can refactor the initial components.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <Avatar
+  @isActive={{true}}
   @title="Tomster's avatar"
   @initial="T"
-  @isActive={{true}}
 />
 ```
 
 ```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
 <Avatar
+  class="current-user"
   @title="Zoey's avatar"
   @initial="Z"
-  class="current-user"
 />
 ```
 
@@ -161,15 +172,27 @@ avatar, and omit it from the sent message avatar.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          When passing literal JavaScript values to a component, we have to wrap
-          the values in double curlies (like <code>{{true}}</code>). Values that
-          are not wrapped in curlies are assigned as strings, matching the
-          behavior of HTML attributes.
+          When passing a literal JavaScript value to a component, we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>). A value that isn't wrapped in curlies is assigned as string, which matches the behavior in HTML attributes. For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
         </p>
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
+
+### Usage
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{if condition value}}
+```
+
+This is the syntax for an `if` statement in inline form. If the `condition` is true, Ember will use `value` at the invocation site.
+
+Ember also allows you to write an `if-else` statement in inline form. It looks similar to a ternary operator.
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{if condition value1 value2}}
+```
+
 
 Refer the [API documentation of the `if` helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.

--- a/guides/v3.17.0/components/conditional-content.md
+++ b/guides/v3.17.0/components/conditional-content.md
@@ -1,4 +1,5 @@
-In a template, you can use `if` to conditionally render content. There are 2 styles of `if`: **block** and **inline**.
+In a template, you can use `if` to conditionally render content.
+There are 2 styles of `if`: **block** and **inline**.
 
 ```handlebars
 {{#if this.thingIsTrue}}
@@ -30,7 +31,8 @@ Let's take a look at two components that display a person's username.
 </h4>
 ```
 
-The components look similar, don't they? The first component shows extra information about the user's local time.
+The components look similar, don't they?
+The first component shows extra information about the user's local time.
 
 Let's say we tried to create a single `username` component.
 
@@ -41,9 +43,11 @@ Let's say we tried to create a single `username` component.
 </h4>
 ```
 
-If the `<Username>` tag doesn't specify a `@localTime` argument, we will see an extra, incomplete text, `their local time is `, on the screen.
+If the `<Username>` tag doesn't specify a `@localTime` argument,
+we will see an extra, incomplete text, `their local time is `, on the screen.
 
-What we need is a way to display the local time if `@localTime` exists. We can do this with an `if`.
+What we need is a way to display the local time if `@localTime` exists.
+We can do this with an `if`.
 
 ```handlebars {data-filename="app/components/username.hbs"}
 <h4 class="username">
@@ -60,7 +64,10 @@ What we need is a way to display the local time if `@localTime` exists. We can d
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          Just like in JavaScript, <code>0</code>, <code>false</code>, <code>null</code>, <code>undefined</code>, and the empty string are falsy in Ember templates. Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
+          Just like in JavaScript, <code>0</code>, <code>false</code>,
+          <code>null</code>, <code>undefined</code>, and
+          the empty string are falsy in Ember templates.
+          Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
         </p>
       </div>
     </div>
@@ -76,9 +83,11 @@ What we need is a way to display the local time if `@localTime` exists. We can d
 {{/if}}
 ```
 
-This is the syntax for an `if` statement in block form. If the `condition` is true, Ember will render the content that is inside the block.
+This is the syntax for an `if` statement in block form.
+If the `condition` is true, Ember will render the content that is inside the block.
 
-Like any programming language, Ember also allows you to write `if-else` and `if-else if` statements in a template.
+Like many programming languages, Ember also allows you to write `if else` and
+`if else if` statements in a template.
 
 ```handlebars {data-filename="app/components/my-component.hbs"}
 {{#if condition}}
@@ -105,7 +114,8 @@ Like any programming language, Ember also allows you to write `if-else` and `if-
 
 Sometimes, you will want to conditionally set an argument or attribute.
 
-For instance, consider two components that display a user's avatar. One is for a recipient and the other for a sender.
+For instance, consider two components that display a user's avatar.
+One is for a recipient and the other for a sender.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <aside>
@@ -129,13 +139,21 @@ For instance, consider two components that display a user's avatar. One is for a
 </aside>
 ```
 
-Again, the two components look similar. The first component has an `is-active` class, while the second a `current-user` class. How should we unify the components into one?
+Again, the two components look similar.
+The first component has an `is-active` class, while the second a `current-user` class.
+How should we unify the components into one?
 
-The `is-active` class is responsible for showing the active icon. _How_ that icon is rendered may change over time, so we won't use `...attributes` to apply the `is-active` class. Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
+The `is-active` class is responsible for showing the active icon.
+_How_ that icon is rendered may change over time,
+so we won't use `...attributes` to apply the `is-active` class.
+Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
 
-As for the `current-user` class, it may have been just one of a few classes that can be applied to the `<aside>` element. Let's use `...attributes` to apply the `current-user` class.
+As for the `current-user` class, it may have been just one of a few classes
+that can be applied to the `<aside>` element.
+Let's use `...attributes` to apply the `current-user` class.
 
-We take these API designs into account and end up with a reusable component. The component uses an inline `if` to conditionally apply the `is-active` class.
+We take these API designs into account and end up with a reusable component.
+The component uses an inline `if` to conditionally apply the `is-active` class.
 
 ```handlebars {data-filename="app/components/avatar.hbs"}
 <aside ...attributes>
@@ -172,7 +190,11 @@ Afterwards, we can refactor the initial components.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          When passing a literal JavaScript value to a component, we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>). A value that isn't wrapped in curlies is assigned as string, which matches the behavior in HTML attributes. For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
+          When passing a literal JavaScript value to a component,
+          we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>).
+          A value that isn't wrapped in curlies is assigned as string,
+          which matches the behavior in HTML attributes.
+          For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
         </p>
       </div>
     </div>
@@ -186,9 +208,11 @@ Afterwards, we can refactor the initial components.
 {{if condition value}}
 ```
 
-This is the syntax for an `if` statement in inline form. If the `condition` is true, Ember will use `value` at the invocation site.
+This is the syntax for an `if` statement in inline form.
+If the `condition` is true, Ember will use `value` at the invocation site.
 
-Ember also allows you to write an `if-else` statement in inline form. It looks similar to a ternary operator.
+Ember also allows you to write an `if else` statement in inline form.
+It looks similar to a ternary operator.
 
 ```handlebars {data-filename="app/components/my-component.hbs"}
 {{if condition value1 value2}}

--- a/guides/v3.18.0/components/conditional-content.md
+++ b/guides/v3.18.0/components/conditional-content.md
@@ -1,6 +1,4 @@
-You can conditionally include some content in the output of a template by using
-Ember's `if` syntax in templates.
-There are two styles of `if`, block and inline:
+In a template, you can use `if` to conditionally render content. There are 2 styles of `if`: **block** and **inline**.
 
 ```handlebars
 {{#if this.thingIsTrue}}
@@ -11,6 +9,7 @@ There are two styles of `if`, block and inline:
   This div used the inline "if" to calculate the class to use.
 </div>
 ```
+
 
 ## Block `if`
 

--- a/guides/v3.18.0/components/conditional-content.md
+++ b/guides/v3.18.0/components/conditional-content.md
@@ -13,7 +13,9 @@ In a template, you can use `if` to conditionally render content. There are 2 sty
 
 ## Block `if`
 
-Let's take a look at two similar components representing a user's username.
+### Motivation
+
+Let's take a look at two components that display a person's username.
 
 ```handlebars {data-filename="app/components/received-message/username.hbs"}
 <h4 class="username">
@@ -23,11 +25,12 @@ Let's take a look at two similar components representing a user's username.
 ```
 
 ```handlebars {data-filename="app/components/sent-message/username.hbs"}
-<h4 class="username">Zoey</h4>
+<h4 class="username">
+  Zoey
+</h4>
 ```
 
-We can use arguments to make these two components dynamic, but the first
-username also has extra information about the local time of the user.
+The components look similar, don't they? The first component shows extra information about the user's local time.
 
 Let's say we tried to create a single `username` component.
 
@@ -38,11 +41,9 @@ Let's say we tried to create a single `username` component.
 </h4>
 ```
 
-If the `<Username>` tag doesn't specify a `@localTime` argument, we'll end up
-with some extra unneeded text in the output.
+If the `<Username>` tag doesn't specify a `@localTime` argument, we will see an extra, incomplete text, `their local time is `, on the screen.
 
-What we need is a way to only include the local time text if `@localTime` exists.
-We can do this with an `if`:
+What we need is a way to display the local time if `@localTime` exists. We can do this with an `if`.
 
 ```handlebars {data-filename="app/components/username.hbs"}
 <h4 class="username">
@@ -53,26 +54,50 @@ We can do this with an `if`:
 </h4>
 ```
 
-This is the syntax for conditionals in an Ember template. The `#if` means that the
-part after the `{{#if ...}}` is nested inside of the conditional. Just like HTML
-tags continue until closed (`<div>` continues until `</div>`), the content
-nested inside an `#if` continues until `{{/if}}`.
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          Just like in JavaScript, <code>0</code>, <code>false</code>, <code>null</code>, <code>undefined</code>, and the empty string are falsy in Ember templates. Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
 
-In our case, if the `@localTime` property exists with truthy value then, the markup (`<span class="local-time">their local time is {{@localTime}}</span>`) will be rendered.
+### Usage
 
-If a value passed to `{{#if}}` evaluates to falsy, the `{{else}}` block
-of that invocation is rendered:
-
-```handlebars
-<h4 class="username">
-  {{@name}}
-  {{#if @localTime}}
-    <span class="local-time">their local time is {{@localTime}}</span>
-  {{else}}
-    Unable to fetch local time!
-  {{/if}}
-</h4>
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{#if condition}}
+  {{!-- some content --}}
+{{/if}}
 ```
+
+This is the syntax for an `if` statement in block form. If the `condition` is true, Ember will render the content that is inside the block.
+
+Like any programming language, Ember also allows you to write `if-else` and `if-else if` statements in a template.
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{#if condition}}
+  {{!-- some content --}}
+{{else}}
+  {{!-- some other content --}}
+{{/if}}
+
+{{#if condition1}}
+  ...
+{{else if condition2}}
+  ...
+{{else if condition3}}
+  ...
+{{else}}
+  ...
+{{/if}}
+```
+
 
 ## Inline `if`
 
@@ -110,23 +135,6 @@ is passed in and is truthy.
   </div>
 </aside>
 ```
-
-<div class="cta">
-  <div class="cta-note">
-    <div class="cta-note-body">
-      <div class="cta-note-heading">Zoey says...</div>
-      <div class="cta-note-message">
-        <p>
-          In Ember templates, the values <code>0</code>, <code>false</code>,
-          <code>null</code>, <code>undefined</code>, and the empty string are
-          falsy, just like in JavaScript. In addition, the empty array is also
-          considered falsy in Ember templates.
-        </p>
-      </div>
-    </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="">
-  </div>
-</div>
 
 We can then use the argument to add the active state to the received message
 avatar, and omit it from the sent message avatar.

--- a/guides/v3.18.0/components/conditional-content.md
+++ b/guides/v3.18.0/components/conditional-content.md
@@ -195,4 +195,6 @@ Ember also allows you to write an `if-else` statement in inline form. It looks s
 ```
 
 
-Refer the [API documentation of the `if` helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.
+## Learn More
+
+Please see the [API documentation of the `if` helper](https://api.emberjs.com/ember/3.18.0/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.

--- a/guides/v3.18.0/components/conditional-content.md
+++ b/guides/v3.18.0/components/conditional-content.md
@@ -101,29 +101,41 @@ Like any programming language, Ember also allows you to write `if-else` and `if-
 
 ## Inline `if`
 
-Sometimes, you need to place conditional content inside an argument or
-attribute. You can do this with _inline_ `if`. For instance, consider these two
-avatar components, for received messages and for sent messages respectively:
+### Motivation
+
+Sometimes, you will want to conditionally set an argument or attribute.
+
+For instance, consider two components that display a user's avatar. One is for a recipient and the other for a sender.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <aside>
-  <div class="avatar is-active" title="Tomster's avatar">T</div>
+  <div
+    class="avatar is-active"
+    title="Tomster's avatar"
+  >
+    T
+  </div>
 </aside>
 ```
 
 ```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
 <aside class="current-user">
-  <div class="avatar" title="Zoey's avatar">Z</div>
+  <div
+    class="avatar"
+    title="Zoey's avatar"
+  >
+    Z
+  </div>
 </aside>
 ```
 
-The first component needs to have an `is-active` class applied to the avatar to
-show the active icon. That icon could also change over time, so it probably
-doesn't make sense to try to use `...attributes` to apply it. It's a part of the
-_public API_ of the component, so an argument makes sense.
+Again, the two components look similar. The first component has an `is-active` class, while the second a `current-user` class. How should we unify the components into one?
 
-So, we want to add the `is-active` class if an argument, like say `@isActive`,
-is passed in and is truthy.
+The `is-active` class is responsible for showing the active icon. _How_ that icon is rendered may change over time, so we won't use `...attributes` to apply the `is-active` class. Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
+
+As for the `current-user` class, it may have been just one of a few classes that can be applied to the `<aside>` element. Let's use `...attributes` to apply the `current-user` class.
+
+We take these API designs into account and end up with a reusable component. The component uses an inline `if` to conditionally apply the `is-active` class.
 
 ```handlebars {data-filename="app/components/avatar.hbs"}
 <aside ...attributes>
@@ -136,22 +148,21 @@ is passed in and is truthy.
 </aside>
 ```
 
-We can then use the argument to add the active state to the received message
-avatar, and omit it from the sent message avatar.
+Afterwards, we can refactor the initial components.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <Avatar
+  @isActive={{true}}
   @title="Tomster's avatar"
   @initial="T"
-  @isActive={{true}}
 />
 ```
 
 ```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
 <Avatar
+  class="current-user"
   @title="Zoey's avatar"
   @initial="Z"
-  class="current-user"
 />
 ```
 
@@ -161,15 +172,27 @@ avatar, and omit it from the sent message avatar.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          When passing literal JavaScript values to a component, we have to wrap
-          the values in double curlies (like <code>{{true}}</code>). Values that
-          are not wrapped in curlies are assigned as strings, matching the
-          behavior of HTML attributes.
+          When passing a literal JavaScript value to a component, we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>). A value that isn't wrapped in curlies is assigned as string, which matches the behavior in HTML attributes. For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
         </p>
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
+
+### Usage
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{if condition value}}
+```
+
+This is the syntax for an `if` statement in inline form. If the `condition` is true, Ember will use `value` at the invocation site.
+
+Ember also allows you to write an `if-else` statement in inline form. It looks similar to a ternary operator.
+
+```handlebars {data-filename="app/components/my-component.hbs"}
+{{if condition value1 value2}}
+```
+
 
 Refer the [API documentation of the `if` helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.

--- a/guides/v3.18.0/components/conditional-content.md
+++ b/guides/v3.18.0/components/conditional-content.md
@@ -1,4 +1,5 @@
-In a template, you can use `if` to conditionally render content. There are 2 styles of `if`: **block** and **inline**.
+In a template, you can use `if` to conditionally render content.
+There are 2 styles of `if`: **block** and **inline**.
 
 ```handlebars
 {{#if this.thingIsTrue}}
@@ -30,7 +31,8 @@ Let's take a look at two components that display a person's username.
 </h4>
 ```
 
-The components look similar, don't they? The first component shows extra information about the user's local time.
+The components look similar, don't they?
+The first component shows extra information about the user's local time.
 
 Let's say we tried to create a single `username` component.
 
@@ -41,9 +43,11 @@ Let's say we tried to create a single `username` component.
 </h4>
 ```
 
-If the `<Username>` tag doesn't specify a `@localTime` argument, we will see an extra, incomplete text, `their local time is `, on the screen.
+If the `<Username>` tag doesn't specify a `@localTime` argument,
+we will see an extra, incomplete text, `their local time is `, on the screen.
 
-What we need is a way to display the local time if `@localTime` exists. We can do this with an `if`.
+What we need is a way to display the local time if `@localTime` exists.
+We can do this with an `if`.
 
 ```handlebars {data-filename="app/components/username.hbs"}
 <h4 class="username">
@@ -60,7 +64,10 @@ What we need is a way to display the local time if `@localTime` exists. We can d
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          Just like in JavaScript, <code>0</code>, <code>false</code>, <code>null</code>, <code>undefined</code>, and the empty string are falsy in Ember templates. Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
+          Just like in JavaScript, <code>0</code>, <code>false</code>,
+          <code>null</code>, <code>undefined</code>, and
+          the empty string are falsy in Ember templates.
+          Unlike in JavaScript, the empty array is also considered falsy in Ember templates.
         </p>
       </div>
     </div>
@@ -76,9 +83,11 @@ What we need is a way to display the local time if `@localTime` exists. We can d
 {{/if}}
 ```
 
-This is the syntax for an `if` statement in block form. If the `condition` is true, Ember will render the content that is inside the block.
+This is the syntax for an `if` statement in block form.
+If the `condition` is true, Ember will render the content that is inside the block.
 
-Like any programming language, Ember also allows you to write `if-else` and `if-else if` statements in a template.
+Like many programming languages, Ember also allows you to write `if else` and
+`if else if` statements in a template.
 
 ```handlebars {data-filename="app/components/my-component.hbs"}
 {{#if condition}}
@@ -105,7 +114,8 @@ Like any programming language, Ember also allows you to write `if-else` and `if-
 
 Sometimes, you will want to conditionally set an argument or attribute.
 
-For instance, consider two components that display a user's avatar. One is for a recipient and the other for a sender.
+For instance, consider two components that display a user's avatar.
+One is for a recipient and the other for a sender.
 
 ```handlebars {data-filename="app/components/received-message/avatar.hbs"}
 <aside>
@@ -129,13 +139,21 @@ For instance, consider two components that display a user's avatar. One is for a
 </aside>
 ```
 
-Again, the two components look similar. The first component has an `is-active` class, while the second a `current-user` class. How should we unify the components into one?
+Again, the two components look similar.
+The first component has an `is-active` class, while the second a `current-user` class.
+How should we unify the components into one?
 
-The `is-active` class is responsible for showing the active icon. _How_ that icon is rendered may change over time, so we won't use `...attributes` to apply the `is-active` class. Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
+The `is-active` class is responsible for showing the active icon.
+_How_ that icon is rendered may change over time,
+so we won't use `...attributes` to apply the `is-active` class.
+Instead, we'll pass the argument `@isActive` to dictate _what_ to do (e.g. render the icon).
 
-As for the `current-user` class, it may have been just one of a few classes that can be applied to the `<aside>` element. Let's use `...attributes` to apply the `current-user` class.
+As for the `current-user` class, it may have been just one of a few classes
+that can be applied to the `<aside>` element.
+Let's use `...attributes` to apply the `current-user` class.
 
-We take these API designs into account and end up with a reusable component. The component uses an inline `if` to conditionally apply the `is-active` class.
+We take these API designs into account and end up with a reusable component.
+The component uses an inline `if` to conditionally apply the `is-active` class.
 
 ```handlebars {data-filename="app/components/avatar.hbs"}
 <aside ...attributes>
@@ -172,7 +190,11 @@ Afterwards, we can refactor the initial components.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         <p>
-          When passing a literal JavaScript value to a component, we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>). A value that isn't wrapped in curlies is assigned as string, which matches the behavior in HTML attributes. For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
+          When passing a literal JavaScript value to a component,
+          we have to wrap the value in double curlies (e.g. <code>@isActive={{true}}</code>).
+          A value that isn't wrapped in curlies is assigned as string,
+          which matches the behavior in HTML attributes.
+          For example, writing <code>@isActive=true</code> will set <code>@isActive</code> to the string <code>'true'</code>.
         </p>
       </div>
     </div>
@@ -186,9 +208,11 @@ Afterwards, we can refactor the initial components.
 {{if condition value}}
 ```
 
-This is the syntax for an `if` statement in inline form. If the `condition` is true, Ember will use `value` at the invocation site.
+This is the syntax for an `if` statement in inline form.
+If the `condition` is true, Ember will use `value` at the invocation site.
 
-Ember also allows you to write an `if-else` statement in inline form. It looks similar to a ternary operator.
+Ember also allows you to write an `if else` statement in inline form.
+It looks similar to a ternary operator.
 
 ```handlebars {data-filename="app/components/my-component.hbs"}
 {{if condition value1 value2}}


### PR DESCRIPTION
## Description

This PR addresses and can close the issue #1237. There are 3 main changes:

1\. I reviewed the current content in `/guides/release/components/conditional-content.md` and updated it so that I can introduce the `if-else` syntax in a natural manner. Afterwards, I backported (copy-pasted) the changes to v3.15-3.18.

2\. The `Block If` and `Inline If` now have subsections called `Motivation` and `Usage`. I think making subsections helps a reader take a break (we don't overload them by showing text after text). People can also link to `Usage` for a quick access to the block and inline syntax.

3\. I created Learn More section at the end. For v3.15-3.18, I ensured that the redirect link to the API docs includes the correct version number. This addresses the issue that was brought up in #1440.


## How to review

I recommend taking one of 2 approaches:

- Review commits one at a time. Each commits corresponds to updating a section in `conditional-content.md`. The end result is the same for v3.15-release, so feel free to look at only the file in the `release` directory.
- For more visual review, check the [preview deploy site](https://deploy-preview-1476--ember-guides.netlify.app/release/components/conditional-content/) or [Percy snapshot](https://percy.io/Ember/guides-app/builds/6058156/view/350018563/1280?mode=diff&browser=firefox&snapshot=350018563).