### PR TITLE
Added missing `data-filename` for code snippet titles

### DIFF
--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -143,7 +143,7 @@ You can think of using `{{yield}}` as leaving a placeholder for the content of t
 </Message>
 ```
 
-```handlebars {app/components/sent-message.hbs}
+```handlebars {data-filename="app/components/sent-message.hbs"}
 <Message
   @username="Zoey"
   @isCurrentUser={{true}}

--- a/guides/v3.15.0/components/block-content.md
+++ b/guides/v3.15.0/components/block-content.md
@@ -143,7 +143,7 @@ You can think of using `{{yield}}` as leaving a placeholder for the content of t
 </Message>
 ```
 
-```handlebars {app/components/sent-message.hbs}
+```handlebars {data-filename="app/components/sent-message.hbs"}
 <Message
   @username="Zoey"
   @isCurrentUser={{true}}

--- a/guides/v3.16.0/components/block-content.md
+++ b/guides/v3.16.0/components/block-content.md
@@ -143,7 +143,7 @@ You can think of using `{{yield}}` as leaving a placeholder for the content of t
 </Message>
 ```
 
-```handlebars {app/components/sent-message.hbs}
+```handlebars {data-filename="app/components/sent-message.hbs"}
 <Message
   @username="Zoey"
   @isCurrentUser={{true}}

--- a/guides/v3.17.0/components/block-content.md
+++ b/guides/v3.17.0/components/block-content.md
@@ -143,7 +143,7 @@ You can think of using `{{yield}}` as leaving a placeholder for the content of t
 </Message>
 ```
 
-```handlebars {app/components/sent-message.hbs}
+```handlebars {data-filename="app/components/sent-message.hbs"}
 <Message
   @username="Zoey"
   @isCurrentUser={{true}}

--- a/guides/v3.18.0/components/block-content.md
+++ b/guides/v3.18.0/components/block-content.md
@@ -143,7 +143,7 @@ You can think of using `{{yield}}` as leaving a placeholder for the content of t
 </Message>
 ```
 
-```handlebars {app/components/sent-message.hbs}
+```handlebars {data-filename="app/components/sent-message.hbs"}
 <Message
   @username="Zoey"
   @isCurrentUser={{true}}


### PR DESCRIPTION
I noticed that the titles were missing on one of the snippets halfway down the page on https://guides.emberjs.com/release/components/block-content/. It looks like the titles were there, but the tag was missing the `data-filename` attribute.