### PR TITLE
Update for readability

### DIFF
--- a/guides/v3.11.0/tutorial/hbs-helper.md
+++ b/guides/v3.11.0/tutorial/hbs-helper.md
@@ -62,7 +62,7 @@ Let's update our `rental-listing` component template to use our new helper and p
 
 Ideally we'll see "Type: Standalone - Estate" for our first rental property.
 Instead, our default template helper is returning back our `rental.category` values.
-Let's update our helper to look if a property exists in an array of `communityPropertyTypes`,
+Let's update our helper to see if a property exists in an array of `communityPropertyTypes`,
 if so, we'll return either `'Community'` or `'Standalone'`:
 
 ```javascript {data-filename="app/helpers/rental-property-type.js" data-diff="-3,-4,-5,+7,+8,+9,+10,+11,+13,+14,+15,+16,+18,+19"}

--- a/guides/v3.12.0/tutorial/hbs-helper.md
+++ b/guides/v3.12.0/tutorial/hbs-helper.md
@@ -62,7 +62,7 @@ Let's update our `rental-listing` component template to use our new helper and p
 
 Ideally we'll see "Type: Standalone - Estate" for our first rental property.
 Instead, our default template helper is returning back our `rental.category` values.
-Let's update our helper to look if a property exists in an array of `communityPropertyTypes`,
+Let's update our helper to see if a property exists in an array of `communityPropertyTypes`,
 if so, we'll return either `'Community'` or `'Standalone'`:
 
 ```javascript {data-filename="app/helpers/rental-property-type.js" data-diff="-3,-4,-5,+7,+8,+9,+10,+11,+13,+14,+15,+16,+18,+19,+21"}

--- a/guides/v3.13.0/tutorial/hbs-helper.md
+++ b/guides/v3.13.0/tutorial/hbs-helper.md
@@ -62,7 +62,7 @@ Let's update our `rental-listing` component template to use our new helper and p
 
 Ideally we'll see "Type: Standalone - Estate" for our first rental property.
 Instead, our default template helper is returning back our `rental.category` values.
-Let's update our helper to look if a property exists in an array of `communityPropertyTypes`,
+Let's update our helper to see if a property exists in an array of `communityPropertyTypes`,
 if so, we'll return either `'Community'` or `'Standalone'`:
 
 ```javascript {data-filename="app/helpers/rental-property-type.js" data-diff="-3,-4,-5,+7,+8,+9,+10,+11,+13,+14,+15,+16,+18,+19,+21"}

--- a/guides/v3.14.0/tutorial/hbs-helper.md
+++ b/guides/v3.14.0/tutorial/hbs-helper.md
@@ -62,7 +62,7 @@ Let's update our `rental-listing` component template to use our new helper and p
 
 Ideally we'll see "Type: Standalone - Estate" for our first rental property.
 Instead, our default template helper is returning back our `rental.category` values.
-Let's update our helper to look if a property exists in an array of `communityPropertyTypes`,
+Let's update our helper to see if a property exists in an array of `communityPropertyTypes`,
 if so, we'll return either `'Community'` or `'Standalone'`:
 
 ```javascript {data-filename="app/helpers/rental-property-type.js" data-diff="-3,-4,-5,+7,+8,+9,+10,+11,+13,+14,+15,+16,+18,+19,+21"}


### PR DESCRIPTION
Just bringing this PR back! 🙂

This PR may be very opinionated or personal preference, but I thought the wording of this sentence is a bit awkward.

> Let's update our helper to look if a property exists in an array of communityPropertyTypes, if so, we'll return either 'Community' or 'Standalone':

I thought maybe see would sound a little better. Maybe the entire sentence needs to be restructured. Look just doesn't seem like the appropriate word here.

> Let's update our helper to see if a property exists in an array of communityPropertyTypes, if so, we'll return either 'Community' or 'Standalone':

This particular wording exist in 3.11, 3.12, 3.13, and 3.14.