### PR TITLE
Removed image alternate text for "Zoey/Tomster Says"

### DIFF
--- a/guides/release/accessibility/components.md
+++ b/guides/release/accessibility/components.md
@@ -86,6 +86,6 @@ However, this option can be a little harder to apply styles to, so both should b
 To dig deeper into accessible input patterns in Ember check out the <a href="https://emberjs-1.gitbook.io/ember-component-patterns/form-components/input">ember-component-patterns article on Input Fields</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>

--- a/guides/release/upgrading/current-edition/action-on-and-fn.md
+++ b/guides/release/upgrading/current-edition/action-on-and-fn.md
@@ -141,7 +141,7 @@ export default class ExampleComponent extends Component {
         The <code>{{action}}</code> modifier called <code>event.preventDefault()</code> under the hood, but the <code>{{on}}</code> modifier does not, so if you need to do anything other than the default action for a particular event, you must call <code>event.preventDefault</code> within the action.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div> 
 

--- a/guides/v3.10.0/components/defining-a-component.md
+++ b/guides/v3.10.0/components/defining-a-component.md
@@ -36,7 +36,7 @@ Given the above template, you can now use the `<BlogPost />` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.10.0/models/index.md
+++ b/guides/v3.10.0/models/index.md
@@ -188,7 +188,7 @@ first ask the store for it.
         so you can access it as `this.store`!
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.10.0/object-model/enumerables.md
+++ b/guides/v3.10.0/object-model/enumerables.md
@@ -33,7 +33,7 @@ where available.
         </a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.10.0/tutorial/simple-component.md
+++ b/guides/v3.10.0/tutorial/simple-component.md
@@ -98,7 +98,7 @@ with our new `RentalListing` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.11.0/components/index.md
+++ b/guides/v3.11.0/components/index.md
@@ -36,7 +36,7 @@ Given the above template, you can now use the `<BlogPost />` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.11.0/models/index.md
+++ b/guides/v3.11.0/models/index.md
@@ -188,7 +188,7 @@ first ask the store for it.
         so you can access it as `this.store`!
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.11.0/object-model/enumerables.md
+++ b/guides/v3.11.0/object-model/enumerables.md
@@ -33,7 +33,7 @@ where available.
         </a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.11.0/tutorial/simple-component.md
+++ b/guides/v3.11.0/tutorial/simple-component.md
@@ -98,7 +98,7 @@ with our new `RentalListing` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.12.0/accessibility/components.md
+++ b/guides/v3.12.0/accessibility/components.md
@@ -86,6 +86,6 @@ However, this option can be a little harder to apply styles to, so both should b
 To dig deeper into accessible input patterns in Ember check out the <a href="https://emberjs-1.gitbook.io/ember-component-patterns/form-components/input">ember-component-patterns article on Input Fields</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>

--- a/guides/v3.12.0/components/index.md
+++ b/guides/v3.12.0/components/index.md
@@ -36,7 +36,7 @@ Given the above template, you can now use the `<BlogPost />` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.12.0/models/defining-models.md
+++ b/guides/v3.12.0/models/defining-models.md
@@ -32,7 +32,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
         Ember Data models are normally setup using the singular form (which is why we use `person` instead of `people` here)
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.12.0/models/index.md
+++ b/guides/v3.12.0/models/index.md
@@ -188,7 +188,7 @@ first ask the store for it.
         so you can access it as `this.store`!
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.12.0/object-model/enumerables.md
+++ b/guides/v3.12.0/object-model/enumerables.md
@@ -33,7 +33,7 @@ where available.
         </a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.12.0/tutorial/simple-component.md
+++ b/guides/v3.12.0/tutorial/simple-component.md
@@ -98,7 +98,7 @@ with our new `RentalListing` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.13.0/accessibility/components.md
+++ b/guides/v3.13.0/accessibility/components.md
@@ -86,6 +86,6 @@ However, this option can be a little harder to apply styles to, so both should b
 To dig deeper into accessible input patterns in Ember check out the <a href="https://emberjs-1.gitbook.io/ember-component-patterns/form-components/input">ember-component-patterns article on Input Fields</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>

--- a/guides/v3.13.0/components/index.md
+++ b/guides/v3.13.0/components/index.md
@@ -36,7 +36,7 @@ Given the above template, you can now use the `<BlogPost />` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.13.0/models/defining-models.md
+++ b/guides/v3.13.0/models/defining-models.md
@@ -32,7 +32,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
         Ember Data models are normally setup using the singular form (which is why we use `person` instead of `people` here)
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.13.0/models/index.md
+++ b/guides/v3.13.0/models/index.md
@@ -188,7 +188,7 @@ first ask the store for it.
         so you can access it as `this.store`!
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.13.0/object-model/enumerables.md
+++ b/guides/v3.13.0/object-model/enumerables.md
@@ -33,7 +33,7 @@ where available.
         </a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.13.0/tutorial/simple-component.md
+++ b/guides/v3.13.0/tutorial/simple-component.md
@@ -98,7 +98,7 @@ with our new `RentalListing` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.14.0/accessibility/components.md
+++ b/guides/v3.14.0/accessibility/components.md
@@ -86,6 +86,6 @@ However, this option can be a little harder to apply styles to, so both should b
 To dig deeper into accessible input patterns in Ember check out the <a href="https://emberjs-1.gitbook.io/ember-component-patterns/form-components/input">ember-component-patterns article on Input Fields</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>

--- a/guides/v3.14.0/components/index.md
+++ b/guides/v3.14.0/components/index.md
@@ -36,7 +36,7 @@ Given the above template, you can now use the `<BlogPost />` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.14.0/models/defining-models.md
+++ b/guides/v3.14.0/models/defining-models.md
@@ -32,7 +32,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
         Ember Data models are normally setup using the singular form (which is why we use `person` instead of `people` here)
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.14.0/models/index.md
+++ b/guides/v3.14.0/models/index.md
@@ -188,7 +188,7 @@ first ask the store for it.
         so you can access it as `this.store`!
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.14.0/object-model/enumerables.md
+++ b/guides/v3.14.0/object-model/enumerables.md
@@ -33,7 +33,7 @@ where available.
         </a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.14.0/tutorial/simple-component.md
+++ b/guides/v3.14.0/tutorial/simple-component.md
@@ -98,7 +98,7 @@ with our new `RentalListing` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.15.0/accessibility/components.md
+++ b/guides/v3.15.0/accessibility/components.md
@@ -86,6 +86,6 @@ However, this option can be a little harder to apply styles to, so both should b
 To dig deeper into accessible input patterns in Ember check out the <a href="https://emberjs-1.gitbook.io/ember-component-patterns/form-components/input">ember-component-patterns article on Input Fields</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>

--- a/guides/v3.16.0/accessibility/components.md
+++ b/guides/v3.16.0/accessibility/components.md
@@ -86,6 +86,6 @@ However, this option can be a little harder to apply styles to, so both should b
 To dig deeper into accessible input patterns in Ember check out the <a href="https://emberjs-1.gitbook.io/ember-component-patterns/form-components/input">ember-component-patterns article on Input Fields</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>

--- a/guides/v3.17.0/accessibility/components.md
+++ b/guides/v3.17.0/accessibility/components.md
@@ -86,6 +86,6 @@ However, this option can be a little harder to apply styles to, so both should b
 To dig deeper into accessible input patterns in Ember check out the <a href="https://emberjs-1.gitbook.io/ember-component-patterns/form-components/input">ember-component-patterns article on Input Fields</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>

--- a/guides/v3.17.0/upgrading/current-edition/action-on-and-fn.md
+++ b/guides/v3.17.0/upgrading/current-edition/action-on-and-fn.md
@@ -141,7 +141,7 @@ export default class ExampleComponent extends Component {
         The <code>{{action}}</code> modifier called <code>event.preventDefault()</code> under the hood, but the <code>{{on}}</code> modifier does not, so if you need to do anything other than the default action for a particular event, you must call <code>event.preventDefault</code> within the action.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div> 
 

--- a/guides/v3.18.0/accessibility/components.md
+++ b/guides/v3.18.0/accessibility/components.md
@@ -86,6 +86,6 @@ However, this option can be a little harder to apply styles to, so both should b
 To dig deeper into accessible input patterns in Ember check out the <a href="https://emberjs-1.gitbook.io/ember-component-patterns/form-components/input">ember-component-patterns article on Input Fields</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>

--- a/guides/v3.18.0/upgrading/current-edition/action-on-and-fn.md
+++ b/guides/v3.18.0/upgrading/current-edition/action-on-and-fn.md
@@ -141,7 +141,7 @@ export default class ExampleComponent extends Component {
         The <code>{{action}}</code> modifier called <code>event.preventDefault()</code> under the hood, but the <code>{{on}}</code> modifier does not, so if you need to do anything other than the default action for a particular event, you must call <code>event.preventDefault</code> within the action.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div> 
 

--- a/guides/v3.7.0/components/defining-a-component.md
+++ b/guides/v3.7.0/components/defining-a-component.md
@@ -35,7 +35,7 @@ Given the above template, you can now use the `<BlogPost />` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.7.0/models/index.md
+++ b/guides/v3.7.0/models/index.md
@@ -186,7 +186,7 @@ first ask the store for it.
         so you can access it as `this.store`!
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.7.0/tutorial/simple-component.md
+++ b/guides/v3.7.0/tutorial/simple-component.md
@@ -98,7 +98,7 @@ with our new `RentalListing` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.8.0/components/defining-a-component.md
+++ b/guides/v3.8.0/components/defining-a-component.md
@@ -35,7 +35,7 @@ Given the above template, you can now use the `<BlogPost />` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.8.0/models/index.md
+++ b/guides/v3.8.0/models/index.md
@@ -184,7 +184,7 @@ first ask the store for it.
         so you can access it as `this.store`!
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.8.0/object-model/enumerables.md
+++ b/guides/v3.8.0/object-model/enumerables.md
@@ -33,7 +33,7 @@ where available.
         </a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.8.0/tutorial/simple-component.md
+++ b/guides/v3.8.0/tutorial/simple-component.md
@@ -98,7 +98,7 @@ with our new `RentalListing` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.9.0/components/defining-a-component.md
+++ b/guides/v3.9.0/components/defining-a-component.md
@@ -35,7 +35,7 @@ Given the above template, you can now use the `<BlogPost />` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.9.0/models/index.md
+++ b/guides/v3.9.0/models/index.md
@@ -186,7 +186,7 @@ first ask the store for it.
         so you can access it as `this.store`!
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.9.0/object-model/enumerables.md
+++ b/guides/v3.9.0/object-model/enumerables.md
@@ -33,7 +33,7 @@ where available.
         </a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 

--- a/guides/v3.9.0/tutorial/simple-component.md
+++ b/guides/v3.9.0/tutorial/simple-component.md
@@ -98,7 +98,7 @@ with our new `RentalListing` component:
 In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="Ember Mascot">
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
   </div>
 </div>
 


### PR DESCRIPTION
## Description

This PR can address and close https://github.com/ember-learn/guides-source/issues/1124. (When an image has the `presentation` role, we don't set the alternate text.)

In the previous attempt https://github.com/ember-learn/guides-source/pull/1125, I had only removed the alternate text `Ember Mascot` in the then-`release` directory. As a result, it seemed like the alternate text began to reappear in more recent directories, possibly through copy-paste.

I used `git grep -n "Ember Mascot"` to find and remove all instances.