### PR TITLE
correct super syntax in the handling metadata examples 

### DIFF
--- a/guides/release/models/handling-metadata.md
+++ b/guides/release/models/handling-metadata.md
@@ -74,9 +74,9 @@ export default class UsersRoute extends Route {
         meta: results.meta
       };
     });
-  },
+  }
   setupController(controller, { users, meta }) {
-    super(controller, users);
+    super.setupController(controller, users);
     controller.meta = meta;
   }
 }

--- a/guides/v3.15.0/models/handling-metadata.md
+++ b/guides/v3.15.0/models/handling-metadata.md
@@ -74,9 +74,9 @@ export default class UsersRoute extends Route {
         meta: results.meta
       };
     });
-  },
+  }
   setupController(controller, { users, meta }) {
-    super(controller, users);
+    super.setupController(controller, users);
     controller.meta = meta;
   }
 }

--- a/guides/v3.16.0/models/handling-metadata.md
+++ b/guides/v3.16.0/models/handling-metadata.md
@@ -74,9 +74,9 @@ export default class UsersRoute extends Route {
         meta: results.meta
       };
     });
-  },
+  }
   setupController(controller, { users, meta }) {
-    super(controller, users);
+    super.setupController(controller, users);
     controller.meta = meta;
   }
 }

--- a/guides/v3.17.0/models/handling-metadata.md
+++ b/guides/v3.17.0/models/handling-metadata.md
@@ -74,9 +74,9 @@ export default class UsersRoute extends Route {
         meta: results.meta
       };
     });
-  },
+  }
   setupController(controller, { users, meta }) {
-    super(controller, users);
+    super.setupController(controller, users);
     controller.meta = meta;
   }
 }

--- a/guides/v3.18.0/models/handling-metadata.md
+++ b/guides/v3.18.0/models/handling-metadata.md
@@ -74,9 +74,9 @@ export default class UsersRoute extends Route {
         meta: results.meta
       };
     });
-  },
+  }
   setupController(controller, { users, meta }) {
-    super(controller, users);
+    super.setupController(controller, users);
     controller.meta = meta;
   }
 }


### PR DESCRIPTION
The example used in handling metadata for versions 3.15-3.19 use the wrong super syntax in the `setupController` hook, this updates it from `super()` to `super.setupController()` and removes the comma on the `model()` hook