### PR TITLE
Fixed a broken link

### DIFF
--- a/guides/release/accessibility/application-considerations.md
+++ b/guides/release/accessibility/application-considerations.md
@@ -83,7 +83,7 @@ An important thing to note in this section is this: "application" in Ember devel
 
 The <abbr title="too long; didn't read">TL;DR</abbr>? Don't use `role="application"` until you have done your research and know exactly how it is to be used correctly (if at all). There are **very** few use cases where the role of application is appropriate.
 
-Read more about it: [https://a11yproject.com/posts/how-to-use-application-role/](https://a11yproject.com/posts/how-to-use-application-role/)
+Read more about it: [https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)
 
 ## Accessibility addons
 

--- a/guides/v3.10.0/reference/accessibility-guide.md
+++ b/guides/v3.10.0/reference/accessibility-guide.md
@@ -54,7 +54,7 @@ An important thing to note in this section is this: "application" in Ember devel
 
 The <abbr title="too long; didn't read">TL;DR</abbr>? Don't use `role="application"` until you have done your research and know exactly how it is to be used correctly (if at all). There are **very** few use cases where the role of application is appropriate. 
 
-Read more about it: [https://a11yproject.com/posts/how-to-use-application-role/](https://a11yproject.com/posts/how-to-use-application-role/)
+Read more about it: [https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)
 
 
 ## Basic Guidelines for Accessibility

--- a/guides/v3.11.0/reference/accessibility-guide.md
+++ b/guides/v3.11.0/reference/accessibility-guide.md
@@ -54,7 +54,7 @@ An important thing to note in this section is this: "application" in Ember devel
 
 The <abbr title="too long; didn't read">TL;DR</abbr>? Don't use `role="application"` until you have done your research and know exactly how it is to be used correctly (if at all). There are **very** few use cases where the role of application is appropriate. 
 
-Read more about it: [https://a11yproject.com/posts/how-to-use-application-role/](https://a11yproject.com/posts/how-to-use-application-role/)
+Read more about it: [https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)
 
 
 ## Basic Guidelines for Accessibility

--- a/guides/v3.12.0/accessibility/application-considerations.md
+++ b/guides/v3.12.0/accessibility/application-considerations.md
@@ -83,7 +83,7 @@ An important thing to note in this section is this: "application" in Ember devel
 
 The <abbr title="too long; didn't read">TL;DR</abbr>? Don't use `role="application"` until you have done your research and know exactly how it is to be used correctly (if at all). There are **very** few use cases where the role of application is appropriate. 
 
-Read more about it: [https://a11yproject.com/posts/how-to-use-application-role/](https://a11yproject.com/posts/how-to-use-application-role/)
+Read more about it: [https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)
 
 ## Accessibility addons
 

--- a/guides/v3.13.0/accessibility/application-considerations.md
+++ b/guides/v3.13.0/accessibility/application-considerations.md
@@ -83,7 +83,7 @@ An important thing to note in this section is this: "application" in Ember devel
 
 The <abbr title="too long; didn't read">TL;DR</abbr>? Don't use `role="application"` until you have done your research and know exactly how it is to be used correctly (if at all). There are **very** few use cases where the role of application is appropriate.
 
-Read more about it: [https://a11yproject.com/posts/how-to-use-application-role/](https://a11yproject.com/posts/how-to-use-application-role/)
+Read more about it: [https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)
 
 ## Accessibility addons
 

--- a/guides/v3.14.0/accessibility/application-considerations.md
+++ b/guides/v3.14.0/accessibility/application-considerations.md
@@ -83,7 +83,7 @@ An important thing to note in this section is this: "application" in Ember devel
 
 The <abbr title="too long; didn't read">TL;DR</abbr>? Don't use `role="application"` until you have done your research and know exactly how it is to be used correctly (if at all). There are **very** few use cases where the role of application is appropriate.
 
-Read more about it: [https://a11yproject.com/posts/how-to-use-application-role/](https://a11yproject.com/posts/how-to-use-application-role/)
+Read more about it: [https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)
 
 ## Accessibility addons
 

--- a/guides/v3.15.0/accessibility/application-considerations.md
+++ b/guides/v3.15.0/accessibility/application-considerations.md
@@ -83,7 +83,7 @@ An important thing to note in this section is this: "application" in Ember devel
 
 The <abbr title="too long; didn't read">TL;DR</abbr>? Don't use `role="application"` until you have done your research and know exactly how it is to be used correctly (if at all). There are **very** few use cases where the role of application is appropriate.
 
-Read more about it: [https://a11yproject.com/posts/how-to-use-application-role/](https://a11yproject.com/posts/how-to-use-application-role/)
+Read more about it: [https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)
 
 ## Accessibility addons
 

--- a/guides/v3.16.0/accessibility/application-considerations.md
+++ b/guides/v3.16.0/accessibility/application-considerations.md
@@ -83,7 +83,7 @@ An important thing to note in this section is this: "application" in Ember devel
 
 The <abbr title="too long; didn't read">TL;DR</abbr>? Don't use `role="application"` until you have done your research and know exactly how it is to be used correctly (if at all). There are **very** few use cases where the role of application is appropriate.
 
-Read more about it: [https://a11yproject.com/posts/how-to-use-application-role/](https://a11yproject.com/posts/how-to-use-application-role/)
+Read more about it: [https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)
 
 ## Accessibility addons
 

--- a/guides/v3.17.0/accessibility/application-considerations.md
+++ b/guides/v3.17.0/accessibility/application-considerations.md
@@ -83,7 +83,7 @@ An important thing to note in this section is this: "application" in Ember devel
 
 The <abbr title="too long; didn't read">TL;DR</abbr>? Don't use `role="application"` until you have done your research and know exactly how it is to be used correctly (if at all). There are **very** few use cases where the role of application is appropriate.
 
-Read more about it: [https://a11yproject.com/posts/how-to-use-application-role/](https://a11yproject.com/posts/how-to-use-application-role/)
+Read more about it: [https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)
 
 ## Accessibility addons
 

--- a/guides/v3.18.0/accessibility/application-considerations.md
+++ b/guides/v3.18.0/accessibility/application-considerations.md
@@ -83,7 +83,7 @@ An important thing to note in this section is this: "application" in Ember devel
 
 The <abbr title="too long; didn't read">TL;DR</abbr>? Don't use `role="application"` until you have done your research and know exactly how it is to be used correctly (if at all). There are **very** few use cases where the role of application is appropriate.
 
-Read more about it: [https://a11yproject.com/posts/how-to-use-application-role/](https://a11yproject.com/posts/how-to-use-application-role/)
+Read more about it: [https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)
 
 ## Accessibility addons
 

--- a/guides/v3.19.0/accessibility/application-considerations.md
+++ b/guides/v3.19.0/accessibility/application-considerations.md
@@ -83,7 +83,7 @@ An important thing to note in this section is this: "application" in Ember devel
 
 The <abbr title="too long; didn't read">TL;DR</abbr>? Don't use `role="application"` until you have done your research and know exactly how it is to be used correctly (if at all). There are **very** few use cases where the role of application is appropriate.
 
-Read more about it: [https://a11yproject.com/posts/how-to-use-application-role/](https://a11yproject.com/posts/how-to-use-application-role/)
+Read more about it: [https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)
 
 ## Accessibility addons
 

--- a/guides/v3.7.0/reference/accessibility-guide.md
+++ b/guides/v3.7.0/reference/accessibility-guide.md
@@ -54,7 +54,7 @@ An important thing to note in this section is this: "application" in Ember devel
 
 The <abbr title="too long; didn't read">TL;DR</abbr>? Don't use `role="application"` until you have done your research and know exactly how it is to be used correctly (if at all). There are **very** few use cases where the role of application is appropriate. 
 
-Read more about it: [https://a11yproject.com/posts/how-to-use-application-role/](https://a11yproject.com/posts/how-to-use-application-role/)
+Read more about it: [https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)
 
 
 ## Basic Guidelines for Accessibility

--- a/guides/v3.8.0/reference/accessibility-guide.md
+++ b/guides/v3.8.0/reference/accessibility-guide.md
@@ -54,7 +54,7 @@ An important thing to note in this section is this: "application" in Ember devel
 
 The <abbr title="too long; didn't read">TL;DR</abbr>? Don't use `role="application"` until you have done your research and know exactly how it is to be used correctly (if at all). There are **very** few use cases where the role of application is appropriate. 
 
-Read more about it: [https://a11yproject.com/posts/how-to-use-application-role/](https://a11yproject.com/posts/how-to-use-application-role/)
+Read more about it: [https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)
 
 
 ## Basic Guidelines for Accessibility

--- a/guides/v3.9.0/reference/accessibility-guide.md
+++ b/guides/v3.9.0/reference/accessibility-guide.md
@@ -54,7 +54,7 @@ An important thing to note in this section is this: "application" in Ember devel
 
 The <abbr title="too long; didn't read">TL;DR</abbr>? Don't use `role="application"` until you have done your research and know exactly how it is to be used correctly (if at all). There are **very** few use cases where the role of application is appropriate. 
 
-Read more about it: [https://a11yproject.com/posts/how-to-use-application-role/](https://a11yproject.com/posts/how-to-use-application-role/)
+Read more about it: [https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)
 
 
 ## Basic Guidelines for Accessibility

--- a/node-tests/local/external-link-checker.js
+++ b/node-tests/local/external-link-checker.js
@@ -9,11 +9,11 @@ const { extname } = require('path');
 const { inspect } = require('util');
 const {
   findMarkdownLinks,
-	checkExternalLink,
-	mapToLocalUrl,
-	removeTrailingApostrophe,
-	randomizeFetchDelays,
-	sleep
+  checkExternalLink,
+  mapToLocalUrl,
+  removeTrailingApostrophe,
+  randomizeFetchDelays,
+  sleep
 } = require('./../helpers');
 
 function printBadLinks(badLinks) {
@@ -33,39 +33,39 @@ const releasePaths = walkSync('guides/release')
  * @type {Array}
  */
 const doNotCheckList = [
-	'http://localhost:4200', // getting-started/quick-start
-	'http://localhost:4200/scientists', // generating routes, link to open local server route
-	'http://localhost:4200/contact', // model hook tutorial code snippet
-	'http://localhost:4200/about', // model hook tutorial code snippet
-	'http://localhost:4200/about/', // routes and templates
-	'https://codepen.io/melsumner/live/ZJeYoP' // ...codepen does not play with fetch api.
-]
+  'http://localhost:4200', // getting-started/quick-start
+  'http://localhost:4200/scientists', // generating routes, link to open local server route
+  'http://localhost:4200/contact', // model hook tutorial code snippet
+  'http://localhost:4200/about', // model hook tutorial code snippet
+  'http://localhost:4200/about/', // routes and templates
+  'https://codepen.io/melsumner/live/ZJeYoP' // ...codepen does not play with fetch api.
+];
 
-describe('check all external links in markdown files', function () {
-	const skipApiUrls = "FOLLOW_API_URLS" in process.env && process.env.FOLLOW_API_URLS === "false";
+describe('check all external links in markdown files', function() {
+  const skipApiUrls = 'FOLLOW_API_URLS' in process.env && process.env.FOLLOW_API_URLS === 'false';
 
-  releasePaths.forEach((filepath) => {
-    it(`processing ${filepath}`, async function () {
-			this.timeout(60000); // high for slow networks and pages with a lot of external links
+  releasePaths.forEach((filePath) => {
+    it(`processing ${filePath}`, async function() {
+      this.timeout(60000); // high for slow networks and pages with a lot of external links
 
-			const externalLinks = findMarkdownLinks(filepath)
-				.filter((link) => link.startsWith("http")) // should have more robust regex
-				.filter((link) => !doNotCheckList.includes(link))
-				.filter((link) => !(skipApiUrls && link.toLowerCase().includes('api.emberjs.com')))
-				.map(mapToLocalUrl)
-				.map(removeTrailingApostrophe)
-				.map(randomizeFetchDelays);
+      const externalLinks = findMarkdownLinks(filePath)
+        .filter((link) => link.startsWith('http')) // should have more robust regex
+        .filter((link) => !doNotCheckList.includes(link))
+        .filter((link) => !(skipApiUrls && link.toLowerCase().includes('api.emberjs.com')))
+        .map(mapToLocalUrl)
+        .map(removeTrailingApostrophe)
+        .map(randomizeFetchDelays);
 
-			let responses = [];
+      let responses = [];
 
-			for (let i = 0; i < externalLinks.length; i++) {
-				await sleep(externalLinks[i].delay);
-				responses.push(await checkExternalLink(externalLinks[i].url));
-			}
+      for (let i = 0; i < externalLinks.length; i++) {
+        await sleep(externalLinks[i].delay);
+        responses.push(await checkExternalLink(externalLinks[i].url));
+      }
 
-			const errors = responses.filter((result) => result != null);
+      const errors = responses.filter((result) => result != null);
 
-			expect(errors, printBadLinks(errors)).to.be.an('array').to.be.empty;
+      expect(errors, printBadLinks(errors)).to.be.an('array').to.be.empty;
     });
   });
 });

--- a/node-tests/local/external-link-checker.js
+++ b/node-tests/local/external-link-checker.js
@@ -33,12 +33,8 @@ const releasePaths = walkSync('guides/release')
  * @type {Array}
  */
 const doNotCheckList = [
-  'http://localhost:4200', // getting-started/quick-start
-  'http://localhost:4200/scientists', // generating routes, link to open local server route
-  'http://localhost:4200/contact', // model hook tutorial code snippet
-  'http://localhost:4200/about', // model hook tutorial code snippet
-  'http://localhost:4200/about/', // routes and templates
-  'https://codepen.io/melsumner/live/ZJeYoP' // ...codepen does not play with fetch api.
+  'http://localhost:4200',
+  'https://codepen.io/melsumner/live/ZJeYoP' // codepen does not play with fetch api
 ];
 
 describe('check all external links in markdown files', function() {
@@ -50,7 +46,10 @@ describe('check all external links in markdown files', function() {
 
       const externalLinks = findMarkdownLinks(filePath)
         .filter((link) => link.startsWith('http')) // should have more robust regex
-        .filter((link) => !doNotCheckList.includes(link))
+        .filter((link) => {
+          const canSkipCheck = doNotCheckList.some(address => link.startsWith(address));
+          return !canSkipCheck;
+        })
         .filter((link) => !(skipApiUrls && link.toLowerCase().includes('api.emberjs.com')))
         .map(mapToLocalUrl)
         .map(removeTrailingApostrophe)


### PR DESCRIPTION
## Description

When I tested the use of `/node-tests/local/external-link-checker.js` on the `/guides/v3.18.0` folder, I found that:

- The link to the article "[How to Use Application Role](https://www.a11yproject.com/posts/2013-02-09-how-to-use-application-role/)" changed over time.
- The script incorrectly flagged `http://localhost:4200/tests` as a broken link.

I corrected the link to a11yproject and updated the script to ignore all URLs that begin with `http://localhost:4200`.