### PR TITLE
Updated API links in guides/3.15.0

### DIFF
--- a/guides/v3.15.0/applications/dependency-injection.md
+++ b/guides/v3.15.0/applications/dependency-injection.md
@@ -11,11 +11,11 @@ guide covers the details of the system, and how to use it when needed.
 
 Applications and application instances each serve a role in Ember's DI implementation.
 
-An [`Application`](https://api.emberjs.com/ember/release/classes/Application) serves as a "registry" for dependency declarations.
+An [`Application`](https://api.emberjs.com/ember/3.15/classes/Application) serves as a "registry" for dependency declarations.
 Factories (i.e. classes) are registered with an application,
 as well as rules about "injecting" dependencies that are applied when objects are instantiated.
 
-An [`ApplicationInstance`](https://api.emberjs.com/ember/release/classes/ApplicationInstance) serves as the "owner" for objects that are instantiated from registered factories.
+An [`ApplicationInstance`](https://api.emberjs.com/ember/3.15/classes/ApplicationInstance) serves as the "owner" for objects that are instantiated from registered factories.
 Application instances provide a means to "look up" (i.e. instantiate and / or retrieve) objects.
 
 > _Note: Although an `Application` serves as the primary registry for an app,
@@ -203,7 +203,7 @@ export default Component.extend({
 ## Factory Instance Lookups
 
 To fetch an instantiated factory from the running application you can call the
-[`lookup`](https://api.emberjs.com/ember/release/classes/ApplicationInstance/methods/lookup?anchor=lookup) method on an application instance. This method takes a string
+[`lookup`](https://api.emberjs.com/ember/3.15/classes/ApplicationInstance/methods/lookup?anchor=lookup) method on an application instance. This method takes a string
 to identify a factory and returns the appropriate object.
 
 ```javascript
@@ -234,9 +234,9 @@ export default {
 
 ### Getting an Application Instance from a Factory Instance
 
-[`Ember.getOwner`](https://api.emberjs.com/ember/release/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) will retrieve the application instance that "owns" an
+[`Ember.getOwner`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) will retrieve the application instance that "owns" an
 object. This means that framework objects like components, helpers, and routes
-can use [`Ember.getOwner`](https://api.emberjs.com/ember/release/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) to perform lookups through their application
+can use [`Ember.getOwner`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) to perform lookups through their application
 instance at runtime.
 
 For example, this component plays songs with different audio services based

--- a/guides/v3.15.0/applications/ember-engines.md
+++ b/guides/v3.15.0/applications/ember-engines.md
@@ -1,6 +1,6 @@
 ## What are Engines?
 
-[Ember Engines](http://ember-engines.com/) allow multiple logical applications to be composed together into a single application from the user's perspective, that provide functionality to their host applications. Engines are isolated, `composable applications`, they have almost all the same features as normal Ember applications, except an [Engine](https://api.emberjs.com/ember/release/classes/Engine) requires a host application to boot it and provide a Router instance.
+[Ember Engines](http://ember-engines.com/) allow multiple logical applications to be composed together into a single application from the user's perspective, that provide functionality to their host applications. Engines are isolated, `composable applications`, they have almost all the same features as normal Ember applications, except an [Engine](https://api.emberjs.com/ember/3.15/classes/Engine) requires a host application to boot it and provide a Router instance.
 
 ## Why use Engines?
 

--- a/guides/v3.15.0/applications/index.md
+++ b/guides/v3.15.0/applications/index.md
@@ -1,8 +1,8 @@
-Every Ember application is represented by a class that extends [`Application`](https://api.emberjs.com/ember/release/classes/Application).
+Every Ember application is represented by a class that extends [`Application`](https://api.emberjs.com/ember/3.15/classes/Application).
 This class is used to declare and configure the many objects that make up your app.
 
 As your application boots,
-it creates an [`ApplicationInstance`](https://api.emberjs.com/ember/release/classes/ApplicationInstance) that is used to manage its stateful aspects.
+it creates an [`ApplicationInstance`](https://api.emberjs.com/ember/3.15/classes/ApplicationInstance) that is used to manage its stateful aspects.
 This instance acts as the "owner" of objects instantiated for your app.
 
 Essentially, the `Application` *defines your application*

--- a/guides/v3.15.0/applications/run-loop.md
+++ b/guides/v3.15.0/applications/run-loop.md
@@ -199,9 +199,9 @@ $('a').click(() => {
 });
 ```
 
-The run loop API calls that _schedule_ work, i.e. [`run.schedule`](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop/methods/schedule?anchor=schedule),
-[`run.scheduleOnce`](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop/methods/scheduleOnce?anchor=scheduleOnce),
-[`run.once`](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop/methods/once?anchor=once) have the property that they will approximate a run loop for you if one does not already exist.
+The run loop API calls that _schedule_ work, i.e. [`run.schedule`](https://api.emberjs.com/ember/3.15/classes/@ember%2Frunloop/methods/schedule?anchor=schedule),
+[`run.scheduleOnce`](https://api.emberjs.com/ember/3.15/classes/@ember%2Frunloop/methods/scheduleOnce?anchor=scheduleOnce),
+[`run.once`](https://api.emberjs.com/ember/3.15/classes/@ember%2Frunloop/methods/once?anchor=once) have the property that they will approximate a run loop for you if one does not already exist.
 These automatically created run loops we call _autoruns_.
 
 Here is some pseudocode to describe what happens using the example above:
@@ -242,5 +242,5 @@ $('a').click(() => {
 
 ## Where can I find more information?
 
-Check out the [Ember.run](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop) API documentation,
+Check out the [Ember.run](https://api.emberjs.com/ember/3.15/classes/@ember%2Frunloop) API documentation,
 as well as the [Backburner library](https://github.com/ebryn/backburner.js/) that powers the run loop.

--- a/guides/v3.15.0/components/built-in-components.md
+++ b/guides/v3.15.0/components/built-in-components.md
@@ -2,7 +2,7 @@ Ember provides a few helpful components out-of-the-box for common tasks,
 including:
 
 * [`<Input />`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.components/methods/Input?anchor=Input)
-* [`<Textarea />`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea)
+* [`<Textarea />`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea)
 
 Using these components, you can create form controls that are almost identical to
 the native HTML `<input>` or `<textarea>` elements, and which automatically
@@ -99,7 +99,7 @@ Checkboxes support the following properties:
 Which can be bound or set as described in the previous section.
 
 
-Checkboxes are a special input type.  If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/release/classes/Component#event-handler-methods),
+Checkboxes are a special input type.  If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.15/classes/Component#event-handler-methods),
 you will always need to either define the event name in camelCase format (e.g. `@keyDown`), or
 use an `on` helper with the [Web-API event name](https://developer.mozilla.org/en-US/docs/Web/API/Document/keydown_event) (e.g. `on 'keydown'`):
 
@@ -126,7 +126,7 @@ Internally, `<Input @type="checkbox" />` creates an instance of Checkbox. Do *no
 
 Will bind the value of the text area to `name` on the current context.
 
-[`<Textarea>`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea) supports binding and/or setting the following properties:
+[`<Textarea>`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea) supports binding and/or setting the following properties:
 
 * `value`
 * `name`
@@ -150,8 +150,8 @@ Will bind the value of the text area to `name` on the current context.
 
 You might need to bind a property dynamically to an input if you're building a
 flexible form, for example. To achieve this you need to use the
-[`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
-and [`{{mut}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/mut?anchor=mut)
+[`{{get}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/get?anchor=get)
+and [`{{mut}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/mut?anchor=mut)
 in conjunction like shown in the following example:
 
 ```handlebars
@@ -162,5 +162,5 @@ in conjunction like shown in the following example:
 The `{{get}}` helper allows you to dynamically specify which property to bind,
 while the `{{mut}}` helper allows the binding to be updated from the input. See
 the respective helper documentation for more detail:
-[`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
-and [`{{mut}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/mut?anchor=mut).
+[`{{get}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/get?anchor=get)
+and [`{{mut}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/mut?anchor=mut).

--- a/guides/v3.15.0/components/helper-functions.md
+++ b/guides/v3.15.0/components/helper-functions.md
@@ -274,7 +274,7 @@ capitalized first name and last name as `firstName` and `lastName` instead of
 
 ### The `array` helper
 
-Using the [`{{array}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
+Using the [`{{array}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
 you can pass arrays directly from the template as an argument to your components.
 
 ```handlebars

--- a/guides/v3.15.0/components/looping-through-lists.md
+++ b/guides/v3.15.0/components/looping-through-lists.md
@@ -185,7 +185,7 @@ as a string.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         Using triple curly brackets is just one way to put dynamic HTML into
-        Ember templates. We can also use the <a href="https://api.emberjs.com/ember/release/functions/@ember%2Ftemplate/htmlSafe">htmlSafe</a>
+        Ember templates. We can also use the <a href="https://api.emberjs.com/ember/3.15/functions/@ember%2Ftemplate/htmlSafe">htmlSafe</a>
         function to wrap template strings. Additionally, inserting unknown HTML
         into an app can always produce unexpected results, so we should be
         careful and always make sure that the HTML is safe (as in, won't cause
@@ -269,7 +269,7 @@ And in the component class, we'll add the `addMessage` action. This action will
 create the new message from the text that the `<NewMessageInput>` component
 gives us, and push it into the messages array. In order for the messages array
 to react to that change, we'll also need to convert it into an
-[`EmberArray`](https://api.emberjs.com/ember/release/classes/EmberArray).
+[`EmberArray`](https://api.emberjs.com/ember/3.15/classes/EmberArray).
 `EmberArray` provides special methods that tell Ember when changes occur to the
 array itself.
 

--- a/guides/v3.15.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.15.0/configuring-ember/disabling-prototype-extensions.md
@@ -9,7 +9,7 @@ objects in the following ways:
 
 * `String` is extended to add convenience methods, such as
   `camelize()` and `w()`. You can find a list of these methods with the
-  [Ember.String documentation](https://api.emberjs.com/ember/release/classes/String).
+  [Ember.String documentation](https://api.emberjs.com/ember/3.15/classes/String).
 
 * `Function` is extended with methods to annotate functions as
   computed properties, via the `property()` method, and as observers,
@@ -90,7 +90,7 @@ islands.pushObject('Maui');
 ### Strings
 
 Strings will no longer have the convenience methods described in the
-[`Ember.String` API reference](https://api.emberjs.com/ember/release/classes/String).
+[`Ember.String` API reference](https://api.emberjs.com/ember/3.15/classes/String).
 Instead,
 you can use the similarly-named methods of the `Ember.String` object and
 pass the string to use as the first parameter:

--- a/guides/v3.15.0/configuring-ember/handling-deprecations.md
+++ b/guides/v3.15.0/configuring-ember/handling-deprecations.md
@@ -10,7 +10,7 @@ Fortunately, Ember provides a way for projects to deal with deprecations in an o
 ## Filtering Deprecations
 
 When your project has a lot of deprecations, you can start by filtering out deprecations that do not have to be addressed right away.
-You can use the [deprecation handlers](https://api.emberjs.com/ember/release/functions/@ember%2Fdebug/registerDeprecationHandler) API to check for what release a deprecated feature will be removed.
+You can use the [deprecation handlers](https://api.emberjs.com/ember/3.15/functions/@ember%2Fdebug/registerDeprecationHandler) API to check for what release a deprecated feature will be removed.
 An example handler is shown below that filters out all deprecations that are not going away in release 2.0.0.
 
 ```javascript {data-filename= app/initializers/main.js}

--- a/guides/v3.15.0/configuring-ember/optional-features.md
+++ b/guides/v3.15.0/configuring-ember/optional-features.md
@@ -102,7 +102,7 @@ Now your app will be about 30KB lighter!
 
 Without jQuery, any code that still relies on it will break, especially the following usages:
 
-- [`this.$()`](https://api.emberjs.com/ember/release/classes/Component/methods/$?anchor=%24) in components
+- [`this.$()`](https://api.emberjs.com/ember/3.15/classes/Component/methods/$?anchor=%24) in components
 - `jQuery` or `$` directly as a global, through `Ember.$()` or by importing it (`import jQuery from jquery;`)
 - global acceptance test helpers like `find()` or `click()`
 - `this.$()` in component tests

--- a/guides/v3.15.0/ember-inspector/data.md
+++ b/guides/v3.15.0/ember-inspector/data.md
@@ -30,4 +30,4 @@ You can also filter records by entering a query in the search box.
 ### Building a Data Custom Adapter
 
 You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter and [DataAdapter](https://api.emberjs.com/ember/release/classes/DataAdapter) documentation.
+using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter and [DataAdapter](https://api.emberjs.com/ember/3.15/classes/DataAdapter) documentation.

--- a/guides/v3.15.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.15.0/models/creating-updating-and-deleting-records.md
@@ -1,7 +1,7 @@
 ## Creating Records
 
 You can create records by calling the
-[`createRecord()`](https://api.emberjs.com/ember-data/release/classes/Adapter/methods/createRecord?anchor=createRecord)
+[`createRecord()`](https://api.emberjs.com/ember-data/3.15/classes/Adapter/methods/createRecord?anchor=createRecord)
 method on the store.
 
 ```javascript
@@ -28,7 +28,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 ## Persisting Records
 
 Records in Ember Data are persisted on a per-instance basis.
-Call [`save()`](https://api.emberjs.com/ember-data/release/classes/Model/methods/save?anchor=save)
+Call [`save()`](https://api.emberjs.com/ember-data/3.15/classes/Model/methods/save?anchor=save)
 on any instance of `Model` and it will make a network request.
 
 Ember Data takes care of tracking the state of each record for
@@ -60,10 +60,10 @@ store.findRecord('post', 1).then(function(post) {
 
 You can tell if a record has outstanding changes that have not yet been
 saved by checking its
-[`hasDirtyAttributes`](https://api.emberjs.com/ember-data/release/classes/Model/properties/hasDirtyAttributes?anchor=hasDirtyAttributes)
+[`hasDirtyAttributes`](https://api.emberjs.com/ember-data/3.15/classes/Model/properties/hasDirtyAttributes?anchor=hasDirtyAttributes)
 property. You can also see what parts of
 the record were changed and what the original value was using the
-[`changedAttributes()`](https://api.emberjs.com/ember-data/release/classes/Model/methods/changedAttributes?anchor=changedAttributes)
+[`changedAttributes()`](https://api.emberjs.com/ember-data/3.15/classes/Model/methods/changedAttributes?anchor=changedAttributes)
 method. `changedAttributes` returns an object, whose keys are the changed
 properties and values are an array of values `[oldValue, newValue]`.
 
@@ -77,7 +77,7 @@ person.changedAttributes(); // => { isAdmin: [false, true] }
 
 At this point, you can either persist your changes via `save()` or you can roll
 back your changes. Calling
-[`rollbackAttributes()`](https://api.emberjs.com/ember-data/release/classes/Model/methods/rollbackAttributes?anchor=rollbackAttributes)
+[`rollbackAttributes()`](https://api.emberjs.com/ember-data/3.15/classes/Model/methods/rollbackAttributes?anchor=rollbackAttributes)
 for a saved record reverts all the `changedAttributes` to their original value.
 If the record `isNew` it will be removed from the store.
 

--- a/guides/v3.15.0/models/customizing-adapters.md
+++ b/guides/v3.15.0/models/customizing-adapters.md
@@ -47,17 +47,17 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
 Ember Data comes with several built-in adapters.
 Feel free to use these adapters as a starting point for creating your own custom adapter.
 
-- [`Adapter`](https://api.emberjs.com/ember-data/release/classes/Adapter) is the basic adapter
+- [`Adapter`](https://api.emberjs.com/ember-data/3.15/classes/Adapter) is the basic adapter
 with no functionality. It is generally a good starting point if you
 want to create an adapter that is radically different from the other
 Ember adapters.
 
-- [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/release/classes/JSONAPIAdapter)
+- [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/3.15/classes/JSONAPIAdapter)
 The `JSONAPIAdapter` is the default adapter and follows JSON:API
 conventions to communicate with an HTTP server by transmitting JSON
 via XHR.
 
-- [`RESTAdapter`](https://api.emberjs.com/ember-data/release/classes/RESTAdapter)
+- [`RESTAdapter`](https://api.emberjs.com/ember-data/3.15/classes/RESTAdapter)
 The `RESTAdapter` allows your store to communicate with an HTTP server
 by transmitting JSON via XHR. Before Ember Data 2.0 this adapter was the default.
 
@@ -65,7 +65,7 @@ by transmitting JSON via XHR. Before Ember Data 2.0 this adapter was the default
 ## Customizing the JSONAPIAdapter
 
 The
-[JSONAPIAdapter](https://api.emberjs.com/ember-data/release/classes/JSONAPIAdapter)
+[JSONAPIAdapter](https://api.emberjs.com/ember-data/3.15/classes/JSONAPIAdapter)
 has a handful of hooks that are commonly used to extend it to work
 with non-standard backends.
 

--- a/guides/v3.15.0/models/customizing-serializers.md
+++ b/guides/v3.15.0/models/customizing-serializers.md
@@ -5,11 +5,11 @@ format, Ember Data allows you to customize the serializer or use a
 different serializer entirely.
 
 Ember Data ships with 3 serializers. The
-[`JSONAPISerializer`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer)
+[`JSONAPISerializer`](https://api.emberjs.com/ember-data/3.15/classes/JSONAPISerializer)
 is the default serializer and works with JSON:API backends. The
-[`JSONSerializer`](https://api.emberjs.com/ember-data/release/classes/JSONSerializer)
+[`JSONSerializer`](https://api.emberjs.com/ember-data/3.15/classes/JSONSerializer)
 is a simple serializer for working with single JSON object or arrays of records. The
-[`RESTSerializer`](https://api.emberjs.com/ember-data/release/classes/RESTSerializer)
+[`RESTSerializer`](https://api.emberjs.com/ember-data/3.15/classes/RESTSerializer)
 is a more complex serializer that supports sideloading and was the default
 serializer before 2.0.
 
@@ -141,7 +141,7 @@ export default class PostSerializer extends JSONAPISerializer {
 ```
 
 To change the format of the data that is sent to the backend store, you can use
-the [`serialize()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/serialize?anchor=serialize)
+the [`serialize()`](https://api.emberjs.com/ember-data/3.15/classes/JSONAPISerializer/methods/serialize?anchor=serialize)
 hook. Let's say that we have this JSON:API response from Ember Data:
 
 ```json
@@ -200,7 +200,7 @@ export default class ApplicationSerializer extends JSONAPISerializer {
 
 Similarly, if your backend store provides data in a format other than JSON:API,
 you can use the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.15/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -258,7 +258,7 @@ To normalize only a single model, you can use the
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
-API documentation](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer).
+API documentation](https://api.emberjs.com/ember-data/3.15/classes/JSONAPISerializer).
 
 ### IDs
 
@@ -311,7 +311,7 @@ in the document payload returned by your server:
 
 If the attributes returned by your server use a different convention
 you can use the serializer's
-[`keyForAttribute()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/keyForAttribute?anchor=keyForAttribute)
+[`keyForAttribute()`](https://api.emberjs.com/ember-data/3.15/classes/JSONAPISerializer/methods/keyForAttribute?anchor=keyForAttribute)
 method to convert an attribute name in your model to a key in your JSON
 payload. For example, if your backend returned attributes that are
 `under_scored` instead of `dash-cased` you could override the `keyForAttribute`
@@ -546,7 +546,7 @@ looks similar to this:
 The `JSONAPISerializer` is built on top of the `JSONSerializer` so they share
 many of the same hooks for customizing the behavior of the
 serialization process. Be sure to check out the
-[API docs](https://api.emberjs.com/ember-data/release/classes/JSONSerializer)
+[API docs](https://api.emberjs.com/ember-data/3.15/classes/JSONSerializer)
 for a full list of methods and properties.
 
 
@@ -764,7 +764,7 @@ the possible values of: `'findRecord'`, `'queryRecord'`, `'findAll'`,
 `'createRecord'`, `'deleteRecord'`, and `'updateRecord'`) as arguments.
 
 A custom serializer will also need to define a
-[normalize](https://api.emberjs.com/ember-data/release/classes/Serializer/methods/normalize?anchor=normalize)
+[normalize](https://api.emberjs.com/ember-data/3.15/classes/Serializer/methods/normalize?anchor=normalize)
 method.
 This method is called by `store.normalize(type, payload)` and is often
 used for normalizing requests made outside of Ember Data because they
@@ -773,7 +773,7 @@ do not fall into the normal CRUD flow that the adapter provides.
 ### Serializing records
 
 Finally a serializer will need to implement a
-[serialize](https://api.emberjs.com/ember-data/release/classes/Serializer/methods/serialize?anchor=serialize)
+[serialize](https://api.emberjs.com/ember-data/3.15/classes/Serializer/methods/serialize?anchor=serialize)
 method.
 Ember Data will provide a record snapshot and an options hash and this
 method should return an object that the adapter will send to the

--- a/guides/v3.15.0/models/defining-models.md
+++ b/guides/v3.15.0/models/defining-models.md
@@ -39,7 +39,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
 ## Defining Attributes
 
 The `person` model we generated earlier didn't have any attributes. Let's
-add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/release/classes/Model/properties/attributes?anchor=attributes):
+add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/3.15/classes/Model/properties/attributes?anchor=attributes):
 
 ```javascript {data-filename=app/models/person.js}
 import Model, { attr } from '@ember-data/model';

--- a/guides/v3.15.0/models/finding-records.md
+++ b/guides/v3.15.0/models/finding-records.md
@@ -22,7 +22,7 @@ let blogPost = this.store.peekRecord('blog-post', 1); // => no network request
 
 ### Retrieving Multiple Records
 
-Use [`store.findAll()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/findAll?anchor=findAll) to retrieve all of the records for a given type:
+Use [`store.findAll()`](https://api.emberjs.com/ember-data/3.15/classes/Store/methods/findAll?anchor=findAll) to retrieve all of the records for a given type:
 
 ```javascript
 // GET /blog-posts
@@ -108,7 +108,7 @@ As in the case of `store.query()`, a query object can also be passed to `store.q
 However the adapter must return a single model object, not an array containing one element,
 otherwise Ember Data will throw an exception.
 
-Note that Ember's default [JSON:API adapter](https://api.emberjs.com/ember-data/release/classes/JSONAPIAdapter) does not provide the functionality needed to support `queryRecord()` directly as it relies on REST request definitions that return result data in the form of an array.
+Note that Ember's default [JSON:API adapter](https://api.emberjs.com/ember-data/3.15/classes/JSONAPIAdapter) does not provide the functionality needed to support `queryRecord()` directly as it relies on REST request definitions that return result data in the form of an array.
 
 If your server API or your adapter only provides array responses but you wish to retrieve just a single record, you can alternatively use the `query()` method as follows:
 

--- a/guides/v3.15.0/models/finding-records.md
+++ b/guides/v3.15.0/models/finding-records.md
@@ -40,7 +40,7 @@ let blogPosts = this.store.peekAll('blog-post'); // => no network request
 
 `store.findAll()` returns a `PromiseArray` that fulfills to a `RecordArray` and `store.peekAll` directly returns a `RecordArray`.
 
-It's important to note that `RecordArray` is not a JavaScript array, it's an object that implements [`MutableArray`](https://api.emberjs.com/ember/release/classes/MutableArray).
+It's important to note that `RecordArray` is not a JavaScript array, it's an object that implements [`MutableArray`](https://api.emberjs.com/ember/3.15/classes/MutableArray).
 This is important because, for example, if you want to retrieve records by index,
 the `[]` notation will not work--you'll have to use `objectAt(index)` instead.
 

--- a/guides/v3.15.0/models/pushing-records-into-the-store.md
+++ b/guides/v3.15.0/models/pushing-records-into-the-store.md
@@ -19,7 +19,7 @@ you want to update the UI immediately.
 
 ### Pushing Records
 
-To push a record into the store, call the store's [`push()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/push?anchor=push) method.
+To push a record into the store, call the store's [`push()`](https://api.emberjs.com/ember-data/3.15/classes/Store/methods/push?anchor=push) method.
 
 For example, imagine we want to preload some data into the store when
 the application boots for the first time.

--- a/guides/v3.15.0/models/relationships.md
+++ b/guides/v3.15.0/models/relationships.md
@@ -361,7 +361,7 @@ include those related records in the response returned to the client.
 The value of the parameter should be a comma-separated list of names of the
 relationships required.
 
-If you are using an adapter that supports JSON:API, such as Ember's default [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/release/classes/JSONAPIAdapter),
+If you are using an adapter that supports JSON:API, such as Ember's default [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/3.15/classes/JSONAPIAdapter),
 you can easily add the `include` parameter to the server requests created by
 the `findRecord()`, `findAll()`,
 `query()` and `queryRecord()` methods.

--- a/guides/v3.15.0/object-model/bindings.md
+++ b/guides/v3.15.0/object-model/bindings.md
@@ -1,7 +1,7 @@
 *__Note:__ Unlike most other frameworks that include some sort of binding implementation, bindings in Ember.js can be used with any object. That said, bindings are most often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.*
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
 that specifies the path to another object.
 
 ```javascript
@@ -35,7 +35,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.15.0/object-model/classes-and-instances.md
+++ b/guides/v3.15.0/object-model/classes-and-instances.md
@@ -67,7 +67,7 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`](https://api.emberjs.com/ember-data/3.15/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
 

--- a/guides/v3.15.0/object-model/classes-and-instances.md
+++ b/guides/v3.15.0/object-model/classes-and-instances.md
@@ -4,8 +4,8 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
-[`EmberObject`](https://api.emberjs.com/ember/release/modules/@ember%2Fobject):
+To define a new Ember _class_, call the [`extend()`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://api.emberjs.com/ember/3.15/modules/@ember%2Fobject):
 
 
 ```javascript
@@ -22,7 +22,7 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`](https://api.emberjs.com/ember/release/classes/Component) class:
+of Ember's built-in [`Component`](https://api.emberjs.com/ember/3.15/classes/Component) class:
 
 ```javascript {data-filename=app/components/todo-item.js}
 import Component from '@ember/component';
@@ -83,7 +83,7 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
+class by calling its [`create()`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
 
@@ -133,7 +133,7 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`](https://api.emberjs.com/ember/release/classes/EmberObject/methods/init?anchor=init) method is invoked automatically. This is the ideal place to implement setup required on new instances:
+When a new instance is created, its [`init()`](https://api.emberjs.com/ember/3.15/classes/EmberObject/methods/init?anchor=init) method is invoked automatically. This is the ideal place to implement setup required on new instances:
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -218,7 +218,7 @@ Person.create({
 
 When reading a property value of an object, you can in most cases use the common JavaScript dot notation, e.g. `myObject.myProperty`.
 
-[Ember proxy objects](https://api.emberjs.com/ember/release/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
+[Ember proxy objects](https://api.emberjs.com/ember/3.15/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
 
 Let's look at the following `blogPost` Ember Data model:
 
@@ -234,7 +234,7 @@ export default Model.extend({
 
 To access the blog post's title you can simply write `blogPost.title`, whereas only the syntax `blogPost.get('comments')` will return the post's comments.
 
-Always use Ember's [`set()`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject/methods/set?anchor=set) method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
+Always use Ember's [`set()`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fobject/methods/set?anchor=set) method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
 
 ```javascript
 import EmberObject from '@ember/object';

--- a/guides/v3.15.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.15.0/object-model/computed-properties-and-aggregate-data.md
@@ -108,7 +108,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}
@@ -200,10 +200,10 @@ export default Component.extend({
 Here, `indexOfSelectedTodo` depends on `todos.[]`, so it will update if we add an item
 to `todos`, but won't update if the value of `isDone` on a `todo` changes.
 
-Several of the [Ember.computed](https://api.emberjs.com/ember/release/classes/@ember%2Fobject%2Fcomputed) macros
+Several of the [Ember.computed](https://api.emberjs.com/ember/3.15/classes/@ember%2Fobject%2Fcomputed) macros
 utilize the `[]` key to implement common use-cases. For instance, to
 create a computed property that mapped properties from an array, you could use
-[Ember.computed.map](https://api.emberjs.com/ember/release/classes/@ember%2Fobject%2Fcomputed/methods/map?anchor=map)
+[Ember.computed.map](https://api.emberjs.com/ember/3.15/classes/@ember%2Fobject%2Fcomputed/methods/map?anchor=map)
 or build the computed property yourself:
 
 ```javascript

--- a/guides/v3.15.0/object-model/computed-properties.md
+++ b/guides/v3.15.0/object-model/computed-properties.md
@@ -259,4 +259,4 @@ class Person extends EmberObject {
 ```
 
 To see the full list of computed property macros, have a look at
-[the API documentation](https://api.emberjs.com/ember/release/modules/@ember%2Fobject)
+[the API documentation](https://api.emberjs.com/ember/3.15/modules/@ember%2Fobject)

--- a/guides/v3.15.0/object-model/enumerables.md
+++ b/guides/v3.15.0/object-model/enumerables.md
@@ -1,6 +1,6 @@
 In Ember.js, an enumerable is any object that contains a number of child
 objects, and which allows you to work with those children using the
-[`MutableArray`](https://api.emberjs.com/ember/release/classes/MutableArray) API. The most common
+[`MutableArray`](https://api.emberjs.com/ember/3.15/classes/MutableArray) API. The most common
 enumerable in the majority of apps is the native JavaScript array, which
 Ember.js extends to conform to the enumerable interface.
 
@@ -69,11 +69,11 @@ in an observable fashion, you should use `myArray.get('firstObject')` and
 
 In the rest of this guide, we'll explore some of the most common enumerable
 conveniences. For the full list, please see the [`MutableArray API
-reference documentation`](https://api.emberjs.com/ember/release/classes/MutableArray).
+reference documentation`](https://api.emberjs.com/ember/3.15/classes/MutableArray).
 
 ### Iterating Over an Enumerable
 
-To enumerate all the values of an enumerable object, use the [`forEach()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/forEach?anchor=forEach)
+To enumerate all the values of an enumerable object, use the [`forEach()`](https://api.emberjs.com/ember/3.15/classes/MutableArray/methods/forEach?anchor=forEach)
 method:
 
 
@@ -91,7 +91,7 @@ food.forEach((item, index) => {
 
 ### First and Last Objects
 
-All enumerables expose [`firstObject`](https://api.emberjs.com/ember/release/classes/MutableArray/properties/firstObject?anchor=firstObject) and [`lastObject`](https://api.emberjs.com/ember/release/classes/MutableArray/properties/lastObject?anchor=lastObject) properties
+All enumerables expose [`firstObject`](https://api.emberjs.com/ember/3.15/classes/MutableArray/properties/firstObject?anchor=firstObject) and [`lastObject`](https://api.emberjs.com/ember/3.15/classes/MutableArray/properties/lastObject?anchor=lastObject) properties
 that you can bind to.
 
 
@@ -113,7 +113,7 @@ animals.get('lastObject');
 ### Map
 
 You can easily transform each item in an enumerable using the
-[`map()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/map?anchor=map) method, which creates a new array with results of calling a
+[`map()`](https://api.emberjs.com/ember/3.15/classes/MutableArray/methods/map?anchor=map) method, which creates a new array with results of calling a
 function on each item in the enumerable.
 
 
@@ -124,7 +124,7 @@ let emphaticWords = words.map(item => `${item}!`);
 //=> ["goodbye!", "cruel!", "world!"]
 ```
 
-If your enumerable is composed of objects, there is a [`mapBy()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/mapBy?anchor=mapBy)
+If your enumerable is composed of objects, there is a [`mapBy()`](https://api.emberjs.com/ember/3.15/classes/MutableArray/methods/mapBy?anchor=mapBy)
 method that will extract the named property from each of those objects
 in turn and return a new array:
 
@@ -153,7 +153,7 @@ Another common task to perform on an enumerable is to take the
 enumerable as input, and return an Array after filtering it based on
 some criteria.
 
-For arbitrary filtering, use the [`filter()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/filter?anchor=filter) method.  The filter method
+For arbitrary filtering, use the [`filter()`](https://api.emberjs.com/ember/3.15/classes/MutableArray/methods/filter?anchor=filter) method.  The filter method
 expects the callback to return `true` if Ember should include it in the
 final Array, and `false` or `undefined` if Ember should not.
 
@@ -166,7 +166,7 @@ arr.filter((item, index, self) => item < 4);
 //=> [1, 2, 3]
 ```
 
-When working with a collection of Ember objects, you will often want to filter a set of objects based upon the value of some property. The [`filterBy()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/filterBy?anchor=filterBy) method provides a shortcut.
+When working with a collection of Ember objects, you will often want to filter a set of objects based upon the value of some property. The [`filterBy()`](https://api.emberjs.com/ember/3.15/classes/MutableArray/methods/filterBy?anchor=filterBy) method provides a shortcut.
 
 
 ```javascript
@@ -189,14 +189,14 @@ todos.filterBy('isDone', true);
 ```
 
 If you only want to return the first matched value, rather than an Array
-containing all of the matched values, you can use [`find()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/find?anchor=find) and [`findBy()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/findBy?anchor=findBy),
+containing all of the matched values, you can use [`find()`](https://api.emberjs.com/ember/3.15/classes/MutableArray/methods/find?anchor=find) and [`findBy()`](https://api.emberjs.com/ember/3.15/classes/MutableArray/methods/findBy?anchor=findBy),
 which work like `filter()` and `filterBy()`, but return only one item.
 
 
 ### Aggregate Information (Every or Any)
 
 To find out whether every item in an enumerable matches some condition, you can
-use the [`every()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/every?anchor=every) method:
+use the [`every()`](https://api.emberjs.com/ember/3.15/classes/MutableArray/methods/every?anchor=every) method:
 
 
 ```javascript
@@ -219,7 +219,7 @@ people.every((person, index, self) => person.get('isHappy'));
 ```
 
 To find out whether at least one item in an enumerable matches some condition,
-you can use the [`any()`](https://api.emberjs.com/ember/release/classes/MutableArray/methods/any?anchor=any) method:
+you can use the [`any()`](https://api.emberjs.com/ember/3.15/classes/MutableArray/methods/any?anchor=any) method:
 
 
 ```javascript

--- a/guides/v3.15.0/object-model/index.md
+++ b/guides/v3.15.0/object-model/index.md
@@ -2,20 +2,20 @@ One of the first things you'll notice when you generate JavaScript files in Embe
 
 ### Introducing: Ember Objects
 
-The [Ember Object](https://api.emberjs.com/ember/release/classes/EmberObject) class extends plain JavaScript objects to provide core framework functions such as participating in Ember's [binding system](../object-model/bindings/) or how changes to an object automatically trigger updates to the user interface.
+The [Ember Object](https://api.emberjs.com/ember/3.15/classes/EmberObject) class extends plain JavaScript objects to provide core framework functions such as participating in Ember's [binding system](../object-model/bindings/) or how changes to an object automatically trigger updates to the user interface.
 
 Most objects in Ember, including Routes, Models, Services, Mixins, Controllers, and Components extend the `EmberObject` class.
 
 ### Why Ember Objects?
 
-The most important reason is that an Ember Object can be watched for changes – or _observed_. For example, being [observable](https://api.emberjs.com/ember/release/classes/Observable) is important for [computed properties](../object-model/computed-properties/). It is one of the fundamental ways that models, controllers and views communicate with each other in an Ember application.
+The most important reason is that an Ember Object can be watched for changes – or _observed_. For example, being [observable](https://api.emberjs.com/ember/3.15/classes/Observable) is important for [computed properties](../object-model/computed-properties/). It is one of the fundamental ways that models, controllers and views communicate with each other in an Ember application.
 
 ### More on Ember Objects
 
-The [@ember/object](https://api.emberjs.com/ember/release/modules/@ember%2Fobject) package also provides a class system, supporting features like mixins and constructor methods, and being observable.
+The [@ember/object](https://api.emberjs.com/ember/3.15/modules/@ember%2Fobject) package also provides a class system, supporting features like mixins and constructor methods, and being observable.
 
 Some features in Ember's object model are not present in JavaScript classes or common patterns, but all are aligned as much as possible with the language and proposed additions.
 
-Ember also extends the JavaScript `Array` prototype with its [@ember/enumerable](https://api.emberjs.com/ember/release/classes/Enumerable) interface to provide change observation for arrays.
+Ember also extends the JavaScript `Array` prototype with its [@ember/enumerable](https://api.emberjs.com/ember/3.15/classes/Enumerable) interface to provide change observation for arrays.
 
-Finally, Ember extends the `String` prototype with a few [formatting and localization methods](https://api.emberjs.com/ember/release/classes/String).
+Finally, Ember extends the `String` prototype with a few [formatting and localization methods](https://api.emberjs.com/ember/3.15/classes/String).

--- a/guides/v3.15.0/object-model/observers.md
+++ b/guides/v3.15.0/object-model/observers.md
@@ -79,7 +79,7 @@ person.set('firstName', 'John');
 person.set('lastName', 'Smith');
 ```
 
-To get around these problems, you should make use of [`Ember.run.once()`](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop/methods/once?anchor=once).
+To get around these problems, you should make use of [`Ember.run.once()`](https://api.emberjs.com/ember/3.15/classes/@ember%2Frunloop/methods/once?anchor=once).
 This will ensure that any processing you need to do only happens once, and
 happens in the next run loop once all bindings are synchronized:
 
@@ -145,7 +145,7 @@ get it in your `init()` method.
 ### Outside of class definitions
 
 You can also add observers to an object outside of a class definition
-using [`addObserver()`](https://api.emberjs.com/ember/release/classes/@ember%2Fobject%2Fobservers/methods/addObserver?anchor=addObserver):
+using [`addObserver()`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fobject%2Fobservers/methods/addObserver?anchor=addObserver):
 
 
 ```javascript

--- a/guides/v3.15.0/routing/asynchronous-routing.md
+++ b/guides/v3.15.0/routing/asynchronous-routing.md
@@ -71,7 +71,7 @@ defined on it to be a promise.
 If the promise fulfills, the transition will pick up where it left off and
 begin resolving the next (child) route's model, pausing if it too is a
 promise, and so on, until all destination route models have been
-resolved. The values passed to the [`setupController()`](https://api.emberjs.com/ember/release/classes/Route/methods/setupController?anchor=setupController) hook for each route
+resolved. The values passed to the [`setupController()`](https://api.emberjs.com/ember/3.15/classes/Route/methods/setupController?anchor=setupController) hook for each route
 will be the fulfilled values from the promises.
 
 

--- a/guides/v3.15.0/routing/controllers.md
+++ b/guides/v3.15.0/routing/controllers.md
@@ -1,8 +1,8 @@
 ### What is a Controller?
 
-A [Controller](https://emberjs.com/api/ember/release/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/release/classes/Route/methods?anchor=model) method.
+A [Controller](https://emberjs.com/api/ember/release/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.15/classes/Route/methods?anchor=model) method.
 
-The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/release/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
+The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.15/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 
 A Controller is usually paired with an individual Route of the same name.
 

--- a/guides/v3.15.0/routing/defining-your-routes.md
+++ b/guides/v3.15.0/routing/defining-your-routes.md
@@ -14,7 +14,7 @@ It also adds the route to the router.
 
 ## Basic Routes
 
-The [`map()`](https://api.emberjs.com/ember/release/classes/EmberRouter/methods/map?anchor=map) method
+The [`map()`](https://api.emberjs.com/ember/3.15/classes/EmberRouter/methods/map?anchor=map) method
 of your Ember application's router can be invoked to define URL mappings. When
 calling `map()`, you should pass a function that will be invoked with the value
 `this` set to an object which you can use to create routes.
@@ -350,8 +350,8 @@ export default class SomeRouteRoute extends Route {
 To have your route do something beyond render a template with the same name, you'll
 need to create a route handler. The following guides will explore the different
 features of route handlers. For more information on routes, see the API documentation
-for [the router](https://api.emberjs.com/ember/release/classes/EmberRouter) and for [route
-handlers](https://api.emberjs.com/ember/release/classes/Route).
+for [the router](https://api.emberjs.com/ember/3.15/classes/EmberRouter) and for [route
+handlers](https://api.emberjs.com/ember/3.15/classes/Route).
 
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:

--- a/guides/v3.15.0/routing/loading-and-error-substates.md
+++ b/guides/v3.15.0/routing/loading-and-error-substates.md
@@ -102,7 +102,7 @@ within the route hierarchy where loading feedback is important.
 ### The `loading` event
 
 If the various `beforeModel`/`model`/`afterModel` hooks
-don't immediately resolve, a [`loading`](https://api.emberjs.com/ember/release/classes/Route/events/loading?anchor=loading) event will be fired on that route.
+don't immediately resolve, a [`loading`](https://api.emberjs.com/ember/3.15/classes/Route/events/loading?anchor=loading) event will be fired on that route.
 
 ```javascript {data-filename=app/routes/user-slow-model.js}
 import Route from '@ember/routing/route';
@@ -215,7 +215,7 @@ logged.
 
 If the `articles.overview` route's `model` hook returns a promise that rejects
 (for instance the server returned an error, the user isn't logged in,
-etc.), an [`error`](https://api.emberjs.com/ember/release/classes/Route/events/error?anchor=error) event will fire from that route and bubble upward.
+etc.), an [`error`](https://api.emberjs.com/ember/3.15/classes/Route/events/error?anchor=error) event will fire from that route and bubble upward.
 This `error` event can be handled and used to display an error message,
 redirect to a login page, etc.
 

--- a/guides/v3.15.0/routing/redirection.md
+++ b/guides/v3.15.0/routing/redirection.md
@@ -7,7 +7,7 @@ Usually you want to redirect them to the login page, and after they have success
 There are many other reasons you probably want to have the last word on whether a user can or cannot access a certain page.
 Ember allows you to control that access with a combination of hooks and methods in your route.
 
-One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo).
+One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/3.15/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://www.emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [`LinkTo`](../../templates/links/) helper.

--- a/guides/v3.15.0/routing/rendering-a-template.md
+++ b/guides/v3.15.0/routing/rendering-a-template.md
@@ -19,7 +19,7 @@ template. For example, the `posts.new` route will render its template into the
 `posts.hbs`'s `{{outlet}}`, and the `posts` route will render its template into
 the `application.hbs`'s `{{outlet}}`.
 
-If you want to render a template other than the default one, set the route's [`templateName`](https://api.emberjs.com/ember/release/classes/Route/properties/templateName?anchor=templateName) property to the name of
+If you want to render a template other than the default one, set the route's [`templateName`](https://api.emberjs.com/ember/3.15/classes/Route/properties/templateName?anchor=templateName) property to the name of
 the template you want to render instead.
 
 ```javascript {data-filename=app/routes/posts.js}
@@ -30,5 +30,5 @@ export default class PostsRoute extends Route {
 }
 ```
 
-You can override the [`renderTemplate()`](https://api.emberjs.com/ember/release/classes/Route/methods/renderTemplate?anchor=renderTemplate) hook if you want finer control over template rendering.
+You can override the [`renderTemplate()`](https://api.emberjs.com/ember/3.15/classes/Route/methods/renderTemplate?anchor=renderTemplate) hook if you want finer control over template rendering.
 Among other things, it allows you to choose the controller used to configure the template and specific outlet to render it into.

--- a/guides/v3.15.0/routing/specifying-a-routes-model.md
+++ b/guides/v3.15.0/routing/specifying-a-routes-model.md
@@ -1,6 +1,6 @@
 A route's JavaScript file is one of the best places in an app to make requests to an API.
 In this section of the guides, you'll learn how to use the
-[`model`](https://api.emberjs.com/ember/release/classes/Route/methods/model?anchor=model)
+[`model`](https://api.emberjs.com/ember/3.15/classes/Route/methods/model?anchor=model)
 method to fetch data by making a HTTP request, and render it in a route's `hbs` template, or pass it down to a component.
 
 For example, take this router:
@@ -125,7 +125,7 @@ identifier, instead):
 Ember Data is a powerful (but optional) library included by default in new Ember apps.
 In the next example, we will use Ember Data's [`findAll`](https://api.emberjs.com/ember-data/release/classes/Store/methods/findAll?anchor=findAll) method, which returns a Promise, and resolves with an array of [Ember Data records](../../models/).
 
-_Note that Ember Data also has a feature called a [`Model`](https://api.emberjs.com/ember-data/release/classes/Model), but it's a separate concept from a route's [`model`](https://api.emberjs.com/ember/release/classes/Route/methods/model?anchor=model) hook._
+_Note that Ember Data also has a feature called a [`Model`](https://api.emberjs.com/ember-data/release/classes/Model), but it's a separate concept from a route's [`model`](https://api.emberjs.com/ember/3.15/classes/Route/methods/model?anchor=model) hook._
 
 ```javascript {data-filename=app/routes/favorite-posts.js}
 import Route from '@ember/routing/route';
@@ -144,7 +144,7 @@ export default class FavoritePostsRoute extends Route {
 What should you do if you need the `model` to return the results of multiple API requests?
 
 Multiple models can be returned through an
-[RSVP.hash](https://api.emberjs.com/ember/release/classes/rsvp/methods/hash?anchor=hash).
+[RSVP.hash](https://api.emberjs.com/ember/3.15/classes/rsvp/methods/hash?anchor=hash).
 The `RSVP.hash` method takes an object containing multiple promises.
 If all of the promises resolve, the returned promise will resolve to an object that contains the results of each request. For example:
 
@@ -232,7 +232,7 @@ method.
 There are two ways to link to a dynamic segment from an `.hbs` template using [`<LinkTo>`](../../templates/links/).
 Depending on which approach you use, it will affect whether that route's `model` hook is run.
 To learn how to link to a dynamic segment from within the JavaScript file, see the API documentation on
-[`transitionTo`](https://api.emberjs.com/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo)
+[`transitionTo`](https://api.emberjs.com/ember/3.15/classes/RouterService/methods/transitionTo?anchor=transitionTo)
 instead.
 
 When you provide a string or number to the `<LinkTo>`, the dynamic segment's `model` hook will run when the app transitions to the new route.
@@ -338,10 +338,10 @@ And calling `modelFor` returned the result of the `model` hook.
 
 If you are having trouble getting a model's data to show up in the template, here are some tips:
 
-- Use the [`{{debugger}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/log?anchor=log) helper to inspect the `{{@model}}` from the template
+- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/log?anchor=log) helper to inspect the `{{@model}}` from the template
 - return hard-coded sample data as a test to see if the problem is really in the model hook, or elsewhere down the line
 - study JavaScript Promises in general, to make sure you are returning data from the Promise correctly
 - make sure your `model` hook has a `return` statement
-- check to see whether the data returned from a `model` hook is an object, array, or JavaScript Primitive. For example, if the result of `model` is an array, using `{{@model}}` in the template won't work. You will need to iterate over the array with an [`{{#each}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=each) helper. If the result is an object, you need to access the individual attribute like `{{@model.title}}` to render it in the template.
+- check to see whether the data returned from a `model` hook is an object, array, or JavaScript Primitive. For example, if the result of `model` is an array, using `{{@model}}` in the template won't work. You will need to iterate over the array with an [`{{#each}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/each?anchor=each) helper. If the result is an object, you need to access the individual attribute like `{{@model.title}}` to render it in the template.
 - use your browser's development tools to examine the outgoing and incoming API responses and see if they match what your code expects
 - If you are using Ember Data, use the [Ember Inspector](../../ember-inspector/) browser plugin to explore the View Tree/Model and Data sections.

--- a/guides/v3.15.0/routing/specifying-a-routes-model.md
+++ b/guides/v3.15.0/routing/specifying-a-routes-model.md
@@ -123,9 +123,9 @@ identifier, instead):
 ### Ember Data example
 
 Ember Data is a powerful (but optional) library included by default in new Ember apps.
-In the next example, we will use Ember Data's [`findAll`](https://api.emberjs.com/ember-data/release/classes/Store/methods/findAll?anchor=findAll) method, which returns a Promise, and resolves with an array of [Ember Data records](../../models/).
+In the next example, we will use Ember Data's [`findAll`](https://api.emberjs.com/ember-data/3.15/classes/Store/methods/findAll?anchor=findAll) method, which returns a Promise, and resolves with an array of [Ember Data records](../../models/).
 
-_Note that Ember Data also has a feature called a [`Model`](https://api.emberjs.com/ember-data/release/classes/Model), but it's a separate concept from a route's [`model`](https://api.emberjs.com/ember/3.15/classes/Route/methods/model?anchor=model) hook._
+_Note that Ember Data also has a feature called a [`Model`](https://api.emberjs.com/ember-data/3.15/classes/Model), but it's a separate concept from a route's [`model`](https://api.emberjs.com/ember/3.15/classes/Route/methods/model?anchor=model) hook._
 
 ```javascript {data-filename=app/routes/favorite-posts.js}
 import Route from '@ember/routing/route';

--- a/guides/v3.15.0/services/index.md
+++ b/guides/v3.15.0/services/index.md
@@ -91,7 +91,7 @@ This injects the shopping cart service into the component and makes it available
 
 Sometimes a service may or may not exist, like when an initializer conditionally registers a service.
 Since normal injection will throw an error if the service doesn't exist,
-you must look up the service using Ember's [`getOwner`](https://api.emberjs.com/ember/release/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) instead.
+you must look up the service using Ember's [`getOwner`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) instead.
 
 ```javascript {data-filename=app/components/cart-contents.js}
 import Component from '@glimmer/component';

--- a/guides/v3.15.0/testing/test-types.md
+++ b/guides/v3.15.0/testing/test-types.md
@@ -62,8 +62,8 @@ module('Unit | Utility | math-library', function() {
 Here are more examples where unit tests are ideal:
 
 - Inside a controller, a computed property continues to filter `this.model` correctly after an action is taken
-- Check how [`normalize()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/normalize?anchor=normalize) in a serializer receives data
-- Check how [`serialize()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/serialize?anchor=serialize) in a serializer sends data
+- Check how [`normalize()`](https://api.emberjs.com/ember-data/3.15/classes/JSONAPISerializer/methods/normalize?anchor=normalize) in a serializer receives data
+- Check how [`serialize()`](https://api.emberjs.com/ember-data/3.15/classes/JSONAPISerializer/methods/serialize?anchor=serialize) in a serializer sends data
 - A [cron](https://en.wikipedia.org/wiki/Cron) utility parses an input string into an object that can be used for UI
 
 ### What to Watch Out for

--- a/guides/v3.15.0/testing/testing-components.md
+++ b/guides/v3.15.0/testing/testing-components.md
@@ -457,7 +457,7 @@ The `settled` function itself returns a Promise that resolves once all async ope
 
 You can use `settled` as a helper in your tests directly and `await` it for all async behavior to settle deliberately.
 
-Imagine you have a typeahead component that uses [`Ember.run.debounce`](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop/methods/debounce?anchor=debounce) to limit requests to the server, and you want to verify that results are displayed after typing a character.
+Imagine you have a typeahead component that uses [`Ember.run.debounce`](https://api.emberjs.com/ember/3.15/classes/@ember%2Frunloop/methods/debounce?anchor=debounce) to limit requests to the server, and you want to verify that results are displayed after typing a character.
 
 > You can follow along by generating your own component with `ember generate
 > component delayed-typeahead`.


### PR DESCRIPTION
## Description

This PR addresses https://github.com/ember-learn/guides-source/issues/1440 for Ember `v3.15`.

I used Find All and Replace to update the URLs. Afterwards, I ran `npm run test:node-local` to check that we can visit the updated URLs.