### PR TITLE
Rewrite `ref` example using custom modifier

### DIFF
--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -310,9 +310,7 @@ Now we can use our custom `{{autofocus}}` modifier throughout our application.
 
 ## Communicating Between Elements in a Component
 
-What if you want to handle an event in one part of your component by calling a DOM method on another part? For example, let's say you're creating an audio component, and you want clicking the "Play" button to call the audio tag's `play` method.
-
-Let's start with the HTML we're working with:
+What if you want to handle an event in one part of your component by calling a DOM method on another part? For example, let's say you're creating an audio component:
 
 ```handlebars {data-filename="app/components/audio-player.hbs"}
 <audio src={{@srcURL}} />
@@ -321,17 +319,21 @@ Let's start with the HTML we're working with:
 <button type="button">Pause</button>
 ```
 
-It might be tempting to define all interactions in the component class. However, as we will see soon, the key to a better solution is to separate concerns. Let the component manage the state and the modifier manage the DOM.
+How should we make it so that clicking the "Play" and "Pause" buttons to call the audio tag's `play` and `pause` methods?
 
-In general, there are 3 reasons why we might want to introduce a modifier:
+While we *could* manage these DOM interactions in the component class (for example, by using `{{did-render}}`), we're better off using a modifier here. It lets us cleanly separate our concerns: the component manages the *state*, and the modifier manages *interactions with the DOM*.
 
-1. Components don't have access to DOM elements directly. We'd have to render the page, push an element back up into the component class, and *then* wire it up. This would come with performance costs, because we would have to render twice before anything could work.
-2. We can't really use autotracking or 1-way data flow that way. If we wanted the caller of our component to be able to pass an argument in and have the component respond appropriately, we'd have to use something like `{{did-update}}`.
-3. None of the logic we built to manage playing and pausing would be reusable! It would be specific to just this component.
+There are three reasons we should keep state management in a component and DOM element management in a modifier:
 
-Using a custom modifier, we can avoid all of these issues!
+1. A component, by itself, doesn't have direct access to DOM elements. We have to render the page, push an element back up into the component class, and only then can we safely refer to that element. This can sometimes require us to render the component's HTML twice in order for things to start working. Modifiers let us avoid this possible performance issue.
 
-First, let's add event handlers to the `Play` and `Pause` buttons:
+2. By keeping state in the component and handling DOM method calls in a modifier, we can use autotracking and practice 1-way data flow. We could change the component's own design later *without* having to change how we interact with the DOM element.
+
+3. The code for calling the audio element's `play` and `pause` can be reused. It isn't tied to this particular audio component. It can be tested independently, too!
+
+Now that we see *why* to use a modifier for our audio component, let's walk through *how* to create one. We will start with the component (to manage the state) and then implement the modifier (the manage the DOM).
+
+First, we add actions to handle the `click` events for the `Play` and `Pause` buttons:
 
 ```handlebars {data-filename="app/components/audio-player.hbs" data-diff="-3,+4,-5,+6"}
 <audio src={{@srcURL}} />

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -392,7 +392,7 @@ ember install ember-modifier
 ember generate modifier play-when
 ```
 
-In this modifier, we'll take an argument that specifies whether we should be playing or paused.
+The modifier takes 1 argument, a Boolean that specifies if we should call the element's `play` or `pause` method.
 
 ```js {data-filename="app/modifiers/play-when.js"}
 import { modifier } from "ember-modifier";

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -319,7 +319,7 @@ What if you want to handle an event in one part of your component by calling a D
 <button type="button">Pause</button>
 ```
 
-How should we make it so that clicking the "Play" and "Pause" buttons to call the audio tag's `play` and `pause` methods?
+How should we connect clicking the "Play" and "Pause" to calling the audio tag's `play` and `pause` methods?
 
 While we *could* manage these DOM interactions in the component class (for example, by using `{{did-render}}`), we're better off using a modifier here. It lets us cleanly separate our concerns: the component manages the *state*, and the modifier manages *interactions with the DOM*.
 

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -418,7 +418,7 @@ With that, we can now click the buttons to play and pause the audio!
 
 In summary, when you want to allow elements in a component to communicate, see if you can separate the concerns of _managing state_ and _managing DOM interactions_. The component can manage the state, while a modifier can manage the DOM.
 
-The modifier that we made for the audio player component can be reused on _any_ element that implements `play` and `pause` methods. In particular, we can reuse the modifier on an `HTMLMediaElement`, which includes `audio` and `video` elements.
+The modifier that we made for the audio player component can be reused on _any_ element that implements `play` and `pause` methods. In particular, we can reuse the modifier on any `HTMLMediaElement`, which includes `audio` and `video` elements.
 
 ## Out-of-Component Modifications
 

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -331,7 +331,7 @@ There are three reasons to reach for modifiers for DOM element interactions:
 
 3. The code for calling the audio element's `play` and `pause` can be reused. It isn't tied to this particular audio component. It can be tested independently, too!
 
-Now that we see *why* to use a modifier for our audio component, let's walk through *how* to create one. We will start with the component (to manage the state) and then implement the modifier (the manage the DOM).
+Now that we see *why* we want to use a modifier for our audio component, let's walk through *how* to create one. We will start with the component (to manage the state) and then implement the modifier (the manage the DOM).
 
 First, we add actions to handle the `click` events for the `Play` and `Pause` buttons:
 

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -326,9 +326,7 @@ While we _could_ manage these DOM interactions in the component class (for examp
 There are three reasons to reach for modifiers for DOM element interactions:
 
 1. A component, by itself, doesn't have direct access to DOM elements. We have to render the page, push an element back up into the component class, and only then can we safely refer to that element. This can sometimes require us to render the component's HTML twice in order for things to start working. Modifiers let us avoid this possible performance issue.
-
 2. By keeping state in the component and handling DOM method calls in a modifier, we can use autotracking and stick to 1-way data flow in the component. Further, we could change the component's own design later _without_ having to change how we interact with the DOM element.
-
 3. The code for calling the audio element's `play` and `pause` can be reused. It isn't tied to this particular audio component. It can be tested independently, too!
 
 Now that we see _why_ we want to use a modifier for our audio component, let's walk through _how_ to create one. We will start with the component (to manage the state) and then implement the modifier (the manage the DOM).

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -359,7 +359,7 @@ export default class AudioPlayerComponent extends Component {
 }
 ```
 
-From the component's point of view, all it needs to do is track whether it should be playing or not, since we're going to manage the DOM element with the modifier. So we can just use `@tracked` and a normal property here.
+Recall that our modifier will manage the DOM (i.e. calling the audio element's `play` or `pause` method). All the component needs to do is to track if the audio is playing.
 
 ```js {data-filename="app/components/audio-player.js" data-diff="+2,+6,+7,-10,+11,-16,+17"}
 import Component from "@glimmer/component";

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -385,7 +385,7 @@ export default class AudioPlayerComponent extends Component {
 }
 ```
 
-That's it for the component: we're succesfully handling all of the *state*. Now we need to build a modifier to translate the state into the appropriate DOM method calls!
+That's it for the component: we're translating the user's interactions into *state*. Now we need to build a modifier to translate the state into the appropriate DOM method calls!
 
 ```bash
 ember install ember-modifier

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -327,7 +327,7 @@ There are three reasons to reach for modifiers for DOM element interactions:
 
 1. A component, by itself, doesn't have direct access to DOM elements. We have to render the page, push an element back up into the component class, and only then can we safely refer to that element. This can sometimes require us to render the component's HTML twice in order for things to start working. Modifiers let us avoid this possible performance issue.
 
-2. By keeping state in the component and handling DOM method calls in a modifier, we can use autotracking and practice 1-way data flow. We could change the component's own design later *without* having to change how we interact with the DOM element.
+2. By keeping state in the component and handling DOM method calls in a modifier, we can use autotracking and stick to 1-way data flow in the component. Further, we could change the component's own design later *without* having to change how we interact with the DOM element.
 
 3. The code for calling the audio element's `play` and `pause` can be reused. It isn't tied to this particular audio component. It can be tested independently, too!
 

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -321,17 +321,17 @@ What if you want to handle an event in one part of your component by calling a D
 
 How should we connect clicking the "Play" and "Pause" to calling the audio tag's `play` and `pause` methods?
 
-While we *could* manage these DOM interactions in the component class (for example, by using `{{did-render}}`), we're better off using a modifier here. It lets us cleanly separate our concerns: the component manages the *state*, and the modifier manages *interactions with the DOM*.
+While we _could_ manage these DOM interactions in the component class (for example, by using `{{did-render}}`), we're better off using a modifier here. It lets us cleanly separate our concerns: the component manages the _state_, and the modifier manages _interactions with the DOM_.
 
 There are three reasons to reach for modifiers for DOM element interactions:
 
 1. A component, by itself, doesn't have direct access to DOM elements. We have to render the page, push an element back up into the component class, and only then can we safely refer to that element. This can sometimes require us to render the component's HTML twice in order for things to start working. Modifiers let us avoid this possible performance issue.
 
-2. By keeping state in the component and handling DOM method calls in a modifier, we can use autotracking and stick to 1-way data flow in the component. Further, we could change the component's own design later *without* having to change how we interact with the DOM element.
+2. By keeping state in the component and handling DOM method calls in a modifier, we can use autotracking and stick to 1-way data flow in the component. Further, we could change the component's own design later _without_ having to change how we interact with the DOM element.
 
 3. The code for calling the audio element's `play` and `pause` can be reused. It isn't tied to this particular audio component. It can be tested independently, too!
 
-Now that we see *why* we want to use a modifier for our audio component, let's walk through *how* to create one. We will start with the component (to manage the state) and then implement the modifier (the manage the DOM).
+Now that we see _why_ we want to use a modifier for our audio component, let's walk through _how_ to create one. We will start with the component (to manage the state) and then implement the modifier (the manage the DOM).
 
 First, we add actions to handle the `click` events for the `Play` and `Pause` buttons:
 
@@ -385,7 +385,7 @@ export default class AudioPlayerComponent extends Component {
 }
 ```
 
-That's it for the component: we're translating the user's interactions into *state*. Now we need to build a modifier to translate the state into the appropriate DOM method calls!
+That's it for the component: we're translating the user's interactions into _state_. Now we need to build a modifier to translate the state into the appropriate DOM method calls!
 
 ```bash
 ember install ember-modifier
@@ -418,9 +418,9 @@ Last but not least, we attach the modifier to the `audio` element:
 
 With that, we can now click the buttons to play and pause the audio!
 
-In summary, when you want to allow elements in a component to communicate, see if you can separate the concerns of *managing state* and *managing DOM interactions*. The component can manage the state, while a modifier can manage the DOM.
+In summary, when you want to allow elements in a component to communicate, see if you can separate the concerns of _managing state_ and _managing DOM interactions_. The component can manage the state, while a modifier can manage the DOM.
 
-The modifier that we made for the audio player component can be reused on *any* element that implements `play` and `pause` methods. In particular, we can reuse the modifier on an `HTMLMediaElement`, which includes `audio` and `video` elements.
+The modifier that we made for the audio player component can be reused on _any_ element that implements `play` and `pause` methods. In particular, we can reuse the modifier on an `HTMLMediaElement`, which includes `audio` and `video` elements.
 
 ## Out-of-Component Modifications
 

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -416,7 +416,11 @@ Last but not least, we attach the modifier to the `audio` element:
 <button type="button" {{on "click" this.pause}}>Pause</button>
 ```
 
-With that, we're done! Notice that we've separated the concerns of *managing state* from *managing DOM interactions*. The component manages the state. The modifier manages the DOM. And this modifier could be reused for *any* `HTMLMediaElement`, including other `audio` or `video` element in our code.
+With that, we can now click the buttons to play and pause the audio!
+
+In summary, when you want to allow elements in a component to communicate, see if you can separate the concerns of *managing state* and *managing DOM interactions*. The component can manage the state, while a modifier can manage the DOM.
+
+The modifier that we made for the audio player component can be reused on *any* element that implements `play` and `pause` methods. In particular, we can reuse the modifier on an `HTMLMediaElement`, which includes `audio` and `video` elements.
 
 ## Out-of-Component Modifications
 

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -404,7 +404,7 @@ export default modifier((element, [isPlaying]) => {
 });
 ```
 
-We can now attach the modifier to the `audio` element:
+Last but not least, we attach the modifier to the `audio` element:
 
 ```handlebars {data-filename="app/components/audio-player.hbs" data-diff="-1,+2"}
 <audio src={{@srcURL}} />

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -385,7 +385,7 @@ export default class AudioPlayerComponent extends Component {
 }
 ```
 
-Now the component is managing the state of the player, but we still need to translate that into the DOM method calls. So let's create a modifier!
+That's it for the component: we're succesfully handling all of the *state*. Now we need to build a modifier to translate the state into the appropriate DOM method calls!
 
 ```bash
 ember install ember-modifier

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -361,7 +361,7 @@ export default class AudioPlayerComponent extends Component {
 }
 ```
 
-Recall that our modifier will manage the DOM (i.e. calling the audio element's `play` or `pause` method). All the component needs to do is to track if the audio is playing.
+Recall that our modifier will manage the DOM (i.e. calling the audio element's `play` or `pause` method). All the component needs to do is to track whether the audio is playing:
 
 ```js {data-filename="app/components/audio-player.js" data-diff="+2,+6,+7,-10,+11,-16,+17"}
 import Component from "@glimmer/component";

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -321,7 +321,9 @@ Let's start with the HTML we're working with:
 <button type="button">Pause</button>
 ```
 
-It might be tempting to try to handle this by managing the whole set of interactions at the component level. But there are three reasons we might want to tackle this using a modifier instead:
+It might be tempting to define all interactions in the component class. However, as we will see soon, the key to a better solution is to separate concerns. Let the component manage the state and the modifier manage the DOM.
+
+In general, there are 3 reasons why we might want to introduce a modifier:
 
 1. Components don't have access to DOM elements directly. We'd have to render the page, push an element back up into the component class, and *then* wire it up. This would come with performance costs, because we would have to render twice before anything could work.
 2. We can't really use autotracking or 1-way data flow that way. If we wanted the caller of our component to be able to pass an argument in and have the component respond appropriately, we'd have to use something like `{{did-update}}`.

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -323,7 +323,7 @@ How should we connect clicking the "Play" and "Pause" to calling the audio tag's
 
 While we *could* manage these DOM interactions in the component class (for example, by using `{{did-render}}`), we're better off using a modifier here. It lets us cleanly separate our concerns: the component manages the *state*, and the modifier manages *interactions with the DOM*.
 
-There are three reasons we should keep state management in a component and DOM element management in a modifier:
+There are three reasons to reach for modifiers for DOM element interactions:
 
 1. A component, by itself, doesn't have direct access to DOM elements. We have to render the page, push an element back up into the component class, and only then can we safely refer to that element. This can sometimes require us to render the component's HTML twice in order for things to start working. Modifiers let us avoid this possible performance issue.
 

--- a/guides/release/configuring-ember/debugging.md
+++ b/guides/release/configuring-ember/debugging.md
@@ -10,13 +10,13 @@ import Application from '@ember/application';
 
 export default class App extends Application {
   // Basic logging, e.g. "Transitioned into 'post'"
-  LOG_TRANSITIONS = true,
+  LOG_TRANSITIONS = true;
 
   // Extremely detailed logging, highlighting every internal
   // step made while transitioning into a route, including
   // `beforeModel`, `model`, and `afterModel` hooks, and
   // information about redirects and aborted transitions
-  LOG_TRANSITIONS_INTERNAL = true
+  LOG_TRANSITIONS_INTERNAL = true;
 }
 ```
 ## Views / Templates
@@ -49,7 +49,7 @@ and which it is generating automatically for you.
 import Application from '@ember/application';
 
 export default class App extends Application {
-  LOG_RESOLVER = true
+  LOG_RESOLVER = true;
 }
 ```
 ### Dealing with deprecations


### PR DESCRIPTION
Per discussion in the [June 2020 Learning Team meeting][minutes], remove the use of `ember-ref-modifier` in favor of a custom modifier implemented using `ember-modifier`, since a custom modifier here is more idiomatic, performs better, and is more maintainable.

[minutes]: https://github.com/emberjs/core-notes/blob/259e63c328af76afff9bea4523290a57557d905d/learning-team/2020-06/2020-06-04.md

Note that this is *not* a criticism of @lifeart's original implementation of `ember-ref-modifier`: it was a very valuable early experiment with modifiers, and filled a gap when `ember-modifier` didn't even exist yet. It was precisely in experimenting with modifiers like `ref` that we figured out the patterns we now want to suggest instead!