### PR TITLE
Updated API links in guides/3.14.0

### DIFF
--- a/guides/release/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/release/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/release/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/release/routing/defining-your-routes.md
+++ b/guides/release/routing/defining-your-routes.md
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`<LinkTo />`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`<LinkTo />`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -356,7 +356,7 @@ handlers](https://api.emberjs.com/ember/release/classes/Route).
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
-- From a template, use [`<LinkTo />`](../linking-between-routes/) as mentioned above
+- From a template, use [`<LinkTo />`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
 - From a route, use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
 - From a controller, use the [`transitionToRoute()`](https://emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
 - From anywhere else in your application, such as a component, inject the [Router Service](https://emberjs.com/api/ember/release/classes/RouterService) and use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/release/routing/linking-between-routes.md
+++ b/guides/release/routing/linking-between-routes.md
@@ -5,7 +5,7 @@ component.
 ## The `<LinkTo />` Component
 
 You create a link to a route using the
-[`<LinkTo />`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`<LinkTo />`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 component.
 
 ```javascript {data-filename=app/router.js}

--- a/guides/v3.10.0/applications/services.md
+++ b/guides/v3.10.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.10/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.10/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.10/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.10/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.10.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.10.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.10/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.10.0/getting-started/core-concepts.md
+++ b/guides/v3.10.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.10/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.10/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.10/classes/Component/methods/willRender?anchor=willRender) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.10/classes/Route/methods/model?anchor=model) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.10/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.10/classes/Component/methods/didRender?anchor=didRender) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.10.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.10.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.10/classes/Component/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.10.0/models/customizing-adapters.md
+++ b/guides/v3.10.0/models/customizing-adapters.md
@@ -244,7 +244,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.10/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.10/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.10.0/object-model/bindings.md
+++ b/guides/v3.10.0/object-model/bindings.md
@@ -1,7 +1,7 @@
 *__Note:__ Unlike most other frameworks that include some sort of binding implementation, bindings in Ember.js can be used with any object. That said, bindings are most often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.*
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.10/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.10/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -35,7 +35,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.10/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.10/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.10.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.10.0/object-model/computed-properties-and-aggregate-data.md
@@ -108,7 +108,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.10/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.10/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.10.0/object-model/observers.md
+++ b/guides/v3.10.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.10/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.10.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.10.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.10/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.10/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.10.0/routing/defining-your-routes.md
+++ b/guides/v3.10.0/routing/defining-your-routes.md
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`<LinkTo>`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`<LinkTo>`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -355,7 +355,7 @@ handlers](https://api.emberjs.com/ember/3.10/classes/Route).
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
-- From a template, use [`<LinkTo>`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) as mentioned above
+- From a template, use [`<LinkTo>`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
 - From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/3.10/classes/Route/methods/transitionTo?anchor=transitionTo) method
 - From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/3.10/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
 - From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/3.10/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/3.10/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.10.0/routing/redirection.md
+++ b/guides/v3.10.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/3.10/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like [`<LinkTo>`](../../templates/links/).
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.10/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.10/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.10/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.10/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.10/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.10/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.10/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.10/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.10.0/routing/specifying-a-routes-model.md
+++ b/guides/v3.10.0/routing/specifying-a-routes-model.md
@@ -67,7 +67,7 @@ Now that data can be used in the `favorite-posts`  template:
 {{/each}}
 ```
 
-Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.10/classes/Route/methods/model?anchor=setupController) receives the results of the model hook, and makes those results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
+Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.10/classes/Route/methods/setupController?anchor=setupController) receives the results of the model hook, and makes those results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
 
 Let's compare some examples using the model hook to make asynchronous HTTP requests to a server somewhere.
 
@@ -303,7 +303,7 @@ And calling `modelFor` returned the result of the `model` hook.
 
 If you are having trouble getting a model's data to show up in the template, here are some tips:
 
-- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/debugger?anchor=log) helper to inspect the `{{model}}` from the template
+- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/log?anchor=log) helper to inspect the `{{model}}` from the template
 - return hard-coded sample data as a test to see if the problem is really in the model hook, or elsewhere down the line
 - study JavaScript Promises in general, to make sure you are returning data from the Promise correctly
 - make sure your `model` hook has a `return` statement

--- a/guides/v3.10.0/templates/conditionals.md
+++ b/guides/v3.10.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.10.0/templates/development-helpers.md
+++ b/guides/v3.10.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.10.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.10.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.10.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.10.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/each?anchor=each) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.10.0/templates/input-helpers.md
+++ b/guides/v3.10.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`<Input>`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`<Textarea>`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`<Input>`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.components/methods/Input?anchor=Input)
+and [`<Textarea>`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea)
 components are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -71,7 +71,7 @@ More [event types](https://api.emberjs.com/ember/3.10/classes/Component#event-ha
 ## Checkboxes
 
 You can also use the
-[`<Input>`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`<Input>`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.components/methods/Input?anchor=Input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars
@@ -108,7 +108,7 @@ Checkboxes are a special input type. If you want to dispatch an action on a cert
 
 Will bind the value of the text area to `name` on the current context.
 
-[`<Textarea>`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea) supports binding and/or setting the following properties:
+[`<Textarea>`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea) supports binding and/or setting the following properties:
 
 * `value`
 * `name`

--- a/guides/v3.10.0/templates/links.md
+++ b/guides/v3.10.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `<LinkTo>` Component
 
 You create a link to a route using the
-[`<LinkTo>`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`<LinkTo>`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -132,7 +132,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`LinkTo`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`LinkTo`](https://api.emberjs.com/ember/3.10/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.10.0/templates/writing-helpers.md
+++ b/guides/v3.10.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.10/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -250,7 +250,7 @@ To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.10/classes/Helper).
 Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/3.10/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.10/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.10/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 

--- a/guides/v3.10.0/tutorial/model-hook.md
+++ b/guides/v3.10.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.10/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.10/classes/Route/methods/model?anchor=model).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.10.0/tutorial/routes-and-templates.md
+++ b/guides/v3.10.0/tutorial/routes-and-templates.md
@@ -224,7 +224,7 @@ All we want to do when a user visits the root (`/`) URL is transition to
 implementing a route lifecycle hook called `redirect`.
 Route lifecycle hooks are special methods that are called automatically when a route renders or data changes.
 Inside, we'll call the
-[`transitionTo`](https://api.emberjs.com/ember/3.9/classes/Route/methods/redirect?anchor=transitionTo)
+[`transitionTo`](https://api.emberjs.com/ember/3.10/classes/Route/methods/transitionTo?anchor=transitionTo)
 function:
 
 ```javascript {data-filename="app/routes/index.js" data-diff="+4,+5,+6"}

--- a/guides/v3.10.0/tutorial/subroutes.md
+++ b/guides/v3.10.0/tutorial/subroutes.md
@@ -347,7 +347,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `RentalListing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.10/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.10/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.

--- a/guides/v3.11.0/applications/services.md
+++ b/guides/v3.11.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.11/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.11/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.11/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.11/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.11.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.11.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.11/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.11.0/getting-started/core-concepts.md
+++ b/guides/v3.11.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.11/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.11/classes/Component/methods/willRender?anchor=willRender) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=model) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.11/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.11/classes/Component/methods/didRender?anchor=didRender) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.11.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.11.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.11/classes/Component/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.11.0/models/customizing-adapters.md
+++ b/guides/v3.11.0/models/customizing-adapters.md
@@ -244,7 +244,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.11/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.11.0/object-model/bindings.md
+++ b/guides/v3.11.0/object-model/bindings.md
@@ -1,7 +1,7 @@
 *__Note:__ Unlike most other frameworks that include some sort of binding implementation, bindings in Ember.js can be used with any object. That said, bindings are most often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.*
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -35,7 +35,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.11.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.11.0/object-model/computed-properties-and-aggregate-data.md
@@ -108,7 +108,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.11.0/object-model/observers.md
+++ b/guides/v3.11.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.11/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.11.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.11.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.11/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.11/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.11.0/routing/defining-your-routes.md
+++ b/guides/v3.11.0/routing/defining-your-routes.md
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -355,7 +355,7 @@ handlers](https://api.emberjs.com/ember/3.11/classes/Route).
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
-- From a template, use [`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) as mentioned above
+- From a template, use [`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
 - From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=transitionTo) method
 - From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/3.11/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
 - From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/3.11/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/3.11/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.11.0/routing/redirection.md
+++ b/guides/v3.11.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/3.11/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like [`<LinkTo>`](../../templates/links/).
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.11.0/routing/specifying-a-routes-model.md
+++ b/guides/v3.11.0/routing/specifying-a-routes-model.md
@@ -67,7 +67,7 @@ Now that data can be used in the `favorite-posts`  template:
 {{/each}}
 ```
 
-Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=setupController) receives the results of the model hook, and makes those results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
+Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.11/classes/Route/methods/setupController?anchor=setupController) receives the results of the model hook, and makes those results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
 
 Let's compare some examples using the model hook to make asynchronous HTTP requests to a server somewhere.
 
@@ -303,7 +303,7 @@ And calling `modelFor` returned the result of the `model` hook.
 
 If you are having trouble getting a model's data to show up in the template, here are some tips:
 
-- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/debugger?anchor=log) helper to inspect the `{{model}}` from the template
+- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/log?anchor=log) helper to inspect the `{{model}}` from the template
 - return hard-coded sample data as a test to see if the problem is really in the model hook, or elsewhere down the line
 - study JavaScript Promises in general, to make sure you are returning data from the Promise correctly
 - make sure your `model` hook has a `return` statement

--- a/guides/v3.11.0/templates/conditionals.md
+++ b/guides/v3.11.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.11.0/templates/development-helpers.md
+++ b/guides/v3.11.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.11.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.11.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.11.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.11.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/each?anchor=each) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.11.0/templates/input-helpers.md
+++ b/guides/v3.11.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`<Input>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`<Textarea>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`<Input>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.components/methods/Input?anchor=Input)
+and [`<Textarea>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea)
 components are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -71,7 +71,7 @@ More [event types](https://api.emberjs.com/ember/3.11/classes/Component#event-ha
 ## Checkboxes
 
 You can also use the
-[`<Input>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`<Input>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.components/methods/Input?anchor=Input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars
@@ -108,7 +108,7 @@ Checkboxes are a special input type. If you want to dispatch an action on a cert
 
 Will bind the value of the text area to `name` on the current context.
 
-[`<Textarea>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea) supports binding and/or setting the following properties:
+[`<Textarea>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea) supports binding and/or setting the following properties:
 
 * `value`
 * `name`

--- a/guides/v3.11.0/templates/links.md
+++ b/guides/v3.11.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `<LinkTo>` Component
 
 You create a link to a route using the
-[`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -132,7 +132,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`LinkTo`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`LinkTo`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.11.0/templates/writing-helpers.md
+++ b/guides/v3.11.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.11/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -250,7 +250,7 @@ To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.11/classes/Helper).
 Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/3.11/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.11/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.11/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 

--- a/guides/v3.11.0/tutorial/model-hook.md
+++ b/guides/v3.11.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=model).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.11.0/tutorial/routes-and-templates.md
+++ b/guides/v3.11.0/tutorial/routes-and-templates.md
@@ -224,7 +224,7 @@ All we want to do when a user visits the root (`/`) URL is transition to
 implementing a route lifecycle hook called `redirect`.
 Route lifecycle hooks are special methods that are called automatically when a route renders or data changes.
 Inside, we'll call the
-[`transitionTo`](https://api.emberjs.com/ember/3.9/classes/Route/methods/redirect?anchor=transitionTo)
+[`transitionTo`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=transitionTo)
 function:
 
 ```javascript {data-filename="app/routes/index.js" data-diff="+4,+5,+6"}

--- a/guides/v3.11.0/tutorial/subroutes.md
+++ b/guides/v3.11.0/tutorial/subroutes.md
@@ -347,7 +347,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `RentalListing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.11/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.11/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.

--- a/guides/v3.12.0/applications/services.md
+++ b/guides/v3.12.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.11/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.12/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.11/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.12/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.12.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.12.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.12/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.12.0/getting-started/core-concepts.md
+++ b/guides/v3.12.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.11/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.12/classes/Component/methods/willRender?anchor=willRender) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.12/classes/Route/methods/model?anchor=model) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.11/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.12/classes/Component/methods/didRender?anchor=didRender) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.12.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.12.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.12/classes/Component/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.12.0/models/customizing-adapters.md
+++ b/guides/v3.12.0/models/customizing-adapters.md
@@ -244,7 +244,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.12/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.12.0/object-model/bindings.md
+++ b/guides/v3.12.0/object-model/bindings.md
@@ -1,7 +1,7 @@
 *__Note:__ Unlike most other frameworks that include some sort of binding implementation, bindings in Ember.js can be used with any object. That said, bindings are most often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.*
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.12/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -35,7 +35,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.12/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.12.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.12.0/object-model/computed-properties-and-aggregate-data.md
@@ -108,7 +108,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.12/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.12.0/object-model/observers.md
+++ b/guides/v3.12.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.12/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.12.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.12.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.12/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.12/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.12.0/routing/defining-your-routes.md
+++ b/guides/v3.12.0/routing/defining-your-routes.md
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`<LinkTo>`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -355,7 +355,7 @@ handlers](https://api.emberjs.com/ember/3.11/classes/Route).
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
-- From a template, use [`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) as mentioned above
+- From a template, use [`<LinkTo>`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
 - From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=transitionTo) method
 - From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/3.11/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
 - From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/3.11/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/3.11/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.12.0/routing/redirection.md
+++ b/guides/v3.12.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/3.11/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like [`<LinkTo>`](../../templates/links/).
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.12/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.12/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.12/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.12/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.12.0/routing/specifying-a-routes-model.md
+++ b/guides/v3.12.0/routing/specifying-a-routes-model.md
@@ -67,7 +67,7 @@ Now that data can be used in the `favorite-posts`  template:
 {{/each}}
 ```
 
-Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=setupController) receives the results of the model hook, and makes those results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
+Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.12/classes/Route/methods/setupController?anchor=setupController) receives the results of the model hook, and makes those results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
 
 Let's compare some examples using the model hook to make asynchronous HTTP requests to a server somewhere.
 
@@ -303,7 +303,7 @@ And calling `modelFor` returned the result of the `model` hook.
 
 If you are having trouble getting a model's data to show up in the template, here are some tips:
 
-- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/debugger?anchor=log) helper to inspect the `{{model}}` from the template
+- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.helpers/methods/log?anchor=log) helper to inspect the `{{model}}` from the template
 - return hard-coded sample data as a test to see if the problem is really in the model hook, or elsewhere down the line
 - study JavaScript Promises in general, to make sure you are returning data from the Promise correctly
 - make sure your `model` hook has a `return` statement

--- a/guides/v3.12.0/templates/conditionals.md
+++ b/guides/v3.12.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.12.0/templates/development-helpers.md
+++ b/guides/v3.12.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.12.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.12.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.12.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.12.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.helpers/methods/each?anchor=each) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.12.0/templates/input-helpers.md
+++ b/guides/v3.12.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`<Input>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`<Textarea>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`<Input>`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.components/methods/Input?anchor=Input)
+and [`<Textarea>`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea)
 components are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -71,7 +71,7 @@ More [event types](https://api.emberjs.com/ember/3.12/classes/Component#event-ha
 ## Checkboxes
 
 You can also use the
-[`<Input>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`<Input>`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.components/methods/Input?anchor=Input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars
@@ -108,7 +108,7 @@ Checkboxes are a special input type. If you want to dispatch an action on a cert
 
 Will bind the value of the text area to `name` on the current context.
 
-[`<Textarea>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea) supports binding and/or setting the following properties:
+[`<Textarea>`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea) supports binding and/or setting the following properties:
 
 * `value`
 * `name`

--- a/guides/v3.12.0/templates/links.md
+++ b/guides/v3.12.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `<LinkTo>` Component
 
 You create a link to a route using the
-[`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`<LinkTo>`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -132,7 +132,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`LinkTo`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`LinkTo`](https://api.emberjs.com/ember/3.12/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.12.0/templates/writing-helpers.md
+++ b/guides/v3.12.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.12/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -250,7 +250,7 @@ To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.11/classes/Helper).
 Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/3.11/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.11/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.12/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 

--- a/guides/v3.12.0/tutorial/model-hook.md
+++ b/guides/v3.12.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.12/classes/Route/methods/model?anchor=model).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.12.0/tutorial/routes-and-templates.md
+++ b/guides/v3.12.0/tutorial/routes-and-templates.md
@@ -224,7 +224,7 @@ All we want to do when a user visits the root (`/`) URL is transition to
 implementing a route lifecycle hook called `redirect`.
 Route lifecycle hooks are special methods that are called automatically when a route renders or data changes.
 Inside, we'll call the
-[`transitionTo`](https://api.emberjs.com/ember/3.9/classes/Route/methods/redirect?anchor=transitionTo)
+[`transitionTo`](https://api.emberjs.com/ember/3.12/classes/Route/methods/transitionTo?anchor=transitionTo)
 function:
 
 ```javascript {data-filename="app/routes/index.js" data-diff="+4,+5,+6"}

--- a/guides/v3.12.0/tutorial/subroutes.md
+++ b/guides/v3.12.0/tutorial/subroutes.md
@@ -347,7 +347,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `RentalListing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.11/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.11/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.

--- a/guides/v3.13.0/applications/services.md
+++ b/guides/v3.13.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.11/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.13/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.11/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.13/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.13.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.13.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.13/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.13.0/getting-started/core-concepts.md
+++ b/guides/v3.13.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.11/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.13/classes/Component/methods/willRender?anchor=willRender) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.13/classes/Route/methods/model?anchor=model) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.11/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.13/classes/Component/methods/didRender?anchor=didRender) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.13.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.13.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.13/classes/Component/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.13.0/models/customizing-adapters.md
+++ b/guides/v3.13.0/models/customizing-adapters.md
@@ -244,7 +244,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.13/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.13.0/object-model/bindings.md
+++ b/guides/v3.13.0/object-model/bindings.md
@@ -1,7 +1,7 @@
 *__Note:__ Unlike most other frameworks that include some sort of binding implementation, bindings in Ember.js can be used with any object. That said, bindings are most often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.*
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.13/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -35,7 +35,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.13/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.13.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.13.0/object-model/computed-properties-and-aggregate-data.md
@@ -108,7 +108,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.13/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.13.0/object-model/observers.md
+++ b/guides/v3.13.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.13/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.13.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.13.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.13/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.13/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.13.0/routing/defining-your-routes.md
+++ b/guides/v3.13.0/routing/defining-your-routes.md
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`<LinkTo>`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -355,7 +355,7 @@ handlers](https://api.emberjs.com/ember/3.11/classes/Route).
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
-- From a template, use [`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) as mentioned above
+- From a template, use [`<LinkTo>`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
 - From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=transitionTo) method
 - From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/3.11/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
 - From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/3.11/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/3.11/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.13.0/routing/redirection.md
+++ b/guides/v3.13.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/3.11/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like [`<LinkTo>`](../../templates/links/).
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.13/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.13/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.13/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.13/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.13.0/routing/specifying-a-routes-model.md
+++ b/guides/v3.13.0/routing/specifying-a-routes-model.md
@@ -67,7 +67,7 @@ Now that data can be used in the `favorite-posts`  template:
 {{/each}}
 ```
 
-Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=setupController) receives the results of the model hook, and makes those results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
+Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.13/classes/Route/methods/setupController?anchor=setupController) receives the results of the model hook, and makes those results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
 
 Let's compare some examples using the model hook to make asynchronous HTTP requests to a server somewhere.
 
@@ -303,7 +303,7 @@ And calling `modelFor` returned the result of the `model` hook.
 
 If you are having trouble getting a model's data to show up in the template, here are some tips:
 
-- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/debugger?anchor=log) helper to inspect the `{{model}}` from the template
+- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.helpers/methods/log?anchor=log) helper to inspect the `{{model}}` from the template
 - return hard-coded sample data as a test to see if the problem is really in the model hook, or elsewhere down the line
 - study JavaScript Promises in general, to make sure you are returning data from the Promise correctly
 - make sure your `model` hook has a `return` statement

--- a/guides/v3.13.0/templates/conditionals.md
+++ b/guides/v3.13.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.13.0/templates/development-helpers.md
+++ b/guides/v3.13.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.13.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.13.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.13.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.13.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.helpers/methods/each?anchor=each) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.13.0/templates/input-helpers.md
+++ b/guides/v3.13.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`<Input>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`<Textarea>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`<Input>`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.components/methods/Input?anchor=Input)
+and [`<Textarea>`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea)
 components are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -71,7 +71,7 @@ More [event types](https://api.emberjs.com/ember/3.13/classes/Component#event-ha
 ## Checkboxes
 
 You can also use the
-[`<Input>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`<Input>`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.components/methods/Input?anchor=Input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars
@@ -108,7 +108,7 @@ Checkboxes are a special input type. If you want to dispatch an action on a cert
 
 Will bind the value of the text area to `name` on the current context.
 
-[`<Textarea>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea) supports binding and/or setting the following properties:
+[`<Textarea>`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea) supports binding and/or setting the following properties:
 
 * `value`
 * `name`

--- a/guides/v3.13.0/templates/links.md
+++ b/guides/v3.13.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `<LinkTo>` Component
 
 You create a link to a route using the
-[`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`<LinkTo>`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -132,7 +132,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`LinkTo`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`LinkTo`](https://api.emberjs.com/ember/3.13/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.13.0/templates/writing-helpers.md
+++ b/guides/v3.13.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.13/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -250,7 +250,7 @@ To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.11/classes/Helper).
 Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/3.11/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.11/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.13/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 

--- a/guides/v3.13.0/tutorial/model-hook.md
+++ b/guides/v3.13.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.13/classes/Route/methods/model?anchor=model).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.13.0/tutorial/routes-and-templates.md
+++ b/guides/v3.13.0/tutorial/routes-and-templates.md
@@ -224,7 +224,7 @@ All we want to do when a user visits the root (`/`) URL is transition to
 implementing a route lifecycle hook called `redirect`.
 Route lifecycle hooks are special methods that are called automatically when a route renders or data changes.
 Inside, we'll call the
-[`transitionTo`](https://api.emberjs.com/ember/3.9/classes/Route/methods/redirect?anchor=transitionTo)
+[`transitionTo`](https://api.emberjs.com/ember/3.13/classes/Route/methods/transitionTo?anchor=transitionTo)
 function:
 
 ```javascript {data-filename="app/routes/index.js" data-diff="+4,+5,+6"}

--- a/guides/v3.13.0/tutorial/subroutes.md
+++ b/guides/v3.13.0/tutorial/subroutes.md
@@ -347,7 +347,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `RentalListing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.11/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.11/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.

--- a/guides/v3.14.0/applications/dependency-injection.md
+++ b/guides/v3.14.0/applications/dependency-injection.md
@@ -2,11 +2,11 @@ Ember applications utilize the [dependency injection](https://en.wikipedia.org/w
 ("DI") design pattern to declare and instantiate classes of objects and dependencies between them.
 Applications and application instances each serve a role in Ember's DI implementation.
 
-An [`Application`](https://api.emberjs.com/ember/3.11/classes/Application) serves as a "registry" for dependency declarations.
+An [`Application`](https://api.emberjs.com/ember/3.14/classes/Application) serves as a "registry" for dependency declarations.
 Factories (i.e. classes) are registered with an application,
 as well as rules about "injecting" dependencies that are applied when objects are instantiated.
 
-An [`ApplicationInstance`](https://api.emberjs.com/ember/3.11/classes/ApplicationInstance) serves as the "owner" for objects that are instantiated from registered factories.
+An [`ApplicationInstance`](https://api.emberjs.com/ember/3.14/classes/ApplicationInstance) serves as the "owner" for objects that are instantiated from registered factories.
 Application instances provide a means to "look up" (i.e. instantiate and / or retrieve) objects.
 
 > _Note: Although an `Application` serves as the primary registry for an app,
@@ -194,7 +194,7 @@ export default Component.extend({
 ## Factory Instance Lookups
 
 To fetch an instantiated factory from the running application you can call the
-[`lookup`](https://api.emberjs.com/ember/3.11/classes/ApplicationInstance/methods/lookup?anchor=lookup) method on an application instance. This method takes a string
+[`lookup`](https://api.emberjs.com/ember/3.14/classes/ApplicationInstance/methods/lookup?anchor=lookup) method on an application instance. This method takes a string
 to identify a factory and returns the appropriate object.
 
 ```javascript
@@ -225,9 +225,9 @@ export default {
 
 ### Getting an Application Instance from a Factory Instance
 
-[`Ember.getOwner`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) will retrieve the application instance that "owns" an
+[`Ember.getOwner`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) will retrieve the application instance that "owns" an
 object. This means that framework objects like components, helpers, and routes
-can use [`Ember.getOwner`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) to perform lookups through their application
+can use [`Ember.getOwner`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) to perform lookups through their application
 instance at runtime.
 
 For example, this component plays songs with different audio services based

--- a/guides/v3.14.0/applications/ember-engines.md
+++ b/guides/v3.14.0/applications/ember-engines.md
@@ -1,6 +1,6 @@
 ## What are Engines?
 
-[Ember Engines](http://ember-engines.com/) allow multiple logical applications to be composed together into a single application from the user's perspective, that provide functionality to their host applications. Engines are isolated, `composable applications`, they have almost all the same features as normal Ember applications, except an [Engine](https://api.emberjs.com/ember/3.11/classes/Engine) requires a host application to boot it and provide a Router instance.
+[Ember Engines](http://ember-engines.com/) allow multiple logical applications to be composed together into a single application from the user's perspective, that provide functionality to their host applications. Engines are isolated, `composable applications`, they have almost all the same features as normal Ember applications, except an [Engine](https://api.emberjs.com/ember/3.14/classes/Engine) requires a host application to boot it and provide a Router instance.
 
 ## Why use Engines?
 

--- a/guides/v3.14.0/applications/index.md
+++ b/guides/v3.14.0/applications/index.md
@@ -1,8 +1,8 @@
-Every Ember application is represented by a class that extends [`Application`](https://api.emberjs.com/ember/3.11/classes/Application).
+Every Ember application is represented by a class that extends [`Application`](https://api.emberjs.com/ember/3.14/classes/Application).
 This class is used to declare and configure the many objects that make up your app.
 
 As your application boots,
-it creates an [`ApplicationInstance`](https://api.emberjs.com/ember/3.11/classes/ApplicationInstance) that is used to manage its stateful aspects.
+it creates an [`ApplicationInstance`](https://api.emberjs.com/ember/3.14/classes/ApplicationInstance) that is used to manage its stateful aspects.
 This instance acts as the "owner" of objects instantiated for your app.
 
 Essentially, the `Application` *defines your application*

--- a/guides/v3.14.0/applications/run-loop.md
+++ b/guides/v3.14.0/applications/run-loop.md
@@ -198,9 +198,9 @@ $('a').click(() => {
 });
 ```
 
-The run loop API calls that _schedule_ work, i.e. [`run.schedule`](https://api.emberjs.com/ember/3.11/classes/@ember%2Frunloop/methods/schedule?anchor=schedule),
-[`run.scheduleOnce`](https://api.emberjs.com/ember/3.11/classes/@ember%2Frunloop/methods/scheduleOnce?anchor=scheduleOnce),
-[`run.once`](https://api.emberjs.com/ember/3.11/classes/@ember%2Frunloop/methods/once?anchor=once) have the property that they will approximate a run loop for you if one does not already exist.
+The run loop API calls that _schedule_ work, i.e. [`run.schedule`](https://api.emberjs.com/ember/3.14/classes/@ember%2Frunloop/methods/schedule?anchor=schedule),
+[`run.scheduleOnce`](https://api.emberjs.com/ember/3.14/classes/@ember%2Frunloop/methods/scheduleOnce?anchor=scheduleOnce),
+[`run.once`](https://api.emberjs.com/ember/3.14/classes/@ember%2Frunloop/methods/once?anchor=once) have the property that they will approximate a run loop for you if one does not already exist.
 These automatically created run loops we call _autoruns_.
 
 Here is some pseudocode to describe what happens using the example above:
@@ -241,5 +241,5 @@ $('a').click(() => {
 
 ## Where can I find more information?
 
-Check out the [Ember.run](https://api.emberjs.com/ember/3.11/classes/@ember%2Frunloop) API documentation,
+Check out the [Ember.run](https://api.emberjs.com/ember/3.14/classes/@ember%2Frunloop) API documentation,
 as well as the [Backburner library](https://github.com/ebryn/backburner.js/) that powers the run loop.

--- a/guides/v3.14.0/applications/services.md
+++ b/guides/v3.14.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.11/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.14/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.11/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.14/modules/@ember%2Fservice) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';
@@ -93,7 +93,7 @@ This injects the shopping cart service into the component and makes it available
 
 Sometimes a service may or may not exist, like when an initializer conditionally registers a service.
 Since normal injection will throw an error if the service doesn't exist,
-you must look up the service using Ember's [`getOwner`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) instead.
+you must look up the service using Ember's [`getOwner`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) instead.
 
 ```javascript {data-filename=app/components/cart-contents.js}
 import Component from '@ember/component';

--- a/guides/v3.14.0/applications/services.md
+++ b/guides/v3.14.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.14/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.14/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.14/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.14/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.14.0/components/handling-events.md
+++ b/guides/v3.14.0/components/handling-events.md
@@ -129,7 +129,7 @@ To utilize an `event` object as a function parameter:
 
 The event handling examples described above respond to one set of events.
 The names of the built-in events are listed below. Custom events can be
-registered by using [Application.customEvents](https://api.emberjs.com/ember/3.11/classes/Application/properties/customEvents?anchor=customEvents).
+registered by using [Application.customEvents](https://api.emberjs.com/ember/3.14/classes/Application/properties/customEvents?anchor=customEvents).
 
 Touch events:
 

--- a/guides/v3.14.0/components/index.md
+++ b/guides/v3.14.0/components/index.md
@@ -33,7 +33,7 @@ Given the above template, you can now use the `<BlogPost />` component:
     <div class="cta-note-body">
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
-In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
+In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.14/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">
@@ -66,7 +66,7 @@ those cases, you do not need to write any JavaScript at all. Handlebars
 allows you to define templates and reuse them as components.
 
 If you need to customize the behavior of the component you'll
-need to define a subclass of [`Component`](https://api.emberjs.com/ember/3.11/classes/Component). For example, you would
+need to define a subclass of [`Component`](https://api.emberjs.com/ember/3.14/classes/Component). For example, you would
 need a custom subclass if you wanted to change a component's element,
 respond to actions from the component's template, or manually make
 changes to the component's element using JavaScript.
@@ -79,7 +79,7 @@ file at `app/components/blog-post.js`. If your component was called
 
 ## Dynamically rendering a component
 
-The [`{{component}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/component?anchor=component) helper can be used to defer the selection of a component to
+The [`{{component}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/component?anchor=component) helper can be used to defer the selection of a component to
 run time. The `<MyComponent />` syntax always renders the same component,
 while using the `{{component}}` helper allows choosing a component to render on
 the fly. This is useful in cases where you want to interact with different
@@ -89,7 +89,7 @@ allow you to keep different logic well separated.
 The first parameter of the helper is the name of a component to render, as a
 string. So `{{component 'blog-post'}}` is the same as using `<BlogPost />`.
 
-The real value of [`{{component}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/component?anchor=component) comes from being able to dynamically pick
+The real value of [`{{component}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/component?anchor=component) comes from being able to dynamically pick
 the component being rendered. Below is an example of using the helper as a
 means of choosing different components for displaying different kinds of posts:
 

--- a/guides/v3.14.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.14.0/components/passing-properties-to-a-component.md
@@ -83,7 +83,7 @@ In other words, you can invoke the above component example like this:
 ```
 
 To set the component up to receive parameters this way, you need to
-set the [`positionalParams`](https://api.emberjs.com/ember/3.11/classes/Component/properties/positionalParams?anchor=positionalParams) attribute in your component class.
+set the [`positionalParams`](https://api.emberjs.com/ember/3.14/classes/Component/properties/positionalParams?anchor=positionalParams) attribute in your component class.
 
 ```javascript {data-filename=app/components/blog-post.js}
 import Component from '@ember/component';

--- a/guides/v3.14.0/components/the-component-lifecycle.md
+++ b/guides/v3.14.0/components/the-component-lifecycle.md
@@ -123,15 +123,15 @@ Suppose you want to integrate your favorite date picker library into an Ember pr
 Typically, 3rd party JS/jQuery libraries require a DOM element to bind to.
 So, where is the best place to initialize and attach the library?
 
-After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`](https://api.emberjs.com/ember/3.11/classes/Component/events/didInsertElement?anchor=didInsertElement) hook.
+After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`](https://api.emberjs.com/ember/3.14/classes/Component/events/didInsertElement?anchor=didInsertElement) hook.
 
 Ember guarantees that, by the time `didInsertElement()` is called:
 
 1. The component's element has been both created and inserted into the
    DOM.
-2. The component's element is accessible via the component's [`this.element`](https://api.emberjs.com/ember/3.11/classes/Component/properties/element?anchor=element) property.
+2. The component's element is accessible via the component's [`this.element`](https://api.emberjs.com/ember/3.14/classes/Component/properties/element?anchor=element) property.
 
-The [`element`](https://api.emberjs.com/ember/3.11/classes/Component/properties/element?anchor=element) property allows you to access the component's DOM element.
+The [`element`](https://api.emberjs.com/ember/3.14/classes/Component/properties/element?anchor=element) property allows you to access the component's DOM element.
 For example, you can set an attribute using the `Element.setAttribute()` method:
 
 ```javascript {data-filename=app/components/profile-editor.js}
@@ -145,7 +145,7 @@ export default Component.extend({
 });
 ```
 
-The [`element`](https://api.emberjs.com/ember/3.11/classes/Component/properties/element?anchor=element) property will, by default, return a DOM object for the component's root element, but you can also target child elements within the component's template by passing a selector to `querySelector` or `querySelectorAll`:
+The [`element`](https://api.emberjs.com/ember/3.14/classes/Component/properties/element?anchor=element) property will, by default, return a DOM object for the component's root element, but you can also target child elements within the component's template by passing a selector to `querySelector` or `querySelectorAll`:
 
 ```javascript {data-filename=app/components/profile-editor.js}
 import Component from '@ember/component';
@@ -161,7 +161,7 @@ export default Component.extend({
 });
 ```
 
-Let's initialize our date picker by overriding the [`didInsertElement()`](https://api.emberjs.com/ember/3.11/classes/Component/events/didInsertElement?anchor=didInsertElement) method.
+Let's initialize our date picker by overriding the [`didInsertElement()`](https://api.emberjs.com/ember/3.14/classes/Component/events/didInsertElement?anchor=didInsertElement) method.
 
 Date picker libraries usually attach to an `<input>` element, so we will use `this.element.querySelector` to find an appropriate input within our component's template.
 
@@ -176,7 +176,7 @@ export default Component.extend({
 });
 ```
 
-[`didInsertElement()`](https://api.emberjs.com/ember/3.11/classes/Component/events/didInsertElement?anchor=didInsertElement) is also a good place to
+[`didInsertElement()`](https://api.emberjs.com/ember/3.14/classes/Component/events/didInsertElement?anchor=didInsertElement) is also a good place to
 attach event listeners. This is particularly useful for custom events or
 other browser events which do not have a [built-in event
 handler](../../components/handling-events/#toc_event-names).
@@ -201,8 +201,8 @@ There are a few things to note about the `didInsertElement()` hook:
 
 - It is only triggered once when the component element is first rendered.
 - In cases where you have components nested inside other components, the child component will always receive the `didInsertElement()` call before its parent does.
-- Setting properties on the component in [`didInsertElement()`](https://api.emberjs.com/ember/3.11/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons, is not allowed.
-- While [`didInsertElement()`](https://api.emberjs.com/ember/3.11/classes/Component/events/didInsertElement?anchor=didInsertElement) is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
+- Setting properties on the component in [`didInsertElement()`](https://api.emberjs.com/ember/3.14/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons, is not allowed.
+- While [`didInsertElement()`](https://api.emberjs.com/ember/3.14/classes/Component/events/didInsertElement?anchor=didInsertElement) is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
   particularly when order of execution is important.
 
 ### Making Updates to the Rendered DOM with `didRender`
@@ -257,7 +257,7 @@ export default Component.extend({
 
 ### Detaching and Tearing Down Component Elements with `willDestroyElement`
 
-When a component detects that it is time to remove itself from the DOM, Ember will trigger the [`willDestroyElement()`](https://api.emberjs.com/ember/3.11/classes/Component/events/willDestroyElement?anchor=willDestroyElement) method, allowing for any teardown logic to be performed.
+When a component detects that it is time to remove itself from the DOM, Ember will trigger the [`willDestroyElement()`](https://api.emberjs.com/ember/3.14/classes/Component/events/willDestroyElement?anchor=willDestroyElement) method, allowing for any teardown logic to be performed.
 
 Component teardown can be triggered by a number of different conditions.
 For instance, the user may navigate to a different route, or a conditional Handlebars block surrounding your component may change:

--- a/guides/v3.14.0/components/wrapping-content-in-a-component.md
+++ b/guides/v3.14.0/components/wrapping-content-in-a-component.md
@@ -62,7 +62,7 @@ We will give them the option to specify either `markdown-style` or `html-style`.
 
 Supporting different editing styles will require different body components to provide special validation and highlighting.
 To load a different body component based on editing style,
-you can yield the component using the [`component helper`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/component?anchor=component) and [`hash helper`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/hash?anchor=hash).
+you can yield the component using the [`component helper`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/component?anchor=component) and [`hash helper`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/hash?anchor=hash).
 Here, the appropriate component is assigned to a hash using nested helpers and yielded to the template.
 Notice `editStyle` being used as an argument to the component helper.
 

--- a/guides/v3.14.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.14.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.14/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.14/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.14.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.14.0/configuring-ember/disabling-prototype-extensions.md
@@ -9,7 +9,7 @@ objects in the following ways:
 
 * `String` is extended to add convenience methods, such as
   `camelize()` and `w()`. You can find a list of these methods with the
-  [Ember.String documentation](https://api.emberjs.com/ember/3.11/classes/String).
+  [Ember.String documentation](https://api.emberjs.com/ember/3.14/classes/String).
 
 * `Function` is extended with methods to annotate functions as
   computed properties, via the `property()` method, and as observers,
@@ -90,7 +90,7 @@ islands.includes('Oahu');
 ### Strings
 
 Strings will no longer have the convenience methods described in the
-[`Ember.String` API reference](https://api.emberjs.com/ember/3.11/classes/String).
+[`Ember.String` API reference](https://api.emberjs.com/ember/3.14/classes/String).
 Instead,
 you can use the similarly-named methods of the `Ember.String` object and
 pass the string to use as the first parameter:
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.14/namespaces/Ember/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.14.0/configuring-ember/handling-deprecations.md
+++ b/guides/v3.14.0/configuring-ember/handling-deprecations.md
@@ -10,7 +10,7 @@ Fortunately, Ember provides a way for projects to deal with deprecations in an o
 ## Filtering Deprecations
 
 When your project has a lot of deprecations, you can start by filtering out deprecations that do not have to be addressed right away.
-You can use the [deprecation handlers](https://api.emberjs.com/ember/3.11/functions/@ember%2Fdebug/registerDeprecationHandler) API to check for what release a deprecated feature will be removed.
+You can use the [deprecation handlers](https://api.emberjs.com/ember/3.14/functions/@ember%2Fdebug/registerDeprecationHandler) API to check for what release a deprecated feature will be removed.
 An example handler is shown below that filters out all deprecations that are not going away in release 2.0.0.
 
 ```javascript {data-filename= app/initializers/main.js}

--- a/guides/v3.14.0/configuring-ember/optional-features.md
+++ b/guides/v3.14.0/configuring-ember/optional-features.md
@@ -75,7 +75,7 @@ Now your app will be about 30KB lighter!
 
 Without jQuery, any code that still relies on it will break, especially the following usages:
 
-- [`this.$()`](https://api.emberjs.com/ember/3.11/classes/Component/methods/$?anchor=%24) in components
+- [`this.$()`](https://api.emberjs.com/ember/3.14/classes/Component/methods/$?anchor=%24) in components
 - `jQuery` or `$` directly as a global, through `Ember.$()` or by importing it (`import jQuery from jquery;`)
 - global acceptance test helpers like `find()` or `click()`
 - `this.$()` in component tests

--- a/guides/v3.14.0/controllers/index.md
+++ b/guides/v3.14.0/controllers/index.md
@@ -1,8 +1,8 @@
 ### What is a Controller?
 
-A [Controller](https://api.emberjs.com/ember/3.11/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.3/classes/Route/methods?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/3.14/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.14/classes/Route/methods?anchor=model) method.
 
-The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
+The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 
 A Controller is usually paired with an individual Route of the same name.
 

--- a/guides/v3.14.0/ember-inspector/data.md
+++ b/guides/v3.14.0/ember-inspector/data.md
@@ -30,4 +30,4 @@ You can also filter records by entering a query in the search box.
 ### Building a Data Custom Adapter
 
 You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter and [DataAdapter](https://api.emberjs.com/ember/3.11/classes/DataAdapter) documentation.
+using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter and [DataAdapter](https://api.emberjs.com/ember/3.14/classes/DataAdapter) documentation.

--- a/guides/v3.14.0/getting-started/core-concepts.md
+++ b/guides/v3.14.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.14/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.14/classes/Component/methods/willRender?anchor=willRender) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/model?anchor=model) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.14/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.14/classes/Component/methods/didRender?anchor=didRender) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.14.0/getting-started/core-concepts.md
+++ b/guides/v3.14.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.11/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.14/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.11/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.14/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.14.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.14.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/3.14/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.14/classes/Component/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.14.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.14.0/models/creating-updating-and-deleting-records.md
@@ -1,7 +1,7 @@
 ## Creating Records
 
 You can create records by calling the
-[`createRecord()`](https://api.emberjs.com/ember-data/release/classes/Adapter/methods/createRecord?anchor=createRecord)
+[`createRecord()`](https://api.emberjs.com/ember-data/3.14/classes/Adapter/methods/createRecord?anchor=createRecord)
 method on the store.
 
 ```javascript
@@ -36,7 +36,7 @@ person.incrementProperty('age'); // Happy birthday!
 ## Persisting Records
 
 Records in Ember Data are persisted on a per-instance basis.
-Call [`save()`](https://api.emberjs.com/ember-data/release/classes/Model/methods/save?anchor=save)
+Call [`save()`](https://api.emberjs.com/ember-data/3.14/classes/Model/methods/save?anchor=save)
 on any instance of `DS.Model` and it will make a network request.
 
 Ember Data takes care of tracking the state of each record for
@@ -68,10 +68,10 @@ store.findRecord('post', 1).then(function(post) {
 
 You can tell if a record has outstanding changes that have not yet been
 saved by checking its
-[`hasDirtyAttributes`](https://api.emberjs.com/ember-data/release/classes/Model/properties/hasDirtyAttributes?anchor=hasDirtyAttributes)
+[`hasDirtyAttributes`](https://api.emberjs.com/ember-data/3.14/classes/Model/properties/hasDirtyAttributes?anchor=hasDirtyAttributes)
 property. You can also see what parts of
 the record were changed and what the original value was using the
-[`changedAttributes()`](https://api.emberjs.com/ember-data/release/classes/Model/methods/changedAttributes?anchor=changedAttributes)
+[`changedAttributes()`](https://api.emberjs.com/ember-data/3.14/classes/Model/methods/changedAttributes?anchor=changedAttributes)
 method. `changedAttributes` returns an object, whose keys are the changed
 properties and values are an array of values `[oldValue, newValue]`.
 
@@ -85,7 +85,7 @@ person.changedAttributes();       // => { isAdmin: [false, true] }
 
 At this point, you can either persist your changes via `save()` or you can roll
 back your changes. Calling
-[`rollbackAttributes()`](https://api.emberjs.com/ember-data/release/classes/Model/methods/rollbackAttributes?anchor=rollbackAttributes)
+[`rollbackAttributes()`](https://api.emberjs.com/ember-data/3.14/classes/Model/methods/rollbackAttributes?anchor=rollbackAttributes)
 for a saved record reverts all the `changedAttributes` to their original value.
 If the record `isNew` it will be removed from the store.
 
@@ -163,4 +163,4 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 });
 ```
 
-The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](https://api.emberjs.com/ember-data/release/classes/Adapter/methods/findRecord?anchor=findRecord) automatically schedules a fetch of the record from the adapter.
+The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](https://api.emberjs.com/ember-data/3.14/classes/Adapter/methods/findRecord?anchor=findRecord) automatically schedules a fetch of the record from the adapter.

--- a/guides/v3.14.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.14.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.14/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.14.0/models/customizing-adapters.md
+++ b/guides/v3.14.0/models/customizing-adapters.md
@@ -48,17 +48,17 @@ export default DS.JSONAPIAdapter.extend({
 Ember Data comes with several built-in adapters.
 Feel free to use these adapters as a starting point for creating your own custom adapter.
 
-- [DS.Adapter](https://api.emberjs.com/ember-data/release/classes/Adapter) is the basic adapter
+- [DS.Adapter](https://api.emberjs.com/ember-data/3.14/classes/Adapter) is the basic adapter
 with no functionality. It is generally a good starting point if you
 want to create an adapter that is radically different from the other
 Ember adapters.
 
-- [DS.JSONAPIAdapter](https://api.emberjs.com/ember-data/release/classes/JSONAPIAdapter)
+- [DS.JSONAPIAdapter](https://api.emberjs.com/ember-data/3.14/classes/JSONAPIAdapter)
 The `JSONAPIAdapter` is the default adapter and follows JSON:API
 conventions to communicate with an HTTP server by transmitting JSON
 via XHR.
 
-- [DS.RESTAdapter](https://api.emberjs.com/ember-data/release/classes/RESTAdapter)
+- [DS.RESTAdapter](https://api.emberjs.com/ember-data/3.14/classes/RESTAdapter)
 The `RESTAdapter` allows your store to communicate with an HTTP server
 by transmitting JSON via XHR. Before Ember Data 2.0 this adapter was the default.
 
@@ -66,7 +66,7 @@ by transmitting JSON via XHR. Before Ember Data 2.0 this adapter was the default
 ## Customizing the JSONAPIAdapter
 
 The
-[DS.JSONAPIAdapter](https://api.emberjs.com/ember-data/release/classes/JSONAPIAdapter)
+[DS.JSONAPIAdapter](https://api.emberjs.com/ember-data/3.14/classes/JSONAPIAdapter)
 has a handful of hooks that are commonly used to extend it to work
 with non-standard backends.
 

--- a/guides/v3.14.0/models/customizing-adapters.md
+++ b/guides/v3.14.0/models/customizing-adapters.md
@@ -244,7 +244,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.14/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.14.0/models/customizing-adapters.md
+++ b/guides/v3.14.0/models/customizing-adapters.md
@@ -244,7 +244,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.14.0/models/customizing-serializers.md
+++ b/guides/v3.14.0/models/customizing-serializers.md
@@ -5,11 +5,11 @@ format, Ember Data allows you to customize the serializer or use a
 different serializer entirely.
 
 Ember Data ships with 3 serializers. The
-[`JSONAPISerializer`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer)
+[`JSONAPISerializer`](https://api.emberjs.com/ember-data/3.14/classes/JSONAPISerializer)
 is the default serializer and works with JSON:API backends. The
-[`JSONSerializer`](https://api.emberjs.com/ember-data/release/classes/JSONSerializer)
+[`JSONSerializer`](https://api.emberjs.com/ember-data/3.14/classes/JSONSerializer)
 is a simple serializer for working with single JSON object or arrays of records. The
-[`RESTSerializer`](https://api.emberjs.com/ember-data/release/classes/RESTSerializer)
+[`RESTSerializer`](https://api.emberjs.com/ember-data/3.14/classes/RESTSerializer)
 is a more complex serializer that supports sideloading and was the default
 serializer before 2.0.
 
@@ -139,7 +139,7 @@ export default DS.JSONAPISerializer.extend({});
 ```
 
 To change the format of the data that is sent to the backend store, you can use
-the [`serialize()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/serialize?anchor=serialize)
+the [`serialize()`](https://api.emberjs.com/ember-data/3.14/classes/JSONAPISerializer/methods/serialize?anchor=serialize)
 hook. Let's say that we have this JSON:API response from Ember Data:
 
 ```json
@@ -198,7 +198,7 @@ export default DS.JSONAPISerializer.extend({
 
 Similarly, if your backend store provides data in a format other than JSON:API,
 you can use the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.14/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -256,7 +256,7 @@ To normalize only a single model, you can use the
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
-API documentation](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer).
+API documentation](https://api.emberjs.com/ember-data/3.14/classes/JSONAPISerializer).
 
 ### IDs
 
@@ -309,7 +309,7 @@ in the document payload returned by your server:
 
 If the attributes returned by your server use a different convention
 you can use the serializer's
-[`keyForAttribute()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/keyForAttribute?anchor=keyForAttribute)
+[`keyForAttribute()`](https://api.emberjs.com/ember-data/3.14/classes/JSONAPISerializer/methods/keyForAttribute?anchor=keyForAttribute)
 method to convert an attribute name in your model to a key in your JSON
 payload. For example, if your backend returned attributes that are
 `under_scored` instead of `dash-cased` you could override the `keyForAttribute`
@@ -544,7 +544,7 @@ looks similar to this:
 The `JSONAPISerializer` is built on top of the `JSONSerializer` so they share
 many of the same hooks for customizing the behavior of the
 serialization process. Be sure to check out the
-[API docs](https://api.emberjs.com/ember-data/release/classes/JSONSerializer)
+[API docs](https://api.emberjs.com/ember-data/3.14/classes/JSONSerializer)
 for a full list of methods and properties.
 
 
@@ -759,7 +759,7 @@ the possible values of: `'findRecord'`, `'queryRecord'`, `'findAll'`,
 `'createRecord'`, `'deleteRecord'`, and `'updateRecord'`) as arguments.
 
 A custom serializer will also need to define a
-[normalize](https://api.emberjs.com/ember-data/release/classes/Serializer/methods/normalize?anchor=normalize)
+[normalize](https://api.emberjs.com/ember-data/3.14/classes/Serializer/methods/normalize?anchor=normalize)
 method.
 This method is called by `store.normalize(type, payload)` and is often
 used for normalizing requests made outside of Ember Data because they
@@ -768,7 +768,7 @@ do not fall into the normal CRUD flow that the adapter provides.
 ### Serializing records
 
 Finally a serializer will need to implement a
-[serialize](https://api.emberjs.com/ember-data/release/classes/Serializer/methods/serialize?anchor=serialize)
+[serialize](https://api.emberjs.com/ember-data/3.14/classes/Serializer/methods/serialize?anchor=serialize)
 method.
 Ember Data will provide a record snapshot and an options hash and this
 method should return an object that the adapter will send to the

--- a/guides/v3.14.0/models/defining-models.md
+++ b/guides/v3.14.0/models/defining-models.md
@@ -39,7 +39,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
 ## Defining Attributes
 
 The `person` model we generated earlier didn't have any attributes. Let's
-add first and last name, as well as the birthday, using [`DS.attr`](https://api.emberjs.com/ember-data/release/classes/Model/properties/attributes?anchor=attributes):
+add first and last name, as well as the birthday, using [`DS.attr`](https://api.emberjs.com/ember-data/3.14/classes/Model/properties/attributes?anchor=attributes):
 
 ```javascript {data-filename=app/models/person.js}
 import DS from 'ember-data';

--- a/guides/v3.14.0/models/finding-records.md
+++ b/guides/v3.14.0/models/finding-records.md
@@ -22,7 +22,7 @@ let blogPost = this.store.peekRecord('blog-post', 1); // => no network request
 
 ### Retrieving Multiple Records
 
-Use [`store.findAll()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/findAll?anchor=findAll) to retrieve all of the records for a given type:
+Use [`store.findAll()`](https://api.emberjs.com/ember-data/3.14/classes/Store/methods/findAll?anchor=findAll) to retrieve all of the records for a given type:
 
 ```javascript
 // GET /blog-posts
@@ -108,7 +108,7 @@ As in the case of `store.query()`, a query object can also be passed to `store.q
 However the adapter must return a single model object, not an array containing one element,
 otherwise Ember Data will throw an exception.
 
-Note that Ember's default [JSON:API adapter](https://api.emberjs.com/ember-data/release/classes/JSONAPIAdapter) does not provide the functionality needed to support `queryRecord()` directly as it relies on REST request definitions that return result data in the form of an array.
+Note that Ember's default [JSON:API adapter](https://api.emberjs.com/ember-data/3.14/classes/JSONAPIAdapter) does not provide the functionality needed to support `queryRecord()` directly as it relies on REST request definitions that return result data in the form of an array.
 
 If your server API or your adapter only provides array responses but you wish to retrieve just a single record, you can alternatively use the `query()` method as follows:
 

--- a/guides/v3.14.0/models/finding-records.md
+++ b/guides/v3.14.0/models/finding-records.md
@@ -40,7 +40,7 @@ let blogPosts = this.store.peekAll('blog-post'); // => no network request
 
 `store.findAll()` returns a `DS.PromiseArray` that fulfills to a `DS.RecordArray` and `store.peekAll` directly returns a `DS.RecordArray`.
 
-It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`MutableArray`](https://api.emberjs.com/ember/3.11/classes/MutableArray).
+It's important to note that `DS.RecordArray` is not a JavaScript array, it's an object that implements [`MutableArray`](https://api.emberjs.com/ember/3.14/classes/MutableArray).
 This is important because, for example, if you want to retrieve records by index,
 the `[]` notation will not work--you'll have to use `objectAt(index)` instead.
 

--- a/guides/v3.14.0/models/pushing-records-into-the-store.md
+++ b/guides/v3.14.0/models/pushing-records-into-the-store.md
@@ -19,7 +19,7 @@ you want to update the UI immediately.
 
 ### Pushing Records
 
-To push a record into the store, call the store's [`push()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/push?anchor=push) method.
+To push a record into the store, call the store's [`push()`](https://api.emberjs.com/ember-data/3.14/classes/Store/methods/push?anchor=push) method.
 
 For example, imagine we want to preload some data into the store when
 the application boots for the first time.

--- a/guides/v3.14.0/models/relationships.md
+++ b/guides/v3.14.0/models/relationships.md
@@ -349,7 +349,7 @@ include those related records in the response returned to the client.
 The value of the parameter should be a comma-separated list of names of the
 relationships required.
 
-If you are using an adapter that supports JSON:API, such as Ember's default [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/release/classes/JSONAPIAdapter),
+If you are using an adapter that supports JSON:API, such as Ember's default [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/3.14/classes/JSONAPIAdapter),
 you can easily add the `include` parameter to the server requests created by
 the `findRecord()`, `findAll()`,
 `query()` and `queryRecord()` methods.

--- a/guides/v3.14.0/object-model/bindings.md
+++ b/guides/v3.14.0/object-model/bindings.md
@@ -1,7 +1,7 @@
 *__Note:__ Unlike most other frameworks that include some sort of binding implementation, bindings in Ember.js can be used with any object. That said, bindings are most often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.*
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
 that specifies the path to another object.
 
 ```javascript
@@ -35,7 +35,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.14.0/object-model/bindings.md
+++ b/guides/v3.14.0/object-model/bindings.md
@@ -1,7 +1,7 @@
 *__Note:__ Unlike most other frameworks that include some sort of binding implementation, bindings in Ember.js can be used with any object. That said, bindings are most often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.*
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -35,7 +35,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.14.0/object-model/classes-and-instances.md
+++ b/guides/v3.14.0/object-model/classes-and-instances.md
@@ -4,8 +4,8 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
-[`EmberObject`](https://api.emberjs.com/ember/3.11/modules/@ember%2Fobject):
+To define a new Ember _class_, call the [`extend()`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://api.emberjs.com/ember/3.14/modules/@ember%2Fobject):
 
 
 ```javascript
@@ -22,7 +22,7 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`](https://api.emberjs.com/ember/3.11/classes/Component) class:
+of Ember's built-in [`Component`](https://api.emberjs.com/ember/3.14/classes/Component) class:
 
 ```javascript {data-filename=app/components/todo-item.js}
 import Component from '@ember/component';
@@ -83,7 +83,7 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
+class by calling its [`create()`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
 
@@ -133,7 +133,7 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`](https://api.emberjs.com/ember/3.11/classes/EmberObject/methods/init?anchor=init) method is invoked automatically. This is the ideal place to implement setup required on new instances:
+When a new instance is created, its [`init()`](https://api.emberjs.com/ember/3.14/classes/EmberObject/methods/init?anchor=init) method is invoked automatically. This is the ideal place to implement setup required on new instances:
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -218,7 +218,7 @@ Person.create({
 
 When reading a property value of an object, you can in most cases use the common JavaScript dot notation, e.g. `myObject.myProperty`.
 
-[Ember proxy objects](https://api.emberjs.com/ember/3.3/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
+[Ember proxy objects](https://api.emberjs.com/ember/3.14/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
 
 Let's look at the following `blogPost` Ember Data model:
 
@@ -236,7 +236,7 @@ export default Model.extend({
 
 To access the blog post's title you can simply write `blogPost.title`, whereas only the syntax `blogPost.get('comments')` will return the post's comments.
 
-Always use Ember's [`set()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject/methods/set?anchor=set) method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
+Always use Ember's [`set()`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject/methods/set?anchor=set) method to update property values. It will propagate the value change to computed properties, observers, templates, etc. If you "just" use JavaScript's dot notation to update a property value, computed properties won't recalculate, observers won't fire and templates won't update.
 
 ```javascript
 import EmberObject from '@ember/object';

--- a/guides/v3.14.0/object-model/classes-and-instances.md
+++ b/guides/v3.14.0/object-model/classes-and-instances.md
@@ -67,7 +67,7 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`](https://api.emberjs.com/ember-data/3.14/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
 

--- a/guides/v3.14.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.14.0/object-model/computed-properties-and-aggregate-data.md
@@ -108,7 +108,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}
@@ -200,10 +200,10 @@ export default Component.extend({
 Here, `indexOfSelectedTodo` depends on `todos.[]`, so it will update if we add an item
 to `todos`, but won't update if the value of `isDone` on a `todo` changes.
 
-Several of the [Ember.computed](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed) macros
+Several of the [Ember.computed](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject%2Fcomputed) macros
 utilize the `[]` key to implement common use-cases. For instance, to
 create a computed property that mapped properties from an array, you could use
-[Ember.computed.map](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fcomputed/methods/map?anchor=map)
+[Ember.computed.map](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject%2Fcomputed/methods/map?anchor=map)
 or build the computed property yourself:
 
 ```javascript

--- a/guides/v3.14.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.14.0/object-model/computed-properties-and-aggregate-data.md
@@ -108,7 +108,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.14.0/object-model/computed-properties.md
+++ b/guides/v3.14.0/object-model/computed-properties.md
@@ -255,4 +255,4 @@ Person = EmberObject.extend({
 ```
 
 To see the full list of computed property macros, have a look at
-[the API documentation](https://api.emberjs.com/ember/3.11/modules/@ember%2Fobject)
+[the API documentation](https://api.emberjs.com/ember/3.14/modules/@ember%2Fobject)

--- a/guides/v3.14.0/object-model/enumerables.md
+++ b/guides/v3.14.0/object-model/enumerables.md
@@ -1,6 +1,6 @@
 In Ember.js, an enumerable is any object that contains a number of child
 objects, and which allows you to work with those children using the
-[`MutableArray`](https://api.emberjs.com/ember/3.11/classes/MutableArray) API. The most common
+[`MutableArray`](https://api.emberjs.com/ember/3.14/classes/MutableArray) API. The most common
 enumerable in the majority of apps is the native JavaScript array, which
 Ember.js extends to conform to the enumerable interface.
 
@@ -69,11 +69,11 @@ in an observable fashion, you should use `myArray.get('firstObject')` and
 
 In the rest of this guide, we'll explore some of the most common enumerable
 conveniences. For the full list, please see the [`MutableArray API
-reference documentation`](https://api.emberjs.com/ember/3.11/classes/MutableArray).
+reference documentation`](https://api.emberjs.com/ember/3.14/classes/MutableArray).
 
 ### Iterating Over an Enumerable
 
-To enumerate all the values of an enumerable object, use the [`forEach()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/forEach?anchor=forEach)
+To enumerate all the values of an enumerable object, use the [`forEach()`](https://api.emberjs.com/ember/3.14/classes/MutableArray/methods/forEach?anchor=forEach)
 method:
 
 
@@ -91,7 +91,7 @@ food.forEach((item, index) => {
 
 ### First and Last Objects
 
-All enumerables expose [`firstObject`](https://api.emberjs.com/ember/3.11/classes/MutableArray/properties/firstObject?anchor=firstObject) and [`lastObject`](https://api.emberjs.com/ember/3.11/classes/MutableArray/properties/lastObject?anchor=lastObject) properties
+All enumerables expose [`firstObject`](https://api.emberjs.com/ember/3.14/classes/MutableArray/properties/firstObject?anchor=firstObject) and [`lastObject`](https://api.emberjs.com/ember/3.14/classes/MutableArray/properties/lastObject?anchor=lastObject) properties
 that you can bind to.
 
 
@@ -113,7 +113,7 @@ animals.get('lastObject');
 ### Map
 
 You can easily transform each item in an enumerable using the
-[`map()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/map?anchor=map) method, which creates a new array with results of calling a
+[`map()`](https://api.emberjs.com/ember/3.14/classes/MutableArray/methods/map?anchor=map) method, which creates a new array with results of calling a
 function on each item in the enumerable.
 
 
@@ -124,7 +124,7 @@ let emphaticWords = words.map(item => `${item}!`);
 //=> ["goodbye!", "cruel!", "world!"]
 ```
 
-If your enumerable is composed of objects, there is a [`mapBy()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/mapBy?anchor=mapBy)
+If your enumerable is composed of objects, there is a [`mapBy()`](https://api.emberjs.com/ember/3.14/classes/MutableArray/methods/mapBy?anchor=mapBy)
 method that will extract the named property from each of those objects
 in turn and return a new array:
 
@@ -153,7 +153,7 @@ Another common task to perform on an enumerable is to take the
 enumerable as input, and return an Array after filtering it based on
 some criteria.
 
-For arbitrary filtering, use the [`filter()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/filter?anchor=filter) method.  The filter method
+For arbitrary filtering, use the [`filter()`](https://api.emberjs.com/ember/3.14/classes/MutableArray/methods/filter?anchor=filter) method.  The filter method
 expects the callback to return `true` if Ember should include it in the
 final Array, and `false` or `undefined` if Ember should not.
 
@@ -166,7 +166,7 @@ arr.filter((item, index, self) => item < 4);
 //=> [1, 2, 3]
 ```
 
-When working with a collection of Ember objects, you will often want to filter a set of objects based upon the value of some property. The [`filterBy()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/filterBy?anchor=filterBy) method provides a shortcut.
+When working with a collection of Ember objects, you will often want to filter a set of objects based upon the value of some property. The [`filterBy()`](https://api.emberjs.com/ember/3.14/classes/MutableArray/methods/filterBy?anchor=filterBy) method provides a shortcut.
 
 
 ```javascript
@@ -189,14 +189,14 @@ todos.filterBy('isDone', true);
 ```
 
 If you only want to return the first matched value, rather than an Array
-containing all of the matched values, you can use [`find()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/find?anchor=find) and [`findBy()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/findBy?anchor=findBy),
+containing all of the matched values, you can use [`find()`](https://api.emberjs.com/ember/3.14/classes/MutableArray/methods/find?anchor=find) and [`findBy()`](https://api.emberjs.com/ember/3.14/classes/MutableArray/methods/findBy?anchor=findBy),
 which work like `filter()` and `filterBy()`, but return only one item.
 
 
 ### Aggregate Information (Every or Any)
 
 To find out whether every item in an enumerable matches some condition, you can
-use the [`every()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/every?anchor=every) method:
+use the [`every()`](https://api.emberjs.com/ember/3.14/classes/MutableArray/methods/every?anchor=every) method:
 
 
 ```javascript
@@ -219,7 +219,7 @@ people.every((person, index, self) => person.get('isHappy'));
 ```
 
 To find out whether at least one item in an enumerable matches some condition,
-you can use the [`any()`](https://api.emberjs.com/ember/3.11/classes/MutableArray/methods/any?anchor=any) method:
+you can use the [`any()`](https://api.emberjs.com/ember/3.14/classes/MutableArray/methods/any?anchor=any) method:
 
 
 ```javascript

--- a/guides/v3.14.0/object-model/index.md
+++ b/guides/v3.14.0/object-model/index.md
@@ -2,20 +2,20 @@ One of the first things you'll notice when you generate JavaScript files in Embe
 
 ### Introducing: Ember Objects
 
-The [Ember Object](https://api.emberjs.com/ember/3.11/classes/EmberObject) class extends plain JavaScript objects to provide core framework functions such as participating in Ember's [binding system](../object-model/bindings/) or how changes to an object automatically trigger updates to the user interface.
+The [Ember Object](https://api.emberjs.com/ember/3.14/classes/EmberObject) class extends plain JavaScript objects to provide core framework functions such as participating in Ember's [binding system](../object-model/bindings/) or how changes to an object automatically trigger updates to the user interface.
 
 Most objects in Ember, including Routes, Models, Services, Mixins, Controllers, and Components extend the `EmberObject` class.
 
 ### Why Ember Objects?
 
-The most important reason is that an Ember Object can be watched for changes – or _observed_. For example, being [observable](https://api.emberjs.com/ember/3.11/classes/Observable) is important for [computed properties](../object-model/computed-properties/). It is one of the fundamental ways that models, controllers and views communicate with each other in an Ember application.
+The most important reason is that an Ember Object can be watched for changes – or _observed_. For example, being [observable](https://api.emberjs.com/ember/3.14/classes/Observable) is important for [computed properties](../object-model/computed-properties/). It is one of the fundamental ways that models, controllers and views communicate with each other in an Ember application.
 
 ### More on Ember Objects
 
-The [@ember/object](https://api.emberjs.com/ember/3.11/modules/@ember%2Fobject) package also provides a class system, supporting features like mixins and constructor methods, and being observable.
+The [@ember/object](https://api.emberjs.com/ember/3.14/modules/@ember%2Fobject) package also provides a class system, supporting features like mixins and constructor methods, and being observable.
 
 Some features in Ember's object model are not present in JavaScript classes or common patterns, but all are aligned as much as possible with the language and proposed additions.
 
-Ember also extends the JavaScript `Array` prototype with its [@ember/enumerable](https://api.emberjs.com/ember/3.11/classes/Enumerable) interface to provide change observation for arrays.
+Ember also extends the JavaScript `Array` prototype with its [@ember/enumerable](https://api.emberjs.com/ember/3.14/classes/Enumerable) interface to provide change observation for arrays.
 
-Finally, Ember extends the `String` prototype with a few [formatting and localization methods](https://api.emberjs.com/ember/3.11/classes/String).
+Finally, Ember extends the `String` prototype with a few [formatting and localization methods](https://api.emberjs.com/ember/3.14/classes/String).

--- a/guides/v3.14.0/object-model/observers.md
+++ b/guides/v3.14.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.14/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.14/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.14.0/object-model/observers.md
+++ b/guides/v3.14.0/object-model/observers.md
@@ -79,7 +79,7 @@ person.set('firstName', 'John');
 person.set('lastName', 'Smith');
 ```
 
-To get around these problems, you should make use of [`Ember.run.once()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Frunloop/methods/once?anchor=once).
+To get around these problems, you should make use of [`Ember.run.once()`](https://api.emberjs.com/ember/3.14/classes/@ember%2Frunloop/methods/once?anchor=once).
 This will ensure that any processing you need to do only happens once, and
 happens in the next run loop once all bindings are synchronized:
 
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.14/namespaces/Ember/methods/on?anchor=on):
 
 
 ```javascript
@@ -145,7 +145,7 @@ get it in your `init()` method.
 ### Outside of class definitions
 
 You can also add observers to an object outside of a class definition
-using [`addObserver()`](https://api.emberjs.com/ember/3.11/classes/@ember%2Fobject%2Fobservers/methods/addObserver?anchor=addObserver):
+using [`addObserver()`](https://api.emberjs.com/ember/3.14/classes/@ember%2Fobject%2Fobservers/methods/addObserver?anchor=addObserver):
 
 
 ```javascript

--- a/guides/v3.14.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.14.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.14/classes/Ember.Object/methods/reopen?anchor=reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.14/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.14.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.14.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/3.14/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.14/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/3.14/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.14/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.14.0/routing/asynchronous-routing.md
+++ b/guides/v3.14.0/routing/asynchronous-routing.md
@@ -71,7 +71,7 @@ defined on it to be a promise.
 If the promise fulfills, the transition will pick up where it left off and
 begin resolving the next (child) route's model, pausing if it too is a
 promise, and so on, until all destination route models have been
-resolved. The values passed to the [`setupController()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/setupController?anchor=setupController) hook for each route
+resolved. The values passed to the [`setupController()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/setupController?anchor=setupController) hook for each route
 will be the fulfilled values from the promises.
 
 

--- a/guides/v3.14.0/routing/defining-your-routes.md
+++ b/guides/v3.14.0/routing/defining-your-routes.md
@@ -14,7 +14,7 @@ It also adds the route to the router.
 
 ## Basic Routes
 
-The [`map()`](https://api.emberjs.com/ember/3.11/classes/EmberRouter/methods/map?anchor=map) method
+The [`map()`](https://api.emberjs.com/ember/3.14/classes/EmberRouter/methods/map?anchor=map) method
 of your Ember application's router can be invoked to define URL mappings. When
 calling `map()`, you should pass a function that will be invoked with the value
 `this` set to an object which you can use to create routes.
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`<LinkTo>`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -349,13 +349,13 @@ export default Route.extend({
 To have your route do something beyond render a template with the same name, you'll
 need to create a route handler. The following guides will explore the different
 features of route handlers. For more information on routes, see the API documentation
-for [the router](https://api.emberjs.com/ember/3.11/classes/EmberRouter) and for [route
-handlers](https://api.emberjs.com/ember/3.11/classes/Route).
+for [the router](https://api.emberjs.com/ember/3.14/classes/EmberRouter) and for [route
+handlers](https://api.emberjs.com/ember/3.14/classes/Route).
 
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
-- From a template, use [`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) as mentioned above
-- From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=transitionTo) method
-- From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/3.11/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
-- From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/3.11/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/3.11/classes/RouterService/methods/transitionTo?anchor=transitionTo) method
+- From a template, use [`<LinkTo>`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) as mentioned above
+- From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/transitionTo?anchor=transitionTo) method
+- From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/3.14/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
+- From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/3.14/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/3.14/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.14.0/routing/defining-your-routes.md
+++ b/guides/v3.14.0/routing/defining-your-routes.md
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`<LinkTo>`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`<LinkTo>`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -355,7 +355,7 @@ handlers](https://api.emberjs.com/ember/3.14/classes/Route).
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
-- From a template, use [`<LinkTo>`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) as mentioned above
+- From a template, use [`<LinkTo>`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
 - From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/transitionTo?anchor=transitionTo) method
 - From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/3.14/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
 - From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/3.14/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/3.14/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.14.0/routing/loading-and-error-substates.md
+++ b/guides/v3.14.0/routing/loading-and-error-substates.md
@@ -102,7 +102,7 @@ within the route hierarchy where loading feedback is important.
 ### The `loading` event
 
 If the various `beforeModel`/`model`/`afterModel` hooks
-don't immediately resolve, a [`loading`](https://api.emberjs.com/ember/3.11/classes/Route/events/loading?anchor=loading) event will be fired on that route.
+don't immediately resolve, a [`loading`](https://api.emberjs.com/ember/3.14/classes/Route/events/loading?anchor=loading) event will be fired on that route.
 
 ```javascript {data-filename=app/routes/user-slow-model.js}
 import Route from '@ember/routing/route';
@@ -217,7 +217,7 @@ logged.
 
 If the `articles.overview` route's `model` hook returns a promise that rejects
 (for instance the server returned an error, the user isn't logged in,
-etc.), an [`error`](https://api.emberjs.com/ember/3.11/classes/Route/events/error?anchor=error) event will fire from that route and bubble upward.
+etc.), an [`error`](https://api.emberjs.com/ember/3.14/classes/Route/events/error?anchor=error) event will fire from that route and bubble upward.
 This `error` event can be handled and used to display an error message,
 redirect to a login page, etc.
 

--- a/guides/v3.14.0/routing/redirection.md
+++ b/guides/v3.14.0/routing/redirection.md
@@ -7,12 +7,12 @@ Usually you want to redirect them to the login page, and after they have success
 There are many other reasons you probably want to have the last word on whether a user can or cannot access a certain page.
 Ember allows you to control that access with a combination of hooks and methods in your route.
 
-One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=transitionTo).
+One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
-[`transitionToRoute()`](https://api.emberjs.com/ember/3.11/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
+[`transitionToRoute()`](https://api.emberjs.com/ember/3.14/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like [`<LinkTo>`](../../templates/links/).
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/transitionTo?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.14.0/routing/redirection.md
+++ b/guides/v3.14.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/3.14/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like [`<LinkTo>`](../../templates/links/).
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.14.0/routing/rendering-a-template.md
+++ b/guides/v3.14.0/routing/rendering-a-template.md
@@ -19,7 +19,7 @@ template. For example, the `posts.new` route will render its template into the
 `posts.hbs`'s `{{outlet}}`, and the `posts` route will render its template into
 the `application.hbs`'s `{{outlet}}`.
 
-If you want to render a template other than the default one, set the route's [`templateName`](https://api.emberjs.com/ember/3.11/classes/Route/properties/templateName?anchor=templateName) property to the name of
+If you want to render a template other than the default one, set the route's [`templateName`](https://api.emberjs.com/ember/3.14/classes/Route/properties/templateName?anchor=templateName) property to the name of
 the template you want to render instead.
 
 ```javascript {data-filename=app/routes/posts.js}
@@ -30,5 +30,5 @@ export default Route.extend({
 });
 ```
 
-You can override the [`renderTemplate()`](https://api.emberjs.com/ember/3.11/classes/Route/methods/renderTemplate?anchor=renderTemplate) hook if you want finer control over template rendering.
+You can override the [`renderTemplate()`](https://api.emberjs.com/ember/3.14/classes/Route/methods/renderTemplate?anchor=renderTemplate) hook if you want finer control over template rendering.
 Among other things, it allows you to choose the controller used to configure the template and specific outlet to render it into.

--- a/guides/v3.14.0/routing/specifying-a-routes-model.md
+++ b/guides/v3.14.0/routing/specifying-a-routes-model.md
@@ -94,9 +94,9 @@ Older browsers may not have `fetch`, but the `ember-fetch` library includes a po
 ### Ember Data example
 
 Ember Data is a powerful (but optional) library included by default in new Ember apps.
-In the next example, we will use Ember Data's [`findAll`](https://api.emberjs.com/ember-data/release/classes/Store/methods/findAll?anchor=findAll) method, which returns a Promise, and resolves with an array of [Ember Data records](../../models/).
+In the next example, we will use Ember Data's [`findAll`](https://api.emberjs.com/ember-data/3.14/classes/Store/methods/findAll?anchor=findAll) method, which returns a Promise, and resolves with an array of [Ember Data records](../../models/).
 
-_Note that Ember Data also has a feature called a [`Model`](https://api.emberjs.com/ember-data/release/classes/Model), but it's a separate concept from a route's [`model`](https://api.emberjs.com/ember/3.14/classes/Route/methods/model?anchor=model) hook._
+_Note that Ember Data also has a feature called a [`Model`](https://api.emberjs.com/ember-data/3.14/classes/Model), but it's a separate concept from a route's [`model`](https://api.emberjs.com/ember/3.14/classes/Route/methods/model?anchor=model) hook._
 
 ```javascript {data-filename=app/routes/favorite-posts.js}
 import Route from '@ember/routing/route';

--- a/guides/v3.14.0/routing/specifying-a-routes-model.md
+++ b/guides/v3.14.0/routing/specifying-a-routes-model.md
@@ -1,6 +1,6 @@
 A route's JavaScript file is one of the best places in an app to make requests to an API.
 In this section of the guides, you'll learn how to use the
-[`model`](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=model)
+[`model`](https://api.emberjs.com/ember/3.14/classes/Route/methods/model?anchor=model)
 method to fetch data by making a HTTP request, and render it in a route's `hbs` template, or pass it down to a component.
 
 For example, take this router:
@@ -67,7 +67,7 @@ Now that data can be used in the `favorite-posts`  template:
 {{/each}}
 ```
 
-Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=setupController) receives the results of the model hook, and makes those results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
+Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.14/classes/Route/methods/model?anchor=setupController) receives the results of the model hook, and makes those results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
 
 Let's compare some examples using the model hook to make asynchronous HTTP requests to a server somewhere.
 
@@ -96,7 +96,7 @@ Older browsers may not have `fetch`, but the `ember-fetch` library includes a po
 Ember Data is a powerful (but optional) library included by default in new Ember apps.
 In the next example, we will use Ember Data's [`findAll`](https://api.emberjs.com/ember-data/release/classes/Store/methods/findAll?anchor=findAll) method, which returns a Promise, and resolves with an array of [Ember Data records](../../models/).
 
-_Note that Ember Data also has a feature called a [`Model`](https://api.emberjs.com/ember-data/release/classes/Model), but it's a separate concept from a route's [`model`](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=model) hook._
+_Note that Ember Data also has a feature called a [`Model`](https://api.emberjs.com/ember-data/release/classes/Model), but it's a separate concept from a route's [`model`](https://api.emberjs.com/ember/3.14/classes/Route/methods/model?anchor=model) hook._
 
 ```javascript {data-filename=app/routes/favorite-posts.js}
 import Route from '@ember/routing/route';
@@ -115,7 +115,7 @@ export default Route.extend({
 What should you do if you need the `model` to return the results of multiple API requests?
 
 Multiple models can be returned through an
-[RSVP.hash](https://api.emberjs.com/ember/3.11/classes/rsvp/methods/hash?anchor=hash).
+[RSVP.hash](https://api.emberjs.com/ember/3.14/classes/rsvp/methods/hash?anchor=hash).
 The `RSVP.hash` method takes an object containing multiple promises.
 If all of the promises resolve, the returned promise will resolve to an object that contains the results of each request. For example:
 
@@ -197,7 +197,7 @@ model(params) {
 There are two ways to link to a dynamic segment from an `.hbs` template using [`<LinkTo>`](../../templates/links/).
 Depending on which approach you use, it will affect whether that route's `model` hook is run.
 To learn how to link to a dynamic segment from within the JavaScript file, see the API documentation on
-[`transitionTo`](https://api.emberjs.com/ember/3.11/classes/RouterService/methods/transitionTo?anchor=transitionTo)
+[`transitionTo`](https://api.emberjs.com/ember/3.14/classes/RouterService/methods/transitionTo?anchor=transitionTo)
 instead.
 
 When you provide a string or number to the `<LinkTo>`, the dynamic segment's `model` hook will run when the app transitions to the new route.
@@ -303,10 +303,10 @@ And calling `modelFor` returned the result of the `model` hook.
 
 If you are having trouble getting a model's data to show up in the template, here are some tips:
 
-- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/debugger?anchor=log) helper to inspect the `{{model}}` from the template
+- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/debugger?anchor=log) helper to inspect the `{{model}}` from the template
 - return hard-coded sample data as a test to see if the problem is really in the model hook, or elsewhere down the line
 - study JavaScript Promises in general, to make sure you are returning data from the Promise correctly
 - make sure your `model` hook has a `return` statement
-- check to see whether the data returned from a `model` hook is an object, array, or JavaScript Primitive. For example, if the result of `model` is an array, using `{{this.model}}` in the template won't work. You will need to iterate over the array with an [`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/each?anchor=each) helper. If the result is an object, you need to access the individual attribute like `{{this.model.title}}` to render it in the template.
+- check to see whether the data returned from a `model` hook is an object, array, or JavaScript Primitive. For example, if the result of `model` is an array, using `{{this.model}}` in the template won't work. You will need to iterate over the array with an [`{{#each}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/each?anchor=each) helper. If the result is an object, you need to access the individual attribute like `{{this.model.title}}` to render it in the template.
 - use your browser's development tools to examine the outgoing and incoming API responses and see if they match what your code expects
 - If you are using Ember Data, use the [Ember Inspector](../../ember-inspector/) browser plugin to explore the View Tree/Model and Data sections.

--- a/guides/v3.14.0/routing/specifying-a-routes-model.md
+++ b/guides/v3.14.0/routing/specifying-a-routes-model.md
@@ -67,7 +67,7 @@ Now that data can be used in the `favorite-posts`  template:
 {{/each}}
 ```
 
-Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.14/classes/Route/methods/model?anchor=setupController) receives the results of the model hook, and makes those results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
+Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.14/classes/Route/methods/setupController?anchor=setupController) receives the results of the model hook, and makes those results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
 
 Let's compare some examples using the model hook to make asynchronous HTTP requests to a server somewhere.
 
@@ -303,7 +303,7 @@ And calling `modelFor` returned the result of the `model` hook.
 
 If you are having trouble getting a model's data to show up in the template, here are some tips:
 
-- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/debugger?anchor=log) helper to inspect the `{{model}}` from the template
+- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/log?anchor=log) helper to inspect the `{{model}}` from the template
 - return hard-coded sample data as a test to see if the problem is really in the model hook, or elsewhere down the line
 - study JavaScript Promises in general, to make sure you are returning data from the Promise correctly
 - make sure your `model` hook has a `return` statement

--- a/guides/v3.14.0/templates/actions.md
+++ b/guides/v3.14.0/templates/actions.md
@@ -3,7 +3,7 @@ change application state. For example, imagine that you have a template
 that shows a blog title, and supports expanding the post to show the body.
 
 If you add the
-[`{{action}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/action?anchor=action)
+[`{{action}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/action?anchor=action)
 helper to any HTML DOM element, when a user clicks the element, the named event
 will be sent to the template's corresponding component or controller.
 
@@ -62,7 +62,7 @@ export default Component.extend({
 ## Specifying the Type of Event
 
 By default, the
-[`{{action}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/action?anchor=action)
+[`{{action}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/action?anchor=action)
 helper listens for click events and triggers the action when the user clicks
 on the element.
 
@@ -116,7 +116,7 @@ You can specify `preventDefault=true` and this reverts to the standard Ember fun
 ## Modifying the action's first parameter
 
 If a `value` option for the
-[`{{action}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/action?anchor=action)
+[`{{action}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/action?anchor=action)
 helper is specified, its value will be considered a property path that will
 be read off of the first parameter of the action. This comes very handy with
 event listeners and enables to work with one-way bindings.

--- a/guides/v3.14.0/templates/built-in-helpers.md
+++ b/guides/v3.14.0/templates/built-in-helpers.md
@@ -2,12 +2,12 @@ In the last section you learned how to write a helper.
 A helper is usually a simple function that can be used in any template.
 Ember comes with a few helpers that can make developing your templates a bit easier.
 These helpers can allow you to be more dynamic in passing data to another helper or component.
-For a full list of built-in Helpers, see the [Ember.Templates.helpers](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/)
+For a full list of built-in Helpers, see the [Ember.Templates.helpers](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/)
 API documentation.
 
 ### Using a helper to get a property dynamically
 
-The [`{{get}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/get?anchor=get) helper
+The [`{{get}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/get?anchor=get) helper
 makes it easy to dynamically send the value of a variable to another helper or component.
 This can be useful if you want to output one of several values based on the result of a computed property.
 
@@ -22,7 +22,7 @@ If it returns "city", you get `this.address.city`.
 
 In the last section it was discussed that helpers can be nested.
 This can be combined with these sorts of dynamic helpers.
-For example, the [`{{concat}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
+For example, the [`{{concat}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
 helper makes it easy to dynamically send a number of parameters to a component or helper as a single parameter in the
 format of a concatenated string.
 
@@ -36,7 +36,7 @@ This will display the result of `this.foo.item1` when index is 1, and `this.foo.
 
 Now let's say your template is starting to get a bit cluttered and you now want to clean up the logic in your templates.
 This can be achieved with the `let` block helper.
-The [`{{let}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/let?anchor=let) helper lets you create new bindings in your template.
+The [`{{let}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/let?anchor=let) helper lets you create new bindings in your template.
 
 Say your template now looks like this:
 
@@ -67,7 +67,7 @@ Now, as long as your template is wrapped in the `let` helper you can access the 
 
 ### Array helper
 
-Using the [`{{array}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
+Using the [`{{array}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
 you can pass arrays directly from the template as an argument to your components.
 
 ```handlebars

--- a/guides/v3.14.0/templates/conditionals.md
+++ b/guides/v3.14.0/templates/conditionals.md
@@ -1,5 +1,5 @@
-Statements like [`if`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+Statements like [`if`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=if)
+and [`unless`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -12,7 +12,7 @@ displaying a property, but helpers accept arguments. For example:
 </div>
 ```
 
-[`{{if}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=if)
+[`{{if}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=if)
 in this case returns `"zoooom"` when `isFast` is true and
 `"putt-putt-putt"` when `isFast` is false. Helpers invoked as inline expressions
 render a single value, the same way that properties are a single value.
@@ -53,7 +53,7 @@ properties on `person` only if that it is present:
 {{/if}}
 ```
 
-[`{{if}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=if)
+[`{{if}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=if)
 checks for truthiness, which means all values except `false`,
 `undefined`, `null`, `''`, `0`  or `[]` (i.e., any JavaScript falsy value or an
 empty array).
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.14.0/templates/conditionals.md
+++ b/guides/v3.14.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.14.0/templates/development-helpers.md
+++ b/guides/v3.14.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.14.0/templates/development-helpers.md
+++ b/guides/v3.14.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.14.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.14.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.14.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.14.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.14.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.14.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.14.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.14.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/each?anchor=each) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.14.0/templates/input-components.md
+++ b/guides/v3.14.0/templates/input-components.md
@@ -104,7 +104,7 @@ If you want to dispatch an action on a certain [event](https://api.emberjs.com/e
 
 Will bind the value of the text area to `name` on the current context.
 
-[`<Textarea>`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea) supports binding and/or setting the following properties:
+[`<Textarea>`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea) supports binding and/or setting the following properties:
 
 - `value`
 - `name`

--- a/guides/v3.14.0/templates/input-components.md
+++ b/guides/v3.14.0/templates/input-components.md
@@ -1,5 +1,5 @@
 The [`<Input>`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.components/methods/Input?anchor=Input)
-and [`<Textarea>`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea)
+and [`<Textarea>`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea)
 components are the easiest way to create common form controls.
 Using these components, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -90,7 +90,7 @@ Checkboxes support the following properties:
 
 Which can be bound or set as described in the previous section.
 
-If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/release/classes/Component#event-handler-methods), you will always need to define the event name in camelCase format:
+If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.14/classes/Component#event-handler-methods), you will always need to define the event name in camelCase format:
 
 ```handlebars
 <Input @type="text" @keyPress={{action "updateName"}} />
@@ -104,7 +104,7 @@ If you want to dispatch an action on a certain [event](https://api.emberjs.com/e
 
 Will bind the value of the text area to `name` on the current context.
 
-[`<Textarea>`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea) supports binding and/or setting the following properties:
+[`<Textarea>`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea) supports binding and/or setting the following properties:
 
 - `value`
 - `name`
@@ -126,10 +126,10 @@ Will bind the value of the text area to `name` on the current context.
 
 ### Binding dynamic attribute
 
-You might need to bind a property dynamically to an input if you're building a flexible form, for example. To achieve this you need to use the [`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get) and [`{{mut}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/mut?anchor=mut) in conjunction like shown in the following example:
+You might need to bind a property dynamically to an input if you're building a flexible form, for example. To achieve this you need to use the [`{{get}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/get?anchor=get) and [`{{mut}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/mut?anchor=mut) in conjunction like shown in the following example:
 
 ```handlebars
 <Input @value={{mut (get this.person this.field)}} />
 ```
 
-The `{{get}}` helper allows you to dynamically specify which property to bind, while the `{{mut}}` helper allows the binding to be updated from the input. See the respective helper documentation for more detail: [`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get) and [`{{mut}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/mut?anchor=mut).
+The `{{get}}` helper allows you to dynamically specify which property to bind, while the `{{mut}}` helper allows the binding to be updated from the input. See the respective helper documentation for more detail: [`{{get}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/get?anchor=get) and [`{{mut}}`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/mut?anchor=mut).

--- a/guides/v3.14.0/templates/links.md
+++ b/guides/v3.14.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `<LinkTo>` Component
 
 You create a link to a route using the
-[`<LinkTo>`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`<LinkTo>`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -132,7 +132,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`LinkTo`](https://api.emberjs.com/ember/3.11/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`LinkTo`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.14.0/templates/links.md
+++ b/guides/v3.14.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `<LinkTo>` Component
 
 You create a link to a route using the
-[`<LinkTo>`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`<LinkTo>`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -132,7 +132,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`LinkTo`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`LinkTo`](https://api.emberjs.com/ember/3.14/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.14.0/templates/writing-helpers.md
+++ b/guides/v3.14.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/3.14/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.14/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -250,7 +250,7 @@ To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.14/classes/Helper).
 Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/3.14/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.14/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.14/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 

--- a/guides/v3.14.0/templates/writing-helpers.md
+++ b/guides/v3.14.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/3.14/classes/Ember.Helper/methods/helper?anchor=helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -247,10 +247,10 @@ access to services in your application, and can optionally save state as well,
 although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
-should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.11/classes/Helper).
+should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.14/classes/Helper).
 Helper classes must contain a
-[`compute`](https://api.emberjs.com/ember/3.11/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.11/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`compute`](https://api.emberjs.com/ember/3.14/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.14/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -331,7 +331,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`](https://api.emberjs.com/ember/3.11/functions/@ember%2Ftemplate/htmlSafe) string utility:
+[`htmlSafe`](https://api.emberjs.com/ember/3.14/functions/@ember%2Ftemplate/htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -345,7 +345,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call to
-[`htmlSafe`](https://api.emberjs.com/ember/3.11/functions/@ember%2Ftemplate/htmlSafe)),
+[`htmlSafe`](https://api.emberjs.com/ember/3.14/functions/@ember%2Ftemplate/htmlSafe)),
 Ember knows that you have vouched on its behalf that it contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently

--- a/guides/v3.14.0/testing/index.md
+++ b/guides/v3.14.0/testing/index.md
@@ -39,7 +39,7 @@ If we need to test the functionality around an Ember class instance, such as a C
 
 To setup the application’s container, we import the [ember-qunit](https://github.com/emberjs/ember-qunit) addon which provides us with QUnit-specific wrappers around the helpers contained in [ember-test-helpers](https://github.com/emberjs/ember-test-helpers).
 
-In the example below, we import the `setupTest` function from `ember-qunit` and call it with the `hooks` object to setup the test context with access to the `this.owner` property. This provides us direct container access to interact with Ember's [Dependency Injection](../applications/dependency-injection/) system. Direct container access allows us to [lookup](https://api.emberjs.com/ember/3.11/classes/ApplicationInstance/methods/lookup?anchor=lookup) everything in the application container, like Controllers, Routes, or Services in order to have an instance of it to test in our QUnit test module.
+In the example below, we import the `setupTest` function from `ember-qunit` and call it with the `hooks` object to setup the test context with access to the `this.owner` property. This provides us direct container access to interact with Ember's [Dependency Injection](../applications/dependency-injection/) system. Direct container access allows us to [lookup](https://api.emberjs.com/ember/3.14/classes/ApplicationInstance/methods/lookup?anchor=lookup) everything in the application container, like Controllers, Routes, or Services in order to have an instance of it to test in our QUnit test module.
 
 For example, the following is a Container Test for the `flash-messages` service:
 

--- a/guides/v3.14.0/testing/testing-components.md
+++ b/guides/v3.14.0/testing/testing-components.md
@@ -459,7 +459,7 @@ The `settled` function itself returns a Promise that resolves once all async ope
 
 You can use `settled` as a helper in your tests directly and `await` it for all async behavior to settle deliberately.
 
-Imagine you have a typeahead component that uses [`Ember.run.debounce`](https://api.emberjs.com/ember/3.11/classes/@ember%2Frunloop/methods/debounce?anchor=debounce) to limit requests to the server, and you want to verify that results are displayed after typing a character.
+Imagine you have a typeahead component that uses [`Ember.run.debounce`](https://api.emberjs.com/ember/3.14/classes/@ember%2Frunloop/methods/debounce?anchor=debounce) to limit requests to the server, and you want to verify that results are displayed after typing a character.
 
 > You can follow along by generating your own component with `ember generate
 > component delayed-typeahead`.

--- a/guides/v3.14.0/tutorial/autocomplete-component.md
+++ b/guides/v3.14.0/tutorial/autocomplete-component.md
@@ -109,7 +109,7 @@ The `filter` function is passed in by the calling object. This is a pattern know
 
 Notice the `then` function called on the result of calling the `filter` function.
 The code expects the `filter` function to return a promise.
-A [promise](https://api.emberjs.com/ember/3.11/classes/Promise) is a JavaScript object that represents the result of an asynchronous function.
+A [promise](https://api.emberjs.com/ember/3.14/classes/Promise) is a JavaScript object that represents the result of an asynchronous function.
 A promise may or may not be executed at the time you receive it.
 To account for this, it provides functions, like `then` that let you give it code it will run when it eventually does receive a result.
 
@@ -289,7 +289,7 @@ The `value` property represents the latest state of the input field.
 Therefore we now check that results match the input field, ensuring that results will stay in sync with the last thing the user has typed.
 
 While this approach will keep our results order consistent, there are other things to consider when dealing with multiple concurrent tasks,
-such as [limiting the number of requests made to the server](https://api.emberjs.com/ember/3.11/classes/@ember%2Frunloop/methods/debounce?anchor=debounce).
+such as [limiting the number of requests made to the server](https://api.emberjs.com/ember/3.14/classes/@ember%2Frunloop/methods/debounce?anchor=debounce).
 To create effective and robust autocomplete behavior for your applications,
 we recommend considering the [`ember-concurrency`](http://ember-concurrency.com/#/docs/introduction) addon project.
 

--- a/guides/v3.14.0/tutorial/ember-data.md
+++ b/guides/v3.14.0/tutorial/ember-data.md
@@ -3,7 +3,7 @@ As our application grows, we will want to persist our rental data on a server, a
 
 Ember comes with a data management library called [Ember Data](https://github.com/emberjs/data) to help deal with persistent application data.
 
-Ember Data requires you to define the structure of the data you wish to provide to your application by extending [`DS.Model`](https://api.emberjs.com/ember-data/release/classes/Model).
+Ember Data requires you to define the structure of the data you wish to provide to your application by extending [`DS.Model`](https://api.emberjs.com/ember-data/3.14/classes/Model).
 
 You can generate an Ember Data Model using Ember CLI.
 We'll call our model `rental` and generate it as follows:
@@ -21,7 +21,7 @@ installing model-test
   create tests/unit/models/rental-test.js
 ```
 
-When we open the model file, we can see a blank class extending [`DS.Model`](https://api.emberjs.com/ember-data/release/classes/Model):
+When we open the model file, we can see a blank class extending [`DS.Model`](https://api.emberjs.com/ember-data/3.14/classes/Model):
 
 ```javascript {data-filename=app/models/rental.js}
 import DS from 'ember-data';
@@ -34,7 +34,7 @@ export default Model.extend({
 
 Let's define the structure of a rental object using the same attributes for our rental that we [previously used](../model-hook/) in our hard-coded array of JavaScript objects -
 _title_, _owner_, _city_, _category_, _image_, _bedrooms_ and _description_.
-Define attributes by giving them the result of the function [`DS.attr()`](https://api.emberjs.com/ember-data/release/classes/Model/properties/attributes?anchor=attributes).
+Define attributes by giving them the result of the function [`DS.attr()`](https://api.emberjs.com/ember-data/3.14/classes/Model/properties/attributes?anchor=attributes).
 For more information on Ember Data Attributes, read the section called [Defining Attributes](../../models/defining-models/#toc_defining-attributes) in the guides.
 
 ```javascript {data-filename="app/models/rental.js" data-diff="+5,+6,+7,+8,+9,+10,+11"}
@@ -58,9 +58,9 @@ We now have a model object that we can use for our Ember Data implementation.
 ### Updating the Model Hook
 
 To use our new Ember Data Model object, we need to update the `model` function we [previously defined](../model-hook/) in our route handler, delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../../models/#toc_the-store-and-a-single-source-of-truth).
-The [store service](https://api.emberjs.com/ember-data/release/classes/Store) is injected into all routes and their corresponding controllers in Ember.
+The [store service](https://api.emberjs.com/ember-data/3.14/classes/Store) is injected into all routes and their corresponding controllers in Ember.
 It is the main interface you use to interact with Ember Data.
-In this case, call the [`findAll`](https://api.emberjs.com/ember-data/release/classes/Store/methods/findAll?anchor=findAll) function on the store and provide it with the name of your newly created rental model class.
+In this case, call the [`findAll`](https://api.emberjs.com/ember-data/3.14/classes/Store/methods/findAll?anchor=findAll) function on the store and provide it with the name of your newly created rental model class.
 
 ```javascript {data-filename="app/routes/rentals.js" data-diff="+5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31,-32,-33"}
 import Route from '@ember/routing/route';

--- a/guides/v3.14.0/tutorial/installing-addons.md
+++ b/guides/v3.14.0/tutorial/installing-addons.md
@@ -152,7 +152,7 @@ For now, let's generate an adapter for our application:
 ember generate adapter application
 ```
 
-This adapter will extend the [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/release/classes/JSONAPIAdapter) base class from Ember Data:
+This adapter will extend the [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/3.14/classes/JSONAPIAdapter) base class from Ember Data:
 
 ```javascript {data-filename="app/adapters/application.js" data-diff="+4"}
 import DS from 'ember-data';

--- a/guides/v3.14.0/tutorial/model-hook.md
+++ b/guides/v3.14.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.11/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.14/classes/Route/methods/model?anchor=model/).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.14.0/tutorial/model-hook.md
+++ b/guides/v3.14.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.14/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.14/classes/Route/methods/model?anchor=model).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.14.0/tutorial/routes-and-templates.md
+++ b/guides/v3.14.0/tutorial/routes-and-templates.md
@@ -224,7 +224,7 @@ All we want to do when a user visits the root (`/`) URL is transition to
 implementing a route lifecycle hook called `redirect`.
 Route lifecycle hooks are special methods that are called automatically when a route renders or data changes.
 Inside, we'll call the
-[`transitionTo`](https://api.emberjs.com/ember/3.9/classes/Route/methods/redirect?anchor=transitionTo)
+[`transitionTo`](https://api.emberjs.com/ember/3.14/classes/Route/methods/redirect?anchor=transitionTo)
 function:
 
 ```javascript {data-filename="app/routes/index.js" data-diff="+4,+5,+6"}

--- a/guides/v3.14.0/tutorial/routes-and-templates.md
+++ b/guides/v3.14.0/tutorial/routes-and-templates.md
@@ -224,7 +224,7 @@ All we want to do when a user visits the root (`/`) URL is transition to
 implementing a route lifecycle hook called `redirect`.
 Route lifecycle hooks are special methods that are called automatically when a route renders or data changes.
 Inside, we'll call the
-[`transitionTo`](https://api.emberjs.com/ember/3.14/classes/Route/methods/redirect?anchor=transitionTo)
+[`transitionTo`](https://api.emberjs.com/ember/3.14/classes/Route/methods/transitionTo?anchor=transitionTo)
 function:
 
 ```javascript {data-filename="app/routes/index.js" data-diff="+4,+5,+6"}

--- a/guides/v3.14.0/tutorial/service.md
+++ b/guides/v3.14.0/tutorial/service.md
@@ -214,10 +214,10 @@ For our service unit test, we'll want to verify that locations that have been pr
 We will isolate our tests from actually calling Leaflet Maps by stubbing the map service.
 On line 20 of `map-element-test.js` below we create a JavaScript object to simulate the behavior of the utility, but instead of creating a Google map, we return an empty JavaScript object.
 
-To instantiate the service, we can instantiate it through ember's resolver using the [`factoryFor`](https://api.emberjs.com/ember/3.11/classes/ApplicationInstance/methods/factoryFor?anchor=factoryFor) method.
+To instantiate the service, we can instantiate it through ember's resolver using the [`factoryFor`](https://api.emberjs.com/ember/3.14/classes/ApplicationInstance/methods/factoryFor?anchor=factoryFor) method.
 `factoryFor` allows us to have control over the creation of the service in Ember, to pass arguments to the constructor that can override parts of the service for our tests.
 
-For cases where we do not need to override parts of the service, we can use [`lookup`](https://api.emberjs.com/ember/3.11/classes/ApplicationInstance/methods/lookup?anchor=lookup)
+For cases where we do not need to override parts of the service, we can use [`lookup`](https://api.emberjs.com/ember/3.14/classes/ApplicationInstance/methods/lookup?anchor=lookup)
 In our test below we are passing in our fake map utility object in the first test, and passing a cache object for the second test.
 
 ```javascript {data-filename="tests/unit/services/map-element-test.js" data-diff="+4,+5,-9,-10,-11,-12,-13,+14,+15,+16,+17,+18,+19,+20,+21,+22,+23,+24,+25,+26,+27,+28,+29,+30,+31,+32,+33,+34,+35,+36,+37,+38,+39,+40,+41,+42,+43"}
@@ -276,7 +276,7 @@ In the second test, only one assert is expected (line 36), since the map element
 Also, note that the second test uses a dummy object as the returned map element (defined on line 4).
 Our map element can be substituted with any object because we are only asserting that the cache has been accessed (see line 42).
 
-The location in the cache has been [`camelized`](https://api.emberjs.com/ember/3.11/classes/String/methods/camelize?anchor=camelize) (line 38),
+The location in the cache has been [`camelized`](https://api.emberjs.com/ember/3.14/classes/String/methods/camelize?anchor=camelize) (line 38),
 so that it may be used as a key to look up our element.
 This matches the behavior in `getMapElement` when city has not yet been cached.
 
@@ -444,7 +444,7 @@ module('Acceptance | list rentals', function(hooks) {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection/#toc_factory-registrations) using the [owner](https://api.emberjs.com/ember/3.0/functions/@ember%2Fapplication/getOwner) object given by the test context. When our component loads the maps service, it gets our stub service instead.
+Then we are putting it in Ember's [registry](../../applications/dependency-injection/#toc_factory-registrations) using the [owner](https://api.emberjs.com/ember/3.14/functions/@ember%2Fapplication/getOwner) object given by the test context. When our component loads the maps service, it gets our stub service instead.
 That way every time that component is created, our stub map service gets injected over the map-element service.
 Now when we run our application tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v3.14.0/tutorial/simple-component.md
+++ b/guides/v3.14.0/tutorial/simple-component.md
@@ -95,7 +95,7 @@ with our new `RentalListing` component:
     <div class="cta-note-body">
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
-In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
+In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.14/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">

--- a/guides/v3.14.0/tutorial/subroutes.md
+++ b/guides/v3.14.0/tutorial/subroutes.md
@@ -347,7 +347,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `RentalListing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.14/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.14/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.

--- a/guides/v3.14.0/tutorial/subroutes.md
+++ b/guides/v3.14.0/tutorial/subroutes.md
@@ -347,7 +347,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `RentalListing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.11/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.14/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.

--- a/guides/v3.15.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.15.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.15/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.15.0/object-model/bindings.md
+++ b/guides/v3.15.0/object-model/bindings.md
@@ -1,7 +1,7 @@
 *__Note:__ Unlike most other frameworks that include some sort of binding implementation, bindings in Ember.js can be used with any object. That said, bindings are most often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.*
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -35,7 +35,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.15/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.15.0/routing/defining-your-routes.md
+++ b/guides/v3.15.0/routing/defining-your-routes.md
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`<LinkTo />`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`<LinkTo />`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -356,7 +356,7 @@ handlers](https://api.emberjs.com/ember/3.15/classes/Route).
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
-- From a template, use [`<LinkTo />`](../linking-between-routes/) as mentioned above
+- From a template, use [`<LinkTo />`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
 - From a route, use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
 - From a controller, use the [`transitionToRoute()`](https://emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
 - From anywhere else in your application, such as a component, inject the [Router Service](https://emberjs.com/api/ember/release/classes/RouterService) and use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.15.0/routing/linking-between-routes.md
+++ b/guides/v3.15.0/routing/linking-between-routes.md
@@ -5,7 +5,7 @@ component.
 ## The `<LinkTo />` Component
 
 You create a link to a route using the
-[`<LinkTo />`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`<LinkTo />`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 component.
 
 ```javascript {data-filename=app/router.js}

--- a/guides/v3.16.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.16.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.16/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.16.0/routing/defining-your-routes.md
+++ b/guides/v3.16.0/routing/defining-your-routes.md
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`<LinkTo />`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`<LinkTo />`](https://api.emberjs.com/ember/3.16/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -356,7 +356,7 @@ handlers](https://api.emberjs.com/ember/3.16/classes/Route).
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
-- From a template, use [`<LinkTo />`](../linking-between-routes/) as mentioned above
+- From a template, use [`<LinkTo />`](https://api.emberjs.com/ember/3.16/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
 - From a route, use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
 - From a controller, use the [`transitionToRoute()`](https://emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
 - From anywhere else in your application, such as a component, inject the [Router Service](https://emberjs.com/api/ember/release/classes/RouterService) and use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.16.0/routing/linking-between-routes.md
+++ b/guides/v3.16.0/routing/linking-between-routes.md
@@ -5,7 +5,7 @@ component.
 ## The `<LinkTo />` Component
 
 You create a link to a route using the
-[`<LinkTo />`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`<LinkTo />`](https://api.emberjs.com/ember/3.16/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 component.
 
 ```javascript {data-filename=app/router.js}

--- a/guides/v3.17.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.17.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.17/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.17.0/routing/defining-your-routes.md
+++ b/guides/v3.17.0/routing/defining-your-routes.md
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`<LinkTo />`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`<LinkTo />`](https://api.emberjs.com/ember/3.17/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -356,7 +356,7 @@ handlers](https://api.emberjs.com/ember/3.17/classes/Route).
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
-- From a template, use [`<LinkTo />`](../linking-between-routes/) as mentioned above
+- From a template, use [`<LinkTo />`](https://api.emberjs.com/ember/3.17/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
 - From a route, use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
 - From a controller, use the [`transitionToRoute()`](https://emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
 - From anywhere else in your application, such as a component, inject the [Router Service](https://emberjs.com/api/ember/release/classes/RouterService) and use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.17.0/routing/linking-between-routes.md
+++ b/guides/v3.17.0/routing/linking-between-routes.md
@@ -5,7 +5,7 @@ component.
 ## The `<LinkTo />` Component
 
 You create a link to a route using the
-[`<LinkTo />`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`<LinkTo />`](https://api.emberjs.com/ember/3.17/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 component.
 
 ```javascript {data-filename=app/router.js}

--- a/guides/v3.18.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.18.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.18/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.18.0/routing/defining-your-routes.md
+++ b/guides/v3.18.0/routing/defining-your-routes.md
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`<LinkTo />`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`<LinkTo />`](https://api.emberjs.com/ember/3.18/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -356,7 +356,7 @@ handlers](https://api.emberjs.com/ember/3.18/classes/Route).
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
-- From a template, use [`<LinkTo />`](../linking-between-routes/) as mentioned above
+- From a template, use [`<LinkTo />`](https://api.emberjs.com/ember/3.18/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
 - From a route, use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
 - From a controller, use the [`transitionToRoute()`](https://emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
 - From anywhere else in your application, such as a component, inject the [Router Service](https://emberjs.com/api/ember/release/classes/RouterService) and use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.18.0/routing/linking-between-routes.md
+++ b/guides/v3.18.0/routing/linking-between-routes.md
@@ -5,7 +5,7 @@ component.
 ## The `<LinkTo />` Component
 
 You create a link to a route using the
-[`<LinkTo />`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`<LinkTo />`](https://api.emberjs.com/ember/3.18/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 component.
 
 ```javascript {data-filename=app/router.js}

--- a/guides/v3.19.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.19.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.19/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.19.0/routing/defining-your-routes.md
+++ b/guides/v3.19.0/routing/defining-your-routes.md
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`<LinkTo />`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`<LinkTo />`](https://api.emberjs.com/ember/3.19/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -356,7 +356,7 @@ handlers](https://api.emberjs.com/ember/3.19/classes/Route).
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
-- From a template, use [`<LinkTo />`](../linking-between-routes/) as mentioned above
+- From a template, use [`<LinkTo />`](https://api.emberjs.com/ember/3.19/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
 - From a route, use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
 - From a controller, use the [`transitionToRoute()`](https://emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
 - From anywhere else in your application, such as a component, inject the [Router Service](https://emberjs.com/api/ember/release/classes/RouterService) and use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.19.0/routing/linking-between-routes.md
+++ b/guides/v3.19.0/routing/linking-between-routes.md
@@ -5,7 +5,7 @@ component.
 ## The `<LinkTo />` Component
 
 You create a link to a route using the
-[`<LinkTo />`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`<LinkTo />`](https://api.emberjs.com/ember/3.19/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 component.
 
 ```javascript {data-filename=app/router.js}

--- a/guides/v3.8.0/applications/services.md
+++ b/guides/v3.8.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.8/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.8/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.8/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.8/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.8.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.8.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.8/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.8.0/getting-started/core-concepts.md
+++ b/guides/v3.8.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.8/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.8/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.8/classes/Component/methods/willRender?anchor=willRender) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.8/classes/Route/methods/model?anchor=model) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.8/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.8/classes/Component/methods/didRender?anchor=didRender) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.8.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.8.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.8/classes/Component/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.8.0/models/customizing-adapters.md
+++ b/guides/v3.8.0/models/customizing-adapters.md
@@ -244,7 +244,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.8/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.8/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.8.0/object-model/bindings.md
+++ b/guides/v3.8.0/object-model/bindings.md
@@ -4,7 +4,7 @@ often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.
 
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.8/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.8/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -38,7 +38,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.8/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.8/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.8.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.8.0/object-model/computed-properties-and-aggregate-data.md
@@ -105,7 +105,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.8/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.8/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.8.0/object-model/observers.md
+++ b/guides/v3.8.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.8/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.8.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.8.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.8/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.8/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.8.0/routing/redirection.md
+++ b/guides/v3.8.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/3.8/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [link-to](../../templates/links/) helper.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.8/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.8/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.8/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.8/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.8/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.8/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.8/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.8/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.8.0/templates/conditionals.md
+++ b/guides/v3.8.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.8.0/templates/development-helpers.md
+++ b/guides/v3.8.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.8.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.8.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.8.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.8.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/each?anchor=each) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.8.0/templates/input-helpers.md
+++ b/guides/v3.8.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`{{input}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`{{textarea}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`{{input}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/input?anchor=input)
+and [`{{textarea}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea)
 helpers in Ember.js are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -67,7 +67,7 @@ More [event types](https://api.emberjs.com/ember/3.8/classes/Component#event-nam
 ## Checkboxes
 
 You can also use the
-[`{{input}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`{{input}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/input?anchor=input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars

--- a/guides/v3.8.0/templates/links.md
+++ b/guides/v3.8.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `{{link-to}}` Component
 
 You create a link to a route using the
-[`{{link-to}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`{{link-to}}`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -151,7 +151,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`link-to`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.8/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.8.0/templates/writing-helpers.md
+++ b/guides/v3.8.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.8/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -249,7 +249,7 @@ although this is usually unnecessary and error-prone.
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.8/classes/Helper). Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/3.8/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.8/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.8/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 

--- a/guides/v3.8.0/tutorial/model-hook.md
+++ b/guides/v3.8.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.8/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.8/classes/Route/methods/model?anchor=model).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.8.0/tutorial/routes-and-templates.md
+++ b/guides/v3.8.0/tutorial/routes-and-templates.md
@@ -224,7 +224,7 @@ All we want to do when a user visits the root (`/`) URL is transition to
 implementing a route lifecycle hook called `beforeModel`.
 Route lifecycle hooks are special methods that are called automatically when a route renders or data changes.
 Inside, we'll call the
-[`replaceWith`](https://api.emberjs.com/ember/3.8/classes/Route/methods/beforeModel?anchor=replaceWith)
+[`replaceWith`](https://api.emberjs.com/ember/3.8/classes/Route/methods/replaceWith?anchor=replaceWith)
 function:
 
 ```javascript {data-filename="app/routes/index.js" data-diff="+4,+5,+6"}

--- a/guides/v3.8.0/tutorial/subroutes.md
+++ b/guides/v3.8.0/tutorial/subroutes.md
@@ -346,7 +346,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `RentalListing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.8/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.8/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.

--- a/guides/v3.9.0/applications/services.md
+++ b/guides/v3.9.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.9/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.9/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.9/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.9/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.9.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.9.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.9/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.9.0/getting-started/core-concepts.md
+++ b/guides/v3.9.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.9/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.9/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.9/classes/Component/methods/willRender?anchor=willRender) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.9/classes/Route/methods/model?anchor=model) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.9/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.9/classes/Component/methods/didRender?anchor=didRender) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.9.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.9.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.9/classes/Component/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.9.0/models/customizing-adapters.md
+++ b/guides/v3.9.0/models/customizing-adapters.md
@@ -244,7 +244,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.9/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.9/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.9.0/object-model/bindings.md
+++ b/guides/v3.9.0/object-model/bindings.md
@@ -4,7 +4,7 @@ often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.
 
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.9/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.9/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -38,7 +38,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.9/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.9/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.9.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.9.0/object-model/computed-properties-and-aggregate-data.md
@@ -105,7 +105,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.9/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.9/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.9.0/object-model/observers.md
+++ b/guides/v3.9.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.9/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.9.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.9.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.9/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.9/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.9.0/routing/redirection.md
+++ b/guides/v3.9.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/3.9/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [link-to](../../templates/links/) helper.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.9/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.9/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.9/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.9/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.9/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.9/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.9/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.9/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.9.0/routing/specifying-a-routes-model.md
+++ b/guides/v3.9.0/routing/specifying-a-routes-model.md
@@ -67,7 +67,7 @@ Now that data can be used in the `favorite-posts`  template:
 {{/each}}
 ```
 
-Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.9/classes/Route/methods/model?anchor=setupController) receives the results of the model hook, and makes those results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
+Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.9/classes/Route/methods/setupController?anchor=setupController) receives the results of the model hook, and makes those results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
 
 Let's compare some examples using the model hook to make asynchronous HTTP requests to a server somewhere.
 
@@ -305,7 +305,7 @@ And calling `modelFor` returned the result of the `model` hook.
 
 If you are having trouble getting a model's data to show up in the template, here are some tips:
 
-- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/debugger?anchor=log) helper to inspect the `{{model}}` from the template
+- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/log?anchor=log) helper to inspect the `{{model}}` from the template
 - return hard-coded sample data as a test to see if the problem is really in the model hook, or elsewhere down the line
 - study JavaScript Promises in general, to make sure you are returning data from the Promise correctly
 - make sure your `model` hook has a `return` statement

--- a/guides/v3.9.0/templates/conditionals.md
+++ b/guides/v3.9.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.9.0/templates/development-helpers.md
+++ b/guides/v3.9.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.9.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.9.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.9.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.9.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/each?anchor=each) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.9.0/templates/input-helpers.md
+++ b/guides/v3.9.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`{{input}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`{{textarea}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`{{input}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/input?anchor=input)
+and [`{{textarea}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea)
 helpers in Ember.js are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -67,7 +67,7 @@ More [event types](https://api.emberjs.com/ember/3.9/classes/Component#event-nam
 ## Checkboxes
 
 You can also use the
-[`{{input}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`{{input}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/input?anchor=input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars

--- a/guides/v3.9.0/templates/links.md
+++ b/guides/v3.9.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `{{link-to}}` Component
 
 You create a link to a route using the
-[`{{link-to}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`{{link-to}}`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -118,7 +118,7 @@ For more information on how to use query parameters see the [query parameters](.
 ### Using link-to as an inline component
 
 In addition to being used as a block expression, the
-[`link-to`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.9/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component can also be used in inline form by specifying the link text as the first
 argument to the component:
 

--- a/guides/v3.9.0/templates/writing-helpers.md
+++ b/guides/v3.9.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.9/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -249,7 +249,7 @@ although this is usually unnecessary and error-prone.
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.9/classes/Helper). Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/3.9/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.9/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.9/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 

--- a/guides/v3.9.0/tutorial/model-hook.md
+++ b/guides/v3.9.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.9/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.9/classes/Route/methods/model?anchor=model).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.9.0/tutorial/routes-and-templates.md
+++ b/guides/v3.9.0/tutorial/routes-and-templates.md
@@ -224,7 +224,7 @@ All we want to do when a user visits the root (`/`) URL is transition to
 implementing a route lifecycle hook called `redirect`.
 Route lifecycle hooks are special methods that are called automatically when a route renders or data changes.
 Inside, we'll call the
-[`transitionTo`](https://api.emberjs.com/ember/3.9/classes/Route/methods/redirect?anchor=transitionTo)
+[`transitionTo`](https://api.emberjs.com/ember/3.9/classes/Route/methods/transitionTo?anchor=transitionTo)
 function:
 
 ```javascript {data-filename="app/routes/index.js" data-diff="+4,+5,+6"}

--- a/guides/v3.9.0/tutorial/subroutes.md
+++ b/guides/v3.9.0/tutorial/subroutes.md
@@ -347,7 +347,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `RentalListing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.9/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.9/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.


### PR DESCRIPTION
## Description

This PR addresses https://github.com/ember-learn/guides-source/issues/1440 for Ember `v3.14.0`. After performing Find All and Replace, I manually visited each link to ensure that we redirect readers to the correct content in the API Guides.

Similarly to https://github.com/ember-learn/guides-source/pull/1494, this PR involves many file changes because it backports fixing incorrect links to `v3.8.0`-`v3.13.0`. (These are the versions grouped under [Phase 2](https://github.com/ember-learn/guides-source/issues/1440#issuecomment-666800602).)

I hope the number of files doesn't deter you from reviewing this PR. Subsequent PRs for Phase 2 (`v3.8.0`-`v3.13.0`) will have fewer file changes.


## How to Review

I recommend reviewing the commits one at a time.

Every commit, starting with commit 4 ("Fixed incorrect links in..."), looks at just 1 Markdown file across different versions. The pattern in URL change often tends to be the same. (The only exception is if the API Guides changed URL from one version to another.)


## TODO

- [x] Use Find All and Replace to update API links.
- [x] Manually check each URL to ensure that we redirect a user to the correct API section.
- [x] Run `npm run test:node-local` to check external links in `v3.14.0`.


## Notes

In `/guides/v3.14.0`, I realized that API links don't always use `release`, but can use some version prior. I will need to open a separate PR to address this issue for `v3.15.0` to `v3.19.0`. 

```
# Use regexes for Find All and Replace
Find:    https://api.emberjs.com/ember/release/
Replace: https://api.emberjs.com/ember/3.14/

Find:    https://api.emberjs.com/ember/\d{1}.\d{1,2}/
Replace: https://api.emberjs.com/ember/3.14/

Find:    https://api.emberjs.com/ember-data/release/
Replace: https://api.emberjs.com/ember-data/3.14/

Find:    https://api.emberjs.com/ember-data/\d{1}.\d{1,2}/
Replace: https://api.emberjs.com/ember-data/3.14/
```