### PR TITLE
Updated missed API links in v3.15 - release

### DIFF
--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -204,7 +204,7 @@ discussing state in the next chapter).
 
 ### The `get` helper
 
-The [`{{get}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
+The [`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
 helper makes it easy to dynamically send the value of a variable to another
 helper or component. This can be useful if you want to output one of several
 values based on the result of a getter.
@@ -220,7 +220,7 @@ If it returns "city", you get `this.address.city`.
 
 We mentioned above that helpers can be nested. This can be
 combined with different dynamic helpers. For example, the
-[`{{concat}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
+[`{{concat}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
 helper makes it easy to dynamically send a number of parameters to a component
 or helper as a single parameter in the format of a concatenated string.
 
@@ -236,7 +236,7 @@ This will display the result of `this.foo.item1` when index is 1, and
 Now let's say your template is starting to get a bit cluttered and you want
 to clean up the logic in your templates. This can be achieved with the `let`
 block helper.
-The [`{{let}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/let?anchor=let)
+The [`{{let}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/let?anchor=let)
 helper lets you create new bindings (or temporary variables) in your template.
 
 Say your template now looks like this:
@@ -298,7 +298,7 @@ In the component's template, you can then use the `people` argument as an array:
 
 ### The `hash` helper
 
-Using the [`{{hash}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/array?anchor=hash)
+Using the [`{{hash}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
 helper, you can pass objects directly from the template as an argument to your
 components.
 

--- a/guides/release/in-depth-topics/native-classes-in-depth.md
+++ b/guides/release/in-depth-topics/native-classes-in-depth.md
@@ -676,7 +676,7 @@ after overriding. This allows the super class method to continue operating as it
 normally would.
 
 One common example is when overriding the
-[`normalizeResponse()`](https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook in one of Ember Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:

--- a/guides/release/in-depth-topics/patterns-for-components.md
+++ b/guides/release/in-depth-topics/patterns-for-components.md
@@ -125,7 +125,7 @@ To learn more about `aria` roles and accessibility in Ember, check out the [Acce
 
 ## Contextual Components
 
-The [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
+The [`{{component}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
 helper can be used to defer the selection of a component to run time. The
 `<MyComponent />` syntax always renders the same component, while using the
 `{{component}}` helper allows choosing a component to render on the fly. This is
@@ -136,7 +136,7 @@ different logic well separated.
 The first parameter of the helper is the name of a component to render, as a
 string. So `{{component 'blog-post'}}` is the same as using `<BlogPost />`.
 
-The real value of [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
+The real value of [`{{component}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
 comes from being able to dynamically pick the component being rendered. Below is
 an example of using the helper as a means of choosing different components for
 displaying different kinds of posts:

--- a/guides/release/models/defining-models.md
+++ b/guides/release/models/defining-models.md
@@ -39,7 +39,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
 ## Defining Attributes
 
 The `person` model we generated earlier didn't have any attributes. Let's
-add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/release/classes/Model/properties/attributes?anchor=attributes):
+add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/release/functions/@ember-data%2Fmodel/attr):
 
 ```javascript {data-filename=app/models/person.js}
 import Model, { attr } from '@ember-data/model';

--- a/guides/release/routing/controllers.md
+++ b/guides/release/routing/controllers.md
@@ -1,6 +1,6 @@
 ### What is a Controller?
 
-A [Controller](https://emberjs.com/api/ember/release/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/release/classes/Route/methods?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/release/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/release/classes/Route/methods/model?anchor=model) method.
 
 The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/release/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 

--- a/guides/release/routing/defining-your-routes.md
+++ b/guides/release/routing/defining-your-routes.md
@@ -357,6 +357,6 @@ handlers](https://api.emberjs.com/ember/release/classes/Route).
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
 - From a template, use [`<LinkTo />`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
-- From a route, use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
-- From a controller, use the [`transitionToRoute()`](https://emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
-- From anywhere else in your application, such as a component, inject the [Router Service](https://emberjs.com/api/ember/release/classes/RouterService) and use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method
+- From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
+- From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
+- From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/release/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/release/routing/redirection.md
+++ b/guides/release/routing/redirection.md
@@ -9,7 +9,7 @@ Ember allows you to control that access with a combination of hooks and methods 
 
 One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
-[`transitionToRoute()`](https://www.emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
+[`transitionToRoute()`](https://api.emberjs.com/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [`LinkTo`](../../templates/links/) helper.
 
 The other one is [`replaceWith()`](https://api.emberjs.com/ember/release/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.

--- a/guides/release/testing/test-types.md
+++ b/guides/release/testing/test-types.md
@@ -90,7 +90,7 @@ module('Unit | Service | flash-messages', function(hooks) {
 });
 ```
 
-By calling `setupTest()`, you gain access to a few things. First is Ember's [Dependency Injection](../../applications/dependency-injection/) system. In short, you can [look up](https://emberjs.com/api/ember/release/classes/ApplicationInstance/methods/lookup?anchor=lookup) anything in your application, with a little help from `this.owner`. Second, you gain access to some common utility functions, `this.get()` and `this.set()`, in your tests. Finally, you can use `pauseTest()` to [debug your tests](../#toc_how-to-debug-tests).
+By calling `setupTest()`, you gain access to a few things. First is Ember's [Dependency Injection](../../applications/dependency-injection/) system. In short, you can [look up](https://api.emberjs.com/ember/release/classes/ApplicationInstance/methods/lookup?anchor=lookup) anything in your application, with a little help from `this.owner`. Second, you gain access to some common utility functions, `this.get()` and `this.set()`, in your tests. Finally, you can use `pauseTest()` to [debug your tests](../#toc_how-to-debug-tests).
 
 
 ## Rendering Tests

--- a/guides/release/upgrading/current-edition/native-classes.md
+++ b/guides/release/upgrading/current-edition/native-classes.md
@@ -469,8 +469,8 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
   const Actress = Person.extend({});
   ```
 
-[1]: https://emberjs.com/api/ember/release/functions/@ember%2Fobject/extend
-[2]: https://www.emberjs.com/api/ember/release/classes/EmberObject
+[1]: https://api.emberjs.com/ember/release/functions/@ember%2Fobject/extend
+[2]: https://api.emberjs.com/ember/release/classes/EmberObject
 
 ### Instantiation
 
@@ -523,7 +523,7 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `init` method instead of the `constructor`.
 
-[3]: https://emberjs.com/api/ember/release/functions/@ember%2Fobject/create
+[3]: https://api.emberjs.com/ember/release/functions/@ember%2Fobject/create
 
 ### Methods
 

--- a/guides/v3.15.0/components/helper-functions.md
+++ b/guides/v3.15.0/components/helper-functions.md
@@ -205,7 +205,7 @@ discussing state in the next chapter).
 
 ### The `get` helper
 
-The [`{{get}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
+The [`{{get}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/get?anchor=get)
 helper makes it easy to dynamically send the value of a variable to another
 helper or component. This can be useful if you want to output one of several
 values based on the result of a getter.
@@ -221,7 +221,7 @@ If it returns "city", you get `this.address.city`.
 
 We mentioned above that helpers can be nested. This can be
 combined with different dynamic helpers. For example, the
-[`{{concat}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
+[`{{concat}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
 helper makes it easy to dynamically send a number of parameters to a component
 or helper as a single parameter in the format of a concatenated string.
 
@@ -237,7 +237,7 @@ This will display the result of `this.foo.item1` when index is 1, and
 Now let's say your template is starting to get a bit cluttered and you want
 to clean up the logic in your templates. This can be achieved with the `let`
 block helper.
-The [`{{let}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/let?anchor=let)
+The [`{{let}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/let?anchor=let)
 helper lets you create new bindings (or temporary variables) in your template.
 
 Say your template now looks like this:
@@ -299,7 +299,7 @@ In the component's template, you can then use the `people` argument as an array:
 
 ### The `hash` helper
 
-Using the [`{{hash}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/array?anchor=hash)
+Using the [`{{hash}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
 helper, you can pass objects directly from the template as an argument to your
 components.
 

--- a/guides/v3.15.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.15.0/in-depth-topics/native-classes-in-depth.md
@@ -676,7 +676,7 @@ after overriding. This allows the super class method to continue operating as it
 normally would.
 
 One common example is when overriding the
-[`normalizeResponse()`](https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.15/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook in one of Ember Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:

--- a/guides/v3.15.0/in-depth-topics/patterns-for-components.md
+++ b/guides/v3.15.0/in-depth-topics/patterns-for-components.md
@@ -125,7 +125,7 @@ To learn more about `aria` roles and accessibility in Ember, check out the [Acce
 
 ## Contextual Components
 
-The [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
+The [`{{component}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/component?anchor=component)
 helper can be used to defer the selection of a component to run time. The
 `<MyComponent />` syntax always renders the same component, while using the
 `{{component}}` helper allows choosing a component to render on the fly. This is
@@ -136,7 +136,7 @@ different logic well separated.
 The first parameter of the helper is the name of a component to render, as a
 string. So `{{component 'blog-post'}}` is the same as using `<BlogPost />`.
 
-The real value of [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
+The real value of [`{{component}}`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.helpers/methods/component?anchor=component)
 comes from being able to dynamically pick the component being rendered. Below is
 an example of using the helper as a means of choosing different components for
 displaying different kinds of posts:

--- a/guides/v3.15.0/models/defining-models.md
+++ b/guides/v3.15.0/models/defining-models.md
@@ -39,7 +39,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
 ## Defining Attributes
 
 The `person` model we generated earlier didn't have any attributes. Let's
-add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/3.15/classes/Model/properties/attributes?anchor=attributes):
+add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/3.15/functions/@ember-data%2Fmodel/attr):
 
 ```javascript {data-filename=app/models/person.js}
 import Model, { attr } from '@ember-data/model';

--- a/guides/v3.15.0/routing/controllers.md
+++ b/guides/v3.15.0/routing/controllers.md
@@ -1,6 +1,6 @@
 ### What is a Controller?
 
-A [Controller](https://emberjs.com/api/ember/release/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.15/classes/Route/methods?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/3.15/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.15/classes/Route/methods/model?anchor=model) method.
 
 The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.15/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 

--- a/guides/v3.15.0/routing/defining-your-routes.md
+++ b/guides/v3.15.0/routing/defining-your-routes.md
@@ -357,6 +357,6 @@ handlers](https://api.emberjs.com/ember/3.15/classes/Route).
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
 - From a template, use [`<LinkTo />`](https://api.emberjs.com/ember/3.15/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
-- From a route, use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
-- From a controller, use the [`transitionToRoute()`](https://emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
-- From anywhere else in your application, such as a component, inject the [Router Service](https://emberjs.com/api/ember/release/classes/RouterService) and use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method
+- From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/3.15/classes/Route/methods/transitionTo?anchor=transitionTo) method
+- From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/3.15/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
+- From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/3.15/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/3.15/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.15.0/routing/redirection.md
+++ b/guides/v3.15.0/routing/redirection.md
@@ -9,7 +9,7 @@ Ember allows you to control that access with a combination of hooks and methods 
 
 One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/3.15/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
-[`transitionToRoute()`](https://www.emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
+[`transitionToRoute()`](https://api.emberjs.com/ember/3.15/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [`LinkTo`](../../templates/links/) helper.
 
 The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.15/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.

--- a/guides/v3.15.0/testing/test-types.md
+++ b/guides/v3.15.0/testing/test-types.md
@@ -90,7 +90,7 @@ module('Unit | Service | flash-messages', function(hooks) {
 });
 ```
 
-By calling `setupTest()`, you gain access to a few things. First is Ember's [Dependency Injection](../../applications/dependency-injection/) system. In short, you can [look up](https://emberjs.com/api/ember/release/classes/ApplicationInstance/methods/lookup?anchor=lookup) anything in your application, with a little help from `this.owner`. Second, you gain access to some common utility functions, `this.get()` and `this.set()`, in your tests. Finally, you can use `pauseTest()` to [debug your tests](../#toc_how-to-debug-tests).
+By calling `setupTest()`, you gain access to a few things. First is Ember's [Dependency Injection](../../applications/dependency-injection/) system. In short, you can [look up](https://api.emberjs.com/ember/3.15/classes/ApplicationInstance/methods/lookup?anchor=lookup) anything in your application, with a little help from `this.owner`. Second, you gain access to some common utility functions, `this.get()` and `this.set()`, in your tests. Finally, you can use `pauseTest()` to [debug your tests](../#toc_how-to-debug-tests).
 
 
 ## Rendering Tests

--- a/guides/v3.15.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.15.0/upgrading/current-edition/native-classes.md
@@ -469,8 +469,8 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
   const Actress = Person.extend({});
   ```
 
-[1]: https://emberjs.com/api/ember/release/functions/@ember%2Fobject/extend
-[2]: https://www.emberjs.com/api/ember/release/classes/EmberObject
+[1]: https://api.emberjs.com/ember/3.15/functions/@ember%2Fobject/extend
+[2]: https://api.emberjs.com/ember/3.15/classes/EmberObject
 
 ### Instantiation
 
@@ -523,7 +523,7 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `init` method instead of the `constructor`.
 
-[3]: https://emberjs.com/api/ember/release/functions/@ember%2Fobject/create
+[3]: https://api.emberjs.com/ember/3.15/functions/@ember%2Fobject/create
 
 ### Methods
 

--- a/guides/v3.16.0/components/helper-functions.md
+++ b/guides/v3.16.0/components/helper-functions.md
@@ -205,7 +205,7 @@ discussing state in the next chapter).
 
 ### The `get` helper
 
-The [`{{get}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
+The [`{{get}}`](https://api.emberjs.com/ember/3.16/classes/Ember.Templates.helpers/methods/get?anchor=get)
 helper makes it easy to dynamically send the value of a variable to another
 helper or component. This can be useful if you want to output one of several
 values based on the result of a getter.
@@ -221,7 +221,7 @@ If it returns "city", you get `this.address.city`.
 
 We mentioned above that helpers can be nested. This can be
 combined with different dynamic helpers. For example, the
-[`{{concat}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
+[`{{concat}}`](https://api.emberjs.com/ember/3.16/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
 helper makes it easy to dynamically send a number of parameters to a component
 or helper as a single parameter in the format of a concatenated string.
 
@@ -237,7 +237,7 @@ This will display the result of `this.foo.item1` when index is 1, and
 Now let's say your template is starting to get a bit cluttered and you want
 to clean up the logic in your templates. This can be achieved with the `let`
 block helper.
-The [`{{let}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/let?anchor=let)
+The [`{{let}}`](https://api.emberjs.com/ember/3.16/classes/Ember.Templates.helpers/methods/let?anchor=let)
 helper lets you create new bindings (or temporary variables) in your template.
 
 Say your template now looks like this:
@@ -299,7 +299,7 @@ In the component's template, you can then use the `people` argument as an array:
 
 ### The `hash` helper
 
-Using the [`{{hash}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/array?anchor=hash)
+Using the [`{{hash}}`](https://api.emberjs.com/ember/3.16/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
 helper, you can pass objects directly from the template as an argument to your
 components.
 

--- a/guides/v3.16.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.16.0/in-depth-topics/native-classes-in-depth.md
@@ -676,7 +676,7 @@ after overriding. This allows the super class method to continue operating as it
 normally would.
 
 One common example is when overriding the
-[`normalizeResponse()`](https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.16/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook in one of Ember Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:

--- a/guides/v3.16.0/in-depth-topics/patterns-for-components.md
+++ b/guides/v3.16.0/in-depth-topics/patterns-for-components.md
@@ -125,7 +125,7 @@ To learn more about `aria` roles and accessibility in Ember, check out the [Acce
 
 ## Contextual Components
 
-The [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
+The [`{{component}}`](https://api.emberjs.com/ember/3.16/classes/Ember.Templates.helpers/methods/component?anchor=component)
 helper can be used to defer the selection of a component to run time. The
 `<MyComponent />` syntax always renders the same component, while using the
 `{{component}}` helper allows choosing a component to render on the fly. This is
@@ -136,7 +136,7 @@ different logic well separated.
 The first parameter of the helper is the name of a component to render, as a
 string. So `{{component 'blog-post'}}` is the same as using `<BlogPost />`.
 
-The real value of [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
+The real value of [`{{component}}`](https://api.emberjs.com/ember/3.16/classes/Ember.Templates.helpers/methods/component?anchor=component)
 comes from being able to dynamically pick the component being rendered. Below is
 an example of using the helper as a means of choosing different components for
 displaying different kinds of posts:

--- a/guides/v3.16.0/models/defining-models.md
+++ b/guides/v3.16.0/models/defining-models.md
@@ -39,7 +39,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
 ## Defining Attributes
 
 The `person` model we generated earlier didn't have any attributes. Let's
-add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/3.16/classes/Model/properties/attributes?anchor=attributes):
+add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/3.16/functions/@ember-data%2Fmodel/attr):
 
 ```javascript {data-filename=app/models/person.js}
 import Model, { attr } from '@ember-data/model';

--- a/guides/v3.16.0/routing/controllers.md
+++ b/guides/v3.16.0/routing/controllers.md
@@ -1,6 +1,6 @@
 ### What is a Controller?
 
-A [Controller](https://emberjs.com/api/ember/release/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.16/classes/Route/methods?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/3.16/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.16/classes/Route/methods/model?anchor=model) method.
 
 The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.16/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 

--- a/guides/v3.16.0/routing/defining-your-routes.md
+++ b/guides/v3.16.0/routing/defining-your-routes.md
@@ -357,6 +357,6 @@ handlers](https://api.emberjs.com/ember/3.16/classes/Route).
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
 - From a template, use [`<LinkTo />`](https://api.emberjs.com/ember/3.16/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
-- From a route, use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
-- From a controller, use the [`transitionToRoute()`](https://emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
-- From anywhere else in your application, such as a component, inject the [Router Service](https://emberjs.com/api/ember/release/classes/RouterService) and use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method
+- From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/3.16/classes/Route/methods/transitionTo?anchor=transitionTo) method
+- From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/3.16/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
+- From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/3.16/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/3.16/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.16.0/routing/redirection.md
+++ b/guides/v3.16.0/routing/redirection.md
@@ -9,7 +9,7 @@ Ember allows you to control that access with a combination of hooks and methods 
 
 One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/3.16/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
-[`transitionToRoute()`](https://www.emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
+[`transitionToRoute()`](https://api.emberjs.com/ember/3.16/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [`LinkTo`](../../templates/links/) helper.
 
 The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.16/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.

--- a/guides/v3.16.0/testing/test-types.md
+++ b/guides/v3.16.0/testing/test-types.md
@@ -90,7 +90,7 @@ module('Unit | Service | flash-messages', function(hooks) {
 });
 ```
 
-By calling `setupTest()`, you gain access to a few things. First is Ember's [Dependency Injection](../../applications/dependency-injection/) system. In short, you can [look up](https://emberjs.com/api/ember/release/classes/ApplicationInstance/methods/lookup?anchor=lookup) anything in your application, with a little help from `this.owner`. Second, you gain access to some common utility functions, `this.get()` and `this.set()`, in your tests. Finally, you can use `pauseTest()` to [debug your tests](../#toc_how-to-debug-tests).
+By calling `setupTest()`, you gain access to a few things. First is Ember's [Dependency Injection](../../applications/dependency-injection/) system. In short, you can [look up](https://api.emberjs.com/ember/3.16/classes/ApplicationInstance/methods/lookup?anchor=lookup) anything in your application, with a little help from `this.owner`. Second, you gain access to some common utility functions, `this.get()` and `this.set()`, in your tests. Finally, you can use `pauseTest()` to [debug your tests](../#toc_how-to-debug-tests).
 
 
 ## Rendering Tests

--- a/guides/v3.16.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.16.0/upgrading/current-edition/native-classes.md
@@ -469,8 +469,8 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
   const Actress = Person.extend({});
   ```
 
-[1]: https://emberjs.com/api/ember/release/functions/@ember%2Fobject/extend
-[2]: https://www.emberjs.com/api/ember/release/classes/EmberObject
+[1]: https://api.emberjs.com/ember/3.16/functions/@ember%2Fobject/extend
+[2]: https://api.emberjs.com/ember/3.16/classes/EmberObject
 
 ### Instantiation
 
@@ -523,7 +523,7 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `init` method instead of the `constructor`.
 
-[3]: https://emberjs.com/api/ember/release/functions/@ember%2Fobject/create
+[3]: https://api.emberjs.com/ember/3.16/functions/@ember%2Fobject/create
 
 ### Methods
 

--- a/guides/v3.17.0/components/helper-functions.md
+++ b/guides/v3.17.0/components/helper-functions.md
@@ -204,7 +204,7 @@ discussing state in the next chapter).
 
 ### The `get` helper
 
-The [`{{get}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
+The [`{{get}}`](https://api.emberjs.com/ember/3.17/classes/Ember.Templates.helpers/methods/get?anchor=get)
 helper makes it easy to dynamically send the value of a variable to another
 helper or component. This can be useful if you want to output one of several
 values based on the result of a getter.
@@ -220,7 +220,7 @@ If it returns "city", you get `this.address.city`.
 
 We mentioned above that helpers can be nested. This can be
 combined with different dynamic helpers. For example, the
-[`{{concat}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
+[`{{concat}}`](https://api.emberjs.com/ember/3.17/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
 helper makes it easy to dynamically send a number of parameters to a component
 or helper as a single parameter in the format of a concatenated string.
 
@@ -236,7 +236,7 @@ This will display the result of `this.foo.item1` when index is 1, and
 Now let's say your template is starting to get a bit cluttered and you want
 to clean up the logic in your templates. This can be achieved with the `let`
 block helper.
-The [`{{let}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/let?anchor=let)
+The [`{{let}}`](https://api.emberjs.com/ember/3.17/classes/Ember.Templates.helpers/methods/let?anchor=let)
 helper lets you create new bindings (or temporary variables) in your template.
 
 Say your template now looks like this:
@@ -298,7 +298,7 @@ In the component's template, you can then use the `people` argument as an array:
 
 ### The `hash` helper
 
-Using the [`{{hash}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/array?anchor=hash)
+Using the [`{{hash}}`](https://api.emberjs.com/ember/3.17/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
 helper, you can pass objects directly from the template as an argument to your
 components.
 

--- a/guides/v3.17.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.17.0/in-depth-topics/native-classes-in-depth.md
@@ -676,7 +676,7 @@ after overriding. This allows the super class method to continue operating as it
 normally would.
 
 One common example is when overriding the
-[`normalizeResponse()`](https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.17/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook in one of Ember Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:

--- a/guides/v3.17.0/in-depth-topics/patterns-for-components.md
+++ b/guides/v3.17.0/in-depth-topics/patterns-for-components.md
@@ -125,7 +125,7 @@ To learn more about `aria` roles and accessibility in Ember, check out the [Acce
 
 ## Contextual Components
 
-The [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
+The [`{{component}}`](https://api.emberjs.com/ember/3.17/classes/Ember.Templates.helpers/methods/component?anchor=component)
 helper can be used to defer the selection of a component to run time. The
 `<MyComponent />` syntax always renders the same component, while using the
 `{{component}}` helper allows choosing a component to render on the fly. This is
@@ -136,7 +136,7 @@ different logic well separated.
 The first parameter of the helper is the name of a component to render, as a
 string. So `{{component 'blog-post'}}` is the same as using `<BlogPost />`.
 
-The real value of [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
+The real value of [`{{component}}`](https://api.emberjs.com/ember/3.17/classes/Ember.Templates.helpers/methods/component?anchor=component)
 comes from being able to dynamically pick the component being rendered. Below is
 an example of using the helper as a means of choosing different components for
 displaying different kinds of posts:

--- a/guides/v3.17.0/models/defining-models.md
+++ b/guides/v3.17.0/models/defining-models.md
@@ -39,7 +39,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
 ## Defining Attributes
 
 The `person` model we generated earlier didn't have any attributes. Let's
-add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/3.17/classes/Model/properties/attributes?anchor=attributes):
+add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/3.17/functions/@ember-data%2Fmodel/attr):
 
 ```javascript {data-filename=app/models/person.js}
 import Model, { attr } from '@ember-data/model';

--- a/guides/v3.17.0/routing/controllers.md
+++ b/guides/v3.17.0/routing/controllers.md
@@ -1,6 +1,6 @@
 ### What is a Controller?
 
-A [Controller](https://emberjs.com/api/ember/release/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.17/classes/Route/methods?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/3.17/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.17/classes/Route/methods/model?anchor=model) method.
 
 The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.17/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 

--- a/guides/v3.17.0/routing/defining-your-routes.md
+++ b/guides/v3.17.0/routing/defining-your-routes.md
@@ -357,6 +357,6 @@ handlers](https://api.emberjs.com/ember/3.17/classes/Route).
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
 - From a template, use [`<LinkTo />`](https://api.emberjs.com/ember/3.17/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
-- From a route, use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
-- From a controller, use the [`transitionToRoute()`](https://emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
-- From anywhere else in your application, such as a component, inject the [Router Service](https://emberjs.com/api/ember/release/classes/RouterService) and use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method
+- From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/3.17/classes/Route/methods/transitionTo?anchor=transitionTo) method
+- From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/3.17/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
+- From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/3.17/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/3.17/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.17.0/routing/redirection.md
+++ b/guides/v3.17.0/routing/redirection.md
@@ -9,7 +9,7 @@ Ember allows you to control that access with a combination of hooks and methods 
 
 One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/3.17/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
-[`transitionToRoute()`](https://www.emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
+[`transitionToRoute()`](https://api.emberjs.com/ember/3.17/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [`LinkTo`](../../templates/links/) helper.
 
 The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.17/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.

--- a/guides/v3.17.0/testing/test-types.md
+++ b/guides/v3.17.0/testing/test-types.md
@@ -90,7 +90,7 @@ module('Unit | Service | flash-messages', function(hooks) {
 });
 ```
 
-By calling `setupTest()`, you gain access to a few things. First is Ember's [Dependency Injection](../../applications/dependency-injection/) system. In short, you can [look up](https://emberjs.com/api/ember/release/classes/ApplicationInstance/methods/lookup?anchor=lookup) anything in your application, with a little help from `this.owner`. Second, you gain access to some common utility functions, `this.get()` and `this.set()`, in your tests. Finally, you can use `pauseTest()` to [debug your tests](../#toc_how-to-debug-tests).
+By calling `setupTest()`, you gain access to a few things. First is Ember's [Dependency Injection](../../applications/dependency-injection/) system. In short, you can [look up](https://api.emberjs.com/ember/3.17/classes/ApplicationInstance/methods/lookup?anchor=lookup) anything in your application, with a little help from `this.owner`. Second, you gain access to some common utility functions, `this.get()` and `this.set()`, in your tests. Finally, you can use `pauseTest()` to [debug your tests](../#toc_how-to-debug-tests).
 
 
 ## Rendering Tests

--- a/guides/v3.17.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.17.0/upgrading/current-edition/native-classes.md
@@ -469,8 +469,8 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
   const Actress = Person.extend({});
   ```
 
-[1]: https://emberjs.com/api/ember/release/functions/@ember%2Fobject/extend
-[2]: https://www.emberjs.com/api/ember/release/classes/EmberObject
+[1]: https://api.emberjs.com/ember/3.17/functions/@ember%2Fobject/extend
+[2]: https://api.emberjs.com/ember/3.17/classes/EmberObject
 
 ### Instantiation
 
@@ -523,7 +523,7 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `init` method instead of the `constructor`.
 
-[3]: https://emberjs.com/api/ember/release/functions/@ember%2Fobject/create
+[3]: https://api.emberjs.com/ember/3.17/functions/@ember%2Fobject/create
 
 ### Methods
 

--- a/guides/v3.18.0/components/helper-functions.md
+++ b/guides/v3.18.0/components/helper-functions.md
@@ -204,7 +204,7 @@ discussing state in the next chapter).
 
 ### The `get` helper
 
-The [`{{get}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
+The [`{{get}}`](https://api.emberjs.com/ember/3.18/classes/Ember.Templates.helpers/methods/get?anchor=get)
 helper makes it easy to dynamically send the value of a variable to another
 helper or component. This can be useful if you want to output one of several
 values based on the result of a getter.
@@ -220,7 +220,7 @@ If it returns "city", you get `this.address.city`.
 
 We mentioned above that helpers can be nested. This can be
 combined with different dynamic helpers. For example, the
-[`{{concat}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
+[`{{concat}}`](https://api.emberjs.com/ember/3.18/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
 helper makes it easy to dynamically send a number of parameters to a component
 or helper as a single parameter in the format of a concatenated string.
 
@@ -236,7 +236,7 @@ This will display the result of `this.foo.item1` when index is 1, and
 Now let's say your template is starting to get a bit cluttered and you want
 to clean up the logic in your templates. This can be achieved with the `let`
 block helper.
-The [`{{let}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/let?anchor=let)
+The [`{{let}}`](https://api.emberjs.com/ember/3.18/classes/Ember.Templates.helpers/methods/let?anchor=let)
 helper lets you create new bindings (or temporary variables) in your template.
 
 Say your template now looks like this:
@@ -298,7 +298,7 @@ In the component's template, you can then use the `people` argument as an array:
 
 ### The `hash` helper
 
-Using the [`{{hash}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/array?anchor=hash)
+Using the [`{{hash}}`](https://api.emberjs.com/ember/3.18/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
 helper, you can pass objects directly from the template as an argument to your
 components.
 

--- a/guides/v3.18.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.18.0/in-depth-topics/native-classes-in-depth.md
@@ -676,7 +676,7 @@ after overriding. This allows the super class method to continue operating as it
 normally would.
 
 One common example is when overriding the
-[`normalizeResponse()`](https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.18/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook in one of Ember Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:

--- a/guides/v3.18.0/in-depth-topics/patterns-for-components.md
+++ b/guides/v3.18.0/in-depth-topics/patterns-for-components.md
@@ -125,7 +125,7 @@ To learn more about `aria` roles and accessibility in Ember, check out the [Acce
 
 ## Contextual Components
 
-The [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
+The [`{{component}}`](https://api.emberjs.com/ember/3.18/classes/Ember.Templates.helpers/methods/component?anchor=component)
 helper can be used to defer the selection of a component to run time. The
 `<MyComponent />` syntax always renders the same component, while using the
 `{{component}}` helper allows choosing a component to render on the fly. This is
@@ -136,7 +136,7 @@ different logic well separated.
 The first parameter of the helper is the name of a component to render, as a
 string. So `{{component 'blog-post'}}` is the same as using `<BlogPost />`.
 
-The real value of [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
+The real value of [`{{component}}`](https://api.emberjs.com/ember/3.18/classes/Ember.Templates.helpers/methods/component?anchor=component)
 comes from being able to dynamically pick the component being rendered. Below is
 an example of using the helper as a means of choosing different components for
 displaying different kinds of posts:

--- a/guides/v3.18.0/models/defining-models.md
+++ b/guides/v3.18.0/models/defining-models.md
@@ -39,7 +39,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
 ## Defining Attributes
 
 The `person` model we generated earlier didn't have any attributes. Let's
-add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/3.18/classes/Model/properties/attributes?anchor=attributes):
+add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/3.18/functions/@ember-data%2Fmodel/attr):
 
 ```javascript {data-filename=app/models/person.js}
 import Model, { attr } from '@ember-data/model';

--- a/guides/v3.18.0/routing/controllers.md
+++ b/guides/v3.18.0/routing/controllers.md
@@ -1,6 +1,6 @@
 ### What is a Controller?
 
-A [Controller](https://emberjs.com/api/ember/release/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.18/classes/Route/methods?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/3.18/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.18/classes/Route/methods/model?anchor=model) method.
 
 The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.18/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 

--- a/guides/v3.18.0/routing/defining-your-routes.md
+++ b/guides/v3.18.0/routing/defining-your-routes.md
@@ -357,6 +357,6 @@ handlers](https://api.emberjs.com/ember/3.18/classes/Route).
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
 - From a template, use [`<LinkTo />`](https://api.emberjs.com/ember/3.18/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
-- From a route, use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
-- From a controller, use the [`transitionToRoute()`](https://emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
-- From anywhere else in your application, such as a component, inject the [Router Service](https://emberjs.com/api/ember/release/classes/RouterService) and use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method
+- From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/3.18/classes/Route/methods/transitionTo?anchor=transitionTo) method
+- From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/3.18/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
+- From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/3.18/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/3.18/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.18.0/routing/redirection.md
+++ b/guides/v3.18.0/routing/redirection.md
@@ -9,7 +9,7 @@ Ember allows you to control that access with a combination of hooks and methods 
 
 One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/3.18/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
-[`transitionToRoute()`](https://www.emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
+[`transitionToRoute()`](https://api.emberjs.com/ember/3.18/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [`LinkTo`](../../templates/links/) helper.
 
 The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.18/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.

--- a/guides/v3.18.0/testing/test-types.md
+++ b/guides/v3.18.0/testing/test-types.md
@@ -90,7 +90,7 @@ module('Unit | Service | flash-messages', function(hooks) {
 });
 ```
 
-By calling `setupTest()`, you gain access to a few things. First is Ember's [Dependency Injection](../../applications/dependency-injection/) system. In short, you can [look up](https://emberjs.com/api/ember/release/classes/ApplicationInstance/methods/lookup?anchor=lookup) anything in your application, with a little help from `this.owner`. Second, you gain access to some common utility functions, `this.get()` and `this.set()`, in your tests. Finally, you can use `pauseTest()` to [debug your tests](../#toc_how-to-debug-tests).
+By calling `setupTest()`, you gain access to a few things. First is Ember's [Dependency Injection](../../applications/dependency-injection/) system. In short, you can [look up](https://api.emberjs.com/ember/3.18/classes/ApplicationInstance/methods/lookup?anchor=lookup) anything in your application, with a little help from `this.owner`. Second, you gain access to some common utility functions, `this.get()` and `this.set()`, in your tests. Finally, you can use `pauseTest()` to [debug your tests](../#toc_how-to-debug-tests).
 
 
 ## Rendering Tests

--- a/guides/v3.18.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.18.0/upgrading/current-edition/native-classes.md
@@ -469,8 +469,8 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
   const Actress = Person.extend({});
   ```
 
-[1]: https://emberjs.com/api/ember/release/functions/@ember%2Fobject/extend
-[2]: https://www.emberjs.com/api/ember/release/classes/EmberObject
+[1]: https://api.emberjs.com/ember/3.18/functions/@ember%2Fobject/extend
+[2]: https://api.emberjs.com/ember/3.18/classes/EmberObject
 
 ### Instantiation
 
@@ -523,7 +523,7 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `init` method instead of the `constructor`.
 
-[3]: https://emberjs.com/api/ember/release/functions/@ember%2Fobject/create
+[3]: https://api.emberjs.com/ember/3.18/functions/@ember%2Fobject/create
 
 ### Methods
 

--- a/guides/v3.19.0/components/helper-functions.md
+++ b/guides/v3.19.0/components/helper-functions.md
@@ -204,7 +204,7 @@ discussing state in the next chapter).
 
 ### The `get` helper
 
-The [`{{get}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
+The [`{{get}}`](https://api.emberjs.com/ember/3.19/classes/Ember.Templates.helpers/methods/get?anchor=get)
 helper makes it easy to dynamically send the value of a variable to another
 helper or component. This can be useful if you want to output one of several
 values based on the result of a getter.
@@ -220,7 +220,7 @@ If it returns "city", you get `this.address.city`.
 
 We mentioned above that helpers can be nested. This can be
 combined with different dynamic helpers. For example, the
-[`{{concat}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
+[`{{concat}}`](https://api.emberjs.com/ember/3.19/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
 helper makes it easy to dynamically send a number of parameters to a component
 or helper as a single parameter in the format of a concatenated string.
 
@@ -236,7 +236,7 @@ This will display the result of `this.foo.item1` when index is 1, and
 Now let's say your template is starting to get a bit cluttered and you want
 to clean up the logic in your templates. This can be achieved with the `let`
 block helper.
-The [`{{let}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/let?anchor=let)
+The [`{{let}}`](https://api.emberjs.com/ember/3.19/classes/Ember.Templates.helpers/methods/let?anchor=let)
 helper lets you create new bindings (or temporary variables) in your template.
 
 Say your template now looks like this:
@@ -298,7 +298,7 @@ In the component's template, you can then use the `people` argument as an array:
 
 ### The `hash` helper
 
-Using the [`{{hash}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/array?anchor=hash)
+Using the [`{{hash}}`](https://api.emberjs.com/ember/3.19/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
 helper, you can pass objects directly from the template as an argument to your
 components.
 

--- a/guides/v3.19.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.19.0/in-depth-topics/native-classes-in-depth.md
@@ -676,7 +676,7 @@ after overriding. This allows the super class method to continue operating as it
 normally would.
 
 One common example is when overriding the
-[`normalizeResponse()`](https://www.emberjs.com/api/ember-data/release/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.19/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook in one of Ember Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:

--- a/guides/v3.19.0/in-depth-topics/patterns-for-components.md
+++ b/guides/v3.19.0/in-depth-topics/patterns-for-components.md
@@ -125,7 +125,7 @@ To learn more about `aria` roles and accessibility in Ember, check out the [Acce
 
 ## Contextual Components
 
-The [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
+The [`{{component}}`](https://api.emberjs.com/ember/3.19/classes/Ember.Templates.helpers/methods/component?anchor=component)
 helper can be used to defer the selection of a component to run time. The
 `<MyComponent />` syntax always renders the same component, while using the
 `{{component}}` helper allows choosing a component to render on the fly. This is
@@ -136,7 +136,7 @@ different logic well separated.
 The first parameter of the helper is the name of a component to render, as a
 string. So `{{component 'blog-post'}}` is the same as using `<BlogPost />`.
 
-The real value of [`{{component}}`](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
+The real value of [`{{component}}`](https://api.emberjs.com/ember/3.19/classes/Ember.Templates.helpers/methods/component?anchor=component)
 comes from being able to dynamically pick the component being rendered. Below is
 an example of using the helper as a means of choosing different components for
 displaying different kinds of posts:

--- a/guides/v3.19.0/models/defining-models.md
+++ b/guides/v3.19.0/models/defining-models.md
@@ -39,7 +39,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
 ## Defining Attributes
 
 The `person` model we generated earlier didn't have any attributes. Let's
-add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/3.19/classes/Model/properties/attributes?anchor=attributes):
+add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/3.19/functions/@ember-data%2Fmodel/attr):
 
 ```javascript {data-filename=app/models/person.js}
 import Model, { attr } from '@ember-data/model';

--- a/guides/v3.19.0/routing/controllers.md
+++ b/guides/v3.19.0/routing/controllers.md
@@ -1,6 +1,6 @@
 ### What is a Controller?
 
-A [Controller](https://emberjs.com/api/ember/release/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.19/classes/Route/methods?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/3.19/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.19/classes/Route/methods/model?anchor=model) method.
 
 The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.19/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 

--- a/guides/v3.19.0/routing/defining-your-routes.md
+++ b/guides/v3.19.0/routing/defining-your-routes.md
@@ -357,6 +357,6 @@ handlers](https://api.emberjs.com/ember/3.19/classes/Route).
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
 - From a template, use [`<LinkTo />`](https://api.emberjs.com/ember/3.19/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
-- From a route, use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
-- From a controller, use the [`transitionToRoute()`](https://emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
-- From anywhere else in your application, such as a component, inject the [Router Service](https://emberjs.com/api/ember/release/classes/RouterService) and use the [`transitionTo()`](https://emberjs.com/api/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method
+- From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/3.19/classes/Route/methods/transitionTo?anchor=transitionTo) method
+- From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/3.19/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
+- From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/3.19/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/3.19/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.19.0/routing/redirection.md
+++ b/guides/v3.19.0/routing/redirection.md
@@ -9,7 +9,7 @@ Ember allows you to control that access with a combination of hooks and methods 
 
 One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/3.19/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
-[`transitionToRoute()`](https://www.emberjs.com/api/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
+[`transitionToRoute()`](https://api.emberjs.com/ember/3.19/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [`LinkTo`](../../templates/links/) helper.
 
 The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.19/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.

--- a/guides/v3.19.0/testing/test-types.md
+++ b/guides/v3.19.0/testing/test-types.md
@@ -90,7 +90,7 @@ module('Unit | Service | flash-messages', function(hooks) {
 });
 ```
 
-By calling `setupTest()`, you gain access to a few things. First is Ember's [Dependency Injection](../../applications/dependency-injection/) system. In short, you can [look up](https://emberjs.com/api/ember/release/classes/ApplicationInstance/methods/lookup?anchor=lookup) anything in your application, with a little help from `this.owner`. Second, you gain access to some common utility functions, `this.get()` and `this.set()`, in your tests. Finally, you can use `pauseTest()` to [debug your tests](../#toc_how-to-debug-tests).
+By calling `setupTest()`, you gain access to a few things. First is Ember's [Dependency Injection](../../applications/dependency-injection/) system. In short, you can [look up](https://api.emberjs.com/ember/3.19/classes/ApplicationInstance/methods/lookup?anchor=lookup) anything in your application, with a little help from `this.owner`. Second, you gain access to some common utility functions, `this.get()` and `this.set()`, in your tests. Finally, you can use `pauseTest()` to [debug your tests](../#toc_how-to-debug-tests).
 
 
 ## Rendering Tests

--- a/guides/v3.19.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.19.0/upgrading/current-edition/native-classes.md
@@ -469,8 +469,8 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
   const Actress = Person.extend({});
   ```
 
-[1]: https://emberjs.com/api/ember/release/functions/@ember%2Fobject/extend
-[2]: https://www.emberjs.com/api/ember/release/classes/EmberObject
+[1]: https://api.emberjs.com/ember/3.19/functions/@ember%2Fobject/extend
+[2]: https://api.emberjs.com/ember/3.19/classes/EmberObject
 
 ### Instantiation
 
@@ -523,7 +523,7 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `init` method instead of the `constructor`.
 
-[3]: https://emberjs.com/api/ember/release/functions/@ember%2Fobject/create
+[3]: https://api.emberjs.com/ember/3.19/functions/@ember%2Fobject/create
 
 ### Methods
 


### PR DESCRIPTION
## Description

In the previous PRs for updating API Guides links for `v3.15.0` - `release` (versions listed in [Phase 1](https://github.com/ember-learn/guides-source/issues/1440#issuecomment-666800602)), I had missed several links because I hadn't accounted for the URL pattern `emberjs.com/api`.

I also checked that no URL contains `DS.`, which refers to Ember Data's package layout prior to `v3.11.0`.

After addressing the URLs in the `release` folder, I backported the changes to `v3.15.0` - `v3.19.0`. Each commit looks at 1 particular version of the Ember Guides.