### PR TITLE
Updated API links in guides/3.10.0

### DIFF
--- a/guides/v3.10.0/components/defining-a-component.md
+++ b/guides/v3.10.0/components/defining-a-component.md
@@ -33,7 +33,7 @@ Given the above template, you can now use the `<BlogPost />` component:
     <div class="cta-note-body">
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
-In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
+In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.10/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">

--- a/guides/v3.10.0/controllers/index.md
+++ b/guides/v3.10.0/controllers/index.md
@@ -1,8 +1,8 @@
 ### What is a Controller?
 
-A [Controller](https://api.emberjs.com/ember/3.10/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.3/classes/Route/methods?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/3.10/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.10/classes/Route/methods/model?anchor=model) method.
 
-The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
+The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.10/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 
 A Controller is usually paired with an individual Route of the same name.
 

--- a/guides/v3.10.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.10.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/3.10/classes/Component/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.10/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.10.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.10.0/models/creating-updating-and-deleting-records.md
@@ -148,7 +148,7 @@ post.save().then(transitionToPost).catch(failure);
 Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/3.10/classes/DS.Model/methods/deleteRecord?anchor=deleteRecord)
 on any instance of `DS.Model`. This flags the record as `isDeleted`. The
 deletion can then be persisted using `save()`.  Alternatively, you can use
-the [`destroyRecord`](https://api.emberjs.com/ember-data/3.10/classes/DS.Model/methods/deleteRecord?anchor=destroyRecord) method to delete and persist at the same time.
+the [`destroyRecord`](https://api.emberjs.com/ember-data/3.10/classes/DS.Model/methods/destroyRecord?anchor=destroyRecord) method to delete and persist at the same time.
 
 ```javascript
 store.findRecord('post', 1, { backgroundReload: false }).then(function(post) {

--- a/guides/v3.10.0/models/customizing-serializers.md
+++ b/guides/v3.10.0/models/customizing-serializers.md
@@ -198,7 +198,7 @@ export default DS.JSONAPISerializer.extend({
 
 Similarly, if your backend store provides data in a format other than JSON:API,
 you can use the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.10/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.10/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -252,7 +252,7 @@ export default DS.JSONAPISerializer.extend({
 ```
 
 To normalize only a single model, you can use the
-[`normalize()`](https://api.emberjs.com/ember-data/3.10/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalize)
+[`normalize()`](https://api.emberjs.com/ember-data/3.10/classes/DS.JSONAPISerializer/methods/normalize?anchor=normalize)
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
@@ -421,7 +421,7 @@ The JSON should encode the relationship as an ID to another record:
 ```
 If needed these naming conventions can be overwritten by implementing
 the
-[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.10/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForRelationship)
+[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.10/classes/DS.JSONAPISerializer/methods/keyForRelationship?anchor=keyForRelationship)
 method.
 
 ```javascript {data-filename=app/serializers/application.js}
@@ -759,7 +759,7 @@ the possible values of: `'findRecord'`, `'queryRecord'`, `'findAll'`,
 `'createRecord'`, `'deleteRecord'`, and `'updateRecord'`) as arguments.
 
 A custom serializer will also need to define a
-[normalize](https://api.emberjs.com/data/classes/DS.Serializer.html#method_normalize)
+[normalize](https://api.emberjs.com/ember-data/3.10/classes/DS.Serializer/methods/normalize?anchor=normalize)
 method.
 This method is called by `store.normalize(type, payload)` and is often
 used for normalizing requests made outside of Ember Data because they

--- a/guides/v3.10.0/models/finding-records.md
+++ b/guides/v3.10.0/models/finding-records.md
@@ -67,7 +67,7 @@ this.store.query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.10/classes/DS.Store/methods/queryRecord?anchor=queryRecord)that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.10/classes/DS.Store/methods/queryRecord?anchor=queryRecord) that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:

--- a/guides/v3.10.0/models/finding-records.md
+++ b/guides/v3.10.0/models/finding-records.md
@@ -13,7 +13,7 @@ this.store.findRecord('blog-post', 1)  // => GET /blog-posts/1
   });
 ```
 
-Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.10/classes/DS.Store/methods/findRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
+Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.10/classes/DS.Store/methods/peekRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
@@ -32,7 +32,7 @@ this.store.findAll('blog-post') // => GET /blog-posts
   });
 ```
 
-Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.10/classes/DS.Store/methods/findAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
+Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.10/classes/DS.Store/methods/peekAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
 
 ```javascript
 let blogPosts = this.store.peekAll('blog-post'); // => no network request
@@ -67,7 +67,7 @@ this.store.query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.10/classes/DS.Store/methods/query?anchor=queryRecord)that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.10/classes/DS.Store/methods/queryRecord?anchor=queryRecord)that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:
@@ -95,7 +95,7 @@ export default DS.Adapter.extend({
 });
 ```
 
-then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.10/classes/DS.Store/methods/query?anchor=queryRecord) will retrieve that object from the server:
+then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.10/classes/DS.Store/methods/queryRecord?anchor=queryRecord) will retrieve that object from the server:
 
 ```javascript
 store.queryRecord('user', {}).then(function(user) {

--- a/guides/v3.10.0/models/pushing-records-into-the-store.md
+++ b/guides/v3.10.0/models/pushing-records-into-the-store.md
@@ -78,7 +78,7 @@ the casing of the properties defined on the Model class.
 
 If you would like the data to be normalized by the model's default
 serializer before pushing it into the store, you can use the
-[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.10/classes/DS.Store/methods/push?anchor=pushPayload) method.
+[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.10/classes/DS.Store/methods/pushPayload?anchor=pushPayload) method.
 
 ```javascript {data-filename=app/serializers/album.js}
 import DS from 'ember-data';

--- a/guides/v3.10.0/object-model/classes-and-instances.md
+++ b/guides/v3.10.0/object-model/classes-and-instances.md
@@ -218,7 +218,7 @@ Person.create({
 
 When reading a property value of an object, you can in most cases use the common JavaScript dot notation, e.g. `myObject.myProperty`.
 
-[Ember proxy objects](https://api.emberjs.com/ember/3.3/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/3.10/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
+[Ember proxy objects](https://api.emberjs.com/ember/3.10/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/3.10/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
 
 Let's look at the following `blogPost` Ember Data model:
 

--- a/guides/v3.10.0/templates/input-helpers.md
+++ b/guides/v3.10.0/templates/input-helpers.md
@@ -93,7 +93,7 @@ Checkboxes support the following properties:
 Which can be bound or set as described in the previous section.
 
 
-Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.10/classes/Component), you will always need to define the event name in camelCase format:
+Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.10/classes/Component#event-handler-methods), you will always need to define the event name in camelCase format:
 
 ```handlebars
 <Input @type="checkbox" @keypress={{action "updateName"}} />

--- a/guides/v3.10.0/tutorial/service.md
+++ b/guides/v3.10.0/tutorial/service.md
@@ -444,7 +444,7 @@ module('Acceptance | list rentals', function(hooks) {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection/#toc_factory-registrations) using the [owner](https://api.emberjs.com/ember/3.0/functions/@ember%2Fapplication/getOwner) object given by the test context. When our component loads the maps service, it gets our stub service instead.
+Then we are putting it in Ember's [registry](../../applications/dependency-injection/#toc_factory-registrations) using the [owner](https://api.emberjs.com/ember/3.10/functions/@ember%2Fapplication/getOwner) object given by the test context. When our component loads the maps service, it gets our stub service instead.
 That way every time that component is created, our stub map service gets injected over the map-element service.
 Now when we run our application tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v3.10.0/tutorial/simple-component.md
+++ b/guides/v3.10.0/tutorial/simple-component.md
@@ -95,7 +95,7 @@ with our new `RentalListing` component:
     <div class="cta-note-body">
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
-In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
+In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.10/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">

--- a/guides/v3.11.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.11.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/3.11/classes/Component/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.11/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.11.0/models/finding-records.md
+++ b/guides/v3.11.0/models/finding-records.md
@@ -67,7 +67,7 @@ this.store.query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.11/classes/Store/methods/queryRecord?anchor=queryRecord)that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.11/classes/Store/methods/queryRecord?anchor=queryRecord) that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:

--- a/guides/v3.11.0/templates/input-helpers.md
+++ b/guides/v3.11.0/templates/input-helpers.md
@@ -93,7 +93,7 @@ Checkboxes support the following properties:
 Which can be bound or set as described in the previous section.
 
 
-Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.11/classes/Component), you will always need to define the event name in camelCase format:
+Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.11/classes/Component#event-handler-methods), you will always need to define the event name in camelCase format:
 
 ```handlebars
 <Input @type="checkbox" @keypress={{action "updateName"}} />

--- a/guides/v3.12.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.12.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/3.12/classes/Component/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.12/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.13.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.13.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/3.13/classes/Component/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.13/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.14.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.14.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/3.14/classes/Component/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.14/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.8.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.8.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/3.8/classes/Component/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.8/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.8.0/templates/input-helpers.md
+++ b/guides/v3.8.0/templates/input-helpers.md
@@ -88,7 +88,7 @@ Checkboxes support the following properties:
 Which can be bound or set as described in the previous section.
 
 
-Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.8/classes/Component), you will always need to define the event name in camelCase format:
+Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.8/classes/Component#event-names), you will always need to define the event name in camelCase format:
 
 ```handlebars
 {{input type="checkbox" keyPress=(action "updateName")}}

--- a/guides/v3.9.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.9.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/3.9/classes/Component/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.9/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.9.0/templates/input-helpers.md
+++ b/guides/v3.9.0/templates/input-helpers.md
@@ -88,7 +88,7 @@ Checkboxes support the following properties:
 Which can be bound or set as described in the previous section.
 
 
-Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.9/classes/Component), you will always need to define the event name in camelCase format:
+Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.9/classes/Component#event-names), you will always need to define the event name in camelCase format:
 
 ```handlebars
 {{input type="checkbox" keyPress=(action "updateName")}}


### PR DESCRIPTION
## Description

This PR addresses https://github.com/ember-learn/guides-source/issues/1440 for Ember `v3.10.0`. After performing Find All and Replace, I ran `npm run test:node-local` to do a quick check that visiting a URL doesn't error.

Because relatively few links changed, I was able to manually visit each to ensure that we redirected the user to the correct page.


## How to review

I recommend reviewing commits one by one.


## TODO

- [x] Use Find All and Replace to update API links.
- [x] ~Manually check each URL to ensure that we redirect a user to the correct API section.~ (skipped due to backport in #1512)
- [x] Run `npm run test:node-local` to check external links in `v3.10.0`.


## Notes

```
# Use regexes for Find All and Replace
Find:    https://api.emberjs.com/ember/release/
Replace: https://api.emberjs.com/ember/3.10/

Find:    https://api.emberjs.com/ember/\d{1}.\d{1,2}/
Replace: https://api.emberjs.com/ember/3.10/

Find:    https://api.emberjs.com/ember-data/release/
Replace: https://api.emberjs.com/ember-data/3.10/

Find:    https://api.emberjs.com/ember-data/\d{1}.\d{1,2}/
Replace: https://api.emberjs.com/ember-data/3.10/
```