### PR TITLE
Updated API links in guides/3.7.0

### DIFF
--- a/guides/v3.0.0/applications/services.md
+++ b/guides/v3.0.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.0/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.0/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.0/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.0/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.0.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.0.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using `Ember.on()`:
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.0/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.0.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.0.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.get('store').findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/classes/Ember.Object.html#method_incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.0/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!
@@ -148,7 +148,7 @@ post.save().then(transitionToPost).catch(failure);
 Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/methods/deleteRecord?anchor=deleteRecord)
 on any instance of `DS.Model`. This flags the record as `isDeleted`. The
 deletion can then be persisted using `save()`.  Alternatively, you can use
-the [`destroyRecord`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/methods/deleteRecord?anchor=destroyRecord) method to delete and persist at the same time.
+the [`destroyRecord`](https://api.emberjs.com/ember-data/3.0/classes/DS.Model/methods/destroyRecord?anchor=destroyRecord) method to delete and persist at the same time.
 
 ```javascript
 store.findRecord('post', 1, { backgroundReload: false }).then(function(post) {
@@ -163,4 +163,4 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 });
 ```
 
-The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/findRecord?anchor=findRecord) automatically schedules a fetch of the record from the adapter.
+The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Store/methods/findRecord?anchor=findRecord) automatically schedules a fetch of the record from the adapter.

--- a/guides/v3.0.0/models/customizing-adapters.md
+++ b/guides/v3.0.0/models/customizing-adapters.md
@@ -235,7 +235,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile&show=inherited%2Cprotected%2Cprivate%2Cdeprecated)
+[volatile](https://api.emberjs.com/ember/3.0/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.0.0/models/customizing-serializers.md
+++ b/guides/v3.0.0/models/customizing-serializers.md
@@ -198,7 +198,7 @@ export default DS.JSONAPISerializer.extend({
 
 Similarly, if your backend store provides data in a format other than JSON API,
 you can use the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.0/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.0/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -252,7 +252,7 @@ export default DS.JSONAPISerializer.extend({
 ```
 
 To normalize only a single model, you can use the
-[`normalize()`](https://api.emberjs.com/ember-data/3.0/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalize)
+[`normalize()`](https://api.emberjs.com/ember-data/3.0/classes/DS.JSONAPISerializer/methods/normalize?anchor=normalize)
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
@@ -421,7 +421,7 @@ The JSON should encode the relationship as an ID to another record:
 ```
 If needed these naming conventions can be overwritten by implementing
 the
-[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.0/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForRelationship)
+[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.0/classes/DS.JSONAPISerializer/methods/keyForRelationship?anchor=keyForRelationship)
 method.
 
 ```javascript {data-filename=app/serializers/application.js}
@@ -764,7 +764,7 @@ the possible values of: `'findRecord'`, `'queryRecord'`, `'findAll'`,
 `'createRecord'`, `'deleteRecord'`, and `'updateRecord'`) as arguments.
 
 A custom serializer will also need to define a
-[normalize](https://api.emberjs.com/data/classes/DS.Serializer.html#method_normalize)
+[normalize](https://api.emberjs.com/ember-data/3.0/classes/DS.Serializer/methods/normalize?anchor=normalize)
 method.
 This method is called by `store.normalize(type, payload)` and is often
 used for normalizing requests made outside of Ember Data because they

--- a/guides/v3.0.0/models/finding-records.md
+++ b/guides/v3.0.0/models/finding-records.md
@@ -9,7 +9,7 @@ This will return a promise that fulfills with the requested record:
 let blogPost = this.get('store').findRecord('blog-post', 1); // => GET /blog-posts/1
 ```
 
-Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/findRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
+Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/peekRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
@@ -24,7 +24,7 @@ Use [`store.findAll()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store
 let blogPosts = this.get('store').findAll('blog-post'); // => GET /blog-posts
 ```
 
-Use [`store.peekAll()`](https://api.emberjs.com/data/classes/DS.Store.html#method_peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
+Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Store/methods/peekAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
 
 ```javascript
 let blogPosts = this.get('store').peekAll('blog-post'); // => no network request
@@ -59,7 +59,7 @@ this.get('store').query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/query?anchor=queryRecord)that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Store/methods/queryRecord?anchor=queryRecord) that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:
@@ -87,7 +87,7 @@ export default DS.Adapter.extend({
 });
 ```
 
-then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/query?anchor=queryRecord) will retrieve that object from the server:
+then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Store/methods/queryRecord?anchor=queryRecord) will retrieve that object from the server:
 
 ```javascript
 store.queryRecord('user', {}).then(function(user) {

--- a/guides/v3.0.0/models/pushing-records-into-the-store.md
+++ b/guides/v3.0.0/models/pushing-records-into-the-store.md
@@ -78,7 +78,7 @@ the casing of the properties defined on the Model class.
 
 If you would like the data to be normalized by the model's default
 serializer before pushing it into the store, you can use the
-[`store.pushPayload()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/push?anchor=pushPayload) method.
+[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Store/methods/pushPayload?anchor=pushPayload) method.
 
 ```javascript {data-filename=app/serializers/album.js}
 import DS from 'ember-data';

--- a/guides/v3.0.0/object-model/bindings.md
+++ b/guides/v3.0.0/object-model/bindings.md
@@ -3,7 +3,7 @@ bindings in Ember.js can be used with any object. That said, bindings are most
 often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.0/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.0/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -37,7 +37,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.0/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.0/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.0.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.0.0/object-model/computed-properties-and-aggregate-data.md
@@ -45,7 +45,7 @@ you would declare the dependency with braces: `todos.@each.{priority,title}`
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.0/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.0.0/object-model/observers.md
+++ b/guides/v3.0.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/classes/Ember.html#method_on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.0/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.0.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.0.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/classes/Ember.Object.html#method_reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.0/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/classes/Ember.Object.html#method_reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.0/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.0.0/routing/redirection.md
+++ b/guides/v3.0.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/2.16/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [link-to](../../templates/links/) helper.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.0.0/templates/conditionals.md
+++ b/guides/v3.0.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.0.0/templates/development-helpers.md
+++ b/guides/v3.0.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.0.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.0.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.0.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.0.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.0.0/templates/input-helpers.md
+++ b/guides/v3.0.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`{{input}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`{{textarea}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`{{input}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/input?anchor=input)
+and [`{{textarea}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea)
 helpers in Ember.js are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -51,12 +51,12 @@ To dispatch an action on specific events, such as `enter` or `key-press`, use th
 {{input value=firstName key-press="updateFirstName"}}
 ```
 
-[Event Names](https://api.emberjs.com/ember/3.0/classes/Component) must be dasherized.
+[Event Names](https://api.emberjs.com/ember/3.0/classes/Component#event-names) must be dasherized.
 
 ## Checkboxes
 
 You can also use the
-[`{{input}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`{{input}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/input?anchor=input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars

--- a/guides/v3.0.0/templates/links.md
+++ b/guides/v3.0.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `{{link-to}}` Component
 
 You create a link to a route using the
-[`{{link-to}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`{{link-to}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -118,7 +118,7 @@ For more information on how to use query parameters see the [query parameters](.
 ### Using link-to as an inline component
 
 In addition to being used as a block expression, the
-[`link-to`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component can also be used in inline form by specifying the link text as the first
 argument to the component:
 
@@ -151,7 +151,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`link-to`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.0.0/templates/writing-helpers.md
+++ b/guides/v3.0.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/classes/Ember.Helper.html#method_helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.0/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -249,7 +249,7 @@ although this is usually unnecessary and error-prone.
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.0/classes/Helper). Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.0/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.0/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -330,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
+[`htmlSafe`](https://api.emberjs.com/ember/3.0/functions/@ember%2Ftemplate/htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -344,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://api.emberjs.com/ember/3.0/functions/@ember%2Ftemplate/htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently

--- a/guides/v3.0.0/testing/testing-models.md
+++ b/guides/v3.0.0/testing/testing-models.md
@@ -102,5 +102,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/packages/-ember-data/tests) for examples of deeper relationship testing if you
 feel the need to do it._

--- a/guides/v3.0.0/tutorial/model-hook.md
+++ b/guides/v3.0.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.0/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.0/classes/Route/methods/model?anchor=model).
 The `model` function acts as a **hook**, meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.0.0/tutorial/routes-and-templates.md
+++ b/guides/v3.0.0/tutorial/routes-and-templates.md
@@ -228,7 +228,7 @@ The [`beforeModel`](https://api.emberjs.com/ember/2.16/classes/Route/methods/bef
 hook gets executed before the data gets fetched from the model hook, and before the page is rendered.
 See [the next section](../model-hook/) for an explanation of the model hook.
 
-In our index route handler, we'll call the [`replaceWith`](https://api.emberjs.com/ember/2.16/classes/Route/methods/beforeModel?anchor=replaceWith) function.
+In our index route handler, we'll call the [`replaceWith`](https://api.emberjs.com/ember/3.0/classes/Route/methods/replaceWith?anchor=replaceWith) function.
 The `replaceWith` function is similar to the route's [`transitionTo()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/transitionTo?anchor=transitionTo) function,
 the difference being that `replaceWith` will replace the current URL in the browser's history,
 while `transitionTo` will add to the history.

--- a/guides/v3.0.0/tutorial/subroutes.md
+++ b/guides/v3.0.0/tutorial/subroutes.md
@@ -339,7 +339,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `rental-listing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/2.16/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/2.16/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Clicking on the title will load the detail page for that rental.

--- a/guides/v3.1.0/applications/services.md
+++ b/guides/v3.1.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.1/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.1/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.1/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.1/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.1.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.1.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.1/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.1.0/getting-started/core-concepts.md
+++ b/guides/v3.1.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.1/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.1/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.1/classes/Component/methods/willRender?anchor=willRender) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.1/classes/Route/methods/model?anchor=model) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.1/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.1/classes/Component/methods/didRender?anchor=didRender) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.1.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.1.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.get('store').findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.1/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!
@@ -148,7 +148,7 @@ post.save().then(transitionToPost).catch(failure);
 Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/3.1/classes/DS.Model/methods/deleteRecord?anchor=deleteRecord)
 on any instance of `DS.Model`. This flags the record as `isDeleted`. The
 deletion can then be persisted using `save()`.  Alternatively, you can use
-the [`destroyRecord`](https://api.emberjs.com/ember-data/3.1/classes/DS.Model/methods/deleteRecord?anchor=destroyRecord) method to delete and persist at the same time.
+the [`destroyRecord`](https://api.emberjs.com/ember-data/3.1/classes/DS.Model/methods/destroyRecord?anchor=destroyRecord) method to delete and persist at the same time.
 
 ```javascript
 store.findRecord('post', 1, { backgroundReload: false }).then(function(post) {

--- a/guides/v3.1.0/models/customizing-adapters.md
+++ b/guides/v3.1.0/models/customizing-adapters.md
@@ -246,7 +246,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.1/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.1/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.1.0/models/customizing-serializers.md
+++ b/guides/v3.1.0/models/customizing-serializers.md
@@ -198,7 +198,7 @@ export default DS.JSONAPISerializer.extend({
 
 Similarly, if your backend store provides data in a format other than JSON API,
 you can use the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.1/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.1/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -252,7 +252,7 @@ export default DS.JSONAPISerializer.extend({
 ```
 
 To normalize only a single model, you can use the
-[`normalize()`](https://api.emberjs.com/ember-data/3.1/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalize)
+[`normalize()`](https://api.emberjs.com/ember-data/3.1/classes/DS.JSONAPISerializer/methods/normalize?anchor=normalize)
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
@@ -421,7 +421,7 @@ The JSON should encode the relationship as an ID to another record:
 ```
 If needed these naming conventions can be overwritten by implementing
 the
-[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.1/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForRelationship)
+[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.1/classes/DS.JSONAPISerializer/methods/keyForRelationship?anchor=keyForRelationship)
 method.
 
 ```javascript {data-filename=app/serializers/application.js}
@@ -759,7 +759,7 @@ the possible values of: `'findRecord'`, `'queryRecord'`, `'findAll'`,
 `'createRecord'`, `'deleteRecord'`, and `'updateRecord'`) as arguments.
 
 A custom serializer will also need to define a
-[normalize](https://api.emberjs.com/data/classes/DS.Serializer.html#method_normalize)
+[normalize](https://api.emberjs.com/ember-data/3.1/classes/DS.Serializer/methods/normalize?anchor=normalize)
 method.
 This method is called by `store.normalize(type, payload)` and is often
 used for normalizing requests made outside of Ember Data because they

--- a/guides/v3.1.0/models/finding-records.md
+++ b/guides/v3.1.0/models/finding-records.md
@@ -9,7 +9,7 @@ This will return a promise that fulfills with the requested record:
 let blogPost = this.get('store').findRecord('blog-post', 1); // => GET /blog-posts/1
 ```
 
-Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.1/classes/DS.Store/methods/findRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
+Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.1/classes/DS.Store/methods/peekRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
@@ -24,7 +24,7 @@ Use [`store.findAll()`](https://api.emberjs.com/ember-data/3.1/classes/DS.Store/
 let blogPosts = this.get('store').findAll('blog-post'); // => GET /blog-posts
 ```
 
-Use [`store.peekAll()`](https://api.emberjs.com/data/classes/DS.Store.html#method_peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
+Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.1/classes/DS.Store/methods/peekAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
 
 ```javascript
 let blogPosts = this.get('store').peekAll('blog-post'); // => no network request
@@ -59,7 +59,7 @@ this.get('store').query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.1/classes/DS.Store/methods/query?anchor=queryRecord)that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.1/classes/DS.Store/methods/queryRecord?anchor=queryRecord) that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:
@@ -87,7 +87,7 @@ export default DS.Adapter.extend({
 });
 ```
 
-then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.1/classes/DS.Store/methods/query?anchor=queryRecord) will retrieve that object from the server:
+then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.1/classes/DS.Store/methods/queryRecord?anchor=queryRecord) will retrieve that object from the server:
 
 ```javascript
 store.queryRecord('user', {}).then(function(user) {

--- a/guides/v3.1.0/models/pushing-records-into-the-store.md
+++ b/guides/v3.1.0/models/pushing-records-into-the-store.md
@@ -78,7 +78,7 @@ the casing of the properties defined on the Model class.
 
 If you would like the data to be normalized by the model's default
 serializer before pushing it into the store, you can use the
-[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.1/classes/DS.Store/methods/push?anchor=pushPayload) method.
+[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.1/classes/DS.Store/methods/pushPayload?anchor=pushPayload) method.
 
 ```javascript {data-filename=app/serializers/album.js}
 import DS from 'ember-data';

--- a/guides/v3.1.0/object-model/bindings.md
+++ b/guides/v3.1.0/object-model/bindings.md
@@ -4,7 +4,7 @@ often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.
 
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.1/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.1/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -38,7 +38,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.1/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.1/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.1.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.1.0/object-model/computed-properties-and-aggregate-data.md
@@ -105,7 +105,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.1/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.1/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.1.0/object-model/observers.md
+++ b/guides/v3.1.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.1/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.1.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.1.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.1/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.1/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.1.0/routing/redirection.md
+++ b/guides/v3.1.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/3.1/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [link-to](../../templates/links/) helper.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.1/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.1/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.1/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.1/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.1/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.1/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.1/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.1/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.1.0/templates/conditionals.md
+++ b/guides/v3.1.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.1.0/templates/development-helpers.md
+++ b/guides/v3.1.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.1.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.1.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.1.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.1.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.1.0/templates/input-helpers.md
+++ b/guides/v3.1.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`{{input}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`{{textarea}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`{{input}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/input?anchor=input)
+and [`{{textarea}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea)
 helpers in Ember.js are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -51,12 +51,12 @@ To dispatch an action on specific events, such as `enter` or `key-press`, use th
 {{input value=firstName key-press="updateFirstName"}}
 ```
 
-[Event Names](https://api.emberjs.com/ember/3.1/classes/Component) must be dasherized.
+[Event Names](https://api.emberjs.com/ember/3.1/classes/Component#event-names) must be dasherized.
 
 ## Checkboxes
 
 You can also use the
-[`{{input}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`{{input}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/input?anchor=input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars

--- a/guides/v3.1.0/templates/links.md
+++ b/guides/v3.1.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `{{link-to}}` Component
 
 You create a link to a route using the
-[`{{link-to}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`{{link-to}}`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -118,7 +118,7 @@ For more information on how to use query parameters see the [query parameters](.
 ### Using link-to as an inline component
 
 In addition to being used as a block expression, the
-[`link-to`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component can also be used in inline form by specifying the link text as the first
 argument to the component:
 
@@ -151,7 +151,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`link-to`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.1/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.1.0/templates/writing-helpers.md
+++ b/guides/v3.1.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.1/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -249,7 +249,7 @@ although this is usually unnecessary and error-prone.
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.1/classes/Helper). Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.1/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.1/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -330,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
+[`htmlSafe`](https://api.emberjs.com/ember/3.1/functions/@ember%2Ftemplate/htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -344,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://api.emberjs.com/ember/3.1/functions/@ember%2Ftemplate/htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently

--- a/guides/v3.1.0/testing/testing-models.md
+++ b/guides/v3.1.0/testing/testing-models.md
@@ -104,5 +104,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/packages/-ember-data/tests) for examples of deeper relationship testing if you
 feel the need to do it.

--- a/guides/v3.1.0/tutorial/model-hook.md
+++ b/guides/v3.1.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.1/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.1/classes/Route/methods/model?anchor=model).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.1.0/tutorial/routes-and-templates.md
+++ b/guides/v3.1.0/tutorial/routes-and-templates.md
@@ -228,7 +228,7 @@ The [`beforeModel`](https://api.emberjs.com/ember/3.1/classes/Route/methods/befo
 hook gets executed before the data gets fetched from the model hook, and before the page is rendered.
 See [the next section](../model-hook/) for an explanation of the model hook.
 
-In our index route handler, we'll call the [`replaceWith`](https://api.emberjs.com/ember/3.1/classes/Route/methods/beforeModel?anchor=replaceWith) function.
+In our index route handler, we'll call the [`replaceWith`](https://api.emberjs.com/ember/3.1/classes/Route/methods/replaceWith?anchor=replaceWith) function.
 The `replaceWith` function is similar to the route's [`transitionTo()`](https://api.emberjs.com/ember/3.1/classes/Route/methods/transitionTo?anchor=transitionTo) function,
 the difference being that `replaceWith` will replace the current URL in the browser's history,
 while `transitionTo` will add to the history.

--- a/guides/v3.1.0/tutorial/subroutes.md
+++ b/guides/v3.1.0/tutorial/subroutes.md
@@ -339,7 +339,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `rental-listing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.1/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.1/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.

--- a/guides/v3.2.0/applications/services.md
+++ b/guides/v3.2.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.2/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.2/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.2/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.2/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.2.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.2.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.2/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.2.0/getting-started/core-concepts.md
+++ b/guides/v3.2.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.2/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.2/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.2/classes/Component/methods/willRender?anchor=willRender) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.2/classes/Route/methods/model?anchor=model) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.2/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.2/classes/Component/methods/didRender?anchor=didRender) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.2.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.2.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.2/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!
@@ -148,7 +148,7 @@ post.save().then(transitionToPost).catch(failure);
 Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/3.2/classes/DS.Model/methods/deleteRecord?anchor=deleteRecord)
 on any instance of `DS.Model`. This flags the record as `isDeleted`. The
 deletion can then be persisted using `save()`.  Alternatively, you can use
-the [`destroyRecord`](https://api.emberjs.com/ember-data/3.2/classes/DS.Model/methods/deleteRecord?anchor=destroyRecord) method to delete and persist at the same time.
+the [`destroyRecord`](https://api.emberjs.com/ember-data/3.2/classes/DS.Model/methods/destroyRecord?anchor=destroyRecord) method to delete and persist at the same time.
 
 ```javascript
 store.findRecord('post', 1, { backgroundReload: false }).then(function(post) {

--- a/guides/v3.2.0/models/customizing-adapters.md
+++ b/guides/v3.2.0/models/customizing-adapters.md
@@ -246,7 +246,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.2/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.2/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.2.0/models/customizing-serializers.md
+++ b/guides/v3.2.0/models/customizing-serializers.md
@@ -198,7 +198,7 @@ export default DS.JSONAPISerializer.extend({
 
 Similarly, if your backend store provides data in a format other than JSON API,
 you can use the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.2/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.2/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -252,7 +252,7 @@ export default DS.JSONAPISerializer.extend({
 ```
 
 To normalize only a single model, you can use the
-[`normalize()`](https://api.emberjs.com/ember-data/3.2/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalize)
+[`normalize()`](https://api.emberjs.com/ember-data/3.2/classes/DS.JSONAPISerializer/methods/normalize?anchor=normalize)
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
@@ -421,7 +421,7 @@ The JSON should encode the relationship as an ID to another record:
 ```
 If needed these naming conventions can be overwritten by implementing
 the
-[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.2/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForRelationship)
+[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.2/classes/DS.JSONAPISerializer/methods/keyForRelationship?anchor=keyForRelationship)
 method.
 
 ```javascript {data-filename=app/serializers/application.js}
@@ -759,7 +759,7 @@ the possible values of: `'findRecord'`, `'queryRecord'`, `'findAll'`,
 `'createRecord'`, `'deleteRecord'`, and `'updateRecord'`) as arguments.
 
 A custom serializer will also need to define a
-[normalize](https://api.emberjs.com/data/classes/DS.Serializer.html#method_normalize)
+[normalize](https://api.emberjs.com/ember-data/3.2/classes/DS.Serializer/methods/normalize?anchor=normalize)
 method.
 This method is called by `store.normalize(type, payload)` and is often
 used for normalizing requests made outside of Ember Data because they

--- a/guides/v3.2.0/models/finding-records.md
+++ b/guides/v3.2.0/models/finding-records.md
@@ -9,7 +9,7 @@ This will return a promise that fulfills with the requested record:
 let blogPost = this.store.findRecord('blog-post', 1); // => GET /blog-posts/1
 ```
 
-Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.2/classes/DS.Store/methods/findRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
+Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.2/classes/DS.Store/methods/peekRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
@@ -24,7 +24,7 @@ Use [`store.findAll()`](https://api.emberjs.com/ember-data/3.2/classes/DS.Store/
 let blogPosts = this.store.findAll('blog-post'); // => GET /blog-posts
 ```
 
-Use [`store.peekAll()`](https://api.emberjs.com/data/classes/DS.Store.html#method_peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
+Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.2/classes/DS.Store/methods/peekAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
 
 ```javascript
 let blogPosts = this.store.peekAll('blog-post'); // => no network request
@@ -59,7 +59,7 @@ this.store.query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.2/classes/DS.Store/methods/query?anchor=queryRecord)that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.2/classes/DS.Store/methods/queryRecord?anchor=queryRecord) that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:
@@ -87,7 +87,7 @@ export default DS.Adapter.extend({
 });
 ```
 
-then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.2/classes/DS.Store/methods/query?anchor=queryRecord) will retrieve that object from the server:
+then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.2/classes/DS.Store/methods/queryRecord?anchor=queryRecord) will retrieve that object from the server:
 
 ```javascript
 store.queryRecord('user', {}).then(function(user) {

--- a/guides/v3.2.0/models/pushing-records-into-the-store.md
+++ b/guides/v3.2.0/models/pushing-records-into-the-store.md
@@ -78,7 +78,7 @@ the casing of the properties defined on the Model class.
 
 If you would like the data to be normalized by the model's default
 serializer before pushing it into the store, you can use the
-[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.2/classes/DS.Store/methods/push?anchor=pushPayload) method.
+[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.2/classes/DS.Store/methods/pushPayload?anchor=pushPayload) method.
 
 ```javascript {data-filename=app/serializers/album.js}
 import DS from 'ember-data';

--- a/guides/v3.2.0/object-model/bindings.md
+++ b/guides/v3.2.0/object-model/bindings.md
@@ -4,7 +4,7 @@ often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.
 
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.2/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.2/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -38,7 +38,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.2/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.2/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.2.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.2.0/object-model/computed-properties-and-aggregate-data.md
@@ -104,7 +104,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.2/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.2/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.2.0/object-model/observers.md
+++ b/guides/v3.2.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.2/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.2.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.2.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.2/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.2/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.2.0/routing/redirection.md
+++ b/guides/v3.2.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/3.2/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [link-to](../../templates/links/) helper.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.2/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.2/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.2/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.2/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.2/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.2/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.2/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.2/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.2.0/templates/conditionals.md
+++ b/guides/v3.2.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.2.0/templates/development-helpers.md
+++ b/guides/v3.2.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.2.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.2.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.2.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.2.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.2.0/templates/input-helpers.md
+++ b/guides/v3.2.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`{{input}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`{{textarea}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`{{input}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/input?anchor=input)
+and [`{{textarea}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea)
 helpers in Ember.js are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -51,12 +51,12 @@ To dispatch an action on specific events, such as `enter` or `key-press`, use th
 {{input value=firstName key-press="updateFirstName"}}
 ```
 
-[Event Names](https://api.emberjs.com/ember/3.2/classes/Component) must be dasherized.
+[Event Names](https://api.emberjs.com/ember/3.2/classes/Component#event-names) must be dasherized.
 
 ## Checkboxes
 
 You can also use the
-[`{{input}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`{{input}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/input?anchor=input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars

--- a/guides/v3.2.0/templates/links.md
+++ b/guides/v3.2.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `{{link-to}}` Component
 
 You create a link to a route using the
-[`{{link-to}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`{{link-to}}`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -118,7 +118,7 @@ For more information on how to use query parameters see the [query parameters](.
 ### Using link-to as an inline component
 
 In addition to being used as a block expression, the
-[`link-to`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component can also be used in inline form by specifying the link text as the first
 argument to the component:
 
@@ -151,7 +151,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`link-to`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.2/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.2.0/templates/writing-helpers.md
+++ b/guides/v3.2.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.2/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -249,7 +249,7 @@ although this is usually unnecessary and error-prone.
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.2/classes/Helper). Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.2/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.2/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -330,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
+[`htmlSafe`](https://api.emberjs.com/ember/3.2/functions/@ember%2Ftemplate/htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -344,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://api.emberjs.com/ember/3.2/functions/@ember%2Ftemplate/htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently

--- a/guides/v3.2.0/testing/testing-models.md
+++ b/guides/v3.2.0/testing/testing-models.md
@@ -104,5 +104,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/packages/-ember-data/tests) for examples of deeper relationship testing if you
 feel the need to do it._

--- a/guides/v3.2.0/tutorial/model-hook.md
+++ b/guides/v3.2.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.2/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.2/classes/Route/methods/model?anchor=model).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.2.0/tutorial/routes-and-templates.md
+++ b/guides/v3.2.0/tutorial/routes-and-templates.md
@@ -228,7 +228,7 @@ The [`beforeModel`](https://api.emberjs.com/ember/3.2/classes/Route/methods/befo
 hook gets executed before the data gets fetched from the model hook, and before the page is rendered.
 See [the next section](../model-hook/) for an explanation of the model hook.
 
-In our index route handler, we'll call the [`replaceWith`](https://api.emberjs.com/ember/3.2/classes/Route/methods/beforeModel?anchor=replaceWith) function.
+In our index route handler, we'll call the [`replaceWith`](https://api.emberjs.com/ember/3.2/classes/Route/methods/replaceWith?anchor=replaceWith) function.
 The `replaceWith` function is similar to the route's [`transitionTo()`](https://api.emberjs.com/ember/3.2/classes/Route/methods/transitionTo?anchor=transitionTo) function,
 the difference being that `replaceWith` will replace the current URL in the browser's history,
 while `transitionTo` will add to the history.

--- a/guides/v3.2.0/tutorial/subroutes.md
+++ b/guides/v3.2.0/tutorial/subroutes.md
@@ -339,7 +339,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `rental-listing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.2/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.2/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.

--- a/guides/v3.3.0/applications/services.md
+++ b/guides/v3.3.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.3/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.3/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.3/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.3/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.3.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.3.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.3/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.3.0/getting-started/core-concepts.md
+++ b/guides/v3.3.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.3/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.3/classes/Component/methods/willRender?anchor=willRender) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/model?anchor=model) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.3/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.3/classes/Component/methods/didRender?anchor=didRender) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.3.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.3.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.3/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!
@@ -148,7 +148,7 @@ post.save().then(transitionToPost).catch(failure);
 Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/3.3/classes/DS.Model/methods/deleteRecord?anchor=deleteRecord)
 on any instance of `DS.Model`. This flags the record as `isDeleted`. The
 deletion can then be persisted using `save()`.  Alternatively, you can use
-the [`destroyRecord`](https://api.emberjs.com/ember-data/3.3/classes/DS.Model/methods/deleteRecord?anchor=destroyRecord) method to delete and persist at the same time.
+the [`destroyRecord`](https://api.emberjs.com/ember-data/3.3/classes/DS.Model/methods/destroyRecord?anchor=destroyRecord) method to delete and persist at the same time.
 
 ```javascript
 store.findRecord('post', 1, { backgroundReload: false }).then(function(post) {

--- a/guides/v3.3.0/models/customizing-adapters.md
+++ b/guides/v3.3.0/models/customizing-adapters.md
@@ -246,7 +246,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.3/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.3/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.3.0/models/customizing-serializers.md
+++ b/guides/v3.3.0/models/customizing-serializers.md
@@ -198,7 +198,7 @@ export default DS.JSONAPISerializer.extend({
 
 Similarly, if your backend store provides data in a format other than JSON API,
 you can use the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.3/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.3/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -252,7 +252,7 @@ export default DS.JSONAPISerializer.extend({
 ```
 
 To normalize only a single model, you can use the
-[`normalize()`](https://api.emberjs.com/ember-data/3.3/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalize)
+[`normalize()`](https://api.emberjs.com/ember-data/3.3/classes/DS.JSONAPISerializer/methods/normalize?anchor=normalize)
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
@@ -421,7 +421,7 @@ The JSON should encode the relationship as an ID to another record:
 ```
 If needed these naming conventions can be overwritten by implementing
 the
-[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.3/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForRelationship)
+[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.3/classes/DS.JSONAPISerializer/methods/keyForRelationship?anchor=keyForRelationship)
 method.
 
 ```javascript {data-filename=app/serializers/application.js}
@@ -759,7 +759,7 @@ the possible values of: `'findRecord'`, `'queryRecord'`, `'findAll'`,
 `'createRecord'`, `'deleteRecord'`, and `'updateRecord'`) as arguments.
 
 A custom serializer will also need to define a
-[normalize](https://api.emberjs.com/data/classes/DS.Serializer.html#method_normalize)
+[normalize](https://api.emberjs.com/ember-data/3.3/classes/DS.Serializer/methods/normalize?anchor=normalize)
 method.
 This method is called by `store.normalize(type, payload)` and is often
 used for normalizing requests made outside of Ember Data because they

--- a/guides/v3.3.0/models/finding-records.md
+++ b/guides/v3.3.0/models/finding-records.md
@@ -13,7 +13,7 @@ this.store.findRecord('blog-post', 1)  // => GET /blog-posts/1
   });
 ```
 
-Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.3/classes/DS.Store/methods/findRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
+Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.3/classes/DS.Store/methods/peekRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
@@ -32,7 +32,7 @@ this.store.findAll('blog-post') // => GET /blog-posts
   });
 ```
 
-Use [`store.peekAll()`](https://api.emberjs.com/data/classes/DS.Store.html#method_peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
+Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.3/classes/DS.Store/methods/peekAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
 
 ```javascript
 let blogPosts = this.store.peekAll('blog-post'); // => no network request
@@ -67,7 +67,7 @@ this.store.query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.3/classes/DS.Store/methods/query?anchor=queryRecord)that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.3/classes/DS.Store/methods/queryRecord?anchor=queryRecord) that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:
@@ -95,7 +95,7 @@ export default DS.Adapter.extend({
 });
 ```
 
-then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.3/classes/DS.Store/methods/query?anchor=queryRecord) will retrieve that object from the server:
+then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.3/classes/DS.Store/methods/queryRecord?anchor=queryRecord) will retrieve that object from the server:
 
 ```javascript
 store.queryRecord('user', {}).then(function(user) {

--- a/guides/v3.3.0/models/pushing-records-into-the-store.md
+++ b/guides/v3.3.0/models/pushing-records-into-the-store.md
@@ -78,7 +78,7 @@ the casing of the properties defined on the Model class.
 
 If you would like the data to be normalized by the model's default
 serializer before pushing it into the store, you can use the
-[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.3/classes/DS.Store/methods/push?anchor=pushPayload) method.
+[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.3/classes/DS.Store/methods/pushPayload?anchor=pushPayload) method.
 
 ```javascript {data-filename=app/serializers/album.js}
 import DS from 'ember-data';

--- a/guides/v3.3.0/object-model/bindings.md
+++ b/guides/v3.3.0/object-model/bindings.md
@@ -4,7 +4,7 @@ often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.
 
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.3/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.3/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -38,7 +38,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.3/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.3/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.3.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.3.0/object-model/computed-properties-and-aggregate-data.md
@@ -104,7 +104,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.3/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.3/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.3.0/object-model/observers.md
+++ b/guides/v3.3.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.3/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.3.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.3.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.3/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.3/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.3.0/routing/redirection.md
+++ b/guides/v3.3.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/3.3/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [link-to](../../templates/links/) helper.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.3.0/templates/conditionals.md
+++ b/guides/v3.3.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.3.0/templates/development-helpers.md
+++ b/guides/v3.3.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.3.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.3.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.3.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.3.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.3.0/templates/input-helpers.md
+++ b/guides/v3.3.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`{{input}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`{{textarea}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`{{input}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/input?anchor=input)
+and [`{{textarea}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea)
 helpers in Ember.js are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -51,12 +51,12 @@ To dispatch an action on specific events, such as `enter` or `key-press`, use th
 {{input value=firstName key-press="updateFirstName"}}
 ```
 
-[Event Names](https://api.emberjs.com/ember/3.3/classes/Component) must be dasherized.
+[Event Names](https://api.emberjs.com/ember/3.3/classes/Component#event-names) must be dasherized.
 
 ## Checkboxes
 
 You can also use the
-[`{{input}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`{{input}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/input?anchor=input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars

--- a/guides/v3.3.0/templates/links.md
+++ b/guides/v3.3.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `{{link-to}}` Component
 
 You create a link to a route using the
-[`{{link-to}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`{{link-to}}`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -117,7 +117,7 @@ For more information on how to use query parameters see the [query parameters](.
 ### Using link-to as an inline component
 
 In addition to being used as a block expression, the
-[`link-to`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component can also be used in inline form by specifying the link text as the first
 argument to the component:
 
@@ -150,7 +150,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`link-to`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.3/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.3.0/templates/writing-helpers.md
+++ b/guides/v3.3.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.3/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -249,7 +249,7 @@ although this is usually unnecessary and error-prone.
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.3/classes/Helper). Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.3/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.3/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -330,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
+[`htmlSafe`](https://api.emberjs.com/ember/3.3/functions/@ember%2Ftemplate/htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -344,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://api.emberjs.com/ember/3.3/functions/@ember%2Ftemplate/htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently

--- a/guides/v3.3.0/testing/testing-models.md
+++ b/guides/v3.3.0/testing/testing-models.md
@@ -104,5 +104,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/packages/-ember-data/tests) for examples of deeper relationship testing if you
 feel the need to do it.

--- a/guides/v3.3.0/tutorial/model-hook.md
+++ b/guides/v3.3.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.3/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.3/classes/Route/methods/model?anchor=model).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.3.0/tutorial/routes-and-templates.md
+++ b/guides/v3.3.0/tutorial/routes-and-templates.md
@@ -228,7 +228,7 @@ The [`beforeModel`](https://api.emberjs.com/ember/3.3/classes/Route/methods/befo
 hook gets executed before the data gets fetched from the model hook, and before the page is rendered.
 See [the next section](../model-hook/) for an explanation of the model hook.
 
-In our index route handler, we'll call the [`replaceWith`](https://api.emberjs.com/ember/3.3/classes/Route/methods/beforeModel?anchor=replaceWith) function.
+In our index route handler, we'll call the [`replaceWith`](https://api.emberjs.com/ember/3.3/classes/Route/methods/replaceWith?anchor=replaceWith) function.
 The `replaceWith` function is similar to the route's [`transitionTo()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/transitionTo?anchor=transitionTo) function,
 the difference being that `replaceWith` will replace the current URL in the browser's history,
 while `transitionTo` will add to the history.

--- a/guides/v3.3.0/tutorial/subroutes.md
+++ b/guides/v3.3.0/tutorial/subroutes.md
@@ -339,7 +339,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `rental-listing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.3/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.3/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.

--- a/guides/v3.4.0/applications/services.md
+++ b/guides/v3.4.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.4/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.4/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.4/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.4/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.4.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.4.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.4/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.4.0/getting-started/core-concepts.md
+++ b/guides/v3.4.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.4/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.4/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.4/classes/Component/methods/willRender?anchor=willRender) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.4/classes/Route/methods/model?anchor=model) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.4/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.4/classes/Component/methods/didRender?anchor=didRender) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.4.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.4.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.4/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!
@@ -148,7 +148,7 @@ post.save().then(transitionToPost).catch(failure);
 Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/3.4/classes/DS.Model/methods/deleteRecord?anchor=deleteRecord)
 on any instance of `DS.Model`. This flags the record as `isDeleted`. The
 deletion can then be persisted using `save()`.  Alternatively, you can use
-the [`destroyRecord`](https://api.emberjs.com/ember-data/3.4/classes/DS.Model/methods/deleteRecord?anchor=destroyRecord) method to delete and persist at the same time.
+the [`destroyRecord`](https://api.emberjs.com/ember-data/3.4/classes/DS.Model/methods/destroyRecord?anchor=destroyRecord) method to delete and persist at the same time.
 
 ```javascript
 store.findRecord('post', 1, { backgroundReload: false }).then(function(post) {

--- a/guides/v3.4.0/models/customizing-adapters.md
+++ b/guides/v3.4.0/models/customizing-adapters.md
@@ -246,7 +246,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.4/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.4/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.4.0/models/customizing-serializers.md
+++ b/guides/v3.4.0/models/customizing-serializers.md
@@ -198,7 +198,7 @@ export default DS.JSONAPISerializer.extend({
 
 Similarly, if your backend store provides data in a format other than JSON API,
 you can use the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.4/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.4/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -252,7 +252,7 @@ export default DS.JSONAPISerializer.extend({
 ```
 
 To normalize only a single model, you can use the
-[`normalize()`](https://api.emberjs.com/ember-data/3.4/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalize)
+[`normalize()`](https://api.emberjs.com/ember-data/3.4/classes/DS.JSONAPISerializer/methods/normalize?anchor=normalize)
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
@@ -421,7 +421,7 @@ The JSON should encode the relationship as an ID to another record:
 ```
 If needed these naming conventions can be overwritten by implementing
 the
-[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.4/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForRelationship)
+[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.4/classes/DS.JSONAPISerializer/methods/keyForRelationship?anchor=keyForRelationship)
 method.
 
 ```javascript {data-filename=app/serializers/application.js}
@@ -759,7 +759,7 @@ the possible values of: `'findRecord'`, `'queryRecord'`, `'findAll'`,
 `'createRecord'`, `'deleteRecord'`, and `'updateRecord'`) as arguments.
 
 A custom serializer will also need to define a
-[normalize](https://api.emberjs.com/data/classes/DS.Serializer.html#method_normalize)
+[normalize](https://api.emberjs.com/ember-data/3.4/classes/DS.Serializer/methods/normalize?anchor=normalize)
 method.
 This method is called by `store.normalize(type, payload)` and is often
 used for normalizing requests made outside of Ember Data because they

--- a/guides/v3.4.0/models/finding-records.md
+++ b/guides/v3.4.0/models/finding-records.md
@@ -13,7 +13,7 @@ this.store.findRecord('blog-post', 1)  // => GET /blog-posts/1
   });
 ```
 
-Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.4/classes/DS.Store/methods/findRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
+Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.4/classes/DS.Store/methods/peekRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
@@ -32,7 +32,7 @@ this.store.findAll('blog-post') // => GET /blog-posts
   });
 ```
 
-Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.4/classes/DS.Store/methods/findAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
+Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.4/classes/DS.Store/methods/peekAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
 
 ```javascript
 let blogPosts = this.store.peekAll('blog-post'); // => no network request
@@ -67,7 +67,7 @@ this.store.query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.4/classes/DS.Store/methods/query?anchor=queryRecord)that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.4/classes/DS.Store/methods/queryRecord?anchor=queryRecord) that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:
@@ -95,7 +95,7 @@ export default DS.Adapter.extend({
 });
 ```
 
-then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.4/classes/DS.Store/methods/query?anchor=queryRecord) will retrieve that object from the server:
+then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.4/classes/DS.Store/methods/queryRecord?anchor=queryRecord) will retrieve that object from the server:
 
 ```javascript
 store.queryRecord('user', {}).then(function(user) {

--- a/guides/v3.4.0/models/pushing-records-into-the-store.md
+++ b/guides/v3.4.0/models/pushing-records-into-the-store.md
@@ -78,7 +78,7 @@ the casing of the properties defined on the Model class.
 
 If you would like the data to be normalized by the model's default
 serializer before pushing it into the store, you can use the
-[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.4/classes/DS.Store/methods/push?anchor=pushPayload) method.
+[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.4/classes/DS.Store/methods/pushPayload?anchor=pushPayload) method.
 
 ```javascript {data-filename=app/serializers/album.js}
 import DS from 'ember-data';

--- a/guides/v3.4.0/object-model/bindings.md
+++ b/guides/v3.4.0/object-model/bindings.md
@@ -4,7 +4,7 @@ often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.
 
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.4/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.4/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -38,7 +38,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.4/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.4/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.4.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.4.0/object-model/computed-properties-and-aggregate-data.md
@@ -104,7 +104,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.4/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.4/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.4.0/object-model/observers.md
+++ b/guides/v3.4.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.4/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.4.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.4.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.4/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.4/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.4.0/routing/redirection.md
+++ b/guides/v3.4.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/3.4/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [link-to](../../templates/links/) helper.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.4/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.4/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.4/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.4/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.4/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.4/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.4/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.4/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.4.0/templates/conditionals.md
+++ b/guides/v3.4.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.4.0/templates/development-helpers.md
+++ b/guides/v3.4.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.4.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.4.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.4.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.4.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.4.0/templates/input-helpers.md
+++ b/guides/v3.4.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`{{input}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`{{textarea}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`{{input}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/input?anchor=input)
+and [`{{textarea}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea)
 helpers in Ember.js are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -51,12 +51,12 @@ To dispatch an action on specific events, such as `enter` or `key-press`, use th
 {{input value=firstName key-press="updateFirstName"}}
 ```
 
-[Event Names](https://api.emberjs.com/ember/3.4/classes/Component) must be dasherized.
+[Event Names](https://api.emberjs.com/ember/3.4/classes/Component#event-names) must be dasherized.
 
 ## Checkboxes
 
 You can also use the
-[`{{input}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`{{input}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/input?anchor=input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars

--- a/guides/v3.4.0/templates/links.md
+++ b/guides/v3.4.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `{{link-to}}` Component
 
 You create a link to a route using the
-[`{{link-to}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`{{link-to}}`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -117,7 +117,7 @@ For more information on how to use query parameters see the [query parameters](.
 ### Using link-to as an inline component
 
 In addition to being used as a block expression, the
-[`link-to`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component can also be used in inline form by specifying the link text as the first
 argument to the component:
 
@@ -150,7 +150,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`link-to`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.4/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.4.0/templates/writing-helpers.md
+++ b/guides/v3.4.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.4/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -249,7 +249,7 @@ although this is usually unnecessary and error-prone.
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.4/classes/Helper). Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.4/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.4/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -330,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
+[`htmlSafe`](https://api.emberjs.com/ember/3.4/functions/@ember%2Ftemplate/htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -344,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://api.emberjs.com/ember/3.4/functions/@ember%2Ftemplate/htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently

--- a/guides/v3.4.0/testing/testing-models.md
+++ b/guides/v3.4.0/testing/testing-models.md
@@ -104,5 +104,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/packages/-ember-data/tests) for examples of deeper relationship testing if you
 feel the need to do it.

--- a/guides/v3.4.0/tutorial/model-hook.md
+++ b/guides/v3.4.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.4/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.4/classes/Route/methods/model?anchor=model).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.4.0/tutorial/routes-and-templates.md
+++ b/guides/v3.4.0/tutorial/routes-and-templates.md
@@ -228,7 +228,7 @@ The [`beforeModel`](https://api.emberjs.com/ember/3.4/classes/Route/methods/befo
 hook gets executed before the data gets fetched from the model hook, and before the page is rendered.
 See [the next section](../model-hook/) for an explanation of the model hook.
 
-In our index route handler, we'll call the [`replaceWith`](https://api.emberjs.com/ember/3.4/classes/Route/methods/beforeModel?anchor=replaceWith) function.
+In our index route handler, we'll call the [`replaceWith`](https://api.emberjs.com/ember/3.4/classes/Route/methods/replaceWith?anchor=replaceWith) function.
 The `replaceWith` function is similar to the route's [`transitionTo()`](https://api.emberjs.com/ember/3.4/classes/Route/methods/transitionTo?anchor=transitionTo) function,
 the difference being that `replaceWith` will replace the current URL in the browser's history,
 while `transitionTo` will add to the history.

--- a/guides/v3.4.0/tutorial/subroutes.md
+++ b/guides/v3.4.0/tutorial/subroutes.md
@@ -339,7 +339,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `rental-listing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.4/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.4/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.

--- a/guides/v3.5.0/applications/services.md
+++ b/guides/v3.5.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.5/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.5/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.5/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.5/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.5.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.5.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.5/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.5.0/getting-started/core-concepts.md
+++ b/guides/v3.5.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.5/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.5/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.5/classes/Component/methods/willRender?anchor=willRender) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.5/classes/Route/methods/model?anchor=model) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.5/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.5/classes/Component/methods/didRender?anchor=didRender) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.5.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.5.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.5/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!
@@ -148,7 +148,7 @@ post.save().then(transitionToPost).catch(failure);
 Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/3.5/classes/DS.Model/methods/deleteRecord?anchor=deleteRecord)
 on any instance of `DS.Model`. This flags the record as `isDeleted`. The
 deletion can then be persisted using `save()`.  Alternatively, you can use
-the [`destroyRecord`](https://api.emberjs.com/ember-data/3.5/classes/DS.Model/methods/deleteRecord?anchor=destroyRecord) method to delete and persist at the same time.
+the [`destroyRecord`](https://api.emberjs.com/ember-data/3.5/classes/DS.Model/methods/destroyRecord?anchor=destroyRecord) method to delete and persist at the same time.
 
 ```javascript
 store.findRecord('post', 1, { backgroundReload: false }).then(function(post) {
@@ -163,5 +163,4 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 });
 ```
 
-The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](<https://api.emberjs.com/ember-data/3.5/classes/DS.Store/methods/findRecord?anchor=findRecord>
-) automatically schedules a fetch of the record from the adapter.
+The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](https://api.emberjs.com/ember-data/3.5/classes/DS.Store/methods/findRecord?anchor=findRecord) automatically schedules a fetch of the record from the adapter.

--- a/guides/v3.5.0/models/customizing-adapters.md
+++ b/guides/v3.5.0/models/customizing-adapters.md
@@ -246,7 +246,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.5/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.5/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.5.0/models/customizing-serializers.md
+++ b/guides/v3.5.0/models/customizing-serializers.md
@@ -198,7 +198,7 @@ export default DS.JSONAPISerializer.extend({
 
 Similarly, if your backend store provides data in a format other than JSON API,
 you can use the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.5/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.5/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -252,7 +252,7 @@ export default DS.JSONAPISerializer.extend({
 ```
 
 To normalize only a single model, you can use the
-[`normalize()`](https://api.emberjs.com/ember-data/3.5/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalize)
+[`normalize()`](https://api.emberjs.com/ember-data/3.5/classes/DS.JSONAPISerializer/methods/normalize?anchor=normalize)
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
@@ -421,7 +421,7 @@ The JSON should encode the relationship as an ID to another record:
 ```
 If needed these naming conventions can be overwritten by implementing
 the
-[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.5/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForRelationship)
+[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.5/classes/DS.JSONAPISerializer/methods/keyForRelationship?anchor=keyForRelationship)
 method.
 
 ```javascript {data-filename=app/serializers/application.js}
@@ -759,7 +759,7 @@ the possible values of: `'findRecord'`, `'queryRecord'`, `'findAll'`,
 `'createRecord'`, `'deleteRecord'`, and `'updateRecord'`) as arguments.
 
 A custom serializer will also need to define a
-[normalize](https://api.emberjs.com/data/classes/DS.Serializer.html#method_normalize)
+[normalize](https://api.emberjs.com/ember-data/3.5/classes/DS.Serializer/methods/normalize?anchor=normalize)
 method.
 This method is called by `store.normalize(type, payload)` and is often
 used for normalizing requests made outside of Ember Data because they

--- a/guides/v3.5.0/models/finding-records.md
+++ b/guides/v3.5.0/models/finding-records.md
@@ -13,7 +13,7 @@ this.store.findRecord('blog-post', 1)  // => GET /blog-posts/1
   });
 ```
 
-Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.5/classes/DS.Store/methods/findRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
+Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.5/classes/DS.Store/methods/peekRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
@@ -32,7 +32,7 @@ this.store.findAll('blog-post') // => GET /blog-posts
   });
 ```
 
-Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.5/classes/DS.Store/methods/findAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
+Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.5/classes/DS.Store/methods/peekAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
 
 ```javascript
 let blogPosts = this.store.peekAll('blog-post'); // => no network request
@@ -67,7 +67,7 @@ this.store.query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.5/classes/DS.Store/methods/query?anchor=queryRecord)that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.5/classes/DS.Store/methods/queryRecord?anchor=queryRecord) that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:
@@ -95,7 +95,7 @@ export default DS.Adapter.extend({
 });
 ```
 
-then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.5/classes/DS.Store/methods/query?anchor=queryRecord) will retrieve that object from the server:
+then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.5/classes/DS.Store/methods/queryRecord?anchor=queryRecord) will retrieve that object from the server:
 
 ```javascript
 store.queryRecord('user', {}).then(function(user) {

--- a/guides/v3.5.0/models/pushing-records-into-the-store.md
+++ b/guides/v3.5.0/models/pushing-records-into-the-store.md
@@ -78,7 +78,7 @@ the casing of the properties defined on the Model class.
 
 If you would like the data to be normalized by the model's default
 serializer before pushing it into the store, you can use the
-[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.5/classes/DS.Store/methods/push?anchor=pushPayload) method.
+[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.5/classes/DS.Store/methods/pushPayload?anchor=pushPayload) method.
 
 ```javascript {data-filename=app/serializers/album.js}
 import DS from 'ember-data';

--- a/guides/v3.5.0/object-model/bindings.md
+++ b/guides/v3.5.0/object-model/bindings.md
@@ -4,7 +4,7 @@ often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.
 
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.5/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.5/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -38,7 +38,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.5/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.5/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.5.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.5.0/object-model/computed-properties-and-aggregate-data.md
@@ -104,7 +104,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.5/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.5/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.5.0/object-model/observers.md
+++ b/guides/v3.5.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.5/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.5.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.5.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.5/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.5/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.5.0/routing/redirection.md
+++ b/guides/v3.5.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/3.5/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [link-to](../../templates/links/) helper.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.5/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.5/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.5/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.5/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.5/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.5/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.5/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.5/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.5.0/templates/conditionals.md
+++ b/guides/v3.5.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.5.0/templates/development-helpers.md
+++ b/guides/v3.5.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.5.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.5.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.5.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.5.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.5.0/templates/input-helpers.md
+++ b/guides/v3.5.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`{{input}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`{{textarea}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`{{input}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/input?anchor=input)
+and [`{{textarea}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea)
 helpers in Ember.js are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -51,12 +51,12 @@ To dispatch an action on specific events, such as `enter` or `key-press`, use th
 {{input value=firstName key-press=(action "updateFirstName")}}
 ```
 
-[Event Names](https://api.emberjs.com/ember/3.5/classes/Component) must be dasherized.
+[Event Names](https://api.emberjs.com/ember/3.5/classes/Component#event-names) must be dasherized.
 
 ## Checkboxes
 
 You can also use the
-[`{{input}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`{{input}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/input?anchor=input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars

--- a/guides/v3.5.0/templates/links.md
+++ b/guides/v3.5.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `{{link-to}}` Component
 
 You create a link to a route using the
-[`{{link-to}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`{{link-to}}`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -118,7 +118,7 @@ For more information on how to use query parameters see the [query parameters](.
 ### Using link-to as an inline component
 
 In addition to being used as a block expression, the
-[`link-to`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component can also be used in inline form by specifying the link text as the first
 argument to the component:
 
@@ -151,7 +151,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`link-to`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.5/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.5.0/templates/writing-helpers.md
+++ b/guides/v3.5.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.5/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -249,7 +249,7 @@ although this is usually unnecessary and error-prone.
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.5/classes/Helper). Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.5/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.5/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -330,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
+[`htmlSafe`](https://api.emberjs.com/ember/3.5/functions/@ember%2Ftemplate/htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -344,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://api.emberjs.com/ember/3.5/functions/@ember%2Ftemplate/htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently

--- a/guides/v3.5.0/testing/testing-models.md
+++ b/guides/v3.5.0/testing/testing-models.md
@@ -104,5 +104,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/packages/-ember-data/tests) for examples of deeper relationship testing if you
 feel the need to do it._

--- a/guides/v3.5.0/tutorial/model-hook.md
+++ b/guides/v3.5.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.5/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.5/classes/Route/methods/model?anchor=model).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.5.0/tutorial/routes-and-templates.md
+++ b/guides/v3.5.0/tutorial/routes-and-templates.md
@@ -224,7 +224,7 @@ All we want to do when a user visits the root (`/`) URL is transition to
 implementing a route lifecycle hook called `beforeModel`.
 Route lifecycle hooks are special methods that are called automatically when a route renders or data changes.
 Inside, we'll call the
-[`replaceWith`](https://api.emberjs.com/ember/3.5/classes/Route/methods/beforeModel?anchor=replaceWith)
+[`replaceWith`](https://api.emberjs.com/ember/3.5/classes/Route/methods/replaceWith?anchor=replaceWith)
 function:
 
 ```javascript {data-filename="app/routes/index.js" data-diff="+4,+5,+6"}

--- a/guides/v3.5.0/tutorial/subroutes.md
+++ b/guides/v3.5.0/tutorial/subroutes.md
@@ -345,7 +345,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `rental-listing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.5/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.5/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.

--- a/guides/v3.6.0/applications/services.md
+++ b/guides/v3.6.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.6/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.6/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.6/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.6/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.6.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.6.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.6/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.6.0/getting-started/core-concepts.md
+++ b/guides/v3.6.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.6/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.6/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.6/classes/Component/methods/willRender?anchor=willRender) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.6/classes/Route/methods/model?anchor=model) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.6/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.6/classes/Component/methods/didRender?anchor=didRender) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.6.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.6.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.6/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!
@@ -148,7 +148,7 @@ post.save().then(transitionToPost).catch(failure);
 Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/3.6/classes/DS.Model/methods/deleteRecord?anchor=deleteRecord)
 on any instance of `DS.Model`. This flags the record as `isDeleted`. The
 deletion can then be persisted using `save()`.  Alternatively, you can use
-the [`destroyRecord`](https://api.emberjs.com/ember-data/3.6/classes/DS.Model/methods/deleteRecord?anchor=destroyRecord) method to delete and persist at the same time.
+the [`destroyRecord`](https://api.emberjs.com/ember-data/3.6/classes/DS.Model/methods/destroyRecord?anchor=destroyRecord) method to delete and persist at the same time.
 
 ```javascript
 store.findRecord('post', 1, { backgroundReload: false }).then(function(post) {
@@ -163,5 +163,4 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 });
 ```
 
-The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](<https://api.emberjs.com/ember-data/3.6/classes/DS.Store/methods/findRecord?anchor=findRecord>
-) automatically schedules a fetch of the record from the adapter.
+The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](https://api.emberjs.com/ember-data/3.6/classes/DS.Store/methods/findRecord?anchor=findRecord) automatically schedules a fetch of the record from the adapter.

--- a/guides/v3.6.0/models/customizing-adapters.md
+++ b/guides/v3.6.0/models/customizing-adapters.md
@@ -246,7 +246,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.6/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.6/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.6.0/models/customizing-serializers.md
+++ b/guides/v3.6.0/models/customizing-serializers.md
@@ -198,7 +198,7 @@ export default DS.JSONAPISerializer.extend({
 
 Similarly, if your backend store provides data in a format other than JSON API,
 you can use the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.6/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.6/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -252,7 +252,7 @@ export default DS.JSONAPISerializer.extend({
 ```
 
 To normalize only a single model, you can use the
-[`normalize()`](https://api.emberjs.com/ember-data/3.6/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalize)
+[`normalize()`](https://api.emberjs.com/ember-data/3.6/classes/DS.JSONAPISerializer/methods/normalize?anchor=normalize)
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
@@ -421,7 +421,7 @@ The JSON should encode the relationship as an ID to another record:
 ```
 If needed these naming conventions can be overwritten by implementing
 the
-[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.6/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForRelationship)
+[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.6/classes/DS.JSONAPISerializer/methods/keyForRelationship?anchor=keyForRelationship)
 method.
 
 ```javascript {data-filename=app/serializers/application.js}
@@ -759,7 +759,7 @@ the possible values of: `'findRecord'`, `'queryRecord'`, `'findAll'`,
 `'createRecord'`, `'deleteRecord'`, and `'updateRecord'`) as arguments.
 
 A custom serializer will also need to define a
-[normalize](https://api.emberjs.com/data/classes/DS.Serializer.html#method_normalize)
+[normalize](https://api.emberjs.com/ember-data/3.6/classes/DS.Serializer/methods/normalize?anchor=normalize)
 method.
 This method is called by `store.normalize(type, payload)` and is often
 used for normalizing requests made outside of Ember Data because they

--- a/guides/v3.6.0/models/finding-records.md
+++ b/guides/v3.6.0/models/finding-records.md
@@ -13,7 +13,7 @@ this.store.findRecord('blog-post', 1)  // => GET /blog-posts/1
   });
 ```
 
-Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.6/classes/DS.Store/methods/findRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
+Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.6/classes/DS.Store/methods/peekRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
@@ -32,7 +32,7 @@ this.store.findAll('blog-post') // => GET /blog-posts
   });
 ```
 
-Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.6/classes/DS.Store/methods/findAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
+Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.6/classes/DS.Store/methods/peekAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
 
 ```javascript
 let blogPosts = this.store.peekAll('blog-post'); // => no network request
@@ -67,7 +67,7 @@ this.store.query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.6/classes/DS.Store/methods/query?anchor=queryRecord)that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.6/classes/DS.Store/methods/queryRecord?anchor=queryRecord) that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:
@@ -95,7 +95,7 @@ export default DS.Adapter.extend({
 });
 ```
 
-then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.6/classes/DS.Store/methods/query?anchor=queryRecord) will retrieve that object from the server:
+then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.6/classes/DS.Store/methods/queryRecord?anchor=queryRecord) will retrieve that object from the server:
 
 ```javascript
 store.queryRecord('user', {}).then(function(user) {

--- a/guides/v3.6.0/models/pushing-records-into-the-store.md
+++ b/guides/v3.6.0/models/pushing-records-into-the-store.md
@@ -78,7 +78,7 @@ the casing of the properties defined on the Model class.
 
 If you would like the data to be normalized by the model's default
 serializer before pushing it into the store, you can use the
-[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.6/classes/DS.Store/methods/push?anchor=pushPayload) method.
+[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.6/classes/DS.Store/methods/pushPayload?anchor=pushPayload) method.
 
 ```javascript {data-filename=app/serializers/album.js}
 import DS from 'ember-data';

--- a/guides/v3.6.0/object-model/bindings.md
+++ b/guides/v3.6.0/object-model/bindings.md
@@ -4,7 +4,7 @@ often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.
 
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.6/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.6/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -38,7 +38,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.6/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.6/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.6.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.6.0/object-model/computed-properties-and-aggregate-data.md
@@ -104,7 +104,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.6/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.6/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.6.0/object-model/observers.md
+++ b/guides/v3.6.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.6/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.6.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.6.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.6/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.6/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.6.0/routing/redirection.md
+++ b/guides/v3.6.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/3.6/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [link-to](../../templates/links/) helper.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.6/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.6/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.6/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.6/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.6/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.6/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.6/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.6/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.6.0/templates/conditionals.md
+++ b/guides/v3.6.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.6.0/templates/development-helpers.md
+++ b/guides/v3.6.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.6.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.6.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.6.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.6.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.6.0/templates/input-helpers.md
+++ b/guides/v3.6.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`{{input}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`{{textarea}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`{{input}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/input?anchor=input)
+and [`{{textarea}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea)
 helpers in Ember.js are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -51,12 +51,12 @@ To dispatch an action on specific events, such as `enter` or `key-press`, use th
 {{input value=this.firstName key-press=(action "updateFirstName")}}
 ```
 
-[Event Names](https://api.emberjs.com/ember/3.6/classes/Component) must be dasherized.
+[Event Names](https://api.emberjs.com/ember/3.6/classes/Component#event-names) must be dasherized.
 
 ## Checkboxes
 
 You can also use the
-[`{{input}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`{{input}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/input?anchor=input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars

--- a/guides/v3.6.0/templates/links.md
+++ b/guides/v3.6.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `{{link-to}}` Component
 
 You create a link to a route using the
-[`{{link-to}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`{{link-to}}`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -118,7 +118,7 @@ For more information on how to use query parameters see the [query parameters](.
 ### Using link-to as an inline component
 
 In addition to being used as a block expression, the
-[`link-to`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component can also be used in inline form by specifying the link text as the first
 argument to the component:
 
@@ -151,7 +151,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`link-to`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.6/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.6.0/templates/writing-helpers.md
+++ b/guides/v3.6.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.6/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -249,7 +249,7 @@ although this is usually unnecessary and error-prone.
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.6/classes/Helper). Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.6/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.6/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -330,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
+[`htmlSafe`](https://api.emberjs.com/ember/3.6/functions/@ember%2Ftemplate/htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -344,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://api.emberjs.com/ember/3.6/functions/@ember%2Ftemplate/htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently

--- a/guides/v3.6.0/testing/testing-models.md
+++ b/guides/v3.6.0/testing/testing-models.md
@@ -104,5 +104,5 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/packages/-ember-data/tests) for examples of deeper relationship testing if you
 feel the need to do it._

--- a/guides/v3.6.0/tutorial/model-hook.md
+++ b/guides/v3.6.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.6/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.6/classes/Route/methods/model?anchor=model).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.6.0/tutorial/routes-and-templates.md
+++ b/guides/v3.6.0/tutorial/routes-and-templates.md
@@ -224,7 +224,7 @@ All we want to do when a user visits the root (`/`) URL is transition to
 implementing a route lifecycle hook called `beforeModel`.
 Route lifecycle hooks are special methods that are called automatically when a route renders or data changes.
 Inside, we'll call the
-[`replaceWith`](https://api.emberjs.com/ember/3.6/classes/Route/methods/beforeModel?anchor=replaceWith)
+[`replaceWith`](https://api.emberjs.com/ember/3.6/classes/Route/methods/replaceWith?anchor=replaceWith)
 function:
 
 ```javascript {data-filename="app/routes/index.js" data-diff="+4,+5,+6"}

--- a/guides/v3.6.0/tutorial/subroutes.md
+++ b/guides/v3.6.0/tutorial/subroutes.md
@@ -345,7 +345,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `rental-listing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.6/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.6/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.

--- a/guides/v3.7.0/applications/services.md
+++ b/guides/v3.7.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/3.7/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.7/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/3.7/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.7/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';

--- a/guides/v3.7.0/components/defining-a-component.md
+++ b/guides/v3.7.0/components/defining-a-component.md
@@ -32,7 +32,7 @@ Given the above template, you can now use the `<BlogPost />` component:
     <div class="cta-note-body">
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
-In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
+In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.7/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">

--- a/guides/v3.7.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.7.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.7/namespaces/Ember/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.7.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.7.0/configuring-ember/disabling-prototype-extensions.md
@@ -147,7 +147,7 @@ fullNameDidChange: observer('fullName', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.7/namespaces/Ember/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.7/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.7.0/controllers/index.md
+++ b/guides/v3.7.0/controllers/index.md
@@ -1,8 +1,8 @@
 ### What is a Controller?
 
-A [Controller](https://api.emberjs.com/ember/3.7/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.3/classes/Route/methods?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/3.7/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.7/classes/Route/methods/model?anchor=model) method.
 
-The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
+The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.7/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 
 A Controller is usually paired with an individual Route of the same name.
 

--- a/guides/v3.7.0/getting-started/core-concepts.md
+++ b/guides/v3.7.0/getting-started/core-concepts.md
@@ -66,10 +66,10 @@ In Ember, we use the term **hook** for methods that are automatically called wit
 
 Some examples of a hook are:
 
-* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.7/classes/Component/methods/willRender?anchor=willRender/) hook gets called before each time a component renders
-* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.7/classes/Route/methods/model?anchor=model/) hook is used to load the model on a route
+* [Component Lifecycle Hooks](../../components/the-component-lifecycle/): the [`willRender()`](https://api.emberjs.com/ember/3.7/classes/Component/methods/willRender?anchor=willRender) hook gets called before each time a component renders
+* Route Hooks: the [`model()`](https://api.emberjs.com/ember/3.7/classes/Route/methods/model?anchor=model) hook is used to load the model on a route
 
-In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.7/classes/Component/methods?anchor=didRender/) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
+In the following example, the [`didRender()`](https://api.emberjs.com/ember/3.7/classes/Component/methods/didRender?anchor=didRender) component lifecycle hook is used to log "I rendered!" to the console after each time the component is rendered.
 
 ```javascript {data-filename=/app/components/foo-did-render-example.js}
 import Component from '@ember/component';

--- a/guides/v3.7.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.7.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/3.7/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.7/classes/EmberObject/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!
@@ -148,7 +148,7 @@ post.save().then(transitionToPost).catch(failure);
 Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/3.7/classes/DS.Model/methods/deleteRecord?anchor=deleteRecord)
 on any instance of `DS.Model`. This flags the record as `isDeleted`. The
 deletion can then be persisted using `save()`.  Alternatively, you can use
-the [`destroyRecord`](https://api.emberjs.com/ember-data/3.7/classes/DS.Model/methods/deleteRecord?anchor=destroyRecord) method to delete and persist at the same time.
+the [`destroyRecord`](https://api.emberjs.com/ember-data/3.7/classes/DS.Model/methods/destroyRecord?anchor=destroyRecord) method to delete and persist at the same time.
 
 ```javascript
 store.findRecord('post', 1, { backgroundReload: false }).then(function(post) {
@@ -163,5 +163,4 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 });
 ```
 
-The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](<https://api.emberjs.com/ember-data/3.7/classes/DS.Store/methods/findRecord?anchor=findRecord>
-) automatically schedules a fetch of the record from the adapter.
+The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`](https://api.emberjs.com/ember-data/3.7/classes/DS.Store/methods/findRecord?anchor=findRecord) automatically schedules a fetch of the record from the adapter.

--- a/guides/v3.7.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.7.0/models/creating-updating-and-deleting-records.md
@@ -27,7 +27,7 @@ this.store.findRecord('person', 1).then(function(tyrion) {
 
 All of the Ember.js conveniences are available for
 modifying attributes. For example, you can use `Ember.Object`'s
-[`incrementProperty`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
+[`incrementProperty`](https://api.emberjs.com/ember/3.7/classes/Ember.Object/methods/incrementProperty?anchor=incrementProperty) helper:
 
 ```javascript
 person.incrementProperty('age'); // Happy birthday!

--- a/guides/v3.7.0/models/customizing-adapters.md
+++ b/guides/v3.7.0/models/customizing-adapters.md
@@ -246,7 +246,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/3.7/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
+[volatile](https://api.emberjs.com/ember/3.7/classes/ComputedProperty/methods/volatile?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v3.7.0/models/customizing-serializers.md
+++ b/guides/v3.7.0/models/customizing-serializers.md
@@ -198,7 +198,7 @@ export default DS.JSONAPISerializer.extend({
 
 Similarly, if your backend store provides data in a format other than JSON:API,
 you can use the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.7/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.7/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -252,7 +252,7 @@ export default DS.JSONAPISerializer.extend({
 ```
 
 To normalize only a single model, you can use the
-[`normalize()`](https://api.emberjs.com/ember-data/3.7/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalize)
+[`normalize()`](https://api.emberjs.com/ember-data/3.7/classes/DS.JSONAPISerializer/methods/normalize?anchor=normalize)
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
@@ -421,7 +421,7 @@ The JSON should encode the relationship as an ID to another record:
 ```
 If needed these naming conventions can be overwritten by implementing
 the
-[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.7/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForRelationship)
+[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.7/classes/DS.JSONAPISerializer/methods/keyForRelationship?anchor=keyForRelationship)
 method.
 
 ```javascript {data-filename=app/serializers/application.js}
@@ -759,7 +759,7 @@ the possible values of: `'findRecord'`, `'queryRecord'`, `'findAll'`,
 `'createRecord'`, `'deleteRecord'`, and `'updateRecord'`) as arguments.
 
 A custom serializer will also need to define a
-[normalize](https://api.emberjs.com/data/classes/DS.Serializer.html#method_normalize)
+[normalize](https://api.emberjs.com/ember-data/3.7/classes/DS.Serializer/methods/normalize?anchor=normalize)
 method.
 This method is called by `store.normalize(type, payload)` and is often
 used for normalizing requests made outside of Ember Data because they

--- a/guides/v3.7.0/models/finding-records.md
+++ b/guides/v3.7.0/models/finding-records.md
@@ -13,7 +13,7 @@ this.store.findRecord('blog-post', 1)  // => GET /blog-posts/1
   });
 ```
 
-Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.7/classes/DS.Store/methods/findRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
+Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.7/classes/DS.Store/methods/peekRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
@@ -32,7 +32,7 @@ this.store.findAll('blog-post') // => GET /blog-posts
   });
 ```
 
-Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.7/classes/DS.Store/methods/findAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
+Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.7/classes/DS.Store/methods/peekAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
 
 ```javascript
 let blogPosts = this.store.peekAll('blog-post'); // => no network request
@@ -67,7 +67,7 @@ this.store.query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.7/classes/DS.Store/methods/query?anchor=queryRecord)that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.7/classes/DS.Store/methods/queryRecord?anchor=queryRecord) that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:
@@ -95,7 +95,7 @@ export default DS.Adapter.extend({
 });
 ```
 
-then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.7/classes/DS.Store/methods/query?anchor=queryRecord) will retrieve that object from the server:
+then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.7/classes/DS.Store/methods/queryRecord?anchor=queryRecord) will retrieve that object from the server:
 
 ```javascript
 store.queryRecord('user', {}).then(function(user) {

--- a/guides/v3.7.0/models/pushing-records-into-the-store.md
+++ b/guides/v3.7.0/models/pushing-records-into-the-store.md
@@ -78,7 +78,7 @@ the casing of the properties defined on the Model class.
 
 If you would like the data to be normalized by the model's default
 serializer before pushing it into the store, you can use the
-[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.7/classes/DS.Store/methods/push?anchor=pushPayload) method.
+[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.7/classes/DS.Store/methods/pushPayload?anchor=pushPayload) method.
 
 ```javascript {data-filename=app/serializers/album.js}
 import DS from 'ember-data';

--- a/guides/v3.7.0/object-model/bindings.md
+++ b/guides/v3.7.0/object-model/bindings.md
@@ -4,7 +4,7 @@ often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.
 
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.7/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/3.7/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias),
 that specifies the path to another object.
 
 ```javascript
@@ -38,7 +38,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/3.7/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/3.7/classes/@ember%2Fobject%2Fcomputed/methods/oneWay?anchor=oneWay). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v3.7.0/object-model/classes-and-instances.md
+++ b/guides/v3.7.0/object-model/classes-and-instances.md
@@ -220,7 +220,7 @@ Person.create({
 
 When reading a property value of an object, you can in most cases use the common JavaScript dot notation, e.g. `myObject.myProperty`.
 
-[Ember proxy objects](https://api.emberjs.com/ember/3.3/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/3.7/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
+[Ember proxy objects](https://api.emberjs.com/ember/3.7/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/3.7/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
 
 Let's look at the following `blogPost` Ember Data model:
 

--- a/guides/v3.7.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.7.0/object-model/computed-properties-and-aggregate-data.md
@@ -104,7 +104,7 @@ changes on individual members of the array.
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/3.7/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy),
+[`computed.filterBy`](https://api.emberjs.com/ember/3.7/classes/@ember%2Fobject%2Fcomputed/methods/filterBy?anchor=filterBy),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}

--- a/guides/v3.7.0/object-model/observers.md
+++ b/guides/v3.7.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/2.15/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.7/namespaces/Ember/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.7.0/object-model/observers.md
+++ b/guides/v3.7.0/object-model/observers.md
@@ -110,7 +110,7 @@ Observers never fire until after the initialization of an object is complete.
 
 If you need an observer to fire as part of the initialization process, you
 cannot rely on the side effect of `set`. Instead, specify that the observer
-should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.7/namespaces/Ember/methods/on?anchor=on):
+should also run after `init` by using [`Ember.on()`](https://api.emberjs.com/ember/3.7/classes/Evented/methods/on?anchor=on):
 
 
 ```javascript

--- a/guides/v3.7.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.7.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.7/classes/Ember.Object/methods/reopen?anchor=reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/2.15/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.7/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.7.0/object-model/reopening-classes-and-instances.md
+++ b/guides/v3.7.0/object-model/reopening-classes-and-instances.md
@@ -1,6 +1,6 @@
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the
-[`reopen()`](https://api.emberjs.com/ember/3.7/classes/Ember.Object/methods/reopen?anchor=reopen)
+[`reopen()`](https://api.emberjs.com/ember/3.7/functions/@ember%2Fobject/reopen)
 method.
 
 ```javascript
@@ -29,7 +29,7 @@ across all instances of a class. It does not add
 methods and properties to a particular instance of a class as in vanilla JavaScript (without using prototype).
 
 But when you need to add static methods or static properties to the class itself
-you can use [`reopenClass()`](https://api.emberjs.com/ember/3.7/classes/Ember.Object/methods/reopenClass?anchor=reopenClass).
+you can use [`reopenClass()`](https://api.emberjs.com/ember/3.7/functions/@ember%2Fobject/reopenClass).
 
 ```javascript
 // add static property to class

--- a/guides/v3.7.0/routing/redirection.md
+++ b/guides/v3.7.0/routing/redirection.md
@@ -12,7 +12,7 @@ Calling `transitionTo()` from a route or
 [`transitionToRoute()`](https://api.emberjs.com/ember/3.7/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [link-to](../../templates/links/) helper.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.7/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.7/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.7/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.7/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.7/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.7/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.7/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.7/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.7.0/templates/conditionals.md
+++ b/guides/v3.7.0/templates/conditionals.md
@@ -1,5 +1,5 @@
 Statements like [`if`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+and [`unless`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/unless?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/unless?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v3.7.0/templates/development-helpers.md
+++ b/guides/v3.7.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/log?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v3.7.0/templates/displaying-a-list-of-items.md
+++ b/guides/v3.7.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/each?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v3.7.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v3.7.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v3.7.0/templates/input-helpers.md
+++ b/guides/v3.7.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`{{input}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`{{textarea}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`{{input}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/input?anchor=input)
+and [`{{textarea}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea)
 helpers in Ember.js are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -67,7 +67,7 @@ More [event types](https://api.emberjs.com/ember/3.7/classes/Component#event-nam
 ## Checkboxes
 
 You can also use the
-[`{{input}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`{{input}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/input?anchor=input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars
@@ -88,7 +88,7 @@ Checkboxes support the following properties:
 Which can be bound or set as described in the previous section.
 
 
-Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.7/classes/Component), you will always need to define the event name in camelCase format:
+Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.7/classes/Component#event-names), you will always need to define the event name in camelCase format:
 
 ```handlebars
 {{input type="checkbox" keyPress=(action "updateName")}}

--- a/guides/v3.7.0/templates/links.md
+++ b/guides/v3.7.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `{{link-to}}` Component
 
 You create a link to a route using the
-[`{{link-to}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`{{link-to}}`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -118,7 +118,7 @@ For more information on how to use query parameters see the [query parameters](.
 ### Using link-to as an inline component
 
 In addition to being used as a block expression, the
-[`link-to`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 component can also be used in inline form by specifying the link text as the first
 argument to the component:
 
@@ -151,7 +151,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`link-to`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/3.7/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v3.7.0/templates/writing-helpers.md
+++ b/guides/v3.7.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/3.7/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`helper()`](https://api.emberjs.com/ember/3.7/functions/@ember%2Fcomponent%2Fhelper/helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -249,7 +249,7 @@ although this is usually unnecessary and error-prone.
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.7/classes/Helper). Helper classes must contain a
 [`compute`](https://api.emberjs.com/ember/3.7/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
-[`Ember.Helper.helper`](https://api.emberjs.com/ember/3.7/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
+[`helper`](https://api.emberjs.com/ember/3.7/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
 
@@ -330,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`](https://api.emberjs.com/ember/3.7/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
+[`htmlSafe`](https://api.emberjs.com/ember/3.7/functions/@ember%2Ftemplate/htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -344,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`](https://api.emberjs.com/ember/3.7/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://api.emberjs.com/ember/3.7/functions/@ember%2Ftemplate/htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently

--- a/guides/v3.7.0/templates/writing-helpers.md
+++ b/guides/v3.7.0/templates/writing-helpers.md
@@ -35,7 +35,7 @@ You can also have Ember generate the file for you from the command line:
 ember generate helper format-currency
 ```
 
-That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/2.15/classes/Ember.Helper/methods/helper?anchor=helper):
+That file should export a function wrapped with [`Ember.Helper.helper()`](https://api.emberjs.com/ember/3.7/classes/Ember.Helper/methods/helper?anchor=helper):
 
 ```javascript {data-filename=app/helpers/format-currency.js}
 import { helper } from '@ember/component/helper';
@@ -248,7 +248,7 @@ although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.7/classes/Helper). Helper classes must contain a
-[`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`compute`](https://api.emberjs.com/ember/3.7/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
 [`Ember.Helper.helper`](https://api.emberjs.com/ember/3.7/classes/Helper/methods/compute?anchor=helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.
@@ -330,7 +330,7 @@ Ember will escape the HTML tags, like this:
 This shows the literal string `<b>Hello world</b>` to the user, rather
 than the text in bold as you probably intended. We can tell Ember not to
 escape the return value (that is, that it is _safe_) by using the
-[`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
+[`htmlSafe`](https://api.emberjs.com/ember/3.7/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe) string utility:
 
 ```javascript {data-filename=app/helpers/make-bold.js}
 import { helper } from '@ember/component/helper';
@@ -344,7 +344,7 @@ export default helper(makeBold);
 ```
 
 If you return a `SafeString` (a string that has been wrapped in a call
-to [`htmlSafe`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
+to [`htmlSafe`](https://api.emberjs.com/ember/3.7/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe)), Ember knows that you have vouched on its behalf that it
 contains no malicious HTML.
 
 However, note that in the above code we may have inadvertently

--- a/guides/v3.7.0/testing/testing-models.md
+++ b/guides/v3.7.0/testing/testing-models.md
@@ -104,4 +104,4 @@ module('Unit | Model | user', function(hooks) {
 
 _Ember Data contains extensive tests around the functionality of
 relationships, so you probably don't need to duplicate those tests.  You could
-look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/tests) for examples of deeper relationship testing if you feel the need to do it._
+look at the [Ember Data tests](https://github.com/emberjs/data/tree/master/packages/-ember-data/tests) for examples of deeper relationship testing if you feel the need to do it._

--- a/guides/v3.7.0/tutorial/model-hook.md
+++ b/guides/v3.7.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.7/classes/Route/methods/model?anchor=model/).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/3.7/classes/Route/methods/model?anchor=model).
 The `model` function acts as a [hook](../../getting-started/core-concepts/#toc_hooks), meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v3.7.0/tutorial/routes-and-templates.md
+++ b/guides/v3.7.0/tutorial/routes-and-templates.md
@@ -224,7 +224,7 @@ All we want to do when a user visits the root (`/`) URL is transition to
 implementing a route lifecycle hook called `beforeModel`.
 Route lifecycle hooks are special methods that are called automatically when a route renders or data changes.
 Inside, we'll call the
-[`replaceWith`](https://api.emberjs.com/ember/3.7/classes/Route/methods/beforeModel?anchor=replaceWith)
+[`replaceWith`](https://api.emberjs.com/ember/3.7/classes/Route/methods/replaceWith?anchor=replaceWith)
 function:
 
 ```javascript {data-filename="app/routes/index.js" data-diff="+4,+5,+6"}

--- a/guides/v3.7.0/tutorial/service.md
+++ b/guides/v3.7.0/tutorial/service.md
@@ -448,7 +448,7 @@ module('Acceptance | list rentals', function(hooks) {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection/#toc_factory-registrations) using the [owner](https://api.emberjs.com/ember/3.0/functions/@ember%2Fapplication/getOwner) object given by the test context. When our component loads the maps service, it gets our stub service instead.
+Then we are putting it in Ember's [registry](../../applications/dependency-injection/#toc_factory-registrations) using the [owner](https://api.emberjs.com/ember/3.7/functions/@ember%2Fapplication/getOwner) object given by the test context. When our component loads the maps service, it gets our stub service instead.
 That way every time that component is created, our stub map service gets injected over the map-element service.
 Now when we run our application tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v3.7.0/tutorial/simple-component.md
+++ b/guides/v3.7.0/tutorial/simple-component.md
@@ -95,7 +95,7 @@ with our new `RentalListing` component:
     <div class="cta-note-body">
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
-In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.6/classes/Component">Ember.js API documentation</a>.
+In Ember templates there are different ways to invoke a Component. The syntax above is referred to as angle bracket invocation syntax, and it might not look familiar if you are looking at older code samples that use the classic invocation syntax. For more examples of ways to use Components in a template, see the <a href="../../reference/syntax-conversion-guide">Syntax Conversion Guide</a>, a <a href="https://guides.emberjs.com/v3.6.0/components/defining-a-component/">previous version of the Guides</a> or <a href="https://api.emberjs.com/ember/3.7/classes/Component">Ember.js API documentation</a>.
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">

--- a/guides/v3.7.0/tutorial/subroutes.md
+++ b/guides/v3.7.0/tutorial/subroutes.md
@@ -345,7 +345,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `RentalListing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.7/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.7/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Notice also that we are providing `rental.id` as the class attribute on the `link-to`.  The class name will help us find the link later on in testing.


### PR DESCRIPTION
## Description

This PR addresses #1440 for Ember `v3.7.0`. After performing Find All and Replace, I manually visited each link to ensure that we redirect readers to the correct content in the API Guides.

Similarly to #1512, this PR involves many file changes because it backports fixing incorrect links to `v3.0.0`-`v3.6.0`. (These are the versions grouped under [Phase 3](https://github.com/ember-learn/guides-source/issues/1440#issuecomment-666800602).)

I hope the number of files doesn't deter you from reviewing this PR. Subsequent PRs for Phase 3 (`v3.0.0`-`v3.6.0`) will have fewer file changes.


## How to review

I recommend reviewing commits one by one.

Every commit, starting with commit 2 ("Fixed incorrect links in..."), looks at just 1 Markdown file across different versions. The pattern in URL change often tends to be the same. (The only exception is if the API Guides changed URL from one version to another.)


## TODO

- [x] Use Find All and Replace to update API links.
- [x] Manually check each URL to ensure that we redirect a user to the correct API section.
- [x] Run `npm run test:node-local` to check external links in `v3.7.0`.


## Notes

```
# Use regexes for Find All and Replace
Find:    https://api.emberjs.com/ember/release/
Replace: https://api.emberjs.com/ember/3.7/

Find:    https://api.emberjs.com/ember/\d{1}.\d{1,2}/
Replace: https://api.emberjs.com/ember/3.7/

Find:    https://api.emberjs.com/ember-data/release/
Replace: https://api.emberjs.com/ember-data/3.7/

Find:    https://api.emberjs.com/ember-data/\d{1}.\d{1,2}/
Replace: https://api.emberjs.com/ember-data/3.7/
```