### PR TITLE
Replace (some) of First & Last Name variable example references

### DIFF
--- a/guides/release/accessibility/components.md
+++ b/guides/release/accessibility/components.md
@@ -62,8 +62,8 @@ Every `<input>` element should have an associated `<label>` element. To do this,
 ![Separate input and label elements with a connection established by matching for and id attributes](/images/accessibility/component-considerations/input-for-id.png)
 
 ```html
-<label for="input-firstName">First Name:</label>
-<input id="input-firstName" name="firstName" value="" type="text" />
+<label for="input-name">Name:</label>
+<input id="input-name" name="name" value="" type="text" />
 ```
 
 It is also valid to wrap the `<label>` element around the `<input />` element: 
@@ -71,8 +71,8 @@ It is also valid to wrap the `<label>` element around the `<input />` element:
 ![A child input element nested within a parent label element without any for and id attributes](/images/accessibility/component-considerations/input-nested.png)
 
 ```html
-<label>First Name:
-  <input name="firstName" value="" type="text" />
+<label>Name:
+  <input name="name" value="" type="text" />
 </label>
 ```
 

--- a/guides/release/components/built-in-components.md
+++ b/guides/release/components/built-in-components.md
@@ -158,7 +158,7 @@ Internally, `<Input @type="checkbox" />` creates an instance of Checkbox. Do *no
 ## `<Textarea />`
 
 ```handlebars
-<label for="textarea-post-name">Post:</label>
+<label for="textarea-post">Post:</label>
 <Textarea @value={{this.post}} name="post" cols="80" rows="6" id="textarea-post" />
 ```
 
@@ -193,8 +193,8 @@ and [`{{mut}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.he
 in conjunction like shown in the following example:
 
 ```handlebars
-<label for="name">Name:</label>
-<Input @value={{mut (get this.person this.field)}} id="name" name="name" />
+<label for="input-name">Name:</label>
+<Input @value={{mut (get this.person this.field)}} id="name" name="input-name" />
 ```
 
 The `{{get}}` helper allows you to dynamically specify which property to bind,

--- a/guides/release/components/built-in-components.md
+++ b/guides/release/components/built-in-components.md
@@ -82,8 +82,8 @@ unquoted, these values will be bound to a property on the template's current
 rendering context. For example:
 
 ```handlebars
-<label for="firstname">First Name</label>
-<Input id="firstname" @type="text" @value={{this.firstName}} size="50" disabled={{this.entryNotAllowed}} />
+<label for="input-name">Name:</label>
+<Input id="input-name" name="name" @value={{this.name}} size="50" disabled={{this.entryNotAllowed}} />
 ```
 
 Will bind the `disabled` attribute to the value of `entryNotAllowed` in the
@@ -94,8 +94,8 @@ current context.
 To dispatch an action on specific events such as `key-down`, use the following
 
 ```handlebars
-<label for="firstname">First Name</label>
-<Input @value={{this.firstName}} @key-down={{this.updateFirstName}} id="firstname" />
+<label for="input-name">Name:</label>
+<Input id="input-name" name="name" @type="text" @value={{this.name}} @key-down={{this.updateName}} />
 ```
 
 The following event types are supported (dasherized format):
@@ -142,15 +142,15 @@ you will always need to either define the event name in camelCase format (e.g. `
 use an `on` helper with the [Web-API event name](https://developer.mozilla.org/en-US/docs/Web/API/Document/keydown_event) (e.g. `on 'keydown'`):
 
 ```handlebars
-<label for="firstname">First Name</label>
+<label for="input-name">Name:</label>
 {{!-- This works: uses camelCase event name --}}
-<Input @type="checkbox" @keyDown={{this.updateName}} id="firstname" />
+<Input @type="checkbox" @keyDown={{this.updateName}} id="input-name" />
 {{!-- This works: uses 'on' with actual event name --}}
-<Input @type="checkbox" {{on "keydown" this.updateName}} id="firstname" />
+<Input @type="checkbox" {{on "keydown" this.updateName}} id="input-name" />
 {{!-- This does not work: uses dasherized event name --}}
-<Input @type="checkbox" @key-down={{this.updateName}} id="firstname" />
+<Input @type="checkbox" @key-down={{this.updateName}} id="input-name" />
 {{!-- This does not work: uses actual event name --}}
-<Input @type="checkbox" @keydown={{this.updateName}} id="firstname" />
+<Input @type="checkbox" @keydown={{this.updateName}} id="input-name" />
 ```
 
 Internally, `<Input @type="checkbox" />` creates an instance of Checkbox. Do *not* use `Checkbox` directly.
@@ -158,11 +158,11 @@ Internally, `<Input @type="checkbox" />` creates an instance of Checkbox. Do *no
 ## `<Textarea />`
 
 ```handlebars
-<label for="firstname">First Name</label>
-<Textarea @value={{this.name}} cols="80" rows="6" id="firstname" />
+<label for="textarea-post-name">Post:</label>
+<Textarea @value={{this.post}} name="post" cols="80" rows="6" id="textarea-post" />
 ```
 
-Will bind the value of the text area to `name` on the current context.
+Will bind the value of the text area to `post` on the current context.
 
 [`<Textarea>`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea) supports binding and/or setting the following properties:
 
@@ -193,8 +193,8 @@ and [`{{mut}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.he
 in conjunction like shown in the following example:
 
 ```handlebars
-<label for="firstname">First Name</label>
-<Input @value={{mut (get this.person this.field)}} id="firstname" />
+<label for="name">Name:</label>
+<Input @value={{mut (get this.person this.field)}} id="name" name="name" />
 ```
 
 The `{{get}}` helper allows you to dynamically specify which property to bind,

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -242,34 +242,34 @@ helper lets you create new bindings (or temporary variables) in your template.
 Say your template now looks like this:
 
 ```handlebars
-Welcome back {{concat (capitalize this.person.firstName) ' ' (capitalize this.person.lastName)}}
+Welcome back {{concat (capitalize this.person.givenName) ' ' (capitalize this.person.familyName)}}
 
 Account Details:
-First Name: {{capitalize this.person.firstName}}
-Last Name: {{capitalize this.person.lastName}}
+Given Name: {{capitalize this.person.givenName}}
+Family Name: {{capitalize this.person.familyName}}
 ```
 
 As mentioned in the previous section, we use the `concat` helper to render both
-`person.firstName` and `person.lastName` in one go. But we also want to make
+`person.givenName` and `person.familyName` in one go. But we also want to make
 sure that the names are capitalized. It gets a bit repetitive to keep writing
 `capitalize` and honestly, we might just forget it at some point. Thankfully, we
 can use the `{{let}}` helper to fix this:
 
 ```handlebars
-{{#let (capitalize this.person.firstName) (capitalize this.person.lastName)
-  as |firstName lastName|
+{{#let (capitalize this.person.givenName) (capitalize this.person.familyName)
+  as |givenName familyName|
 }}
-  Welcome back {{concat firstName ' ' lastName}}
+  Welcome back {{concat givenName ' ' familyName}}
 
   Account Details:
-  First Name: {{firstName}}
-  Last Name: {{lastName}}
+  Given Name: {{givenName}}
+  Family Name: {{familyName}}
 {{/let}}
 ```
 
 Now, as long as your template is wrapped in the `let` helper, you can access the
-capitalized first name and last name as `firstName` and `lastName` instead of
-`(capitalize this.person.firstName)`.
+capitalized given name and family name as `givenName` and `familyName` instead of
+`(capitalize this.person.givenName)`.
 
 ### The `array` helper
 
@@ -305,8 +305,8 @@ components.
 ```handlebars
 <Greeting
   @person={{hash
-    firstName='Jen'
-    lastName='Weber'
+    givenName='Jen'
+    familyName='Weber'
   }}
 />
 ```
@@ -314,7 +314,7 @@ components.
 In the component's template, you can then use the `person` object:
 
 ```handlebars {data-filename=app/components/greeting/template.hbs}
-Hello, {{@person.firstName}} {{@person.lastName}}
+Hello, {{@person.givenName}} {{@person.familyName}}
 ```
 
 To consult all available built-in helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/).

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -196,10 +196,10 @@ can be set to run asynchronously using the `sync: false` option.
 import { observer } from '@ember/object';
 
 Person.extend({
-  partOfNameChanged: observer({
-    dependentKeys: ['firstName', 'lastName'],
+  aspectRatioChanged: observer({
+    dependentKeys: ['width', 'height'],
     fn() {
-      // Fires async after firstName or lastName have updated
+      // Fires async after width or height have updated
     },
     sync: false,
   })

--- a/guides/release/configuring-ember/optional-features.md
+++ b/guides/release/configuring-ember/optional-features.md
@@ -195,8 +195,8 @@ can be set to run asynchronously using the `sync: false` option.
 ```javascript
 import { observer } from '@ember/object';
 
-Person.extend({
-  aspectRatioChanged: observer({
+Image.extend({
+  onImageSizeChange: observer({
     dependentKeys: ['width', 'height'],
     fn() {
       // Fires async after width or height have updated

--- a/guides/release/models/creating-updating-and-deleting-records.md
+++ b/guides/release/models/creating-updating-and-deleting-records.md
@@ -21,7 +21,7 @@ want to change:
 ```javascript
 this.store.findRecord('post', 1).then(function(post) {
   // ...after the record has loaded
-  post.title = 'UPDATED: Rails is Omakase';
+  post.title = 'A new post';
 });
 ```
 

--- a/guides/release/models/creating-updating-and-deleting-records.md
+++ b/guides/release/models/creating-updating-and-deleting-records.md
@@ -19,9 +19,9 @@ Making changes to Ember Data records is as simple as setting the attribute you
 want to change:
 
 ```javascript
-this.store.findRecord('person', 1).then(function(tyrion) {
+this.store.findRecord('post', 1).then(function(post) {
   // ...after the record has loaded
-  tyrion.firstName = 'Yollo';
+  post.title = 'UPDATED: Rails is Omakase';
 });
 ```
 

--- a/guides/release/models/customizing-serializers.md
+++ b/guides/release/models/customizing-serializers.md
@@ -35,8 +35,8 @@ should be dash-cased. For example, if you request a record from
     "type": "people",
     "id": "123",
     "attributes": {
-      "first-name": "Jeff",
-      "last-name": "Atwood"
+      "given-name": "Jeff",
+      "family-name": "Atwood"
     }
   }
 }
@@ -51,15 +51,15 @@ A response that contains multiple records may have an array in its
     "type": "people",
     "id": "123",
     "attributes": {
-      "first-name": "Jeff",
-      "last-name": "Atwood"
+      "given-name": "Jeff",
+      "family-name": "Atwood"
     }
   }, {
     "type": "people",
     "id": "124",
     "attributes": {
-      "first-name": "Yehuda",
-      "last-name": "Katz"
+      "given-name": "Yehuda",
+      "family-name": "Katz"
     }
   }]
 }
@@ -286,8 +286,8 @@ model. For example:
 import Model, { attr } from '@ember-data/model';
 
 export default class PersonModel extends Model {
-  @attr('string') firstName;
-  @attr('string') lastName;
+  @attr('string') givenName;
+  @attr('string') familyName;
   @attr('boolean') isPersonOfTheYear;
 }
 ```
@@ -301,8 +301,8 @@ in the document payload returned by your server:
     "id": "44",
     "type": "people",
     "attributes": {
-      "first-name": "Zaphod",
-      "last-name": "Beeblebrox",
+      "given-name": "Zaphod",
+      "family-name": "Beeblebrox",
       "is-person-of-the-year": true
     }
   }
@@ -335,15 +335,15 @@ representing the record. An object with the property key can also be
 used to designate the attribute's key on the response payload.
 
 
-If the JSON for `person` has a key of `lastNameOfPerson`, and the
-desired attribute name is simply `lastName`, then create a custom
+If the JSON for `person` has a key of `familyNameOfPerson`, and the
+desired attribute name is simply `familyName`, then create a custom
 Serializer for the model and override the `attrs` property.
 
 ```javascript {data-filename=app/models/person.js}
 import Model, { attr } from '@ember-data/model';
 
 export default class PersonModel extends Model {
-  @attr('string') lastName;
+  @attr('string') familyName;
 }
 ```
 
@@ -352,7 +352,7 @@ import JSONAPISerializer from '@ember-data/serializer/json-api';
 
 export default class PersonSerializer extends JSONAPISerializer {
   attrs = {
-    lastName: 'lastNameOfPerson'
+    familyName: 'familyNameOfPerson'
   };
 }
 ```

--- a/guides/release/models/index.md
+++ b/guides/release/models/index.md
@@ -201,14 +201,14 @@ defines the attributes, relationships, and behavior of the data that you
 present to the user.
 
 Models define the type of data that will be provided by your server. For
-example, a `Person` model might have a `firstName` attribute that is a
+example, a `Person` model might have a `name` attribute that is a
 string, and a `birthday` attribute that is a date:
 
 ```javascript {data-filename=app/models/person.js}
 import Model, { attr } from '@ember-data/model';
 
 export default class PersonModel extends Model {
-  @attr('string') firstName;
+  @attr('string') name;
   @attr('date') birthday;
 }
 ```

--- a/guides/release/testing/unit-testing-basics.md
+++ b/guides/release/testing/unit-testing-basics.md
@@ -240,7 +240,7 @@ module('Unit | Service | employees', function(hooks) {
 
     let person = new MockPerson();
 
-    assert.equal(someThing.hire(person), 'John Smith is now an employee');
+    assert.equal(someThing.hire(person), 'Dr. Zoey is now an employee');
     assert.equal(someThing.employees[0], person);
   });
 });

--- a/guides/release/testing/unit-testing-basics.md
+++ b/guides/release/testing/unit-testing-basics.md
@@ -213,7 +213,7 @@ export default class EmployeesService extends Service {
   hire(person) {
     person.addJob();
     this.employees.push(person);
-    return `${person.firstName} ${person.lastName} is now an employee`;
+    return `${person.title} ${person.name} is now an employee`;
   }
 }
 ```
@@ -233,8 +233,8 @@ module('Unit | Service | employees', function(hooks) {
     const someThing = this.owner.lookup('service:some-thing');
 
     class MockPerson {
-      firstName = 'John';
-      lastName = 'Smith';
+      title = 'Dr.';
+      name = 'Zoey';
       addJob() {}
     }
 


### PR DESCRIPTION
## Issue
https://github.com/ember-learn/guides-source/issues/1480

TL;DR Replacing `firstName` and `lastName` example code with `givenName` or `familyName`, or `title` and `name`, or just simply `name`, or something else entirely for i18n/W3C/respect concerns.

## Pages touched in this batch of changes

* [X] Configuration - Optional Features - default-async-observers
* [X] Ember Data - Creating, Updating and Deleting - Updating Records
* [X] Ember Data - Customizing Serializers - Attribute Names
* [X] Testing - Testing Basics - Stubbing an Object
* [X] Accessibility - Component Considerations - Accessible name - Adding a label to an input element
* [X] Components - Helper Functions - Built-in Helpers - The let helper
* [X] Components - Built-in Components - <Input/> - Setting attributes on Input
* [X] Components - Built-in Components - <Textarea />
* [X] Models - Introduction - Models

## Notes

I don't feel this needs to go back prior to `/release` but I'm open to a suggested amount of backporting.

Open to suggested alternatives for these changes as well.