### PR TITLE
Updated Ember API links for 3.6.0

### DIFF
--- a/guides/v3.6.0/controllers/index.md
+++ b/guides/v3.6.0/controllers/index.md
@@ -1,8 +1,8 @@
 ### What is a Controller?
 
-A [Controller](https://api.emberjs.com/ember/3.6/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.3/classes/Route/methods?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/3.6/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.6/classes/Route/methods/model?anchor=model) method.
 
-The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
+The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.6/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 
 A Controller is usually paired with an individual Route of the same name.
 

--- a/guides/v3.6.0/object-model/classes-and-instances.md
+++ b/guides/v3.6.0/object-model/classes-and-instances.md
@@ -220,7 +220,7 @@ Person.create({
 
 When reading a property value of an object, you can in most cases use the common JavaScript dot notation, e.g. `myObject.myProperty`.
 
-[Ember proxy objects](https://api.emberjs.com/ember/3.3/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/3.6/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
+[Ember proxy objects](https://api.emberjs.com/ember/3.6/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/3.6/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
 
 Let's look at the following `blogPost` Ember Data model:
 

--- a/guides/v3.6.0/templates/writing-helpers.md
+++ b/guides/v3.6.0/templates/writing-helpers.md
@@ -248,7 +248,7 @@ although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.6/classes/Helper). Helper classes must contain a
-[`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`compute`](https://api.emberjs.com/ember/3.6/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
 [`helper`](https://api.emberjs.com/ember/3.6/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.

--- a/guides/v3.6.0/tutorial/service.md
+++ b/guides/v3.6.0/tutorial/service.md
@@ -400,7 +400,7 @@ module('Acceptance | list rentals', function(hooks) {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection/#toc_factory-registrations) using the [owner](https://api.emberjs.com/ember/3.0/functions/@ember%2Fapplication/getOwner) object given by the test context. When our component loads the maps service, it gets our stub service instead.
+Then we are putting it in Ember's [registry](../../applications/dependency-injection/#toc_factory-registrations) using the [owner](https://api.emberjs.com/ember/3.6/functions/@ember%2Fapplication/getOwner) object given by the test context. When our component loads the maps service, it gets our stub service instead.
 That way every time that component is created, our stub map service gets injected over the map-element service.
 Now when we run our application tests, you'll notice that maps do not get rendered as the test runs.
 


### PR DESCRIPTION
## Description

This PR addresses #1440 for Ember `v3.6.0`.


## How to review

I recommend reviewing commits one by one.


## TODO

- [x] Use Find All and Replace to update API links.
- [x] Manually check each URL to ensure that we redirect a user to the correct API section. (skipped)
- [x] Run `npm run test:node-local` to check external links in `v3.6.0`.


## Notes

```
# Use regexes for Find All and Replace
Find:    https://api.emberjs.com/ember/release/
Replace: https://api.emberjs.com/ember/3.6/

Find:    https://api.emberjs.com/ember/\d{1}.\d{1,2}/
Replace: https://api.emberjs.com/ember/3.6/

Find:    https://api.emberjs.com/ember-data/release/
Replace: https://api.emberjs.com/ember-data/3.6/

Find:    https://api.emberjs.com/ember-data/\d{1}.\d{1,2}/
Replace: https://api.emberjs.com/ember-data/3.6/
```