### PR TITLE
Removed incorrect assertion

### DIFF
--- a/guides/release/testing/unit-testing-basics.md
+++ b/guides/release/testing/unit-testing-basics.md
@@ -241,7 +241,6 @@ module('Unit | Service | employees', function(hooks) {
     let person = new MockPerson();
 
     assert.equal(someThing.hire(person), 'John Smith is now an employee');
-    assert.equal(someThing.employees[0], person);
   });
 });
 ```

--- a/guides/v3.15.0/testing/unit-testing-basics.md
+++ b/guides/v3.15.0/testing/unit-testing-basics.md
@@ -241,7 +241,6 @@ module('Unit | Service | employees', function(hooks) {
     let person = new MockPerson();
 
     assert.equal(someThing.hire(person), 'John Smith is now an employee');
-    assert.equal(someThing.employees[0], person);
   });
 });
 ```

--- a/guides/v3.16.0/testing/unit-testing-basics.md
+++ b/guides/v3.16.0/testing/unit-testing-basics.md
@@ -241,7 +241,6 @@ module('Unit | Service | employees', function(hooks) {
     let person = new MockPerson();
 
     assert.equal(someThing.hire(person), 'John Smith is now an employee');
-    assert.equal(someThing.employees[0], person);
   });
 });
 ```

--- a/guides/v3.17.0/testing/unit-testing-basics.md
+++ b/guides/v3.17.0/testing/unit-testing-basics.md
@@ -241,7 +241,6 @@ module('Unit | Service | employees', function(hooks) {
     let person = new MockPerson();
 
     assert.equal(someThing.hire(person), 'John Smith is now an employee');
-    assert.equal(someThing.employees[0], person);
   });
 });
 ```

--- a/guides/v3.18.0/testing/unit-testing-basics.md
+++ b/guides/v3.18.0/testing/unit-testing-basics.md
@@ -241,7 +241,6 @@ module('Unit | Service | employees', function(hooks) {
     let person = new MockPerson();
 
     assert.equal(someThing.hire(person), 'John Smith is now an employee');
-    assert.equal(someThing.employees[0], person);
   });
 });
 ```

--- a/guides/v3.19.0/testing/unit-testing-basics.md
+++ b/guides/v3.19.0/testing/unit-testing-basics.md
@@ -241,7 +241,6 @@ module('Unit | Service | employees', function(hooks) {
     let person = new MockPerson();
 
     assert.equal(someThing.hire(person), 'John Smith is now an employee');
-    assert.equal(someThing.employees[0], person);
   });
 });
 ```

--- a/guides/v3.20.0/testing/unit-testing-basics.md
+++ b/guides/v3.20.0/testing/unit-testing-basics.md
@@ -241,7 +241,6 @@ module('Unit | Service | employees', function(hooks) {
     let person = new MockPerson();
 
     assert.equal(someThing.hire(person), 'John Smith is now an employee');
-    assert.equal(someThing.employees[0], person);
   });
 });
 ```


### PR DESCRIPTION
As pointed out by @ijlee2 in #1530 this assertion is invalid because...

> ...`someThing.employees[0]` and `person` are both class instances...

```js
assert.equal(someThing.employees[0], person);
```