### PR TITLE
Replace (some) of First & Last Name variable example references (Batch 2)

### DIFF
--- a/guides/release/applications/run-loop.md
+++ b/guides/release/applications/run-loop.md
@@ -61,20 +61,20 @@ baz.offsetHeight // read (fast since style and layout are already known)
 Interestingly, this pattern holds true for many other types of work.
 Essentially, batching similar work allows for better pipelining, and further optimization.
 
-Let's look at a similar example that is optimized in Ember, starting with a `User` object:
+Let's look at a similar example that is optimized in Ember, starting with an `Image` object:
 
 ```javascript
 import EmberObject, {
   computed
 } from '@ember/object';
 
-class User extends EmberObject {
-  firstName = null;
-  lastName = null;
+class Image extends EmberObject {
+  width = null;
+  height = null;
 
-  @computed('firstName', 'lastName')
-  get fullName() {
-    return `${this.firstName} ${this.lastName}`;
+  @computed('width', 'height')
+  get aspectRatio() {
+    return this.width / this.height;
   }
 }
 ```
@@ -82,19 +82,19 @@ class User extends EmberObject {
 and a template to display its attributes:
 
 ```handlebars
-{{this.firstName}}
-{{this.fullName}}
+{{this.width}}
+{{this.aspectRatio}}
 ```
 
 If we execute the following code without the run loop:
 
 ```javascript
-let user = User.create({ firstName: 'Tom', lastName: 'Huda' });
-user.set('firstName', 'Yehuda');
-// {{firstName}} and {{fullName}} are updated
+let profilePhoto = Image.create({ width: 250, height: 500 });
+user.set('width', 300);
+// {{width}} and {{aspectRatio}} are updated
 
-user.set('lastName', 'Katz');
-// {{lastName}} and {{fullName}} are updated
+user.set('height', 300);
+// {{height}} and {{aspectRatio}} are updated
 ```
 
 We see that the browser will rerender the template twice.
@@ -103,11 +103,11 @@ However, if we have the run loop in the above code,
 the browser will only rerender the template once the attributes have all been set.
 
 ```javascript
-let user = User.create({ firstName: 'Tom', lastName: 'Huda' });
-user.set('firstName', 'Yehuda');
-user.set('lastName', 'Katz');
-user.set('firstName', 'Tom');
-user.set('lastName', 'Huda');
+let profilePhoto = Image.create({ width: 250, height: 500 });
+user.set('width', 600);
+user.set('height', 600);
+user.set('width', 300);
+user.set('height', 300);
 ```
 
 In the above example with the run loop, since the user's attributes end up at the same values as before execution,
@@ -168,7 +168,7 @@ which will make you a better Ember developer.
 You should begin a run loop when the callback fires.
 
 The `Ember.run` method can be used to create a run loop.
-In this example, `Ember.run` is used to handle an online 
+In this example, `Ember.run` is used to handle an online
 event (browser gains internet access) and run some Ember code.
 
 ```javascript

--- a/guides/release/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/release/configuring-ember/disabling-prototype-extensions.md
@@ -119,14 +119,14 @@ wrap the function:
 import { computed } from '@ember/object';
 
 // This won't work:
-fullName: function() {
-  return `${this.firstName} ${this.lastName}`;
-}.property('firstName', 'lastName')
+aspectRatio: function() {
+  return this.width / this.height;
+}.property('width', 'height')
 
 
 // Instead, do this:
-fullName: computed('firstName', 'lastName', function() {
-  return `${this.firstName} ${this.lastName}`;
+aspectRatio: computed('width', 'height', function() {
+  return this.width / this.height;
 })
 ```
 
@@ -136,14 +136,14 @@ Observers are annotated using `Ember.observer()`:
 import { observer } from '@ember/object';
 
 // This won't work:
-fullNameDidChange: function() {
-  console.log('Full name changed');
-}.observes('fullName')
+aspectRatioDidChange: function() {
+  console.log('Aspect ratio changed');
+}.observes('aspectRatio')
 
 
 // Instead, do this:
-fullNameDidChange: observer('fullName', function() {
-  console.log('Full name changed');
+aspectRatioDidChange: observer('aspectRatio', function() {
+  console.log('Aspect ratio changed');
 })
 ```
 

--- a/guides/release/getting-started/working-with-html-css-and-javascript.md
+++ b/guides/release/getting-started/working-with-html-css-and-javascript.md
@@ -73,12 +73,12 @@ Ember uses [JavaScript classes](https://developer.mozilla.org/en-US/docs/Web/Jav
 for many of its constructs, such as Components, Routes, Services, and more:
 
 ```js
-export default class PersonController extends Controller {
-  @tracked firstName = 'Yehuda';
-  @tracked lastName = 'Katz';
+export default class PermissionController extends Controller {
+  @tracked isAdmin = false;
+  @tracked isManager = false;
 
-  get fullName() {
-    return `${this.firstName} ${this.lastName}`;
+  get canEdit() {
+    return this.isAdmin || this.isManager;
   }
 }
 ```
@@ -95,18 +95,18 @@ Class fields allow you to assign properties to an instance of the class on
 construction. You can define a field like this:
 
 ```js
-class Person {
-  name = 'Yehuda Katz';
+class Permission {
+  canEdit = false;
 }
 ```
 
-This is very similar to defining the `Person` class with a constructor like
+This is very similar to defining the `Permission` class with a constructor like
 this:
 
 ```js
-class Person {
+class Permission {
   constructor() {
-    this.name = 'Yehuda Katz';
+    this.canEdit = false;
   }
 }
 ```
@@ -118,14 +118,14 @@ if the field is a primitive, like a string or a number, but does matter if it's
 an object or an array:
 
 ```js
-class Person {
-  friends = [];
+class Permission {
+  roles = [];
 }
 
-let tom = new Person();
-let yehuda = new Person();
+let tom = new Permission();
+let yehuda = new Permission();
 
-tom.friends === yehuda.friends;
+tom.roles === yehuda.roles;
 // false, they're different arrays
 ```
 
@@ -182,20 +182,20 @@ can be applied to classes directly as well:
 
 ```js
 @observable
-class Person {}
+class Permission {}
 ```
 
 Some decorators can also receive arguments:
 
 ```js
-class Person {
-  fullName = 'Matthew Beale';
+class Permission {
+  canEdit = false;
 
-  @alias('fullName') name;
+  @alias('canEdit') editable;
 }
 
-let matt = new Person();
-console.log(matt.name); // Matthew Beale
+let current = new Permission();
+console.log(current.editable); // false
 ```
 
 Ember provides a number of decorators, such as the `@tracked` decorator, that
@@ -214,12 +214,12 @@ which looks like this:
 
 ```js
 export default Controller.extend({
-  firstName: tracked({ value: 'Yehuda' }),
-  lastName: tracked({ value: 'Katz' }),
+  isAdmin: tracked({ value: false }),
+  isManager: tracked({ value: false }),
 
-  fullName: descriptor({
+  canEdit: descriptor({
     get() {
-      return `${this.firstName} ${this.lastName}`;
+      return this.isAdmin || this.isManager;
     },
   }),
 });

--- a/guides/release/in-depth-topics/autotracking-in-depth.md
+++ b/guides/release/in-depth-topics/autotracking-in-depth.md
@@ -221,16 +221,16 @@ within your components and routes:
 
 ```js {data-filename=src/utils/person.js}
 export default class Person {
-  @tracked firstName;
-  @tracked lastName;
+  @tracked title;
+  @tracked name;
 
-  constructor(firstName, lastName) {
-    this.firstName = firstName;
-    this.lastName = lastName;
+  constructor(title, name) {
+    this.title = title;
+    this.name = name;
   }
 
   get fullName() {
-    return `${this.firstName} ${this.lastName}`;
+    return `${this.title} ${this.name}`;
   }
 }
 ```
@@ -241,7 +241,7 @@ import Person from '../../../../utils/person';
 
 export default class ApplicationRoute extends Route {
   model() {
-    return new Person('Tobias', 'Bieniek');
+    return new Person('Dr.', 'Zoey');
   }
 }
 ```
@@ -252,9 +252,9 @@ import { action } from '@ember/object';
 
 export default class ApplicationController extends Controller {
   @action
-  updateName(firstName, lastName) {
-    this.model.firstName = firstName;
-    this.model.lastName = lastName;
+  updateName(title, name) {
+    this.model.title = title;
+    this.model.name = name;
   }
 }
 ```
@@ -262,7 +262,7 @@ export default class ApplicationController extends Controller {
 ```handlebars {data-filename=app/templates/application.hbs}
 {{@model.fullName}}
 
-<button type="button" {{on "click" (fn this.updateName 'Krati' 'Ahuja')}}>
+<button type="button" {{on "click" (fn this.updateName 'Prof.' 'Tomster')}}>
   Update Name
 </button>
 ```

--- a/guides/release/upgrading/current-edition/tracked-properties.md
+++ b/guides/release/upgrading/current-edition/tracked-properties.md
@@ -10,9 +10,9 @@ For example, a computed property like this:
 ```js
 import EmberObject, { computed } from '@ember/object';
 
-const Person = EmberObject.extend({
-  fullName: computed('firstName', 'lastName', function() {
-    return `${this.firstName} ${this.lastName}`;
+const Image = EmberObject.extend({
+  aspectRatio: computed('width', 'height', function() {
+    return this.width / this.height;
   }),
 });
 ```
@@ -22,17 +22,17 @@ Could be rewritten as:
 ```js
 import { tracked } from '@glimmer/tracking';
 
-class Person {
-  @tracked firstName;
-  @tracked lastName;
+class Image {
+  @tracked width;
+  @tracked height;
 
-  get fullName() {
-    return `${this.firstName} ${this.lastName}`;
+  get aspectRatio() {
+    return this.width / this.height;
   }
 }
 ```
 
-Notice how `fullName` doesn't require _any_ annotation at all - it's a plain old
+Notice how `aspectRatio` doesn't require _any_ annotation at all - it's a plain old
 native getter, and it'll still work and invalidate if it's used anywhere in a
 template, directly or indirectly.
 
@@ -41,16 +41,16 @@ values, you can use standard JavaScript syntax instead!
 
 ```js
 // Before
-let chad = Person.create();
-chad.set('firstName', 'Chad');
-chad.set('lastName', 'Hietala');
+let profilePhoto = Image.create();
+profilePhoto.set('width', 300);
+profilePhoto.set('height', 300);
 ```
 
 ```js
 // After
-let chad = new Person();
-chad.firstName = 'Chad';
-chad.lastName = 'Hietala';
+let profilePhoto = new Image();
+profilePhoto.width = 300;
+profilePhoto.height = 300;
 ```
 
 `@tracked` installs a native setter that tracks updates to these properties,
@@ -61,9 +61,9 @@ Tracked properties have subtler benefits as well:
 - They enforce that all of the trackable properties in your classes are
   annotated, making them easy to find. With computed properties, it was common
   to have properties be "implicit" in a class definition, like in the example
-  above; the classic class version of `Person` doesn't have `firstName` and
-  `lastName` properties defined, but they are _implied_ by their existence as
-  dependencies in the `fullName` computed property.
+  above; the classic class version of `Image` doesn't have `width` and
+  `height` properties defined, but they are _implied_ by their existence as
+  dependencies in the `aspectRatio` computed property.
 - They enforce a "public API" of all values that are trackable in your class.
   With computed properties, it was possible to watch _any_ value in a class for changes, and
   there was nothing you as the class author could do about it. With tracked
@@ -187,19 +187,19 @@ dependency:
 import { tracked } from '@glimmer/tracking';
 import { computed } from '@ember/object';
 
-class Person {
-  @tracked firstName;
+class Image {
+  @tracked width;
 
-  @computed('firstName', 'lastName')
-  get fullName() {
-    return `${this.firstName} ${this.lastName}`;
+  @computed('width', 'height')
+  get aspectRatio() {
+    return this.width / this.height;
   }
 }
 
-let person = new Person();
+let profilePhoto = new Image();
 
-// This will correctly invalidate `fullName`
-person.firstName = 'Tom';
+// This will correctly invalidate `aspectRatio`
+profilePhoto.width = 200;
 ```
 
 Note, however, that if you want to use a getter as a dependent key, you will
@@ -211,14 +211,14 @@ Vice-versa, computed properties used in native getters will autotrack and
 cause the getter to update correctly:
 
 ```js
-class Person {
-  @computed('firstName', 'lastName')
-  get fullName() {
-    return `${this.firstName} ${this.lastName}`;
+class Image {
+  @computed('width', 'height')
+  get aspectRatio() {
+    return this.width / this.height;
   }
 
   get helloMessage() {
-    return `${this.fullName} says hello!`;
+    return `Image aspect ratio is: ${this.aspectRatio}!`;
   }
 }
 ```
@@ -228,18 +228,18 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
-class Person {
-  get fullName() {
-    let firstName = get(this, 'firstName');
-    let lastName = get(this, 'lastName');
+class Image {
+  get aspectRatio() {
+    let width = get(this, 'width');
+    let height = get(this, 'height');
 
-    return `${firstName} ${lastName}`;
+    return this.width / this.height;
   }
 }
 
-let kris = new Person();
-set(kris, 'firstName', 'Kris');
-set(kris, 'lastName', 'Selden');
+let profilePhoto = new Image();
+set(profilePhoto, 'width', 300);
+set(profilePhoto, 'height', 300);
 ```
 
 However, you _must_ use `get` for these properties, since they are not tracked
@@ -247,15 +247,15 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
-class Person {
-  get fullName() {
-    return `${this.firstName} ${this.lastName}`;
+class Image {
+  get aspectRatio() {
+    return this.width / this.height;
   }
 }
 
-let kris = new Person();
-set(kris, 'firstName', 'Kris');
-set(kris, 'lastName', 'Selden');
+let profilePhoto = new Image();
+set(profilePhoto, 'width', 259);
+set(profilePhoto, 'height', 259);
 ```
 
 Additionally, certain Ember objects still require the use of `get` and `set`,
@@ -287,13 +287,13 @@ was accessed properly and updated correctly: `get` and `set`.
 ```js
 import { get, set } from '@ember/object';
 
-let person = {};
+let image = {};
 
-set(person, 'firstName', 'Amy');
-set(person, 'lastName', 'Lam');
+set(image, 'width', 250);
+set(image, 'height', 500);
 
-get(person, 'firstName'); // 'Amy'
-get(person, 'lastName'); // 'Lam'
+get(image, 'width'); // 250
+get(image, 'height'); // 500
 ```
 
 In classic Ember, all property access had to go through these two methods. Over
@@ -334,13 +334,13 @@ updates.
 
 ```js
 class Profile {
-  person = {
-    firstName: 'Chris',
-    lastName: 'Thoburn',
+  photo = {
+    width: 300,
+    height: 300,
   };
 
-  get profileName() {
-    return `${get(this.person, 'firstName')} ${get(this.person, 'lastName')}`;
+  get photoAspectRatio() {
+    return get(this.photo, 'width') / get(this.photo, 'height');
   }
 }
 
@@ -348,7 +348,7 @@ let profile = new Profile();
 
 // render the page...
 
-set(profile.person, 'firstName', 'Christopher'); // triggers an update
+set(profile.photo, 'width', 500); // triggers an update
 ```
 
 This is also useful when working with older Ember code which has not yet
@@ -378,16 +378,16 @@ Most `ObjectProxy` classes have their own `get` and `set` method on them, like
 instance:
 
 ```js
-proxy.get('firstName');
-proxy.set('firstName', 'Amy');
+proxy.get('width');
+proxy.set('width', 100);
 ```
 
 If you're unsure whether or not a given object will be a proxy or not, you can
 still use Ember's `get` and `set` functions:
 
 ```js
-get(maybeProxy, 'firstName');
-set(maybeProxy, 'firstName', 'Amy');
+get(maybeProxy, 'width');
+set(maybeProxy, 'width', 100);
 ```
 
 <!-- eof - needed for pages that end in a code block  -->

--- a/guides/release/upgrading/current-edition/tracked-properties.md
+++ b/guides/release/upgrading/current-edition/tracked-properties.md
@@ -254,8 +254,8 @@ class Image {
 }
 
 let profilePhoto = new Image();
-set(profilePhoto, 'width', 259);
-set(profilePhoto, 'height', 259);
+set(profilePhoto, 'width', 250);
+set(profilePhoto, 'height', 250);
 ```
 
 Additionally, certain Ember objects still require the use of `get` and `set`,


### PR DESCRIPTION
## Issue
https://github.com/ember-learn/guides-source/issues/1480
Prior batch: https://github.com/ember-learn/guides-source/pull/1530

TL;DR Replacing `firstName` and `lastName` example code with `title` and `name`, or just simply `name`, or something else entirely for i18n/W3C/respect concerns.

## Pages touched in this batch of changes
* [x] [Configuration - Disabling Prototype Extensions - Functions](https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/#toc_functions)
* [x] [Getting Started - Working with HTML, CSS, and JavaScript - JavaScript Classes](https://guides.emberjs.com/release/getting-started/working-with-html-css-and-javascript/#toc_javascript-classes)
* [x] [Upgrading - Octane Upgrade Guide - Tracked Properties](https://guides.emberjs.com/release/upgrading/current-edition/tracked-properties/)
* [x] [Application Concerns - Run Loop - Why is the run loop useful?](https://guides.emberjs.com/release/applications/run-loop/#toc_why-is-the-run-loop-useful)
* [x] [In-Depth Topics - Autotracking In-Depth - Tracked Properties in Custom Classes](https://guides.emberjs.com/release/in-depth-topics/autotracking-in-depth/#toc_tracked-properties-in-custom-classes)

## Notes

I don't feel this needs to go back prior to `/release` but I'm open to a suggested amount of backporting.

Open to suggested alternatives for these changes as well.