### PR TITLE
Revert "Added GitHub and OpenCollective as sponsorship methods"

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: emberjs
-open_collective: emberjs


### PR DESCRIPTION
## Description

Now that the Sponsor button is [added at the `ember-learn` organization level](https://github.com/ember-learn/.github/pull/1), we can revert #1544 to remove the repo-specific `.github/FUNDING.yml` file.