### PR TITLE
Replace (some) of First & Last Name variable example references (Batch 3)

### DIFF
--- a/guides/release/in-depth-topics/native-classes-in-depth.md
+++ b/guides/release/in-depth-topics/native-classes-in-depth.md
@@ -269,18 +269,18 @@ refactoring:
 ```js
 // Avoid this 🛑
 class Person {
-  firstName = 'Yehuda';
-  lastName = 'Katz';
+  title = 'Prof.';
+  name = 'Tomster';
 
-  fullName = `${this.firstName} ${this.lastName}`;
+  fullName = `${this.title} ${this.name}`;
 }
 
 // because it breaks if you change the order
 class Person {
-  fullName = `${this.firstName} ${this.lastName}`;
+  fullName = `${this.title} ${this.name}`;
 
-  firstName = 'Yehuda';
-  lastName = 'Katz';
+  title = 'Prof.';
+  name = 'Tomster';
 }
 
 let yehuda = new Person();
@@ -289,11 +289,11 @@ console.log(yehuda.fullName); // undefined undefined
 // This is ok, works no matter what the order is ✅
 class Person {
   constructor() {
-    this.fullName = `${this.firstName} ${this.lastName}`;
+    this.fullName = `${this.title} ${this.name}`;
   }
 
-  firstName = 'Yehuda';
-  lastName = 'Katz';
+  title = 'Prof.';
+  name = 'Tomster';
 }
 ```
 
@@ -357,11 +357,11 @@ Getters can also be used on their own to calculate values dynamically:
 
 ```js
 class Person {
-  firstName = 'Mel';
-  lastName = 'Sumner';
+  title = 'Dr.';
+  name = 'Zoey';
 
   get fullName() {
-    return `${this.firstName} ${this.lastName}`;
+    return `${this.title} ${this.name}`;
   }
 }
 ```

--- a/guides/release/models/defining-models.md
+++ b/guides/release/models/defining-models.md
@@ -45,8 +45,8 @@ add first and last name, as well as the birthday, using [`attr`](https://api.emb
 import Model, { attr } from '@ember-data/model';
 
 export default class PersonModel extends Model {
-  @attr firstName;
-  @attr lastName;
+  @attr title;
+  @attr name;
   @attr birthday;
 }
 ```
@@ -61,11 +61,11 @@ You can use attributes like any other property, including from within [getter fu
 import Model, { attr } from '@ember-data/model';
 
 export default class PersonModel extends Model {
-  @attr firstName;
-  @attr lastName;
+  @attr title;
+  @attr name;
 
   get fullName() {
-    return `${this.firstName} ${this.lastName}`;
+    return `${this.title} ${this.name}`;
   }
 }
 ```

--- a/guides/release/upgrading/current-edition/glimmer-components.md
+++ b/guides/release/upgrading/current-edition/glimmer-components.md
@@ -435,7 +435,7 @@ import Component from '@glimmer/component';
 
 export default class ImageComponent extends Component {
   get width() {
-    return this.args.width === undefined ? this.args.width : 0;
+    return this.args.width ?? 0;
   }
 
   get height() {

--- a/guides/release/upgrading/current-edition/glimmer-components.md
+++ b/guides/release/upgrading/current-edition/glimmer-components.md
@@ -370,18 +370,18 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 
 export default Component.extend({
-  firstName: '',
-  lastName: '',
+  width: 0,
+  height: 0,
 
-  fullName: computed('firstName', 'lastName', function() {
-    return `${this.firstName} ${this.lastName}`;
+  aspectRatio: computed('width', 'height', function() {
+    return this.width / this.height;
   })
 });
 ```
 
 ```handlebars
 {{!-- Usage --}}
-<Person @firstName="Kenneth" @lastName="Larsen" />
+<Image @width="1920" @height="1080" />
 ```
 
 After:
@@ -389,21 +389,21 @@ After:
 ```js
 import Component from '@glimmer/component';
 
-export default class PersonComponent extends Component {
-  get fullName() {
-    return `${this.args.firstName} ${this.args.lastName}`;
+export default class ImageComponent extends Component {
+  get aspectRatio() {
+    return this.args.width / this.args.height;
   }
 }
 ```
 
 ```handlebars
 {{!-- Usage --}}
-<Person @firstName="Kenneth" @lastName="Larsen" />
+<Image @width="1920" @height="1080" />
 ```
 
 `args` and its values are automatically tracked, so there is no need to annotate
-them, the `fullName` getter will invalidate properly when they change and the
-component will rerender (if `fullName` is used in the template).
+them, the `aspectRatio` getter will invalidate properly when they change and the
+component will rerender (if `aspectRatio` is used in the template).
 
 Additionally, `args` is _not_ mutable, and is frozen in development modes. This
 is partially to prevent folks from trying to accomplish two-way bindings (which
@@ -419,11 +419,11 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 
 export default Component.extend({
-  firstName: 'Kenneth',
-  lastName: 'Larsen',
+  width: 0,
+  height: 0,
 
-  fullName: computed('firstName', 'lastName', function() {
-    return `${this.firstName} ${this.lastName}`;
+  aspectRatio: computed('width', 'height', function() {
+    return this.width / this.height;
   })
 });
 ```
@@ -433,17 +433,17 @@ After:
 ```js
 import Component from '@glimmer/component';
 
-export default class PersonComponent extends Component {
-  get firstName() {
-    return this.args.firstName || 'Kenneth';
+export default class ImageComponent extends Component {
+  get width() {
+    return this.args.width === undefined ? this.args.width : 0;
   }
 
-  get lastName() {
-    return this.args.lastName || 'Larsen';
+  get height() {
+    return this.args.height === undefined ? this.args.height : 0;
   }
 
-  get fullName() {
-    return `${this.firstName} ${this.lastName}`;
+  get aspectRatio() {
+    return this.args.width / this.args.height;
   }
 }
 ```

--- a/guides/release/upgrading/current-edition/glimmer-components.md
+++ b/guides/release/upgrading/current-edition/glimmer-components.md
@@ -439,7 +439,7 @@ export default class ImageComponent extends Component {
   }
 
   get height() {
-    return this.args.height === undefined ? this.args.height : 0;
+    return this.args.height ?? 0;
   }
 
   get aspectRatio() {

--- a/guides/release/upgrading/current-edition/native-classes.md
+++ b/guides/release/upgrading/current-edition/native-classes.md
@@ -268,7 +268,7 @@ const ClassicPerson = EmberObject.extend({
   name: 'Tomster',
 
   fullName: join('title', 'name'),
-  displayName: alias('nickName'),
+  displayName: alias('nickname'),
 });
 
 // After

--- a/guides/release/upgrading/current-edition/native-classes.md
+++ b/guides/release/upgrading/current-edition/native-classes.md
@@ -263,7 +263,7 @@ function join(...keys) {
 
 // Before
 const ClassicPerson = EmberObject.extend({
-  nickName: 'Tom',
+  nickname: 'Tom',
   title: 'Prof.',
   name: 'Tomster',
 

--- a/guides/release/upgrading/current-edition/native-classes.md
+++ b/guides/release/upgrading/current-edition/native-classes.md
@@ -278,7 +278,7 @@ class Person {
   name = 'Tomster';
 
   @join('title', 'name') fullName;
-  @alias('nickName') displayName;
+  @alias('nickname') displayName;
 }
 ```
 

--- a/guides/release/upgrading/current-edition/native-classes.md
+++ b/guides/release/upgrading/current-edition/native-classes.md
@@ -176,12 +176,12 @@ Other than that, fields can generally safely replace properties.
 Getters and setters can be defined directly on native classes:
 
 ```js
-export default class Person {
-  firstName = 'Katie';
-  lastName = 'Gengler';
+export default class Image {
+  width = 0;
+  height = 0;
 
-  get fullName() {
-    return `${this.firstName} ${this.lastName}`;
+  get aspectRatio() {
+    return this.width / this.height;
   }
 }
 ```
@@ -197,11 +197,11 @@ recently, but you can define them now with the standard JavaScript getter syntax
 
 ```js
 export default EmberObject.extend({
-  firstName: 'Katie',
-  lastName: 'Gengler',
+  width: 0,
+  height: 0,
 
-  get fullName() {
-    return `${this.firstName} ${this.lastName}`;
+  get aspectRatio() {
+    return this.width / this.height;
   },
 });
 ```
@@ -216,12 +216,12 @@ fact a type of decorator:
 import EmberObject, { computed } from '@ember/object';
 
 export default EmberObject.extend({
-  firstName: 'Katie',
-  lastName: 'Gengler',
+  width: 0,
+  height: 0,
 
-  fullName: computed('firstName', 'lastName', {
+  aspectRatio: computed('width', 'height', {
     get() {
-      return `${this.firstName} ${this.lastName}`;
+      return this.width / this.height;
     },
   }),
 });
@@ -233,13 +233,13 @@ syntax:
 ```js
 import { computed } from '@ember/object';
 
-export default class Person {
-  firstName = 'Katie';
-  lastName = 'Gengler';
+export default class Image {
+  width = 0;
+  height = 0;
 
-  @computed('firstName', 'lastName')
-  get fullName() {
-    return `${this.firstName} ${this.lastName}`;
+  @computed('width', 'height')
+  get aspectRatio() {
+    return this.width / this.height;
   }
 }
 ```
@@ -263,20 +263,22 @@ function join(...keys) {
 
 // Before
 const ClassicPerson = EmberObject.extend({
-  firstName: 'Katie',
-  lastName: 'Gengler',
+  nickName: 'Tom',
+  title: 'Prof.',
+  name: 'Tomster',
 
-  fullName: join('firstName', 'lastName'),
-  name: alias('fullName'),
+  fullName: join('title', 'name'),
+  displayName: alias('nickName'),
 });
 
 // After
 class Person {
-  firstName = 'Katie';
-  lastName = 'Gengler';
+  nickName = 'Tom';
+  title = 'Prof.';
+  name = 'Tomster';
 
-  @join('firstName', 'lastName') fullName;
-  @alias('fullName') name;
+  @join('title', 'name') fullName;
+  @alias('nickName') displayName;
 }
 ```
 
@@ -335,8 +337,7 @@ const Person = EmberObject.extend();
 const Firefighter = Person.extend({
   init() {
     this._super(...arguments);
-    this.firstName = 'Rob';
-    this.lastName = 'Jackson';
+    this.name = 'Rob Jackson';
   },
 
   saveKitten() {
@@ -351,8 +352,7 @@ class Person {}
 class Firefighter extends Person {
   constructor() {
     super();
-    this.firstName = 'Rob';
-    this.lastName = 'Jackson';
+    this.name = 'Rob Jackson';
   }
 
   saveKitten() {
@@ -575,21 +575,21 @@ const Person = EmberObject.extend({
 
   ```js
   // bad 🛑
-  class Person {
-    firstName = 'Chad';
-    lastName = 'Hietala';
+  class Image {
+    width = 0;
+    height = 0;
 
-    fullName = `${this.firstName} ${this.lastName}`;
+    aspectRatio = this.width / this.height;
   }
 
   // good ✅
   class Person {
     constructor() {
-      this.fullName = `${this.firstName} ${this.lastName}`;
+      this.aspectRatio = this.width / this.height;
     }
 
-    firstName = 'Chad';
-    lastName = 'Hietala';
+    width = 0;
+    height = 0;
   }
   ```
 


### PR DESCRIPTION
## Issue
https://github.com/ember-learn/guides-source/issues/1480
Prior batch: https://github.com/ember-learn/guides-source/pull/1537
_This is the last batch!_

TL;DR Replacing `firstName` and `lastName` example code with `title` and `name`, or just simply `name`, or something else entirely for i18n/W3C/respect concerns.

## Pages touched in this batch of changes
* [x] [In-Depth Topics - Native Classes In-Depth - Fields](https://guides.emberjs.com/release/in-depth-topics/native-classes-in-depth/#toc_fields)
* [x] [Upgrading - Glimmer Components - Arguments](https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/#toc_arguments)
* [x] [Upgrading - Native Classes](https://guides.emberjs.com/release/upgrading/current-edition/native-classes/)
* [x] [Models - Defining Models - Defining Attributes](https://guides.emberjs.com/release/models/defining-models/#toc_defining-attributes)

## Notes

I don't feel this needs to go back prior to `/release` but I'm open to a suggested amount of backporting.

Open to suggested alternatives for these changes as well.