### PR TITLE
Document how to use caching primitives in Ember 3.15 - 3.21

### DIFF
--- a/guides/release/in-depth-topics/autotracking-in-depth.md
+++ b/guides/release/in-depth-topics/autotracking-in-depth.md
@@ -407,4 +407,6 @@ console.log(count); // 2
 From the value of `count`, we see that, this time, `aspectRatio` was calculated
 only twice.
 
+The cache API was released in Ember 3.22. If you want to leverage this API between versions 3.13 and 3.21, you can install [ember-cache-primitive-polyfill](https://github.com/ember-polyfills/ember-cache-primitive-polyfill) to your project.
+
 <!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.15.0/in-depth-topics/autotracking-in-depth.md
+++ b/guides/v3.15.0/in-depth-topics/autotracking-in-depth.md
@@ -407,4 +407,6 @@ console.log(count); // 2
 From the value of `count`, we see that, this time, `aspectRatio` was calculated
 only twice.
 
+The cache API was released in Ember 3.22. If you want to leverage this API between versions 3.13 and 3.21, you can install [ember-cache-primitive-polyfill](https://github.com/ember-polyfills/ember-cache-primitive-polyfill) to your project.
+
 <!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.16.0/in-depth-topics/autotracking-in-depth.md
+++ b/guides/v3.16.0/in-depth-topics/autotracking-in-depth.md
@@ -407,4 +407,6 @@ console.log(count); // 2
 From the value of `count`, we see that, this time, `aspectRatio` was calculated
 only twice.
 
+The cache API was released in Ember 3.22. If you want to leverage this API between versions 3.13 and 3.21, you can install [ember-cache-primitive-polyfill](https://github.com/ember-polyfills/ember-cache-primitive-polyfill) to your project.
+
 <!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.17.0/in-depth-topics/autotracking-in-depth.md
+++ b/guides/v3.17.0/in-depth-topics/autotracking-in-depth.md
@@ -407,4 +407,6 @@ console.log(count); // 2
 From the value of `count`, we see that, this time, `aspectRatio` was calculated
 only twice.
 
+The cache API was released in Ember 3.22. If you want to leverage this API between versions 3.13 and 3.21, you can install [ember-cache-primitive-polyfill](https://github.com/ember-polyfills/ember-cache-primitive-polyfill) to your project.
+
 <!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.18.0/in-depth-topics/autotracking-in-depth.md
+++ b/guides/v3.18.0/in-depth-topics/autotracking-in-depth.md
@@ -407,4 +407,6 @@ console.log(count); // 2
 From the value of `count`, we see that, this time, `aspectRatio` was calculated
 only twice.
 
+The cache API was released in Ember 3.22. If you want to leverage this API between versions 3.13 and 3.21, you can install [ember-cache-primitive-polyfill](https://github.com/ember-polyfills/ember-cache-primitive-polyfill) to your project.
+
 <!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.19.0/in-depth-topics/autotracking-in-depth.md
+++ b/guides/v3.19.0/in-depth-topics/autotracking-in-depth.md
@@ -407,4 +407,6 @@ console.log(count); // 2
 From the value of `count`, we see that, this time, `aspectRatio` was calculated
 only twice.
 
+The cache API was released in Ember 3.22. If you want to leverage this API between versions 3.13 and 3.21, you can install [ember-cache-primitive-polyfill](https://github.com/ember-polyfills/ember-cache-primitive-polyfill) to your project.
+
 <!-- eof - needed for pages that end in a code block  -->

--- a/guides/v3.20.0/in-depth-topics/autotracking-in-depth.md
+++ b/guides/v3.20.0/in-depth-topics/autotracking-in-depth.md
@@ -407,4 +407,6 @@ console.log(count); // 2
 From the value of `count`, we see that, this time, `aspectRatio` was calculated
 only twice.
 
+The cache API was released in Ember 3.22. If you want to leverage this API between versions 3.13 and 3.21, you can install [ember-cache-primitive-polyfill](https://github.com/ember-polyfills/ember-cache-primitive-polyfill) to your project.
+
 <!-- eof - needed for pages that end in a code block  -->


### PR DESCRIPTION
Fixes #1551 

- [x] Added the following paragraph to the corresponding files.

<pre>The cache API was released in Ember 3.22. If you want to leverage this API between versions 3.13 and 3.21, you can install [ember-cache-primitive-polyfill](https://github.com/ember-polyfills/ember-cache-primitive-polyfill) to your project.</pre>

  - guides/v3.15.0/in-depth-topics/autotracking-in-depth.md
  - guides/v3.16.0/in-depth-topics/autotracking-in-depth.md
  - guides/v3.17.0/in-depth-topics/autotracking-in-depth.md
  - guides/v3.18.0/in-depth-topics/autotracking-in-depth.md
  - guides/v3.19.0/in-depth-topics/autotracking-in-depth.md
  - guides/v3.20.0/in-depth-topics/autotracking-in-depth.md
  - guides/release/in-depth-topics/autotracking-in-depth.md
