### PR TITLE
Adding Ember Inspector link to debugging.md

### DIFF
--- a/guides/release/configuring-ember/debugging.md
+++ b/guides/release/configuring-ember/debugging.md
@@ -1,8 +1,9 @@
-Ember provides several configuration options that can help you debug problems
-with your application.
+Ember provides a browser extension and several configuration options
+to help you debug your application.
 
 ## Ember Inspector
-The [Ember Inspector](https://github.com/emberjs/ember-inspector) is a browser extension that makes understanding and debugging your Ember.js application a snap. To learn more about it check out the [dedicated guide](../../ember-inspector/).
+The [Ember Inspector](https://github.com/emberjs/ember-inspector) is a browser extension that makes it easy to
+understand and debug your Ember.js application. To learn more, check out the [dedicated guide](../../ember-inspector/).
 
 ## Routing
 

--- a/guides/release/configuring-ember/debugging.md
+++ b/guides/release/configuring-ember/debugging.md
@@ -1,6 +1,9 @@
 Ember provides several configuration options that can help you debug problems
 with your application.
 
+## Ember Inspector
+The [Ember Inspector](https://github.com/emberjs/ember-inspector) is a browser extension that makes understanding and debugging your Ember.js application a snap. To learn more about it check out the [dedicated guide](../../ember-inspector/).
+
 ## Routing
 
 ### Log router transitions


### PR DESCRIPTION
This should address #1574. Originally I had written a blurb on the features of ember inspector and included the install links until I realized that we had a whole section dedicated to it. So I slimmed down the description and included a link to the existing guide.

I felt like the Ember inspector was important enough to be included at the top of the debugging section. IMO, its the equivalent of "is your computer turned on?"