### PR TITLE
Update the url of ember-cli-mirage testing docs to avoid test failure

### DIFF
--- a/node-tests/local/external-link-checker.js
+++ b/node-tests/local/external-link-checker.js
@@ -34,7 +34,8 @@ const releasePaths = walkSync('guides/release')
  */
 const doNotCheckList = [
   'http://localhost:4200',
-  'https://codepen.io/melsumner/live/ZJeYoP' // codepen does not play with fetch api
+  'https://codepen.io/melsumner/live/ZJeYoP', // codepen does not play with fetch api
+  'https://www.ember-cli-mirage.com/docs/testing/acceptance-tests', // results in an initial 404, but forwards to the correct path
 ];
 
 describe('check all external links in markdown files', function() {


### PR DESCRIPTION
While opening https://github.com/ember-learn/guides-source/pull/1582 I ran through all the link tests listed in README.md. There was a single test failure when I ran `npm run test:node-local-exclude-api-urls`

![image](https://user-images.githubusercontent.com/675098/96631470-5ef6ad00-12e4-11eb-8e48-69b9dad71f5b.png)

Navigating to https://www.ember-cli-mirage.com/docs/testing/acceptance-tests does result in a 404. Then the router kicks in and puts the path of the request onto a query parameter.

![image](https://user-images.githubusercontent.com/675098/96631676-9ebd9480-12e4-11eb-88b3-b1df6a7366d8.png)

I have changed the URL to the query param'd URL, so that the curl receives a 200 from that link.

However, I don't know how future-proof that link is (if they ever change the router). Another option we have is to adding that link to the `doNotCheckList` in `external-link-checker.js`

```js
const doNotCheckList = [
  'http://localhost:4200',
  'https://codepen.io/melsumner/live/ZJeYoP', // codepen does not play with fetch API
  'https://www.ember-cli-mirage.com/docs/testing/acceptance-tests', // results in an initial 404, but forwards to the correct path
];
```
