### PR TITLE
New script to update version links using the correct version number instead of release

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:node-local": "mocha node-tests/local",
     "test:node-local-exclude-api-urls": "FOLLOW_API_URLS=false npm run test:node-local",
     "release:guides:minor": "scripts/create-new-minor-version",
+    "release:guides:links": "node scripts/update-version-links",
     "release:search": "scripts/update-search-index"
   },
   "devDependencies": {

--- a/scripts/create-new-minor-version
+++ b/scripts/create-new-minor-version
@@ -66,6 +66,11 @@ sed -i .bak -e "/currentVersion/i \\
 rm guides/versions.yml.bak
 echo "  DONE"
 
+# Update version numbers in links
+echo "🤖 Updating version number for links in /guides/$CURRENT_VERSION/**/*.md"
+node scripts/update-version-links guides/$CURRENT_VERSION $(echo $CURRENT_VERSION | cut -d "v" -f2) --silent
+echo "  DONE"
+
 echo
 echo "🤖 Committing changes and publishing branch to remote"
 git add .

--- a/scripts/update-version-links
+++ b/scripts/update-version-links
@@ -1,0 +1,140 @@
+#!/usr/bin/node
+
+/**
+ * Search & Replace previous release numbers
+ * such as `3.15`, `3.15.0`, `v3.15.0` or `release`
+ * to the provided release number for guides and api URLs
+ *
+ * Running tests:
+ * ./update-version-links --tests
+ *
+ * How to use:
+ * ./update-version-links <guides-path> <release-number> <options...>
+ *
+ * Examples:
+ * ./update-version-links ../guides/v3.21.0 3.21
+ * ./update-version-links ../guides/v3.21.0 3.21 --dry-run
+ *
+ * Will replace the following:
+ * https://api.emberjs.com/ember/release/ -> https://api.emberjs.com/ember/3.21/
+ * https://api.emberjs.com/ember/3.15/ -> https://api.emberjs.com/ember/3.21/
+ * https://api.emberjs.com/ember-data/release/ -> https://api.emberjs.com/ember-data/3.21/
+ * https://api.emberjs.com/ember-data/3.15/ -> https://api.emberjs.com/ember-data/3.21/
+ * https://guides.emberjs.com/release/getting-started/ -> https://guides.emberjs.com/v3.21/getting-started/
+ */
+
+const fs = require('fs');
+
+const replaceURLsVersions = (str, version) => {
+  let output;
+
+  // guides use `v3.20.0` version format
+  const patchVersion = /\d+\.\d+.\d+/.test(version) ? version : version + '.0';
+  output = str.replace(
+    /https:\/\/guides.emberjs.com\/(release|v\d+\.\d+.\d+)(\/?)/g,
+    `https://guides.emberjs.com/v${patchVersion}$2`
+  );
+
+  // apis use `3.20` version format
+  output = output.replace(
+    /https:\/\/api.emberjs.com\/(ember|ember-data)\/(release|\d+\.\d+)(\/?)/g,
+    `https://api.emberjs.com/$1/${version}$3`
+  );
+
+  return output;
+};
+
+const runTests = () => {
+  let test;
+
+  console.log('Running tests...');
+
+  test = replaceURLsVersions('https://api.emberjs.com/ember/release/', '3.15');
+  console.log(test === 'https://api.emberjs.com/ember/3.15/' ? '✅' : '❌', test);
+
+  test = replaceURLsVersions('https://api.emberjs.com/ember/release', '3.15');
+  console.log(test === 'https://api.emberjs.com/ember/3.15' ? '✅' : '❌', test);
+
+  test = replaceURLsVersions('https://api.emberjs.com/ember/3.20/', '3.15');
+  console.log(test === 'https://api.emberjs.com/ember/3.15/' ? '✅' : '❌', test);
+
+  test = replaceURLsVersions('https://api.emberjs.com/ember/3.20', '3.15');
+  console.log(test === 'https://api.emberjs.com/ember/3.15' ? '✅' : '❌', test);
+
+  test = replaceURLsVersions('https://api.emberjs.com/ember/release/classes/Application', '3.15');
+  console.log(test === 'https://api.emberjs.com/ember/3.15/classes/Application' ? '✅' : '❌', test);
+
+  test = replaceURLsVersions('https://api.emberjs.com/ember-data/release/', '3.15');
+  console.log(test === 'https://api.emberjs.com/ember-data/3.15/' ? '✅' : '❌', test);
+
+  test = replaceURLsVersions('https://api.emberjs.com/ember-data/release', '3.15');
+  console.log(test === 'https://api.emberjs.com/ember-data/3.15' ? '✅' : '❌', test);
+
+  test = replaceURLsVersions('https://api.emberjs.com/ember-data/release/classes/Model/', '3.15');
+  console.log(test === 'https://api.emberjs.com/ember-data/3.15/classes/Model/' ? '✅' : '❌', test);
+
+  test = replaceURLsVersions('https://api.emberjs.com/ember-data/3.20/classes/Model/', '3.15');
+  console.log(test === 'https://api.emberjs.com/ember-data/3.15/classes/Model/' ? '✅' : '❌', test);
+
+  test = replaceURLsVersions('https://api.emberjs.com/ember/release/classes/@ember%2Fapplication/methods/getOwner', '3.15');
+  console.log(test === 'https://api.emberjs.com/ember/3.15/classes/@ember%2Fapplication/methods/getOwner' ? '✅' : '❌', test);
+
+  test = replaceURLsVersions('https://guides.emberjs.com/release/getting-started/', '3.15');
+  console.log(test === 'https://guides.emberjs.com/v3.15.0/getting-started/' ? '✅' : '❌', test);
+
+  test = replaceURLsVersions('https://guides.emberjs.com/release/getting-started/', '3.16.0');
+  console.log(test === 'https://guides.emberjs.com/v3.16.0/getting-started/' ? '✅' : '❌', test);
+};
+
+if (process.argv[2] === '--tests') {
+  runTests();
+  process.exit(0);
+}
+
+const currentFolder = fs.realpathSync(process.argv[2]);
+const newVersionNumber = process.argv[3];
+const dryRun = process.argv[4] && process.argv[4] === '--dry-run';
+
+let filesFound = [];
+let filesUpdated = [];
+
+const recursion = (path) => {
+  const files = fs.readdirSync(path);
+  files.forEach((fileName) => {
+    const filePath = `${path}/${fileName}`;
+    const stat = fs.statSync(filePath);
+    if (stat.isDirectory()) {
+      recursion(filePath);
+    } else if (fileName.endsWith('.md')) {
+      const currentOutput = fs.readFileSync(filePath).toString();
+      const newOutput = replaceURLsVersions(currentOutput, newVersionNumber);
+
+      if (currentOutput !== newOutput) {
+        if (!dryRun) {
+          fs.writeFileSync(filePath, newOutput);
+        }
+        filesUpdated.push(filePath);
+      }
+
+      filesFound.push(filePath);
+    }
+  });
+}
+
+console.log('Welcome to the automated process of updating the Guides version links');
+console.log();
+
+if (dryRun) {
+  console.log('❗ Running on --dry-run. Files will NOT be updated.');
+  console.log();
+}
+
+recursion(currentFolder);
+
+console.log(`Found: ${filesFound.length} files`);
+console.log(`${dryRun ? 'To be updated:' : 'Updated:'} ${filesUpdated.length} files`);
+
+if (filesUpdated.length) {
+  console.log();
+  console.log(filesUpdated);
+}

--- a/scripts/update-version-links
+++ b/scripts/update-version-links
@@ -14,6 +14,8 @@
  * Examples:
  * ./update-version-links ../guides/v3.21.0 3.21
  * ./update-version-links ../guides/v3.21.0 3.21 --dry-run
+ * ./update-version-links ../guides/v3.21.0 3.21 --silent
+ * ./update-version-links ../guides/v3.21.0 3.21 --verbose
  *
  * Will replace the following:
  * https://api.emberjs.com/ember/release/ -> https://api.emberjs.com/ember/3.21/
@@ -93,7 +95,17 @@ if (process.argv[2] === '--tests') {
 
 const currentFolder = fs.realpathSync(process.argv[2]);
 const newVersionNumber = process.argv[3];
-const dryRun = process.argv[4] && process.argv[4] === '--dry-run';
+
+let dryRun = false;
+let verbose = false;
+let silent = false;
+
+if (process.argv.length > 4) {
+  const options = process.argv.slice(4);
+  dryRun = options.includes('--dry-run');
+  verbose = options.includes('--verbose');
+  silent = options.includes('--silent');
+}
 
 let filesFound = [];
 let filesUpdated = [];
@@ -121,20 +133,24 @@ const recursion = (path) => {
   });
 }
 
-console.log('Welcome to the automated process of updating the Guides version links');
-console.log();
-
-if (dryRun) {
-  console.log('❗ Running on --dry-run. Files will NOT be updated.');
+if (silent) {
+  recursion(currentFolder);
+} else {
+  console.log('Welcome to the automated process of updating the Guides version links');
   console.log();
-}
 
-recursion(currentFolder);
+  if (dryRun) {
+    console.log('❗ Running on --dry-run. Files will NOT be updated.');
+    console.log();
+  }
 
-console.log(`Found: ${filesFound.length} files`);
-console.log(`${dryRun ? 'To be updated:' : 'Updated:'} ${filesUpdated.length} files`);
+  recursion(currentFolder);
 
-if (filesUpdated.length) {
-  console.log();
-  console.log(filesUpdated);
+  console.log(`Found: ${filesFound.length} files`);
+  console.log(`${dryRun ? 'To be updated:' : 'Updated:'} ${filesUpdated.length} files`);
+
+  if (verbose) {
+    console.log();
+    console.log(filesUpdated);
+  }
 }


### PR DESCRIPTION
Currently using `npm run release:guides:minor` to create a new release copies `guides/release` to a its version number (eg. `guides/v3.22.0`), but there is no automated way to update the version numbers in all links pointing to its guides or API links.

See issue #1440 and its https://github.com/ember-learn/guides-source/issues/1440#issuecomment-666800602 to see how much of a chore this convoluted process is.

This PR attempts to:

* Provide a CLI script that can be used on old releases and update its version numbers
![image](https://user-images.githubusercontent.com/127994/97797952-7b9db980-1bef-11eb-8b4b-884ff21019a6.png)

* Hook into the current `release:guides:minor` script and automate the process for future releases
![Code_yRoYCR7jrp](https://user-images.githubusercontent.com/127994/97797923-41341c80-1bef-11eb-967f-e5ce237cda61.png)


---

The new npm script `release:guides:links` syntax looks like this:

```
npm run release:guides:links <guides-path> <release-number> -- <options...>
```

A good example for this use case is version `v3.21.0` which hasn't gone through the process to be updated.

```
npm run release:guides:links guides/v3.21.0 3.21
```

Would return:

```
Welcome to the automated process of updating the Guides version links

Found: 168 files
Updated: 34 files
```

And would update all `.md` files that contain links like:

```
https://api.emberjs.com/ember/release/ -> https://api.emberjs.com/ember/3.21/
https://api.emberjs.com/ember/3.15/ -> https://api.emberjs.com/ember/3.21/
https://api.emberjs.com/ember-data/release/ -> https://api.emberjs.com/ember-data/3.21/
https://api.emberjs.com/ember-data/3.15/ -> https://api.emberjs.com/ember-data/3.21/
https://guides.emberjs.com/release/getting-started/ -> https://guides.emberjs.com/v3.21/getting-started/
```

---

There are a set of options built into the script:

* `--verbose` to display the full list of updated files
* `--silent` to prevent messages to be sent to the console; used in `release:guides:minor`.
* `--dry-run` to see how many files are to be updated. Use it in combination with `--verbose` to see the full list. 
* `--tests` to see a simple list of unit tests used to match the URLs

---

Hopefully this will make things easier moving forward, and will be significantly easier to update older releases as well.

**Note:** this script can work independently from npm and doesn't have to be an npm-script to run. We can remove it from the npm-scripts if preferred.

---

![image](https://user-images.githubusercontent.com/127994/97798177-b86ab000-1bf1-11eb-9fd0-20bbff8b875b.png)