### PR TITLE
Fix guides links

### DIFF
--- a/guides/release/index.md
+++ b/guides/release/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/">Ember.js</a>
+		<a href="./getting-started/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="./models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="./ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.10.0/index.md
+++ b/guides/v3.10.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/intro/">Ember.js</a>
+		<a href="./getting-started/intro/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="./models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="./ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.10.0/object-model/enumerables.md
+++ b/guides/v3.10.0/object-model/enumerables.md
@@ -20,7 +20,7 @@ where available.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         It is best practice to
-        <a href="https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/">
+        <a href="../../configuring-ember/disabling-prototype-extensions/">
           disable prototype extensions
         </a>
         in your app.

--- a/guides/v3.11.0/index.md
+++ b/guides/v3.11.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/intro/">Ember.js</a>
+		<a href="./getting-started/intro/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="./models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="./ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.11.0/object-model/enumerables.md
+++ b/guides/v3.11.0/object-model/enumerables.md
@@ -20,7 +20,7 @@ where available.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         It is best practice to
-        <a href="https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/">
+        <a href="../../configuring-ember/disabling-prototype-extensions/">
           disable prototype extensions
         </a>
         in your app.

--- a/guides/v3.12.0/index.md
+++ b/guides/v3.12.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/intro/">Ember.js</a>
+		<a href="./getting-started/intro/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="./models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="./ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.12.0/object-model/enumerables.md
+++ b/guides/v3.12.0/object-model/enumerables.md
@@ -20,7 +20,7 @@ where available.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         It is best practice to
-        <a href="https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/">
+        <a href="../../configuring-ember/disabling-prototype-extensions/">
           disable prototype extensions
         </a>
         in your app.

--- a/guides/v3.13.0/index.md
+++ b/guides/v3.13.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/intro/">Ember.js</a>
+		<a href="./getting-started/intro/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="./models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="./ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.13.0/object-model/enumerables.md
+++ b/guides/v3.13.0/object-model/enumerables.md
@@ -20,7 +20,7 @@ where available.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         It is best practice to
-        <a href="https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/">
+        <a href="../../configuring-ember/disabling-prototype-extensions/">
           disable prototype extensions
         </a>
         in your app.

--- a/guides/v3.14.0/index.md
+++ b/guides/v3.14.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/intro/">Ember.js</a>
+		<a href="./getting-started/intro/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="./models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="./ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.14.0/object-model/enumerables.md
+++ b/guides/v3.14.0/object-model/enumerables.md
@@ -20,7 +20,7 @@ where available.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         It is best practice to
-        <a href="https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/">
+        <a href="../../configuring-ember/disabling-prototype-extensions/">
           disable prototype extensions
         </a>
         in your app.

--- a/guides/v3.15.0/index.md
+++ b/guides/v3.15.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/">Ember.js</a>
+		<a href="./getting-started/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="./models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="./ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.15.0/object-model/enumerables.md
+++ b/guides/v3.15.0/object-model/enumerables.md
@@ -20,7 +20,7 @@ where available.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         It is best practice to
-        <a href="https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/">
+        <a href="https://guides.emberjs.com/v3.15.0/configuring-ember/disabling-prototype-extensions/">
           disable prototype extensions
         </a>
         in your app.

--- a/guides/v3.15.0/object-model/enumerables.md
+++ b/guides/v3.15.0/object-model/enumerables.md
@@ -20,7 +20,7 @@ where available.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         It is best practice to
-        <a href="https://guides.emberjs.com/v3.15.0/configuring-ember/disabling-prototype-extensions/">
+        <a href="../../configuring-ember/disabling-prototype-extensions/">
           disable prototype extensions
         </a>
         in your app.

--- a/guides/v3.16.0/index.md
+++ b/guides/v3.16.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/">Ember.js</a>
+		<a href="./getting-started/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="./models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="./ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.17.0/index.md
+++ b/guides/v3.17.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/">Ember.js</a>
+		<a href="./getting-started/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="./models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="./ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.18.0/index.md
+++ b/guides/v3.18.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/">Ember.js</a>
+		<a href="./getting-started/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="./models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="./ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.19.0/index.md
+++ b/guides/v3.19.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/">Ember.js</a>
+		<a href="./getting-started/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="./models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="./ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.20.0/index.md
+++ b/guides/v3.20.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/">Ember.js</a>
+		<a href="./getting-started/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="./models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="./ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.21.0/applications/dependency-injection.md
+++ b/guides/v3.21.0/applications/dependency-injection.md
@@ -11,11 +11,11 @@ guide covers the details of the system, and how to use it when needed.
 
 Applications and application instances each serve a role in Ember's DI implementation.
 
-An [`Application`](https://api.emberjs.com/ember/release/classes/Application) serves as a "registry" for dependency declarations.
+An [`Application`](https://api.emberjs.com/ember/3.21/classes/Application) serves as a "registry" for dependency declarations.
 Factories (i.e. classes) are registered with an application,
 as well as rules about "injecting" dependencies that are applied when objects are instantiated.
 
-An [`ApplicationInstance`](https://api.emberjs.com/ember/release/classes/ApplicationInstance) serves as the "owner" for objects that are instantiated from registered factories.
+An [`ApplicationInstance`](https://api.emberjs.com/ember/3.21/classes/ApplicationInstance) serves as the "owner" for objects that are instantiated from registered factories.
 Application instances provide a means to "look up" (i.e. instantiate and / or retrieve) objects.
 
 > _Note: Although an `Application` serves as the primary registry for an app,
@@ -203,7 +203,7 @@ export default Component.extend({
 ## Factory Instance Lookups
 
 To fetch an instantiated factory from the running application you can call the
-[`lookup`](https://api.emberjs.com/ember/release/classes/ApplicationInstance/methods/lookup?anchor=lookup) method on an application instance. This method takes a string
+[`lookup`](https://api.emberjs.com/ember/3.21/classes/ApplicationInstance/methods/lookup?anchor=lookup) method on an application instance. This method takes a string
 to identify a factory and returns the appropriate object.
 
 ```javascript
@@ -234,9 +234,9 @@ export default {
 
 ### Getting an Application Instance from a Factory Instance
 
-[`Ember.getOwner`](https://api.emberjs.com/ember/release/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) will retrieve the application instance that "owns" an
+[`Ember.getOwner`](https://api.emberjs.com/ember/3.21/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) will retrieve the application instance that "owns" an
 object. This means that framework objects like components, helpers, and routes
-can use [`Ember.getOwner`](https://api.emberjs.com/ember/release/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) to perform lookups through their application
+can use [`Ember.getOwner`](https://api.emberjs.com/ember/3.21/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) to perform lookups through their application
 instance at runtime.
 
 For example, this component plays songs with different audio services based

--- a/guides/v3.21.0/applications/ember-engines.md
+++ b/guides/v3.21.0/applications/ember-engines.md
@@ -1,6 +1,6 @@
 ## What are Engines?
 
-[Ember Engines](http://ember-engines.com/) allow multiple logical applications to be composed together into a single application from the user's perspective, that provide functionality to their host applications. Engines are isolated, `composable applications`, they have almost all the same features as normal Ember applications, except an [Engine](https://api.emberjs.com/ember/release/classes/Engine) requires a host application to boot it and provide a Router instance.
+[Ember Engines](http://ember-engines.com/) allow multiple logical applications to be composed together into a single application from the user's perspective, that provide functionality to their host applications. Engines are isolated, `composable applications`, they have almost all the same features as normal Ember applications, except an [Engine](https://api.emberjs.com/ember/3.21/classes/Engine) requires a host application to boot it and provide a Router instance.
 
 ## Why use Engines?
 

--- a/guides/v3.21.0/applications/index.md
+++ b/guides/v3.21.0/applications/index.md
@@ -1,8 +1,8 @@
-Every Ember application is represented by a class that extends [`Application`](https://api.emberjs.com/ember/release/classes/Application).
+Every Ember application is represented by a class that extends [`Application`](https://api.emberjs.com/ember/3.21/classes/Application).
 This class is used to declare and configure the many objects that make up your app.
 
 As your application boots,
-it creates an [`ApplicationInstance`](https://api.emberjs.com/ember/release/classes/ApplicationInstance) that is used to manage its stateful aspects.
+it creates an [`ApplicationInstance`](https://api.emberjs.com/ember/3.21/classes/ApplicationInstance) that is used to manage its stateful aspects.
 This instance acts as the "owner" of objects instantiated for your app.
 
 Essentially, the `Application` *defines your application*

--- a/guides/v3.21.0/applications/run-loop.md
+++ b/guides/v3.21.0/applications/run-loop.md
@@ -197,9 +197,9 @@ window.addEventListener('online', () => {
 });
 ```
 
-The run loop API calls that _schedule_ work, i.e. [`run.schedule`](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop/methods/schedule?anchor=schedule),
-[`run.scheduleOnce`](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop/methods/scheduleOnce?anchor=scheduleOnce),
-[`run.once`](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop/methods/once?anchor=once) have the property that they will approximate a run loop for you if one does not already exist.
+The run loop API calls that _schedule_ work, i.e. [`run.schedule`](https://api.emberjs.com/ember/3.21/classes/@ember%2Frunloop/methods/schedule?anchor=schedule),
+[`run.scheduleOnce`](https://api.emberjs.com/ember/3.21/classes/@ember%2Frunloop/methods/scheduleOnce?anchor=scheduleOnce),
+[`run.once`](https://api.emberjs.com/ember/3.21/classes/@ember%2Frunloop/methods/once?anchor=once) have the property that they will approximate a run loop for you if one does not already exist.
 These automatically created run loops we call _autoruns_.
 
 Here is some pseudocode to describe what happens using the example above:
@@ -240,5 +240,5 @@ window.addEventListener('online', () => {
 
 ## Where can I find more information?
 
-Check out the [Ember.run](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop) API documentation,
+Check out the [Ember.run](https://api.emberjs.com/ember/3.21/classes/@ember%2Frunloop) API documentation,
 as well as the [Backburner library](https://github.com/ebryn/backburner.js/) that powers the run loop.

--- a/guides/v3.21.0/components/built-in-components.md
+++ b/guides/v3.21.0/components/built-in-components.md
@@ -1,7 +1,7 @@
 Out of the box, Ember provides 2 components for building a form:
 
-* [`<Input>`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input)
-* [`<Textarea>`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea)
+* [`<Input>`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.components/methods/Input?anchor=Input)
+* [`<Textarea>`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea)
 
 These components are similar in HTML markup to the native `<input>` or `<textarea>` elements. In contrast to the native elements, `<Input>` and `<Textarea>` automatically update the state of their bound values.
 
@@ -161,7 +161,7 @@ Note, the `keydown` event was used for `Escape` because `keypress` is deprecated
 ### Checkboxes
 
 You can use the
-[`<Input>`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input)
+[`<Input>`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.components/methods/Input?anchor=Input)
 component to create a checkbox. Set `@type` to the string `"checkbox"`, and use `@checked` instead of `@value`.
 
 ```handlebars
@@ -215,8 +215,8 @@ With the exception of `@value` argument, you can use any [attribute](https://dev
 
 You might need to bind a property dynamically to an input if you're building a
 flexible form, for example. To achieve this you need to use the
-[`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
-and [`{{mut}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/mut?anchor=mut)
+[`{{get}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/get?anchor=get)
+and [`{{mut}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/mut?anchor=mut)
 in conjunction like shown in the following example:
 
 ```handlebars
@@ -230,5 +230,5 @@ in conjunction like shown in the following example:
 The `{{get}}` helper allows you to dynamically specify which property to bind,
 while the `{{mut}}` helper allows the binding to be updated from the input. See
 the respective helper documentation for more detail:
-[`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
-and [`{{mut}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/mut?anchor=mut).
+[`{{get}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/get?anchor=get)
+and [`{{mut}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/mut?anchor=mut).

--- a/guides/v3.21.0/components/conditional-content.md
+++ b/guides/v3.21.0/components/conditional-content.md
@@ -221,4 +221,4 @@ It looks similar to a ternary operator.
 
 ## Learn More
 
-Please see the [API documentation of the `if` helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.
+Please see the [API documentation of the `if` helper](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/if?anchor=if) for more patterns.

--- a/guides/v3.21.0/components/helper-functions.md
+++ b/guides/v3.21.0/components/helper-functions.md
@@ -204,7 +204,7 @@ discussing state in the next chapter).
 
 ### The `get` helper
 
-The [`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
+The [`{{get}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/get?anchor=get)
 helper makes it easy to dynamically send the value of a variable to another
 helper or component. This can be useful if you want to output one of several
 values based on the result of a getter.
@@ -220,7 +220,7 @@ If it returns "city", you get `this.address.city`.
 
 We mentioned above that helpers can be nested. This can be
 combined with different dynamic helpers. For example, the
-[`{{concat}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
+[`{{concat}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
 helper makes it easy to dynamically send a number of parameters to a component
 or helper as a single parameter in the format of a concatenated string.
 
@@ -236,7 +236,7 @@ This will display the result of `this.foo.item1` when index is 1, and
 Now let's say your template is starting to get a bit cluttered and you want
 to clean up the logic in your templates. This can be achieved with the `let`
 block helper.
-The [`{{let}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/let?anchor=let)
+The [`{{let}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/let?anchor=let)
 helper lets you create new bindings (or temporary variables) in your template.
 
 Say your template now looks like this:
@@ -273,7 +273,7 @@ capitalized given name and family name as `givenName` and `familyName` instead o
 
 ### The `array` helper
 
-Using the [`{{array}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
+Using the [`{{array}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
 you can pass arrays directly from the template as an argument to your components.
 
 ```handlebars
@@ -298,7 +298,7 @@ In the component's template, you can then use the `people` argument as an array:
 
 ### The `hash` helper
 
-Using the [`{{hash}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
+Using the [`{{hash}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
 helper, you can pass objects directly from the template as an argument to your
 components.
 
@@ -317,4 +317,4 @@ In the component's template, you can then use the `person` object:
 Hello, {{@person.givenName}} {{@person.familyName}}
 ```
 
-To consult all available built-in helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/).
+To consult all available built-in helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/).

--- a/guides/v3.21.0/components/looping-through-lists.md
+++ b/guides/v3.21.0/components/looping-through-lists.md
@@ -1,6 +1,6 @@
 Oftentimes we'll need to repeat a component multiple times in a row, with
 different data for each usage of the component. We can use the
-[`{{#each}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper to loop through lists of items like this, repeating a section of template
 for each item in the list.
 
@@ -191,7 +191,7 @@ as a string.
         Be sure to sanitize the HTML before you render it.
         </p>
         <p>
-        We can use the <a href="https://api.emberjs.com/ember/release/functions/@ember%2Ftemplate/htmlSafe">htmlSafe</a>
+        We can use the <a href="https://api.emberjs.com/ember/3.21/functions/@ember%2Ftemplate/htmlSafe">htmlSafe</a>
         function to mark a sanitized HTML as safe, then use double curly brackets to render the HTML.
         We can also create a <a href="../helper-functions">helper</a> that sanitizes the HTML, marks it as safe,
         and returns the output.
@@ -275,7 +275,7 @@ And in the component class, we'll add the `addMessage` action. This action will
 create the new message from the text that the `<NewMessageInput>` component
 gives us, and push it into the messages array. In order for the messages array
 to react to that change, we'll also need to convert it into an
-[`EmberArray`](https://api.emberjs.com/ember/release/classes/EmberArray).
+[`EmberArray`](https://api.emberjs.com/ember/3.21/classes/EmberArray).
 `EmberArray` provides special methods that tell Ember when changes occur to the
 array itself.
 
@@ -375,7 +375,7 @@ export default class SomeComponent extends Component {
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can also have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 
@@ -391,7 +391,7 @@ render if the array passed to `{{#each}}` is empty:
 
 There are also times when we need to loop through the keys and values of an
 object rather than an array, similar to JavaScript's `for...in` loop. We can use
-the [`{{#each-in}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
+the [`{{#each-in}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper to do this:
 
 ```javascript {data-filename=/app/components/store-categories.js}
@@ -451,12 +451,12 @@ The above example will print a list like this:
 An object's keys will be listed in the same order as the array returned from
 calling `Object.keys` on that object. If you want a different sort order, you
 should use `Object.keys` to get an array, sort that array with the built-in JavaScript
-tools, and use the [`{{#each}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=each)
+tools, and use the [`{{#each}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`. The contents of this block will render if
 the object is empty, null, or undefined:
 

--- a/guides/v3.21.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.21.0/configuring-ember/disabling-prototype-extensions.md
@@ -9,7 +9,7 @@ objects in the following ways:
 
 * `String` is extended to add convenience methods, such as
   `camelize()` and `w()`. You can find a list of these methods with the
-  [Ember.String documentation](https://api.emberjs.com/ember/release/classes/String).
+  [Ember.String documentation](https://api.emberjs.com/ember/3.21/classes/String).
 
 * `Function` is extended with methods to annotate functions as
   computed properties, via the `property()` method, and as observers,
@@ -90,7 +90,7 @@ islands.pushObject('Maui');
 ### Strings
 
 Strings will no longer have the convenience methods described in the
-[`Ember.String` API reference](https://api.emberjs.com/ember/release/classes/String).
+[`Ember.String` API reference](https://api.emberjs.com/ember/3.21/classes/String).
 Instead,
 you can use the similarly-named methods of the `Ember.String` object and
 pass the string to use as the first parameter:
@@ -147,7 +147,7 @@ aspectRatioDidChange: observer('aspectRatio', function() {
 })
 ```
 
-Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/release/classes/Evented/methods/on?anchor=on):
+Evented functions are annotated using [`Ember.on()`](https://api.emberjs.com/ember/3.21/classes/Evented/methods/on?anchor=on):
 
 ```javascript
 import { on } from '@ember/object/evented';

--- a/guides/v3.21.0/configuring-ember/handling-deprecations.md
+++ b/guides/v3.21.0/configuring-ember/handling-deprecations.md
@@ -10,7 +10,7 @@ Fortunately, Ember provides a way for projects to deal with deprecations in an o
 ## Filtering Deprecations
 
 When your project has a lot of deprecations, you can start by filtering out deprecations that do not have to be addressed right away.
-You can use the [deprecation handlers](https://api.emberjs.com/ember/release/functions/@ember%2Fdebug/registerDeprecationHandler) API to check for what release a deprecated feature will be removed.
+You can use the [deprecation handlers](https://api.emberjs.com/ember/3.21/functions/@ember%2Fdebug/registerDeprecationHandler) API to check for what release a deprecated feature will be removed.
 An example handler is shown below that filters out all deprecations that are not going away in release 2.0.0.
 
 ```javascript {data-filename= app/initializers/main.js}

--- a/guides/v3.21.0/configuring-ember/optional-features.md
+++ b/guides/v3.21.0/configuring-ember/optional-features.md
@@ -102,7 +102,7 @@ Now your app will be about 30KB lighter!
 
 Without jQuery, any code that still relies on it will break, especially the following usages:
 
-- [`this.$()`](https://api.emberjs.com/ember/release/classes/Component/methods/$?anchor=%24) in components
+- [`this.$()`](https://api.emberjs.com/ember/3.21/classes/Component/methods/$?anchor=%24) in components
 - `jQuery` or `$` directly as a global, through `Ember.$()` or by importing it (`import jQuery from jquery;`)
 - global acceptance test helpers like `find()` or `click()`
 - `this.$()` in component tests

--- a/guides/v3.21.0/ember-inspector/data.md
+++ b/guides/v3.21.0/ember-inspector/data.md
@@ -30,4 +30,4 @@ You can also filter records by entering a query in the search box.
 ### Building a Data Custom Adapter
 
 You can use your own data persistence library with the Inspector. Build a [data adapter](https://github.com/emberjs/ember.js/blob/3ac2fdb0b7373cbe9f3100bdb9035dd87a849f64/packages/ember-extension-support/lib/data_adapter.js), and you can inspect your models
-using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter and [DataAdapter](https://api.emberjs.com/ember/release/classes/DataAdapter) documentation.
+using the Data tab. Use [Ember Data's data adapter](https://github.com/emberjs/data/blob/d7988679590bff63f4d92c4b5ecab173bd624ebb/packages/ember-data/lib/system/debug/debug_adapter.js) as an example for how to build your data adapter and [DataAdapter](https://api.emberjs.com/ember/3.21/classes/DataAdapter) documentation.

--- a/guides/v3.21.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.21.0/in-depth-topics/native-classes-in-depth.md
@@ -676,7 +676,7 @@ after overriding. This allows the super class method to continue operating as it
 normally would.
 
 One common example is when overriding the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.21/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook in one of Ember Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:

--- a/guides/v3.21.0/in-depth-topics/patterns-for-components.md
+++ b/guides/v3.21.0/in-depth-topics/patterns-for-components.md
@@ -125,7 +125,7 @@ To learn more about `aria` roles and accessibility in Ember, check out the [Acce
 
 ## Contextual Components
 
-The [`{{component}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
+The [`{{component}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/component?anchor=component)
 helper can be used to defer the selection of a component to run time. The
 `<MyComponent />` syntax always renders the same component, while using the
 `{{component}}` helper allows choosing a component to render on the fly. This is
@@ -136,7 +136,7 @@ different logic well separated.
 The first parameter of the helper is the name of a component to render, as a
 string. So `{{component 'blog-post'}}` is the same as using `<BlogPost />`.
 
-The real value of [`{{component}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)
+The real value of [`{{component}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/component?anchor=component)
 comes from being able to dynamically pick the component being rendered. Below is
 an example of using the helper as a means of choosing different components for
 displaying different kinds of posts:

--- a/guides/v3.21.0/index.md
+++ b/guides/v3.21.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/v3.21.0/getting-started/">Ember.js</a>
+		<a href="./getting-started/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/v3.21.0/models/">Ember Data</a>
+		<a href="./models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/v3.21.0/ember-inspector/">Ember Inspector</a></li>
+		<a href="./ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.21.0/index.md
+++ b/guides/v3.21.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/">Ember.js</a>
+		<a href="https://guides.emberjs.com/v3.21.0/getting-started/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="https://guides.emberjs.com/v3.21.0/models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="https://guides.emberjs.com/v3.21.0/ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.21.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.21.0/models/creating-updating-and-deleting-records.md
@@ -1,7 +1,7 @@
 ## Creating Records
 
 You can create records by calling the
-[`createRecord()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/createRecord?anchor=createRecord)
+[`createRecord()`](https://api.emberjs.com/ember-data/3.21/classes/Store/methods/createRecord?anchor=createRecord)
 method on the store.
 
 ```javascript
@@ -28,7 +28,7 @@ this.store.findRecord('post', 1).then(function(post) {
 ## Persisting Records
 
 Records in Ember Data are persisted on a per-instance basis.
-Call [`save()`](https://api.emberjs.com/ember-data/release/classes/Model/methods/save?anchor=save)
+Call [`save()`](https://api.emberjs.com/ember-data/3.21/classes/Model/methods/save?anchor=save)
 on any instance of `Model` and it will make a network request.
 
 Ember Data takes care of tracking the state of each record for
@@ -60,10 +60,10 @@ store.findRecord('post', 1).then(function(post) {
 
 You can tell if a record has outstanding changes that have not yet been
 saved by checking its
-[`hasDirtyAttributes`](https://api.emberjs.com/ember-data/release/classes/Model/properties/hasDirtyAttributes?anchor=hasDirtyAttributes)
+[`hasDirtyAttributes`](https://api.emberjs.com/ember-data/3.21/classes/Model/properties/hasDirtyAttributes?anchor=hasDirtyAttributes)
 property. You can also see what parts of
 the record were changed and what the original value was using the
-[`changedAttributes()`](https://api.emberjs.com/ember-data/release/classes/Model/methods/changedAttributes?anchor=changedAttributes)
+[`changedAttributes()`](https://api.emberjs.com/ember-data/3.21/classes/Model/methods/changedAttributes?anchor=changedAttributes)
 method. `changedAttributes` returns an object, whose keys are the changed
 properties and values are an array of values `[oldValue, newValue]`.
 
@@ -77,7 +77,7 @@ person.changedAttributes(); // => { isAdmin: [false, true] }
 
 At this point, you can either persist your changes via `save()` or you can roll
 back your changes. Calling
-[`rollbackAttributes()`](https://api.emberjs.com/ember-data/release/classes/Model/methods/rollbackAttributes?anchor=rollbackAttributes)
+[`rollbackAttributes()`](https://api.emberjs.com/ember-data/3.21/classes/Model/methods/rollbackAttributes?anchor=rollbackAttributes)
 for a saved record reverts all the `changedAttributes` to their original value.
 If the record `isNew` it will be removed from the store.
 
@@ -109,7 +109,7 @@ the errors from saving a blog post in your template:
 
 ## Promises
 
-[`save()`](https://api.emberjs.com/ember-data/release/classes/Model/methods/save?anchor=save) returns
+[`save()`](https://api.emberjs.com/ember-data/3.21/classes/Model/methods/save?anchor=save) returns
 a promise, which makes it easy to asynchronously handle success and failure
 scenarios. Here's a common pattern:
 
@@ -140,10 +140,10 @@ post
 
 ## Deleting Records
 
-Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/release/classes/Model/methods/deleteRecord?anchor=deleteRecord)
+Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/3.21/classes/Model/methods/deleteRecord?anchor=deleteRecord)
 on any instance of `Model`. This flags the record as `isDeleted`. The
 deletion can then be persisted using `save()`. Alternatively, you can use
-the [`destroyRecord`](https://api.emberjs.com/ember-data/release/classes/Model/methods/destroyRecord?anchor=destroyRecord) method to delete and persist at the same time.
+the [`destroyRecord`](https://api.emberjs.com/ember-data/3.21/classes/Model/methods/destroyRecord?anchor=destroyRecord) method to delete and persist at the same time.
 
 ```javascript
 let post = store.peekRecord('post', 1);

--- a/guides/v3.21.0/models/customizing-adapters.md
+++ b/guides/v3.21.0/models/customizing-adapters.md
@@ -47,17 +47,17 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
 Ember Data comes with several built-in adapters.
 Feel free to use these adapters as a starting point for creating your own custom adapter.
 
-- [`Adapter`](https://api.emberjs.com/ember-data/release/classes/Adapter) is the basic adapter
+- [`Adapter`](https://api.emberjs.com/ember-data/3.21/classes/Adapter) is the basic adapter
 with no functionality. It is generally a good starting point if you
 want to create an adapter that is radically different from the other
 Ember adapters.
 
-- [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/release/classes/JSONAPIAdapter)
+- [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/3.21/classes/JSONAPIAdapter)
 The `JSONAPIAdapter` is the default adapter and follows JSON:API
 conventions to communicate with an HTTP server by transmitting JSON
 via XHR.
 
-- [`RESTAdapter`](https://api.emberjs.com/ember-data/release/classes/RESTAdapter)
+- [`RESTAdapter`](https://api.emberjs.com/ember-data/3.21/classes/RESTAdapter)
 The `RESTAdapter` allows your store to communicate with an HTTP server
 by transmitting JSON via XHR. Before Ember Data 2.0 this adapter was the default.
 
@@ -65,7 +65,7 @@ by transmitting JSON via XHR. Before Ember Data 2.0 this adapter was the default
 ## Customizing the JSONAPIAdapter
 
 The
-[JSONAPIAdapter](https://api.emberjs.com/ember-data/release/classes/JSONAPIAdapter)
+[JSONAPIAdapter](https://api.emberjs.com/ember-data/3.21/classes/JSONAPIAdapter)
 has a handful of hooks that are commonly used to extend it to work
 with non-standard backends.
 

--- a/guides/v3.21.0/models/customizing-serializers.md
+++ b/guides/v3.21.0/models/customizing-serializers.md
@@ -5,11 +5,11 @@ format, Ember Data allows you to customize the serializer or use a
 different serializer entirely.
 
 Ember Data ships with 3 serializers. The
-[`JSONAPISerializer`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer)
+[`JSONAPISerializer`](https://api.emberjs.com/ember-data/3.21/classes/JSONAPISerializer)
 is the default serializer and works with JSON:API backends. The
-[`JSONSerializer`](https://api.emberjs.com/ember-data/release/classes/JSONSerializer)
+[`JSONSerializer`](https://api.emberjs.com/ember-data/3.21/classes/JSONSerializer)
 is a simple serializer for working with single JSON object or arrays of records. The
-[`RESTSerializer`](https://api.emberjs.com/ember-data/release/classes/RESTSerializer)
+[`RESTSerializer`](https://api.emberjs.com/ember-data/3.21/classes/RESTSerializer)
 is a more complex serializer that supports sideloading and was the default
 serializer before 2.0.
 
@@ -141,7 +141,7 @@ export default class PostSerializer extends JSONAPISerializer {
 ```
 
 To change the format of the data that is sent to the backend store, you can use
-the [`serialize()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/serialize?anchor=serialize)
+the [`serialize()`](https://api.emberjs.com/ember-data/3.21/classes/JSONAPISerializer/methods/serialize?anchor=serialize)
 hook. Let's say that we have this JSON:API response from Ember Data:
 
 ```json
@@ -200,7 +200,7 @@ export default class ApplicationSerializer extends JSONAPISerializer {
 
 Similarly, if your backend store provides data in a format other than JSON:API,
 you can use the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/3.21/classes/JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -254,11 +254,11 @@ export default class ApplicationSerializer extends JSONAPISerializer {
 ```
 
 To normalize only a single model, you can use the
-[`normalize()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/normalize?anchor=normalize)
+[`normalize()`](https://api.emberjs.com/ember-data/3.21/classes/JSONAPISerializer/methods/normalize?anchor=normalize)
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
-API documentation](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer).
+API documentation](https://api.emberjs.com/ember-data/3.21/classes/JSONAPISerializer).
 
 ### IDs
 
@@ -311,7 +311,7 @@ in the document payload returned by your server:
 
 If the attributes returned by your server use a different convention
 you can use the serializer's
-[`keyForAttribute()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/keyForAttribute?anchor=keyForAttribute)
+[`keyForAttribute()`](https://api.emberjs.com/ember-data/3.21/classes/JSONAPISerializer/methods/keyForAttribute?anchor=keyForAttribute)
 method to convert an attribute name in your model to a key in your JSON
 payload. For example, if your backend returned attributes that are
 `under_scored` instead of `dash-cased` you could override the `keyForAttribute`
@@ -423,7 +423,7 @@ The JSON should encode the relationship as an ID to another record:
 ```
 If needed these naming conventions can be overwritten by implementing
 the
-[`keyForRelationship()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/keyForRelationship?anchor=keyForRelationship)
+[`keyForRelationship()`](https://api.emberjs.com/ember-data/3.21/classes/JSONAPISerializer/methods/keyForRelationship?anchor=keyForRelationship)
 method.
 
 ```javascript {data-filename=app/serializers/application.js}
@@ -546,7 +546,7 @@ looks similar to this:
 The `JSONAPISerializer` is built on top of the `JSONSerializer` so they share
 many of the same hooks for customizing the behavior of the
 serialization process. Be sure to check out the
-[API docs](https://api.emberjs.com/ember-data/release/classes/JSONSerializer)
+[API docs](https://api.emberjs.com/ember-data/3.21/classes/JSONSerializer)
 for a full list of methods and properties.
 
 
@@ -752,7 +752,7 @@ Note that the type is `"post"` to match the post model and the
 ### Normalizing adapter responses
 
 When creating a custom serializer you will need to define a
-[normalizeResponse](https://api.emberjs.com/ember-data/release/classes/Serializer/methods/normalizeResponse?anchor=normalizeResponse)
+[normalizeResponse](https://api.emberjs.com/ember-data/3.21/classes/Serializer/methods/normalizeResponse?anchor=normalizeResponse)
 method to transform the response from the adapter into the normalized
 JSON object described above.
 
@@ -764,7 +764,7 @@ the possible values of: `'findRecord'`, `'queryRecord'`, `'findAll'`,
 `'createRecord'`, `'deleteRecord'`, and `'updateRecord'`) as arguments.
 
 A custom serializer will also need to define a
-[normalize](https://api.emberjs.com/ember-data/release/classes/Serializer/methods/normalize?anchor=normalize)
+[normalize](https://api.emberjs.com/ember-data/3.21/classes/Serializer/methods/normalize?anchor=normalize)
 method.
 This method is called by `store.normalize(type, payload)` and is often
 used for normalizing requests made outside of Ember Data because they
@@ -773,7 +773,7 @@ do not fall into the normal CRUD flow that the adapter provides.
 ### Serializing records
 
 Finally a serializer will need to implement a
-[serialize](https://api.emberjs.com/ember-data/release/classes/Serializer/methods/serialize?anchor=serialize)
+[serialize](https://api.emberjs.com/ember-data/3.21/classes/Serializer/methods/serialize?anchor=serialize)
 method.
 Ember Data will provide a record snapshot and an options hash and this
 method should return an object that the adapter will send to the

--- a/guides/v3.21.0/models/defining-models.md
+++ b/guides/v3.21.0/models/defining-models.md
@@ -39,7 +39,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
 ## Defining Attributes
 
 The `person` model we generated earlier didn't have any attributes. Let's
-add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/release/functions/@ember-data%2Fmodel/attr):
+add first and last name, as well as the birthday, using [`attr`](https://api.emberjs.com/ember-data/3.21/functions/@ember-data%2Fmodel/attr):
 
 ```javascript {data-filename=app/models/person.js}
 import Model, { attr } from '@ember-data/model';

--- a/guides/v3.21.0/models/finding-records.md
+++ b/guides/v3.21.0/models/finding-records.md
@@ -2,7 +2,7 @@ The Ember Data store provides an interface for retrieving records of a single ty
 
 ### Retrieving a Single Record
 
-Use [`store.findRecord()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/findRecord?anchor=findRecord) to retrieve a record by its type and ID.
+Use [`store.findRecord()`](https://api.emberjs.com/ember-data/3.21/classes/Store/methods/findRecord?anchor=findRecord) to retrieve a record by its type and ID.
 This will return a promise that fulfills with the requested record:
 
 ```javascript
@@ -13,7 +13,7 @@ this.store.findRecord('blog-post', 1)  // => GET /blog-posts/1
   });
 ```
 
-Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/peekRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
+Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.21/classes/Store/methods/peekRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
@@ -22,7 +22,7 @@ let blogPost = this.store.peekRecord('blog-post', 1); // => no network request
 
 ### Retrieving Multiple Records
 
-Use [`store.findAll()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/findAll?anchor=findAll) to retrieve all of the records for a given type:
+Use [`store.findAll()`](https://api.emberjs.com/ember-data/3.21/classes/Store/methods/findAll?anchor=findAll) to retrieve all of the records for a given type:
 
 ```javascript
 // GET /blog-posts
@@ -32,7 +32,7 @@ this.store.findAll('blog-post') // => GET /blog-posts
   });
 ```
 
-Use [`store.peekAll()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/peekAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
+Use [`store.peekAll()`](https://api.emberjs.com/ember-data/3.21/classes/Store/methods/peekAll?anchor=peekAll) to retrieve all of the records for a given type that are already loaded into the store, without making a network request:
 
 ```javascript
 let blogPosts = this.store.peekAll('blog-post'); // => no network request
@@ -40,14 +40,14 @@ let blogPosts = this.store.peekAll('blog-post'); // => no network request
 
 `store.findAll()` returns a `PromiseArray` that fulfills to a `RecordArray` and `store.peekAll` directly returns a `RecordArray`.
 
-It's important to note that `RecordArray` is not a JavaScript array, it's an object that implements [`MutableArray`](https://api.emberjs.com/ember/release/classes/MutableArray).
+It's important to note that `RecordArray` is not a JavaScript array, it's an object that implements [`MutableArray`](https://api.emberjs.com/ember/3.21/classes/MutableArray).
 This is important because, for example, if you want to retrieve records by index,
 the `[]` notation will not work--you'll have to use `objectAt(index)` instead.
 
 ### Querying for Multiple Records
 
 Ember Data provides the ability to query for records that meet certain criteria.
-Calling [`store.query()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/query?anchor=query) will make a `GET` request with the passed object serialized as query params.
+Calling [`store.query()`](https://api.emberjs.com/ember-data/3.21/classes/Store/methods/query?anchor=query) will make a `GET` request with the passed object serialized as query params.
 This method returns a `PromiseArray` in the same way as `findAll`.
 
 For example, we could search for all `person` models who have the name of
@@ -67,7 +67,7 @@ this.store.query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/queryRecord?anchor=queryRecord) that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.21/classes/Store/methods/queryRecord?anchor=queryRecord) that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:
@@ -95,7 +95,7 @@ export default class UserAdapter extends Adapter {
 }
 ```
 
-Then, calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/queryRecord?anchor=queryRecord) will retrieve that object from the server:
+Then, calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/3.21/classes/Store/methods/queryRecord?anchor=queryRecord) will retrieve that object from the server:
 
 ```javascript
 store.queryRecord('user', {}).then(function(user) {
@@ -108,7 +108,7 @@ As in the case of `store.query()`, a query object can also be passed to `store.q
 However the adapter must return a single model object, not an array containing one element,
 otherwise Ember Data will throw an exception.
 
-Note that Ember's default [JSON:API adapter](https://api.emberjs.com/ember-data/release/classes/JSONAPIAdapter) does not provide the functionality needed to support `queryRecord()` directly as it relies on REST request definitions that return result data in the form of an array.
+Note that Ember's default [JSON:API adapter](https://api.emberjs.com/ember-data/3.21/classes/JSONAPIAdapter) does not provide the functionality needed to support `queryRecord()` directly as it relies on REST request definitions that return result data in the form of an array.
 
 If your server API or your adapter only provides array responses but you wish to retrieve just a single record, you can alternatively use the `query()` method as follows:
 

--- a/guides/v3.21.0/models/pushing-records-into-the-store.md
+++ b/guides/v3.21.0/models/pushing-records-into-the-store.md
@@ -19,7 +19,7 @@ you want to update the UI immediately.
 
 ### Pushing Records
 
-To push a record into the store, call the store's [`push()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/push?anchor=push) method.
+To push a record into the store, call the store's [`push()`](https://api.emberjs.com/ember-data/3.21/classes/Store/methods/push?anchor=push) method.
 
 For example, imagine we want to preload some data into the store when
 the application boots for the first time.
@@ -81,7 +81,7 @@ the casing of the properties defined on the Model class.
 
 If you would like the data to be normalized by the model's default
 serializer before pushing it into the store, you can use the
-[`store.pushPayload()`](https://api.emberjs.com/ember-data/release/classes/Store/methods/pushPayload?anchor=pushPayload) method.
+[`store.pushPayload()`](https://api.emberjs.com/ember-data/3.21/classes/Store/methods/pushPayload?anchor=pushPayload) method.
 
 ```javascript {data-filename=app/serializers/album.js}
 import RESTSerializer from '@ember-data/serializer/rest';

--- a/guides/v3.21.0/models/relationships.md
+++ b/guides/v3.21.0/models/relationships.md
@@ -361,7 +361,7 @@ include those related records in the response returned to the client.
 The value of the parameter should be a comma-separated list of names of the
 relationships required.
 
-If you are using an adapter that supports JSON:API, such as Ember's default [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/release/classes/JSONAPIAdapter),
+If you are using an adapter that supports JSON:API, such as Ember's default [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/3.21/classes/JSONAPIAdapter),
 you can easily add the `include` parameter to the server requests created by
 the `findRecord()`, `findAll()`,
 `query()` and `queryRecord()` methods.

--- a/guides/v3.21.0/routing/asynchronous-routing.md
+++ b/guides/v3.21.0/routing/asynchronous-routing.md
@@ -71,7 +71,7 @@ defined on it to be a promise.
 If the promise fulfills, the transition will pick up where it left off and
 begin resolving the next (child) route's model, pausing if it too is a
 promise, and so on, until all destination route models have been
-resolved. The values passed to the [`setupController()`](https://api.emberjs.com/ember/release/classes/Route/methods/setupController?anchor=setupController) hook for each route
+resolved. The values passed to the [`setupController()`](https://api.emberjs.com/ember/3.21/classes/Route/methods/setupController?anchor=setupController) hook for each route
 will be the fulfilled values from the promises.
 
 

--- a/guides/v3.21.0/routing/controllers.md
+++ b/guides/v3.21.0/routing/controllers.md
@@ -1,8 +1,8 @@
 ### What is a Controller?
 
-A [Controller](https://api.emberjs.com/ember/release/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/release/classes/Route/methods/model?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/3.21/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.21/classes/Route/methods/model?anchor=model) method.
 
-The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/release/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
+The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.21/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 
 A Controller is usually paired with an individual Route of the same name.
 

--- a/guides/v3.21.0/routing/defining-your-routes.md
+++ b/guides/v3.21.0/routing/defining-your-routes.md
@@ -14,7 +14,7 @@ It also adds the route to the router.
 
 ## Basic Routes
 
-The [`map()`](https://api.emberjs.com/ember/release/classes/EmberRouter/methods/map?anchor=map) method
+The [`map()`](https://api.emberjs.com/ember/3.21/classes/EmberRouter/methods/map?anchor=map) method
 of your Ember application's router can be invoked to define URL mappings. When
 calling `map()`, you should pass a function that will be invoked with the value
 `this` set to an object which you can use to create routes.
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`<LinkTo />`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) to navigate between
+Inside your templates, you can use [`<LinkTo />`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -352,13 +352,13 @@ export default class SomeRouteRoute extends Route {
 To have your route do something beyond render a template with the same name, you'll
 need to create a route handler. The following guides will explore the different
 features of route handlers. For more information on routes, see the API documentation
-for [the router](https://api.emberjs.com/ember/release/classes/EmberRouter) and for [route
-handlers](https://api.emberjs.com/ember/release/classes/Route).
+for [the router](https://api.emberjs.com/ember/3.21/classes/EmberRouter) and for [route
+handlers](https://api.emberjs.com/ember/3.21/classes/Route).
 
 ## Transitioning Between Routes
 Once the routes are defined, how do we go about transitioning between them within our application? It depends on where the transition needs to take place:
 
-- From a template, use [`<LinkTo />`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
-- From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo) method
-- From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
-- From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/release/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo) method
+- From a template, use [`<LinkTo />`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo) as mentioned above
+- From a route, use the [`transitionTo()`](https://api.emberjs.com/ember/3.21/classes/Route/methods/transitionTo?anchor=transitionTo) method
+- From a controller, use the [`transitionToRoute()`](https://api.emberjs.com/ember/3.21/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) method
+- From anywhere else in your application, such as a component, inject the [Router Service](https://api.emberjs.com/ember/3.21/classes/RouterService) and use the [`transitionTo()`](https://api.emberjs.com/ember/3.21/classes/RouterService/methods/transitionTo?anchor=transitionTo) method

--- a/guides/v3.21.0/routing/linking-between-routes.md
+++ b/guides/v3.21.0/routing/linking-between-routes.md
@@ -5,7 +5,7 @@ component.
 ## The `<LinkTo />` Component
 
 You create a link to a route using the
-[`<LinkTo />`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
+[`<LinkTo />`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)
 component.
 
 ```javascript {data-filename=app/router.js}

--- a/guides/v3.21.0/routing/loading-and-error-substates.md
+++ b/guides/v3.21.0/routing/loading-and-error-substates.md
@@ -105,7 +105,7 @@ within the route hierarchy where loading feedback is important.
 ### The `loading` event
 
 If the various `beforeModel`/`model`/`afterModel` hooks
-don't immediately resolve, a [`loading`](https://api.emberjs.com/ember/release/classes/Route/events/loading?anchor=loading) event will be fired on that route.
+don't immediately resolve, a [`loading`](https://api.emberjs.com/ember/3.21/classes/Route/events/loading?anchor=loading) event will be fired on that route.
 
 ```javascript {data-filename=app/routes/user-slow-model.js}
 import Route from '@ember/routing/route';
@@ -221,7 +221,7 @@ logged.
 
 If the `articles.overview` route's `model` hook returns a promise that rejects
 (for instance the server returned an error, the user isn't logged in,
-etc.), an [`error`](https://api.emberjs.com/ember/release/classes/Route/events/error?anchor=error) event will fire from that route and bubble upward.
+etc.), an [`error`](https://api.emberjs.com/ember/3.21/classes/Route/events/error?anchor=error) event will fire from that route and bubble upward.
 This `error` event can be handled and used to display an error message,
 redirect to a login page, etc.
 

--- a/guides/v3.21.0/routing/redirection.md
+++ b/guides/v3.21.0/routing/redirection.md
@@ -7,12 +7,12 @@ Usually you want to redirect them to the login page, and after they have success
 There are many other reasons you probably want to have the last word on whether a user can or cannot access a certain page.
 Ember allows you to control that access with a combination of hooks and methods in your route.
 
-One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo).
+One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/3.21/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
-[`transitionToRoute()`](https://api.emberjs.com/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
+[`transitionToRoute()`](https://api.emberjs.com/ember/3.21/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [`LinkTo`](../../templates/links/) helper.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/release/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.21/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/release/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.21/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/release/classes/Route/methods/afterModel?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.21/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -112,7 +112,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/release/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.21/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.21.0/routing/specifying-a-routes-model.md
+++ b/guides/v3.21.0/routing/specifying-a-routes-model.md
@@ -1,6 +1,6 @@
 A route's JavaScript file is one of the best places in an app to make requests to an API.
 In this section of the guides, you'll learn how to use the
-[`model`](https://api.emberjs.com/ember/release/classes/Route/methods/model?anchor=model)
+[`model`](https://api.emberjs.com/ember/3.21/classes/Route/methods/model?anchor=model)
 method to fetch data by making a HTTP request, and render it in a route's `hbs` template, or pass it down to a component.
 
 For example, take this router:
@@ -63,7 +63,7 @@ Now that data can be used in the `favorite-posts` template:
 {{/each}}
 ```
 
-Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/release/classes/Route/methods/setupController?anchor=setupController) receives the results of the model hook, and Ember makes the model hook results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
+Behind the scenes, what is happening is that the [route's controller](https://api.emberjs.com/ember/3.21/classes/Route/methods/setupController?anchor=setupController) receives the results of the model hook, and Ember makes the model hook results available to the template. Your app may not have a controller file for the route, but the behavior is the same regardless.
 
 Let's compare some examples using the model hook to make asynchronous HTTP requests to a server somewhere.
 
@@ -90,7 +90,7 @@ export default class PhotosRoute extends Route {
 ### Ember Data example
 
 Ember Data is a powerful (but optional) library included by default in new Ember apps.
-In the next example, we will use Ember Data's [`findAll`](https://api.emberjs.com/ember-data/release/classes/Store/methods/findAll?anchor=findAll) method, which returns a Promise, and resolves with an array of [Ember Data records](../../models/).
+In the next example, we will use Ember Data's [`findAll`](https://api.emberjs.com/ember-data/3.21/classes/Store/methods/findAll?anchor=findAll) method, which returns a Promise, and resolves with an array of [Ember Data records](../../models/).
 
 ```javascript {data-filename=app/routes/favorite-posts.js}
 import Route from '@ember/routing/route';
@@ -105,14 +105,14 @@ export default class FavoritePostsRoute extends Route {
 }
 ```
 
-Note that Ember Data also has a feature called a [`Model`](https://api.emberjs.com/ember-data/release/classes/Model), but it's a separate concept from a route's [`model`](https://api.emberjs.com/ember/release/classes/Route/methods/model?anchor=model) hook.
+Note that Ember Data also has a feature called a [`Model`](https://api.emberjs.com/ember-data/3.21/classes/Model), but it's a separate concept from a route's [`model`](https://api.emberjs.com/ember/3.21/classes/Route/methods/model?anchor=model) hook.
 
 ## Multiple Models
 
 What should you do if you need the `model` to return the results of multiple API requests?
 
 Multiple models can be returned through an
-[RSVP.hash](https://api.emberjs.com/ember/release/classes/rsvp/methods/hash?anchor=hash).
+[RSVP.hash](https://api.emberjs.com/ember/3.21/classes/rsvp/methods/hash?anchor=hash).
 The `RSVP.hash` method takes an object containing multiple promises.
 If all of the promises resolve, the returned promise will resolve to an object that contains the results of each request. For example:
 
@@ -203,7 +203,7 @@ method.
 There are two ways to link to a dynamic segment from an `.hbs` template using [`<LinkTo>`](../../templates/links/).
 Depending on which approach you use, it will affect whether that route's `model` hook is run.
 To learn how to link to a dynamic segment from within the JavaScript file, see the API documentation on
-[`transitionTo`](https://api.emberjs.com/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo)
+[`transitionTo`](https://api.emberjs.com/ember/3.21/classes/RouterService/methods/transitionTo?anchor=transitionTo)
 instead.
 
 When you provide a string or number to the `<LinkTo>`, the dynamic segment's `model` hook will run when the app transitions to the new route.
@@ -315,10 +315,10 @@ And calling `modelFor` returned the result of the `model` hook.
 
 If you are having trouble getting a model's data to show up in the template, here are some tips:
 
-- Use the [`{{debugger}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/log?anchor=log) helper to inspect the `{{@model}}` from the template
+- Use the [`{{debugger}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/debugger?anchor=debugger) or [`{{log}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/log?anchor=log) helper to inspect the `{{@model}}` from the template
 - return hard-coded sample data as a test to see if the problem is really in the model hook, or elsewhere down the line
 - study JavaScript Promises in general, to make sure you are returning data from the Promise correctly
 - make sure your `model` hook has a `return` statement
-- check to see whether the data returned from a `model` hook is an object, array, or JavaScript Primitive. For example, if the result of `model` is an array, using `{{@model}}` in the template won't work. You will need to iterate over the array with an [`{{#each}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=each) helper. If the result is an object, you need to access the individual attribute like `{{@model.title}}` to render it in the template.
+- check to see whether the data returned from a `model` hook is an object, array, or JavaScript Primitive. For example, if the result of `model` is an array, using `{{@model}}` in the template won't work. You will need to iterate over the array with an [`{{#each}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/each?anchor=each) helper. If the result is an object, you need to access the individual attribute like `{{@model.title}}` to render it in the template.
 - use your browser's development tools to examine the outgoing and incoming API responses and see if they match what your code expects
 - If you are using Ember Data, use the [Ember Inspector](../../ember-inspector/) browser plugin to explore the View Tree/Model and Data sections.

--- a/guides/v3.21.0/services/index.md
+++ b/guides/v3.21.0/services/index.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/release/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/3.21/classes/Service) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/release/classes/Service) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/3.21/classes/Service) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';
@@ -91,7 +91,7 @@ This injects the shopping cart service into the component and makes it available
 
 Sometimes a service may or may not exist, like when an initializer conditionally registers a service.
 Since normal injection will throw an error if the service doesn't exist,
-you must look up the service using Ember's [`getOwner`](https://api.emberjs.com/ember/release/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) instead.
+you must look up the service using Ember's [`getOwner`](https://api.emberjs.com/ember/3.21/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) instead.
 
 ```javascript {data-filename=app/components/cart-contents.js}
 import Component from '@glimmer/component';

--- a/guides/v3.21.0/testing/test-types.md
+++ b/guides/v3.21.0/testing/test-types.md
@@ -62,8 +62,8 @@ module('Unit | Utility | math-library', function() {
 Here are more examples where unit tests are ideal:
 
 - Inside a controller, a computed property continues to filter `this.model` correctly after an action is taken
-- Check how [`normalize()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/normalize?anchor=normalize) in a serializer receives data
-- Check how [`serialize()`](https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer/methods/serialize?anchor=serialize) in a serializer sends data
+- Check how [`normalize()`](https://api.emberjs.com/ember-data/3.21/classes/JSONAPISerializer/methods/normalize?anchor=normalize) in a serializer receives data
+- Check how [`serialize()`](https://api.emberjs.com/ember-data/3.21/classes/JSONAPISerializer/methods/serialize?anchor=serialize) in a serializer sends data
 - A [cron](https://en.wikipedia.org/wiki/Cron) utility parses an input string into an object that can be used for UI
 
 ### What to Watch Out for
@@ -90,7 +90,7 @@ module('Unit | Service | flash-messages', function(hooks) {
 });
 ```
 
-By calling `setupTest()`, you gain access to a few things. First is Ember's [Dependency Injection](../../applications/dependency-injection/) system. In short, you can [look up](https://api.emberjs.com/ember/release/classes/ApplicationInstance/methods/lookup?anchor=lookup) anything in your application, with a little help from `this.owner`. Second, you gain access to some common utility functions, `this.get()` and `this.set()`, in your tests. Finally, you can use `pauseTest()` to [debug your tests](../#toc_how-to-debug-tests).
+By calling `setupTest()`, you gain access to a few things. First is Ember's [Dependency Injection](../../applications/dependency-injection/) system. In short, you can [look up](https://api.emberjs.com/ember/3.21/classes/ApplicationInstance/methods/lookup?anchor=lookup) anything in your application, with a little help from `this.owner`. Second, you gain access to some common utility functions, `this.get()` and `this.set()`, in your tests. Finally, you can use `pauseTest()` to [debug your tests](../#toc_how-to-debug-tests).
 
 
 ## Rendering Tests

--- a/guides/v3.21.0/testing/testing-components.md
+++ b/guides/v3.21.0/testing/testing-components.md
@@ -460,7 +460,7 @@ The `settled` function itself returns a Promise that resolves once all async ope
 
 You can use `settled` as a helper in your tests directly and `await` it for all async behavior to settle deliberately.
 
-Imagine you have a typeahead component that uses [`Ember.run.debounce`](https://api.emberjs.com/ember/release/classes/@ember%2Frunloop/methods/debounce?anchor=debounce) to limit requests to the server, and you want to verify that results are displayed after typing a character.
+Imagine you have a typeahead component that uses [`Ember.run.debounce`](https://api.emberjs.com/ember/3.21/classes/@ember%2Frunloop/methods/debounce?anchor=debounce) to limit requests to the server, and you want to verify that results are displayed after typing a character.
 
 > You can follow along by generating your own component with `ember generate
 > component delayed-typeahead`.

--- a/guides/v3.21.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.21.0/upgrading/current-edition/native-classes.md
@@ -469,8 +469,8 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
   const Actress = Person.extend({});
   ```
 
-[1]: https://api.emberjs.com/ember/release/functions/@ember%2Fobject/extend
-[2]: https://api.emberjs.com/ember/release/classes/EmberObject
+[1]: https://api.emberjs.com/ember/3.21/functions/@ember%2Fobject/extend
+[2]: https://api.emberjs.com/ember/3.21/classes/EmberObject
 
 ### Instantiation
 
@@ -523,7 +523,7 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `init` method instead of the `constructor`.
 
-[3]: https://api.emberjs.com/ember/release/functions/@ember%2Fobject/create
+[3]: https://api.emberjs.com/ember/3.21/functions/@ember%2Fobject/create
 
 ### Methods
 

--- a/guides/v3.21.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.21.0/upgrading/current-edition/tracked-properties.md
@@ -203,7 +203,7 @@ profilePhoto.width = 200;
 ```
 
 Note, however, that if you want to use a getter as a dependent key, you will
-need to use the [`dependentKeyCompat`](https://api.emberjs.com/ember/release/functions/@ember%2Fobject%2Fcompat/dependentKeyCompat) decorator. This allows you to refactor
+need to use the [`dependentKeyCompat`](https://api.emberjs.com/ember/3.21/functions/@ember%2Fobject%2Fcompat/dependentKeyCompat) decorator. This allows you to refactor
 existing computed properties into getters without breaking existing code that
 observes them.
 

--- a/guides/v3.8.0/object-model/enumerables.md
+++ b/guides/v3.8.0/object-model/enumerables.md
@@ -20,7 +20,7 @@ where available.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         It is best practice to
-        <a href="https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/">
+        <a href="../../configuring-ember/disabling-prototype-extensions/">
           disable prototype extensions
         </a>
         in your app.

--- a/guides/v3.9.0/index.md
+++ b/guides/v3.9.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/intro/">Ember.js</a>
+		<a href="./getting-started/intro/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="./models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="./ember-inspector/">Ember Inspector</a></li>
 </ul>

--- a/guides/v3.9.0/object-model/enumerables.md
+++ b/guides/v3.9.0/object-model/enumerables.md
@@ -20,7 +20,7 @@ where available.
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
         It is best practice to
-        <a href="https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/">
+        <a href="../../configuring-ember/disabling-prototype-extensions/">
           disable prototype extensions
         </a>
         in your app.


### PR DESCRIPTION
This PR addresses #1440 for Ember `v3.21.0`.

## Process

1. Ran script from #1592
2. Manually checked updated links
3. Ran `npm test:node-local` to check all external links automatically

## Result

```
node update-version-links.js ../guides/v3.21.0 3.21

> Welcome to the automated process of updating the Guides version links
> 
> Found: 168 files
> Updated: 34 files


npm run test:node-local

> check all external links in markdown files
> ...
> 168 passing (4m)
```