### PR TITLE
Fix guides links for v3.17.0 #1440

### DIFF
--- a/guides/v3.17.0/index.md
+++ b/guides/v3.17.0/index.md
@@ -7,13 +7,13 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/getting-started/">Ember.js</a>
+		<a href="https://guides.emberjs.com/v3.17.0/getting-started/">Ember.js</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>
-		<a href="https://guides.emberjs.com/release/models/">Ember Data</a>
+		<a href="https://guides.emberjs.com/v3.17.0/models/">Ember Data</a>
 	</li>
 	<li class="list-item-card">
 		<div class="shape shape--dark"></div>
@@ -24,5 +24,5 @@ With the plethora of libraries readily available for front-end development, some
 		<div class="shape shape--dark"></div>
     <div class="shape shape--accent"></div>
     <div class="shape shape--light"></div>		
-		<a href="https://guides.emberjs.com/release/ember-inspector/">Ember Inspector</a></li>
+		<a href="https://guides.emberjs.com/v3.17.0/ember-inspector/">Ember Inspector</a></li>
 </ul>


### PR DESCRIPTION
This PR addresses #1440 for Ember `v3.17.0`.

## Process

1. Ran script from #1592
2. Manually checked updated links
3. Ran `npm test:node-local` to check all external links automatically

## Result

```
node update-version-links.js ../guides/v3.17.0 3.17

> Welcome to the automated process of updating the Guides version links
> 
> Found: 168 files
> Updated: 1 files


npm run test:node-local

> check all external links in markdown files
> ...
> 168 passing (2m)
```