### PR TITLE
Updated API links in guides - phase 3

### DIFF
--- a/guides/v3.1.0/object-model/classes-and-instances.md
+++ b/guides/v3.1.0/object-model/classes-and-instances.md
@@ -4,8 +4,8 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
-[`EmberObject`](https://api.emberjs.com/ember/2.16/modules/@ember%2Fobject):
+To define a new Ember _class_, call the [`extend()`](https://api.emberjs.com/ember/3.1/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://api.emberjs.com/ember/3.1/modules/@ember%2Fobject):
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -21,7 +21,7 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`](https://api.emberjs.com/ember/2.16/classes/Component) class:
+of Ember's built-in [`Component`](https://api.emberjs.com/ember/3.1/classes/Component) class:
 
 
 ```javascript {data-filename=app/components/todo-item.js}
@@ -67,7 +67,7 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`](https://api.emberjs.com/ember-data/3.1/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
 
@@ -83,7 +83,7 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
+class by calling its [`create()`](https://api.emberjs.com/ember/3.1/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
 
@@ -133,7 +133,7 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`](https://api.emberjs.com/ember/2.16/classes/EmberObject/methods/init?anchor=init) method is invoked
+When a new instance is created, its [`init()`](https://api.emberjs.com/ember/3.1/classes/EmberObject/methods/init?anchor=init) method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
 
@@ -216,8 +216,8 @@ Person.create({
 
 ### Accessing Object Properties
 
-When accessing the properties of an object, use the [`get()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/get?anchor=get)
-and [`set()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/set?anchor=set) accessor methods:
+When accessing the properties of an object, use the [`get()`](https://api.emberjs.com/ember/3.1/classes/@ember%2Fobject/methods/get?anchor=get)
+and [`set()`](https://api.emberjs.com/ember/3.1/classes/@ember%2Fobject/methods/set?anchor=set) accessor methods:
 
 
 ```javascript

--- a/guides/v3.1.0/templates/writing-helpers.md
+++ b/guides/v3.1.0/templates/writing-helpers.md
@@ -248,7 +248,7 @@ although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.1/classes/Helper). Helper classes must contain a
-[`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`compute`](https://api.emberjs.com/ember/3.1/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
 [`helper`](https://api.emberjs.com/ember/3.1/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.

--- a/guides/v3.1.0/tutorial/service.md
+++ b/guides/v3.1.0/tutorial/service.md
@@ -423,7 +423,7 @@ module('Acceptance | list rentals', function(hooks) {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection/#toc_factory-registrations) using the [owner](https://api.emberjs.com/ember/3.0/functions/@ember%2Fapplication/getOwner) object given by the test context. When our component loads the maps service, it gets our stub service instead.
+Then we are putting it in Ember's [registry](../../applications/dependency-injection/#toc_factory-registrations) using the [owner](https://api.emberjs.com/ember/3.1/functions/@ember%2Fapplication/getOwner) object given by the test context. When our component loads the maps service, it gets our stub service instead.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our application tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v3.2.0/object-model/classes-and-instances.md
+++ b/guides/v3.2.0/object-model/classes-and-instances.md
@@ -4,8 +4,8 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
-[`EmberObject`](https://api.emberjs.com/ember/2.16/modules/@ember%2Fobject):
+To define a new Ember _class_, call the [`extend()`](https://api.emberjs.com/ember/3.2/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://api.emberjs.com/ember/3.2/modules/@ember%2Fobject):
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -21,7 +21,7 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`](https://api.emberjs.com/ember/2.16/classes/Component) class:
+of Ember's built-in [`Component`](https://api.emberjs.com/ember/3.2/classes/Component) class:
 
 
 ```javascript {data-filename=app/components/todo-item.js}
@@ -67,7 +67,7 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`](https://api.emberjs.com/ember-data/3.2/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
 
@@ -83,7 +83,7 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
+class by calling its [`create()`](https://api.emberjs.com/ember/3.2/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
 
@@ -133,7 +133,7 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`](https://api.emberjs.com/ember/2.16/classes/EmberObject/methods/init?anchor=init) method is invoked
+When a new instance is created, its [`init()`](https://api.emberjs.com/ember/3.2/classes/EmberObject/methods/init?anchor=init) method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
 
@@ -216,8 +216,8 @@ Person.create({
 
 ### Accessing Object Properties
 
-When accessing the properties of an object, use the [`get()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/get?anchor=get)
-and [`set()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/set?anchor=set) accessor methods:
+When accessing the properties of an object, use the [`get()`](https://api.emberjs.com/ember/3.2/classes/@ember%2Fobject/methods/get?anchor=get)
+and [`set()`](https://api.emberjs.com/ember/3.2/classes/@ember%2Fobject/methods/set?anchor=set) accessor methods:
 
 
 ```javascript

--- a/guides/v3.2.0/templates/writing-helpers.md
+++ b/guides/v3.2.0/templates/writing-helpers.md
@@ -248,7 +248,7 @@ although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.2/classes/Helper). Helper classes must contain a
-[`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`compute`](https://api.emberjs.com/ember/3.2/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
 [`helper`](https://api.emberjs.com/ember/3.2/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.

--- a/guides/v3.2.0/tutorial/service.md
+++ b/guides/v3.2.0/tutorial/service.md
@@ -422,7 +422,7 @@ module('Acceptance | list rentals', function(hooks) {
 ```
 
 What's happening here is we are adding our own stub maps service that simply creates an empty div.
-Then we are putting it in Ember's [registry](../../applications/dependency-injection/#toc_factory-registrations) using the [owner](https://api.emberjs.com/ember/3.0/functions/@ember%2Fapplication/getOwner) object given by the test context. When our component loads the maps service, it gets our stub service instead.
+Then we are putting it in Ember's [registry](../../applications/dependency-injection/#toc_factory-registrations) using the [owner](https://api.emberjs.com/ember/3.2/functions/@ember%2Fapplication/getOwner) object given by the test context. When our component loads the maps service, it gets our stub service instead.
 That way every time that component is created, our stub map service gets injected over the Google maps service.
 Now when we run our application tests, you'll notice that maps do not get rendered as the test runs.
 

--- a/guides/v3.3.0/templates/writing-helpers.md
+++ b/guides/v3.3.0/templates/writing-helpers.md
@@ -248,7 +248,7 @@ although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.3/classes/Helper). Helper classes must contain a
-[`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`compute`](https://api.emberjs.com/ember/3.3/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
 [`helper`](https://api.emberjs.com/ember/3.3/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.

--- a/guides/v3.4.0/controllers/index.md
+++ b/guides/v3.4.0/controllers/index.md
@@ -1,8 +1,8 @@
 ### What is a Controller?
 
-A [Controller](https://api.emberjs.com/ember/3.4/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.3/classes/Route/methods?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/3.4/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.4/classes/Route/methods?anchor=model) method.
 
-The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
+The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.4/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 
 A Controller is usually paired with an individual Route of the same name.
 

--- a/guides/v3.4.0/controllers/index.md
+++ b/guides/v3.4.0/controllers/index.md
@@ -1,6 +1,6 @@
 ### What is a Controller?
 
-A [Controller](https://api.emberjs.com/ember/3.4/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.4/classes/Route/methods?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/3.4/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.4/classes/Route/methods/model?anchor=model) method.
 
 The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.4/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 

--- a/guides/v3.4.0/object-model/classes-and-instances.md
+++ b/guides/v3.4.0/object-model/classes-and-instances.md
@@ -220,7 +220,7 @@ Person.create({
 
 When reading a property value of an object, you can in most cases use the common JavaScript dot notation, e.g. `myObject.myProperty`.
 
-[Ember proxy objects](https://api.emberjs.com/ember/3.3/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/3.4/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
+[Ember proxy objects](https://api.emberjs.com/ember/3.4/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/3.4/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
 
 Let's look at the following `blogPost` Ember Data model:
 

--- a/guides/v3.4.0/templates/writing-helpers.md
+++ b/guides/v3.4.0/templates/writing-helpers.md
@@ -248,7 +248,7 @@ although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.4/classes/Helper). Helper classes must contain a
-[`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`compute`](https://api.emberjs.com/ember/3.4/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
 [`helper`](https://api.emberjs.com/ember/3.4/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.

--- a/guides/v3.5.0/controllers/index.md
+++ b/guides/v3.5.0/controllers/index.md
@@ -1,8 +1,8 @@
 ### What is a Controller?
 
-A [Controller](https://api.emberjs.com/ember/3.5/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.3/classes/Route/methods?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/3.5/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.5/classes/Route/methods?anchor=model) method.
 
-The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.3/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
+The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.5/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 
 A Controller is usually paired with an individual Route of the same name.
 

--- a/guides/v3.5.0/controllers/index.md
+++ b/guides/v3.5.0/controllers/index.md
@@ -1,6 +1,6 @@
 ### What is a Controller?
 
-A [Controller](https://api.emberjs.com/ember/3.5/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.5/classes/Route/methods?anchor=model) method.
+A [Controller](https://api.emberjs.com/ember/3.5/classes/Controller) is routable object which receives a single property from the Route – `model` – which is the return value of the Route's [`model()`](https://api.emberjs.com/ember/3.5/classes/Route/methods/model?anchor=model) method.
 
 The model is passed from the Route to the Controller by default using the [`setupController()`](https://api.emberjs.com/ember/3.5/classes/Route/methods/setupController?anchor=setupController) function. The Controller is then often used to decorate the model with display properties such as retrieving the full name from a name model.
 

--- a/guides/v3.5.0/object-model/classes-and-instances.md
+++ b/guides/v3.5.0/object-model/classes-and-instances.md
@@ -220,7 +220,7 @@ Person.create({
 
 When reading a property value of an object, you can in most cases use the common JavaScript dot notation, e.g. `myObject.myProperty`.
 
-[Ember proxy objects](https://api.emberjs.com/ember/3.3/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/3.5/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
+[Ember proxy objects](https://api.emberjs.com/ember/3.5/classes/ObjectProxy) are the one big exception to this rule. If you're working with Ember proxy objects, including promise proxies for async relationships in Ember Data, you have to use Ember's [`get()`](https://api.emberjs.com/ember/3.5/classes/@ember%2Fobject/methods/get?anchor=get) accessor method to read values.
 
 Let's look at the following `blogPost` Ember Data model:
 

--- a/guides/v3.5.0/templates/writing-helpers.md
+++ b/guides/v3.5.0/templates/writing-helpers.md
@@ -248,7 +248,7 @@ although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.5/classes/Helper). Helper classes must contain a
-[`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`compute`](https://api.emberjs.com/ember/3.5/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
 [`helper`](https://api.emberjs.com/ember/3.5/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.


### PR DESCRIPTION
This PR addresses #1440 for Ember `v3.1.0` to `v3.5.0`.

## Process

1. Ran the script `npm run release:guides:links <guides-path> <version>`
2. Manually checked updated links
3. Ran `npm run test:node-local` to check all external links automatically