### PR TITLE
Updated API links in guides - phase 4

### DIFF
--- a/guides/v2.17.0/applications/dependency-injection.md
+++ b/guides/v2.17.0/applications/dependency-injection.md
@@ -2,11 +2,11 @@ Ember applications utilize the [dependency injection](https://en.wikipedia.org/w
 ("DI") design pattern to declare and instantiate classes of objects and dependencies between them.
 Applications and application instances each serve a role in Ember's DI implementation.
 
-An [`Application`](https://api.emberjs.com/ember/2.16/classes/Application) serves as a "registry" for dependency declarations.
+An [`Application`](https://api.emberjs.com/ember/2.17/classes/Application) serves as a "registry" for dependency declarations.
 Factories (i.e. classes) are registered with an application,
 as well as rules about "injecting" dependencies that are applied when objects are instantiated.
 
-An [`ApplicationInstance`](https://api.emberjs.com/ember/2.16/classes/ApplicationInstance) serves as the "owner" for objects that are instantiated from registered factories.
+An [`ApplicationInstance`](https://api.emberjs.com/ember/2.17/classes/ApplicationInstance) serves as the "owner" for objects that are instantiated from registered factories.
 Application instances provide a means to "look up" (i.e. instantiate and / or retrieve) objects.
 
 > _Note: Although an `Application` serves as the primary registry for an app,
@@ -194,7 +194,7 @@ export default Component.extend({
 ## Factory Instance Lookups
 
 To fetch an instantiated factory from the running application you can call the
-[`lookup`](https://api.emberjs.com/ember/2.16/classes/ApplicationInstance/methods/lookup?anchor=lookup) method on an application instance. This method takes a string
+[`lookup`](https://api.emberjs.com/ember/2.17/classes/ApplicationInstance/methods/lookup?anchor=lookup) method on an application instance. This method takes a string
 to identify a factory and returns the appropriate object.
 
 ```javascript
@@ -225,9 +225,9 @@ export default {
 
 ### Getting an Application Instance from a Factory Instance
 
-[`Ember.getOwner`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) will retrieve the application instance that "owns" an
+[`Ember.getOwner`](https://api.emberjs.com/ember/2.17/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) will retrieve the application instance that "owns" an
 object. This means that framework objects like components, helpers, and routes
-can use [`Ember.getOwner`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) to perform lookups through their application
+can use [`Ember.getOwner`](https://api.emberjs.com/ember/2.17/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) to perform lookups through their application
 instance at runtime.
 
 For example, this component plays songs with different audio services based

--- a/guides/v2.17.0/applications/index.md
+++ b/guides/v2.17.0/applications/index.md
@@ -1,8 +1,8 @@
-Every Ember application is represented by a class that extends [`Application`](https://api.emberjs.com/ember/2.16/classes/Application).
+Every Ember application is represented by a class that extends [`Application`](https://api.emberjs.com/ember/2.17/classes/Application).
 This class is used to declare and configure the many objects that make up your app.
 
 As your application boots,
-it creates an [`ApplicationInstance`](https://api.emberjs.com/ember/2.16/classes/ApplicationInstance) that is used to manage its stateful aspects.
+it creates an [`ApplicationInstance`](https://api.emberjs.com/ember/2.17/classes/ApplicationInstance) that is used to manage its stateful aspects.
 This instance acts as the "owner" of objects instantiated for your app.
 
 Essentially, the `Application` *defines your application*

--- a/guides/v2.17.0/applications/run-loop.md
+++ b/guides/v2.17.0/applications/run-loop.md
@@ -197,9 +197,9 @@ $('a').click(() => {
 });
 ```
 
-The run loop API calls that _schedule_ work, i.e. [`run.schedule`](https://api.emberjs.com/ember/2.16/classes/@ember%2Frunloop/methods/schedule?anchor=schedule),
-[`run.scheduleOnce`](https://api.emberjs.com/ember/2.16/classes/@ember%2Frunloop/methods/scheduleOnce?anchor=scheduleOnce),
-[`run.once`](https://api.emberjs.com/ember/2.16/classes/@ember%2Frunloop/methods/once?anchor=once) have the property that they will approximate a run loop for you if one does not already exist.
+The run loop API calls that _schedule_ work, i.e. [`run.schedule`](https://api.emberjs.com/ember/2.17/classes/@ember%2Frunloop/methods/schedule?anchor=schedule),
+[`run.scheduleOnce`](https://api.emberjs.com/ember/2.17/classes/@ember%2Frunloop/methods/scheduleOnce?anchor=scheduleOnce),
+[`run.once`](https://api.emberjs.com/ember/2.17/classes/@ember%2Frunloop/methods/once?anchor=once) have the property that they will approximate a run loop for you if one does not already exist.
 These automatically created run loops we call _autoruns_.
 
 Here is some pseudocode to describe what happens using the example above:
@@ -264,5 +264,5 @@ Disabling autoruns help you identify these scenarios and helps both your testing
 
 ## Where can I find more information?
 
-Check out the [Ember.run](https://api.emberjs.com/ember/2.16/classes/@ember%2Frunloop) API documentation,
+Check out the [Ember.run](https://api.emberjs.com/ember/2.17/classes/@ember%2Frunloop) API documentation,
 as well as the [Backburner library](https://github.com/ebryn/backburner.js/) that powers the run loop.

--- a/guides/v2.17.0/applications/services.md
+++ b/guides/v2.17.0/applications/services.md
@@ -1,4 +1,4 @@
-A [`Service`](https://api.emberjs.com/ember/2.16/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
+A [`Service`](https://api.emberjs.com/ember/2.17/modules/@ember%2Fservice) is an Ember object that lives for the duration of the application, and can be made available in different parts of your application.
 
 Services are useful for features that require shared state or persistent connections. Example uses of services might
 include:
@@ -20,7 +20,7 @@ For example, the following command will create the `ShoppingCart` service:
 ember generate service shopping-cart
 ```
 
-Services must extend the [`Service`](https://api.emberjs.com/ember/2.16/modules/@ember%2Fservice) base class:
+Services must extend the [`Service`](https://api.emberjs.com/ember/2.17/modules/@ember%2Fservice) base class:
 
 ```javascript {data-filename=app/services/shopping-cart.js}
 import Service from '@ember/service';
@@ -92,7 +92,7 @@ This injects the shopping cart service into the component and makes it available
 
 Sometimes a service may or may not exist, like when an initializer conditionally registers a service.
 Since normal injection will throw an error if the service doesn't exist,
-you must look up the service using Ember's [`getOwner`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) instead.
+you must look up the service using Ember's [`getOwner`](https://api.emberjs.com/ember/2.17/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) instead.
 
 ```javascript {data-filename=app/components/cart-contents.js}
 import Component from '@ember/component';

--- a/guides/v2.17.0/components/handling-events.md
+++ b/guides/v2.17.0/components/handling-events.md
@@ -128,7 +128,7 @@ To utilize an `event` object as a function parameter:
 
 The event handling examples described above respond to one set of events.
 The names of the built-in events are listed below. Custom events can be
-registered by using [Application.customEvents](https://api.emberjs.com/ember/2.16/classes/Application/properties/customEvents?anchor=customEvents).
+registered by using [Application.customEvents](https://api.emberjs.com/ember/2.17/classes/Application/properties/customEvents?anchor=customEvents).
 
 Touch events:
 

--- a/guides/v2.17.0/components/index.md
+++ b/guides/v2.17.0/components/index.md
@@ -58,7 +58,7 @@ the Handlebars template as described above and use the component that is
 created.
 
 If you need to customize the behavior of the component you'll
-need to define a subclass of [`Component`](https://api.emberjs.com/ember/2.16/classes/Component). For example, you would
+need to define a subclass of [`Component`](https://api.emberjs.com/ember/2.17/classes/Component). For example, you would
 need a custom subclass if you wanted to change a component's element,
 respond to actions from the component's template, or manually make
 changes to the component's element using JavaScript.
@@ -71,7 +71,7 @@ file at `app/components/blog-post.js`. If your component was called
 
 ## Dynamically rendering a component
 
-The [`{{component}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/component?anchor=component) helper can be used to defer the selection of a component to
+The [`{{component}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/component?anchor=component) helper can be used to defer the selection of a component to
 run time. The `{{my-component}}` syntax always renders the same component,
 while using the `{{component}}` helper allows choosing a component to render on
 the fly. This is useful in cases where you want to interact with different
@@ -81,7 +81,7 @@ allow you to keep different logic well separated.
 The first parameter of the helper is the name of a component to render, as a
 string. So `{{component 'blog-post'}}` is the same as using `{{blog-post}}`.
 
-The real value of [`{{component}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/component?anchor=component) comes from being able to dynamically pick
+The real value of [`{{component}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/component?anchor=component) comes from being able to dynamically pick
 the component being rendered. Below is an example of using the helper as a
 means of choosing different components for displaying different kinds of posts:
 

--- a/guides/v2.17.0/components/passing-properties-to-a-component.md
+++ b/guides/v2.17.0/components/passing-properties-to-a-component.md
@@ -66,7 +66,7 @@ In other words, you can invoke the above component example like this:
 ```
 
 To set the component up to receive parameters this way, you need to
-set the [`positionalParams`](https://api.emberjs.com/ember/2.16/classes/Component/properties/positionalParams?anchor=positionalParams) attribute in your component class.
+set the [`positionalParams`](https://api.emberjs.com/ember/2.17/classes/Component/properties/positionalParams?anchor=positionalParams) attribute in your component class.
 
 ```javascript {data-filename=app/components/blog-post.js}
 import Component from '@ember/component';

--- a/guides/v2.17.0/components/the-component-lifecycle.md
+++ b/guides/v2.17.0/components/the-component-lifecycle.md
@@ -198,8 +198,8 @@ There are a few things to note about the `didInsertElement()` hook:
 - While [`didInsertElement()`][did-insert-element] is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
   particularly when order of execution is important.
 
-[did-insert-element]: https://api.emberjs.com/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement
-[dollar]: https://api.emberjs.com/ember/2.16/classes/Component/methods/$?anchor=%24
+[did-insert-element]: https://api.emberjs.com/ember/2.17/classes/Component/events/didInsertElement?anchor=didInsertElement
+[dollar]: https://api.emberjs.com/ember/2.17/classes/Component/methods/$?anchor=%24
 [event-names]: ../handling-events/#toc_event-names
 
 ### Making Updates to the Rendered DOM with `didRender`
@@ -254,7 +254,7 @@ export default Component.extend({
 
 ### Detaching and Tearing Down Component Elements with `willDestroyElement`
 
-When a component detects that it is time to remove itself from the DOM, Ember will trigger the [`willDestroyElement()`](https://api.emberjs.com/ember/2.16/classes/Component/events/willDestroyElement?anchor=willDestroyElement) method,
+When a component detects that it is time to remove itself from the DOM, Ember will trigger the [`willDestroyElement()`](https://api.emberjs.com/ember/2.17/classes/Component/events/willDestroyElement?anchor=willDestroyElement) method,
 allowing for any teardown logic to be performed.
 
 Component teardown can be triggered by a number of different conditions.

--- a/guides/v2.17.0/components/wrapping-content-in-a-component.md
+++ b/guides/v2.17.0/components/wrapping-content-in-a-component.md
@@ -65,7 +65,7 @@ We will give them the option to specify either `markdown-style` or `html-style`.
 
 Supporting different editing styles will require different body components to provide special validation and highlighting.
 To load a different body component based on editing style,
-you can yield the component using the [`component helper`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/component?anchor=component) and [`hash helper`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/hash?anchor=hash).
+you can yield the component using the [`component helper`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/component?anchor=component) and [`hash helper`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/hash?anchor=hash).
 Here, the appropriate component is assigned to a hash using nested helpers and yielded to the template.
 Notice `editStyle` being used as an argument to the component helper.
 

--- a/guides/v2.17.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v2.17.0/configuring-ember/disabling-prototype-extensions.md
@@ -9,7 +9,7 @@ objects in the following ways:
 
 * `String` is extended to add convenience methods, such as
   `camelize()` and `w()`. You can find a list of these methods with the
-  [Ember.String documentation](https://api.emberjs.com/ember/2.16/classes/String).
+  [Ember.String documentation](https://api.emberjs.com/ember/2.17/classes/String).
 
 * `Function` is extended with methods to annotate functions as
   computed properties, via the `property()` method, and as observers,
@@ -94,7 +94,7 @@ islands.includes('Oahu');
 ### Strings
 
 Strings will no longer have the convenience methods described in the
-[`Ember.String` API reference](https://api.emberjs.com/ember/2.16/classes/String).
+[`Ember.String` API reference](https://api.emberjs.com/ember/2.17/classes/String).
 Instead,
 you can use the similarly-named methods of the `Ember.String` object and
 pass the string to use as the first parameter:

--- a/guides/v2.17.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v2.17.0/models/creating-updating-and-deleting-records.md
@@ -1,7 +1,7 @@
 ## Creating Records
 
 You can create records by calling the
-[`createRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/createRecord?anchor=createRecord)
+[`createRecord()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/createRecord?anchor=createRecord)
 method on the store.
 
 ```javascript
@@ -36,7 +36,7 @@ person.incrementProperty('age'); // Happy birthday!
 ## Persisting Records
 
 Records in Ember Data are persisted on a per-instance basis.
-Call [`save()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/methods/save?anchor=save)
+Call [`save()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Model/methods/save?anchor=save)
 on any instance of `DS.Model` and it will make a network request.
 
 Ember Data takes care of tracking the state of each record for
@@ -68,10 +68,10 @@ store.findRecord('post', 1).then(function(post) {
 
 You can tell if a record has outstanding changes that have not yet been
 saved by checking its
-[`hasDirtyAttributes`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/properties/hasDirtyAttributes?anchor=hasDirtyAttributes)
+[`hasDirtyAttributes`](https://api.emberjs.com/ember-data/2.17/classes/DS.Model/properties/hasDirtyAttributes?anchor=hasDirtyAttributes)
 property. You can also see what parts of
 the record were changed and what the original value was using the
-[`changedAttributes()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/methods/changedAttributes?anchor=changedAttributes)
+[`changedAttributes()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Model/methods/changedAttributes?anchor=changedAttributes)
 method. `changedAttributes` returns an object, whose keys are the changed
 properties and values are an array of values `[oldValue, newValue]`.
 
@@ -85,7 +85,7 @@ person.changedAttributes();       //=> { isAdmin: [false, true] }
 
 At this point, you can either persist your changes via `save()` or you can roll
 back your changes. Calling
-[`rollbackAttributes()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/methods/rollbackAttributes?anchor=rollbackAttributes)
+[`rollbackAttributes()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Model/methods/rollbackAttributes?anchor=rollbackAttributes)
 for a saved record reverts all the `changedAttributes` to their original value.
 If the record `isNew` it will be removed from the store.
 
@@ -117,7 +117,7 @@ the errors from saving a blog post in your template:
 
 ## Promises
 
-[`save()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/methods/save?anchor=save) returns
+[`save()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Model/methods/save?anchor=save) returns
 a promise, which makes it easy to asynchronously handle success and failure
 scenarios.  Here's a common pattern:
 
@@ -145,10 +145,10 @@ post.save().then(transitionToPost).catch(failure);
 
 ## Deleting Records
 
-Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/methods/deleteRecord?anchor=deleteRecord)
+Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Model/methods/deleteRecord?anchor=deleteRecord)
 on any instance of `DS.Model`. This flags the record as `isDeleted`. The
 deletion can then be persisted using `save()`.  Alternatively, you can use
-the [`destroyRecord`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/methods/deleteRecord?anchor=destroyRecord) method to delete and persist at the same time.
+the [`destroyRecord`](https://api.emberjs.com/ember-data/2.17/classes/DS.Model/methods/deleteRecord?anchor=destroyRecord) method to delete and persist at the same time.
 
 ```javascript
 store.findRecord('post', 1, { backgroundReload: false }).then(function(post) {
@@ -165,4 +165,4 @@ store.findRecord('post', 2, { backgroundReload: false }).then(function(post) {
 
 The `backgroundReload` option is used to prevent the fetching of the destroyed record, since [`findRecord()`][findRecord] automatically schedules a fetch of the record from the adapter.
 
-[findRecord]: <https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/findRecord?anchor=findRecord>
+[findRecord]: <https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/findRecord?anchor=findRecord>

--- a/guides/v2.17.0/models/customizing-adapters.md
+++ b/guides/v2.17.0/models/customizing-adapters.md
@@ -49,17 +49,17 @@ export default DS.JSONAPIAdapter.extend({
 Ember Data comes with several built-in adapters.
 Feel free to use these adapters as a starting point for creating your own custom adapter.
 
-- [DS.Adapter](https://api.emberjs.com/ember-data/2.16/classes/DS.Adapter) is the basic adapter
+- [DS.Adapter](https://api.emberjs.com/ember-data/2.17/classes/DS.Adapter) is the basic adapter
 with no functionality. It is generally a good starting point if you
 want to create an adapter that is radically different from the other
 Ember adapters.
 
-- [DS.JSONAPIAdapter](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPIAdapter)
+- [DS.JSONAPIAdapter](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPIAdapter)
 The `JSONAPIAdapter` is the default adapter and follows JSON API
 conventions to communicate with an HTTP server by transmitting JSON
 via XHR.
 
-- [DS.RESTAdapter](https://api.emberjs.com/ember-data/2.16/classes/DS.RESTAdapter)
+- [DS.RESTAdapter](https://api.emberjs.com/ember-data/2.17/classes/DS.RESTAdapter)
 The `RESTAdapter` allows your store to communicate with an HTTP server
 by transmitting JSON via XHR. Before Ember Data 2.0 this adapter was the default.
 
@@ -67,7 +67,7 @@ by transmitting JSON via XHR. Before Ember Data 2.0 this adapter was the default
 ## Customizing the JSONAPIAdapter
 
 The
-[DS.JSONAPIAdapter](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPIAdapter)
+[DS.JSONAPIAdapter](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPIAdapter)
 has a handful of hooks that are commonly used to extend it to work
 with non-standard backends.
 
@@ -235,7 +235,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile&show=inherited%2Cprotected%2Cprivate%2Cdeprecated)
+[volatile](https://api.emberjs.com/ember/2.17/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile&show=inherited%2Cprotected%2Cprivate%2Cdeprecated)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v2.17.0/models/customizing-adapters.md
+++ b/guides/v2.17.0/models/customizing-adapters.md
@@ -235,7 +235,7 @@ export default DS.JSONAPIAdapter.extend({
 In some cases, your dynamic headers may require data from some
 object outside of Ember's observer system (for example
 `document.cookie`). You can use the
-[volatile](https://api.emberjs.com/ember/2.17/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile&show=inherited%2Cprotected%2Cprivate%2Cdeprecated)
+[volatile](https://api.emberjs.com/ember/2.17/classes/@ember%2Fobject%2Fcomputed/methods/property?anchor=volatile)
 function to set the property into a non-cached mode causing the headers to
 be recomputed with every request.
 

--- a/guides/v2.17.0/models/customizing-serializers.md
+++ b/guides/v2.17.0/models/customizing-serializers.md
@@ -198,7 +198,7 @@ export default DS.JSONAPISerializer.extend({
 
 Similarly, if your backend store provides data in a format other than JSON API,
 you can use the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -252,7 +252,7 @@ export default DS.JSONAPISerializer.extend({
 ```
 
 To normalize only a single model, you can use the
-[`normalize()`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalize)
+[`normalize()`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPISerializer/methods/normalize?anchor=normalize)
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
@@ -421,7 +421,7 @@ The JSON should encode the relationship as an ID to another record:
 ```
 If needed these naming conventions can be overwritten by implementing
 the
-[`keyForRelationship()`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForRelationship)
+[`keyForRelationship()`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPISerializer/methods/keyForRelationship?anchor=keyForRelationship)
 method.
 
 ```javascript {data-filename=app/serializers/application.js}

--- a/guides/v2.17.0/models/customizing-serializers.md
+++ b/guides/v2.17.0/models/customizing-serializers.md
@@ -5,11 +5,11 @@ format, Ember Data allows you to customize the serializer or use a
 different serializer entirely.
 
 Ember Data ships with 3 serializers. The
-[`JSONAPISerializer`](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPISerializer)
+[`JSONAPISerializer`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPISerializer)
 is the default serializer and works with JSON API backends. The
-[`JSONSerializer`](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONSerializer)
+[`JSONSerializer`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONSerializer)
 is a simple serializer for working with single JSON object or arrays of records. The
-[`RESTSerializer`](https://api.emberjs.com/ember-data/2.16/classes/DS.RESTSerializer)
+[`RESTSerializer`](https://api.emberjs.com/ember-data/2.17/classes/DS.RESTSerializer)
 is a more complex serializer that supports sideloading and was the default
 serializer before 2.0.
 
@@ -139,7 +139,7 @@ export default DS.JSONAPISerializer.extend({});
 ```
 
 To change the format of the data that is sent to the backend store, you can use
-the [`serialize()`](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPISerializer/methods/serialize?anchor=serialize)
+the [`serialize()`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPISerializer/methods/serialize?anchor=serialize)
 hook. Let's say that we have this JSON API response from Ember Data:
 
 ```json
@@ -198,7 +198,7 @@ export default DS.JSONAPISerializer.extend({
 
 Similarly, if your backend store provides data in a format other than JSON API,
 you can use the
-[`normalizeResponse()`](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalizeResponse)
+[`normalizeResponse()`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalizeResponse)
 hook. Using the same example as above, if the server provides data that looks
 like:
 
@@ -252,11 +252,11 @@ export default DS.JSONAPISerializer.extend({
 ```
 
 To normalize only a single model, you can use the
-[`normalize()`](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalize)
+[`normalize()`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPISerializer/methods/serialize?anchor=normalize)
 hook similarly.
 
 For more hooks to customize the serializer with, see the [Ember Data serializer
-API documentation](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPISerializer).
+API documentation](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPISerializer).
 
 ### IDs
 
@@ -309,7 +309,7 @@ in the document payload returned by your server:
 
 If the attributes returned by your server use a different convention
 you can use the serializer's
-[`keyForAttribute()`](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForAttribute)
+[`keyForAttribute()`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForAttribute)
 method to convert an attribute name in your model to a key in your JSON
 payload. For example, if your backend returned attributes that are
 `under_scored` instead of `dash-cased` you could override the `keyForAttribute`
@@ -421,7 +421,7 @@ The JSON should encode the relationship as an ID to another record:
 ```
 If needed these naming conventions can be overwritten by implementing
 the
-[`keyForRelationship()`](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForRelationship)
+[`keyForRelationship()`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPISerializer/methods/keyForAttribute?anchor=keyForRelationship)
 method.
 
 ```javascript {data-filename=app/serializers/application.js}
@@ -544,7 +544,7 @@ looks similar to this:
 The `JSONAPISerializer` is built on top of the `JSONSerializer` so they share
 many of the same hooks for customizing the behavior of the
 serialization process. Be sure to check out the
-[API docs](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONSerializer)
+[API docs](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONSerializer)
 for a full list of methods and properties.
 
 
@@ -752,7 +752,7 @@ Note that the type is `"post"` to match the post model and the
 #### Normalizing adapter responses
 
 When creating a custom serializer you will need to define a
-[normalizeResponse](https://api.emberjs.com/ember-data/2.16/classes/DS.Serializer/methods/normalizeResponse?anchor=normalizeResponse)
+[normalizeResponse](https://api.emberjs.com/ember-data/2.17/classes/DS.Serializer/methods/normalizeResponse?anchor=normalizeResponse)
 method to transform the response from the adapter into the normalized
 JSON object described above.
 
@@ -773,7 +773,7 @@ do not fall into the normal CRUD flow that the adapter provides.
 #### Serializing records
 
 Finally a serializer will need to implement a
-[serialize](https://api.emberjs.com/ember-data/2.16/classes/DS.Serializer/methods/serialize?anchor=serialize)
+[serialize](https://api.emberjs.com/ember-data/2.17/classes/DS.Serializer/methods/serialize?anchor=serialize)
 method.
 Ember Data will provide a record snapshot and an options hash and this
 method should return an object that the adapter will send to the

--- a/guides/v2.17.0/models/defining-models.md
+++ b/guides/v2.17.0/models/defining-models.md
@@ -28,7 +28,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
 ## Defining Attributes
 
 The `person` model we generated earlier didn't have any attributes. Let's
-add first and last name, as well as the birthday, using [`DS.attr`](https://api.emberjs.com/ember-data/2.16/classes/DS/methods/attr?anchor=attr):
+add first and last name, as well as the birthday, using [`DS.attr`](https://api.emberjs.com/ember-data/2.17/classes/DS/methods/attr?anchor=attr):
 
 ```javascript {data-filename=app/models/person.js}
 import DS from 'ember-data';

--- a/guides/v2.17.0/models/finding-records.md
+++ b/guides/v2.17.0/models/finding-records.md
@@ -9,7 +9,7 @@ This will return a promise that fulfills with the requested record:
 let blogPost = this.get('store').findRecord('blog-post', 1); // => GET /blog-posts/1
 ```
 
-Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/findRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
+Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/peekRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
@@ -59,7 +59,7 @@ this.get('store').query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/query?anchor=queryRecord)that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/queryRecord?anchor=queryRecord)that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:
@@ -87,7 +87,7 @@ export default DS.Adapter.extend({
 });
 ```
 
-then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/query?anchor=queryRecord) will retrieve that object from the server:
+then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/queryRecord?anchor=queryRecord) will retrieve that object from the server:
 
 ```javascript
 store.queryRecord('user', {}).then(function(user) {

--- a/guides/v2.17.0/models/finding-records.md
+++ b/guides/v2.17.0/models/finding-records.md
@@ -2,14 +2,14 @@ The Ember Data store provides an interface for retrieving records of a single ty
 
 ### Retrieving a Single Record
 
-Use [`store.findRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/findRecord?anchor=findRecord) to retrieve a record by its type and ID.
+Use [`store.findRecord()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/findRecord?anchor=findRecord) to retrieve a record by its type and ID.
 This will return a promise that fulfills with the requested record:
 
 ```javascript
 let blogPost = this.get('store').findRecord('blog-post', 1); // => GET /blog-posts/1
 ```
 
-Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/findRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
+Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/findRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
@@ -18,7 +18,7 @@ let blogPost = this.get('store').peekRecord('blog-post', 1); // => no network re
 
 ### Retrieving Multiple Records
 
-Use [`store.findAll()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/findAll?anchor=findAll) to retrieve all of the records for a given type:
+Use [`store.findAll()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/findAll?anchor=findAll) to retrieve all of the records for a given type:
 
 ```javascript
 let blogPosts = this.get('store').findAll('blog-post'); // => GET /blog-posts
@@ -39,7 +39,7 @@ the `[]` notation will not work--you'll have to use `objectAt(index)` instead.
 ### Querying for Multiple Records
 
 Ember Data provides the ability to query for records that meet certain criteria.
-Calling [`store.query()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/query?anchor=query) will make a `GET` request with the passed object serialized as query params.
+Calling [`store.query()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/query?anchor=query) will make a `GET` request with the passed object serialized as query params.
 This method returns a `DS.PromiseArray` in the same way as `findAll`.
 
 For example, we could search for all `person` models who have the name of
@@ -59,7 +59,7 @@ this.get('store').query('person', {
 ### Querying for A Single Record
 
 If you are using an adapter that supports server requests capable of returning a single model object,
-Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/query?anchor=queryRecord)that will return a promise that resolves with that single record.
+Ember Data provides a convenience method [`store.queryRecord()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/query?anchor=queryRecord)that will return a promise that resolves with that single record.
 The request is made via a method `queryRecord()` defined by the adapter.
 
 For example, if your server API provides an endpoint for the currently logged in user:
@@ -87,7 +87,7 @@ export default DS.Adapter.extend({
 });
 ```
 
-then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/query?anchor=queryRecord) will retrieve that object from the server:
+then calling [`store.queryRecord()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/query?anchor=queryRecord) will retrieve that object from the server:
 
 ```javascript
 store.queryRecord('user', {}).then(function(user) {
@@ -100,7 +100,7 @@ As in the case of `store.query()`, a query object can also be passed to `store.q
 However the adapter must return a single model object, not an array containing one element,
 otherwise Ember Data will throw an exception.
 
-Note that Ember's default [JSON API adapter](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPIAdapter) does not provide the functionality needed to support `queryRecord()` directly as it relies on REST request definitions that return result data in the form of an array.
+Note that Ember's default [JSON API adapter](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPIAdapter) does not provide the functionality needed to support `queryRecord()` directly as it relies on REST request definitions that return result data in the form of an array.
 
 If your server API or your adapter only provides array responses but you wish to retrieve just a single record, you can alternatively use the `query()` method as follows:
 

--- a/guides/v2.17.0/models/pushing-records-into-the-store.md
+++ b/guides/v2.17.0/models/pushing-records-into-the-store.md
@@ -78,7 +78,7 @@ the casing of the properties defined on the Model class.
 
 If you would like the data to be normalized by the model's default
 serializer before pushing it into the store, you can use the
-[`store.pushPayload()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/push?anchor=pushPayload) method.
+[`store.pushPayload()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/pushPayload?anchor=pushPayload) method.
 
 ```javascript {data-filename=app/serializers/album.js}
 import DS from 'ember-data';

--- a/guides/v2.17.0/models/pushing-records-into-the-store.md
+++ b/guides/v2.17.0/models/pushing-records-into-the-store.md
@@ -19,7 +19,7 @@ you want to update the UI immediately.
 
 ### Pushing Records
 
-To push a record into the store, call the store's [`push()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/push?anchor=push) method.
+To push a record into the store, call the store's [`push()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/push?anchor=push) method.
 
 For example, imagine we want to preload some data into the store when
 the application boots for the first time.
@@ -78,7 +78,7 @@ the casing of the properties defined on the Model class.
 
 If you would like the data to be normalized by the model's default
 serializer before pushing it into the store, you can use the
-[`store.pushPayload()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/push?anchor=pushPayload) method.
+[`store.pushPayload()`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/push?anchor=pushPayload) method.
 
 ```javascript {data-filename=app/serializers/album.js}
 import DS from 'ember-data';

--- a/guides/v2.17.0/models/relationships.md
+++ b/guides/v2.17.0/models/relationships.md
@@ -340,7 +340,7 @@ include those related records in the response returned to the client.
 The value of the parameter should be a comma-separated list of names of the
 relationships required.
 
-If you are using an adapter that supports JSON API, such as Ember's default [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPIAdapter),
+If you are using an adapter that supports JSON API, such as Ember's default [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPIAdapter),
 you can easily add the `include` parameter to the server requests created by
 the `findRecord()`, `findAll()`,
 `query()` and `queryRecord()` methods.

--- a/guides/v2.17.0/object-model/bindings.md
+++ b/guides/v2.17.0/object-model/bindings.md
@@ -3,7 +3,7 @@ bindings in Ember.js can be used with any object. That said, bindings are most
 often used within the Ember framework itself, and for most problems Ember app
 developers face, computed properties are the appropriate solution.
 
-The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+The easiest way to create a two-way binding is to use a [`computed.alias()`](https://api.emberjs.com/ember/2.17/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=alias&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
 that specifies the path to another object.
 
 ```javascript
@@ -37,7 +37,7 @@ overhead of syncing bindings when values are transient.
 ## One-Way Bindings
 
 A one-way binding only propagates changes in one direction, using
-[`computed.oneWay()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
+[`computed.oneWay()`](https://api.emberjs.com/ember/2.17/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=oneWay&show=inherited%2Cprotected%2Cprivate%2Cdeprecated). Often, one-way bindings are a performance
 optimization and you can safely use a two-way binding (which are de facto one-way bindings if you only ever change one side).
 Sometimes one-way bindings are useful to achieve specific behavior such as a
 default that is the same as another property but can be overridden (e.g. a

--- a/guides/v2.17.0/object-model/classes-and-instances.md
+++ b/guides/v2.17.0/object-model/classes-and-instances.md
@@ -7,8 +7,8 @@ as other major features of the Ember object model.
 To define a new Ember _class_, call the [`extend()`][1] method on
 [`EmberObject`][2]:
 
-[1]: https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/extend?anchor=extend
-[2]: https://api.emberjs.com/ember/2.16/modules/@ember%2Fobject
+[1]: https://api.emberjs.com/ember/2.17/classes/@ember%2Fobject/methods/extend?anchor=extend
+[2]: https://api.emberjs.com/ember/2.17/modules/@ember%2Fobject
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -26,7 +26,7 @@ You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
 of Ember's built-in [`Component`][3] class:
 
-[3]: https://api.emberjs.com/ember/2.16/classes/Component
+[3]: https://api.emberjs.com/ember/2.17/classes/Component
 
 ```javascript {data-filename=app/components/todo-item.js}
 import Component from '@ember/component';
@@ -75,7 +75,7 @@ One common example is when overriding the [`normalizeResponse()`][4] hook in one
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
 
-[4]: https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse
+[4]: https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse
 
 ```javascript
 normalizeResponse(store, primaryModelClass, payload, id, requestType)  {
@@ -93,7 +93,7 @@ class by calling its [`create()`][5] method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
 
-[5]: https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/create?anchor=create
+[5]: https://api.emberjs.com/ember/2.17/classes/@ember%2Fobject/methods/create?anchor=create
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -145,7 +145,7 @@ When a new instance is created, its [`init()`][6] method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
 
-[6]: https://api.emberjs.com/ember/2.16/classes/EmberObject/methods/init?anchor=init
+[6]: https://api.emberjs.com/ember/2.17/classes/EmberObject/methods/init?anchor=init
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -229,8 +229,8 @@ Person.create({
 When accessing the properties of an object, use the [`get()`][7]
 and [`set()`][8] accessor methods:
 
-[7]: https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/get?anchor=get
-[8]: https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/set?anchor=set
+[7]: https://api.emberjs.com/ember/2.17/classes/@ember%2Fobject/methods/get?anchor=get
+[8]: https://api.emberjs.com/ember/2.17/classes/@ember%2Fobject/methods/set?anchor=set
 
 ```javascript
 import EmberObject from '@ember/object';

--- a/guides/v2.17.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v2.17.0/object-model/computed-properties-and-aggregate-data.md
@@ -45,7 +45,7 @@ you would declare the dependency with braces: `todos.@each.{priority,title}`
 ### Computed Property Macros
 
 Ember also provides a computed property macro
-[`computed.filterBy`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
+[`computed.filterBy`](https://api.emberjs.com/ember/2.17/classes/@ember%2Fobject%2Fcomputed/methods/alias?anchor=filterBy&show=inherited%2Cprotected%2Cprivate%2Cdeprecated),
 which is a shorter way of expressing the above computed property:
 
 ```javascript {data-filename=app/components/todo-list.js}
@@ -133,10 +133,10 @@ export default Component.extend({
 Here, `indexOfSelectedTodo` depends on `todos.[]`, so it will update if we add an item
 to `todos`, but won't update if the value of `isDone` on a `todo` changes.
 
-Several of the [Ember.computed](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject%2Fcomputed) macros
+Several of the [Ember.computed](https://api.emberjs.com/ember/2.17/classes/@ember%2Fobject%2Fcomputed) macros
 utilize the `[]` key to implement common use-cases. For instance, to
 create a computed property that mapped properties from an array, you could use
-[Ember.computed.map](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject%2Fcomputed/methods/map?anchor=map)
+[Ember.computed.map](https://api.emberjs.com/ember/2.17/classes/@ember%2Fobject%2Fcomputed/methods/map?anchor=map)
 or build the computed property yourself:
 
 ```javascript

--- a/guides/v2.17.0/object-model/computed-properties.md
+++ b/guides/v2.17.0/object-model/computed-properties.md
@@ -206,4 +206,4 @@ Person = EmberObject.extend({
 ```
 
 To see the full list of computed property macros, have a look at
-[the API documentation](https://api.emberjs.com/ember/2.16/modules/@ember%2Fobject)
+[the API documentation](https://api.emberjs.com/ember/2.17/modules/@ember%2Fobject)

--- a/guides/v2.17.0/object-model/index.md
+++ b/guides/v2.17.0/object-model/index.md
@@ -6,7 +6,7 @@ JavaScript objects don't support the observation of property value changes.
 Consequently, if an object is going to participate in Ember's binding
 system you may see an `Ember.Object` instead of a plain object.
 
-[Ember.Object](https://api.emberjs.com/ember/2.16/modules/@ember%2Fobject) also provides a class system, supporting features like mixins
+[Ember.Object](https://api.emberjs.com/ember/2.17/modules/@ember%2Fobject) also provides a class system, supporting features like mixins
 and constructor methods. Some features in Ember's object model are not present in
 JavaScript classes or common patterns, but all are aligned as much as possible
 with the language and proposed additions.
@@ -15,4 +15,4 @@ Ember also extends the JavaScript `Array` prototype with its
 [Ember.Enumerable](https://api.emberjs.com/classes/Ember.Enumerable.html) interface to provide change observation for arrays.
 
 Finally, Ember extends the `String` prototype with a few [formatting and
-localization methods](https://api.emberjs.com/ember/2.16/classes/String).
+localization methods](https://api.emberjs.com/ember/2.17/classes/String).

--- a/guides/v2.17.0/object-model/observers.md
+++ b/guides/v2.17.0/object-model/observers.md
@@ -79,7 +79,7 @@ person.set('firstName', 'John');
 person.set('lastName', 'Smith');
 ```
 
-To get around these problems, you should make use of [`Ember.run.once()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Frunloop/methods/once?anchor=once).
+To get around these problems, you should make use of [`Ember.run.once()`](https://api.emberjs.com/ember/2.17/classes/@ember%2Frunloop/methods/once?anchor=once).
 This will ensure that any processing you need to do only happens once, and
 happens in the next run loop once all bindings are synchronized:
 
@@ -145,7 +145,7 @@ get it in your `init()` method.
 ### Outside of class definitions
 
 You can also add observers to an object outside of a class definition
-using [`addObserver()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject%2Fobservers/methods/addObserver?anchor=addObserver):
+using [`addObserver()`](https://api.emberjs.com/ember/2.17/classes/@ember%2Fobject%2Fobservers/methods/addObserver?anchor=addObserver):
 
 
 ```javascript

--- a/guides/v2.17.0/routing/asynchronous-routing.md
+++ b/guides/v2.17.0/routing/asynchronous-routing.md
@@ -8,7 +8,7 @@ heavy use of the concept of Promises. In short, promises are objects that
 represent an eventual value. A promise can either _fulfill_
 (successfully resolve the value) or _reject_ (fail to resolve the
 value). The way to retrieve this eventual value, or handle the cases
-when the promise rejects, is via the promise's [`then()`](https://api.emberjs.com/ember/2.16/classes/Promise/methods/then?anchor=then) method, which
+when the promise rejects, is via the promise's [`then()`](https://api.emberjs.com/ember/2.17/classes/RSVP.Promise/methods/then?anchor=then) method, which
 accepts two optional callbacks, one for fulfillment and one for
 rejection. If the promise fulfills, the fulfillment handler gets called
 with the fulfilled value as its sole argument, and if the promise rejects,
@@ -74,7 +74,7 @@ defined on it to be a promise.
 If the promise fulfills, the transition will pick up where it left off and
 begin resolving the next (child) route's model, pausing if it too is a
 promise, and so on, until all destination route models have been
-resolved. The values passed to the [`setupController()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/setupController?anchor=setupController) hook for each route
+resolved. The values passed to the [`setupController()`](https://api.emberjs.com/ember/2.17/classes/Route/methods/setupController?anchor=setupController) hook for each route
 will be the fulfilled values from the promises.
 
 

--- a/guides/v2.17.0/routing/defining-your-routes.md
+++ b/guides/v2.17.0/routing/defining-your-routes.md
@@ -14,7 +14,7 @@ It also adds the route to the router.
 
 ## Basic Routes
 
-The [`map()`](https://api.emberjs.com/ember/2.16/classes/Router/methods/map?anchor=map) method
+The [`map()`](https://api.emberjs.com/ember/2.17/classes/Router/methods/map?anchor=map) method
 of your Ember application's router can be invoked to define URL mappings. When
 calling `map()`, you should pass a function that will be invoked with the value
 `this` set to an object which you can use to create routes.
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`{{link-to}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`{{link-to}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars
@@ -269,5 +269,5 @@ so that when a user navigates to `/a/non-existent/path` they will be shown a mes
 To have your route do something beyond render a template with the same name, you'll
 need to create a route handler. The following guides will explore the different
 features of route handlers. For more information on routes, see the API documentation
-for [the router](https://api.emberjs.com/ember/2.16/classes/Router) and for [route
-handlers](https://api.emberjs.com/ember/2.16/classes/Route).
+for [the router](https://api.emberjs.com/ember/2.17/classes/Router) and for [route
+handlers](https://api.emberjs.com/ember/2.17/classes/Route).

--- a/guides/v2.17.0/routing/loading-and-error-substates.md
+++ b/guides/v2.17.0/routing/loading-and-error-substates.md
@@ -84,7 +84,7 @@ It's important to note that `foo.bar.loading` is not considered now.
 ### The `loading` event
 
 If the various `beforeModel`/`model`/`afterModel` hooks
-don't immediately resolve, a [`loading`](https://api.emberjs.com/ember/2.16/classes/Route/events/loading?anchor=loading) event will be fired on that route.
+don't immediately resolve, a [`loading`](https://api.emberjs.com/ember/2.17/classes/Route/events/loading?anchor=loading) event will be fired on that route.
 
 ```javascript {data-filename=app/routes/foo-slow-model.js}
 import Route from '@ember/routing/route';
@@ -199,7 +199,7 @@ logged.
 
 If the `articles.overview` route's `model` hook returns a promise that rejects
 (for instance the server returned an error, the user isn't logged in,
-etc.), an [`error`](https://api.emberjs.com/ember/2.16/classes/Route/events/error?anchor=error) event will fire from that route and bubble upward.
+etc.), an [`error`](https://api.emberjs.com/ember/2.17/classes/Route/events/error?anchor=error) event will fire from that route and bubble upward.
 This `error` event can be handled and used to display an error message,
 redirect to a login page, etc.
 

--- a/guides/v2.17.0/routing/redirection.md
+++ b/guides/v2.17.0/routing/redirection.md
@@ -7,12 +7,12 @@ Usually you want to redirect them to the login page, and after they have success
 There are many other reasons you probably want to have the last word on whether a user can or cannot access a certain page.
 Ember allows you to control that access with a combination of hooks and methods in your route.
 
-One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/transitionTo?anchor=transitionTo).
+One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/2.17/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
-[`transitionToRoute()`](https://api.emberjs.com/ember/2.16/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
+[`transitionToRoute()`](https://api.emberjs.com/ember/2.17/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [link-to](../../templates/links/) helper.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/transitionTo?anchor=replaceWith/) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/2.17/classes/Route/methods/transitionTo?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/2.17/classes/Route/methods/transitionTo?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/transitionTo?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/2.17/classes/Route/methods/transitionTo?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/2.17/classes/Route/methods/transitionTo?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v2.17.0/routing/rendering-a-template.md
+++ b/guides/v2.17.0/routing/rendering-a-template.md
@@ -19,7 +19,7 @@ template. For example, the `posts.new` route will render its template into the
 `posts.hbs`'s `{{outlet}}`, and the `posts` route will render its template into
 the `application.hbs`'s `{{outlet}}`.
 
-If you want to render a template other than the default one, set the route's [`templateName`](https://api.emberjs.com/ember/2.16/classes/Route/properties/templateName?anchor=templateName) property to the name of
+If you want to render a template other than the default one, set the route's [`templateName`](https://api.emberjs.com/ember/2.17/classes/Route/properties/templateName?anchor=templateName) property to the name of
 the template you want to render instead.
 
 ```javascript {data-filename=app/routes/posts.js}
@@ -30,5 +30,5 @@ export default Route.extend({
 });
 ```
 
-You can override the [`renderTemplate()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/renderTemplate?anchor=renderTemplate) hook if you want finer control over template rendering.
+You can override the [`renderTemplate()`](https://api.emberjs.com/ember/2.17/classes/Route/methods/renderTemplate?anchor=renderTemplate) hook if you want finer control over template rendering.
 Among other things, it allows you to choose the controller used to configure the template and specific outlet to render it into.

--- a/guides/v2.17.0/routing/specifying-a-routes-model.md
+++ b/guides/v2.17.0/routing/specifying-a-routes-model.md
@@ -9,7 +9,7 @@ Router.map(function() {
 });
 ```
 
-To load a model for the `favorite-posts` route, you would use the [`model()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/model?anchor=model)
+To load a model for the `favorite-posts` route, you would use the [`model()`](https://api.emberjs.com/ember/2.17/classes/Route/methods/model?anchor=model)
 hook in the `favorite-posts` route handler:
 
 ```javascript {data-filename=app/routes/favorite-posts.js}
@@ -122,7 +122,7 @@ Routes without dynamic segments will always execute the model hook.
 ## Multiple Models
 
 Multiple models can be returned through an
-[RSVP.hash](https://api.emberjs.com/ember/2.16/classes/rsvp/methods/hash?anchor=hash).
+[RSVP.hash](https://api.emberjs.com/ember/2.17/classes/RSVP/methods/hash?anchor=hash).
 The `RSVP.hash` takes
 parameters that return promises, and when all parameter promises resolve, then
 the `RSVP.hash` promise resolves. For example:

--- a/guides/v2.17.0/templates/actions.md
+++ b/guides/v2.17.0/templates/actions.md
@@ -3,7 +3,7 @@ change application state. For example, imagine that you have a template
 that shows a blog title, and supports expanding the post to show the body.
 
 If you add the
-[`{{action}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/action?anchor=action)
+[`{{action}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/action?anchor=action)
 helper to any HTML DOM element, when a user clicks the element, the named event
 will be sent to the template's corresponding component or controller.
 
@@ -62,7 +62,7 @@ export default Component.extend({
 ## Specifying the Type of Event
 
 By default, the
-[`{{action}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/action?anchor=action)
+[`{{action}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/action?anchor=action)
 helper listens for click events and triggers the action when the user clicks
 on the element.
 
@@ -116,7 +116,7 @@ will trigger the action *and* the user will be directed to the new page.
 ## Modifying the action's first parameter
 
 If a `value` option for the
-[`{{action}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/action?anchor=action)
+[`{{action}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/action?anchor=action)
 helper is specified, its value will be considered a property path that will
 be read off of the first parameter of the action. This comes very handy with
 event listeners and enables to work with one-way bindings.

--- a/guides/v2.17.0/templates/binding-element-attributes.md
+++ b/guides/v2.17.0/templates/binding-element-attributes.md
@@ -59,8 +59,8 @@ renders the following HTML:
 
 To enable support for data attributes an attribute binding must be
 added to the component, e.g.
-[`Ember.LinkComponent`](https://api.emberjs.com/ember/2.16/classes/LinkComponent)
-or [`Ember.TextField`](https://api.emberjs.com/ember/2.16/classes/TextField)
+[`Ember.LinkComponent`](https://api.emberjs.com/ember/2.17/classes/LinkComponent)
+or [`Ember.TextField`](https://api.emberjs.com/ember/2.17/classes/TextField)
 for the specific attribute:
 
 ```javascript

--- a/guides/v2.17.0/templates/built-in-helpers.md
+++ b/guides/v2.17.0/templates/built-in-helpers.md
@@ -10,7 +10,7 @@ passing data to another helper or component.
 
 ### Using a helper to get a property dynamically
 
-The [`{{get}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=get) helper makes it easy to dynamically send the value of a
+The [`{{get}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/get?anchor=get) helper makes it easy to dynamically send the value of a
 variable to another helper or component.
 This can be useful if you want
 to output one of several values based on the result of a computed property.
@@ -26,7 +26,7 @@ if the `part` computed property returns "zip", this will display the result of
 
 In the last section it was discussed that helpers can be nested.
 This can be combined with these sorts of dynamic helpers.
-For example, the [`{{concat}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=concat) helper makes it easy to dynamically send
+For example, the [`{{concat}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/get?anchor=concat) helper makes it easy to dynamically send
 a number of parameters to a component or helper as a single parameter in the
 format of a concatenated string.
 

--- a/guides/v2.17.0/templates/conditionals.md
+++ b/guides/v2.17.0/templates/conditionals.md
@@ -1,5 +1,5 @@
-Statements like [`if`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=if)
-and [`unless`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=unless)
+Statements like [`if`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=if)
+and [`unless`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=unless)
 are implemented as built-in helpers. Helpers can be invoked three ways, each
 of which is illustrated below with conditionals.
 
@@ -12,7 +12,7 @@ displaying a property, but helpers accept arguments. For example:
 </div>
 ```
 
-[`{{if}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=if)
+[`{{if}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=if)
 in this case returns `"zoooom"` when `isFast` is true and
 `"putt-putt-putt"` when `isFast` is false. Helpers invoked as inline expressions
 render a single value, the same way that properties are a single value.
@@ -53,7 +53,7 @@ properties on `person` only if that it is present:
 {{/if}}
 ```
 
-[`{{if}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=if)
+[`{{if}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=if)
 checks for truthiness, which means all values except `false`,
 `undefined`, `null`, `''`, `0`  or `[]` (i.e., any JavaScript falsy value or an
 empty array).
@@ -81,7 +81,7 @@ of that invocation is rendered:
 ```
 
 The inverse of `{{if}}` is
-[`{{unless}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=unless),
+[`{{unless}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=unless),
 which can be used in the same three styles of invocation. For example, this
 template only shows an amount due when the user has not paid:
 

--- a/guides/v2.17.0/templates/development-helpers.md
+++ b/guides/v2.17.0/templates/development-helpers.md
@@ -6,7 +6,7 @@ your browser's console, or activate the debugger from your templates.
 
 ### Logging
 
-The [`{{log}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
+The [`{{log}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=log) helper makes it easy to output variables or expressions in
  the
 current rendering context into your browser's console:
 
@@ -18,7 +18,7 @@ The `{{log}}` helper also accepts primitive types such as strings or numbers.
 
 ### Adding a breakpoint
 
-The [``{{debugger}}``](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
+The [``{{debugger}}``](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper provides a handlebars equivalent to JavaScript's
 `debugger` keyword.  It will halt execution inside the debugger helper and give
 you the ability to inspect the current rendering context:
 

--- a/guides/v2.17.0/templates/displaying-a-list-of-items.md
+++ b/guides/v2.17.0/templates/displaying-a-list-of-items.md
@@ -1,5 +1,5 @@
 To iterate over a list of items, use the
-[`{{#each}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each)
+[`{{#each}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=each)
 helper. The first argument to this helper is the array to be iterated, and
 the value being iterated is yielded as a block param. Block params are only
 available inside the block of their helper.
@@ -47,7 +47,7 @@ or removed from the iterated array, the DOM will be updated without having to
 write any additional code. That said, Ember requires that you use [special
 methods](../../object-model/enumerables/#toc_use-of-observable-methods-and-properties)
 to update bound arrays. Also be aware that [using the `key` option with an each
-helper](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each)
+helper](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=each)
 can improve re-render performance when an array is replaced with another
 containing similar items.
 
@@ -66,7 +66,7 @@ block param. Block params are space-separated, without commas. For example:
 
 ### Empty Lists
 
-The [`{{#each}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each)
+The [`{{#each}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=each)
 helper can have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 

--- a/guides/v2.17.0/templates/displaying-the-keys-in-an-object.md
+++ b/guides/v2.17.0/templates/displaying-the-keys-in-an-object.md
@@ -1,5 +1,5 @@
 If you need to display all of the keys or values of a JavaScript object in your template,
-you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
+you can use the [`{{#each-in}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper:
 
 ```javascript {data-filename=/app/components/store-categories.js}
 import Component from '@ember/component';
@@ -59,11 +59,11 @@ The above example will print a list like this:
 
 An object's keys will be listed in the same order as the array returned from calling `Object.keys` on that object.
 If you want a different sort order, you should use `Object.keys` to get an array, sort that array with the built-in JavaScript tools,
-and use the [`{{#each}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
+and use the [`{{#each}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=each-in) helper instead.
 
 ### Empty Lists
 
-The [`{{#each-in}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
+The [`{{#each-in}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=each-in)
 helper can have a matching `{{else}}`.
 The contents of this block will render if the object is empty, null, or undefined:
 

--- a/guides/v2.17.0/templates/input-helpers.md
+++ b/guides/v2.17.0/templates/input-helpers.md
@@ -1,5 +1,5 @@
-The [`{{input}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=input)
-and [`{{textarea}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
+The [`{{input}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=input)
+and [`{{textarea}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=textarea)
 helpers in Ember.js are the easiest way to create common form controls.
 Using these helpers, you can create form controls that are almost identical to the native HTML `<input>` or `<textarea>` elements, but are aware of Ember's two-way bindings and can automatically update.
 
@@ -51,12 +51,12 @@ To dispatch an action on specific events, such as `enter` or `key-press`, use th
 {{input value=firstName key-press="updateFirstName"}}
 ```
 
-[Event Names](https://api.emberjs.com/ember/2.16/classes/Component#toc_event-names) must be dasherized.
+[Event Names](https://api.emberjs.com/ember/2.17/classes/Component/events) must be dasherized.
 
 ## Checkboxes
 
 You can also use the
-[`{{input}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/if?anchor=input)
+[`{{input}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/if?anchor=input)
 helper to create a checkbox by setting its `type`:
 
 ```handlebars
@@ -84,7 +84,7 @@ Which can be bound or set as described in the previous section.
 
 Will bind the value of the text area to `name` on the current context.
 
-[`{{textarea}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea) supports binding and/or setting the following properties:
+[`{{textarea}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/textarea?anchor=textarea) supports binding and/or setting the following properties:
 
 * `value`
 * `name`
@@ -106,7 +106,7 @@ Will bind the value of the text area to `name` on the current context.
 
 ### Binding dynamic attribute
 
-You might need to bind a property dynamically to an input if you're building a flexible form, for example. To achieve this you need to use the [`{{get}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=get) and [`{{mut}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/mut?anchor=mut) in conjunction like shown in the following example:
+You might need to bind a property dynamically to an input if you're building a flexible form, for example. To achieve this you need to use the [`{{get}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/get?anchor=get) and [`{{mut}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/mut?anchor=mut) in conjunction like shown in the following example:
 
 ```handlebars
 {{input value=(mut (get person field))}}

--- a/guides/v2.17.0/templates/links.md
+++ b/guides/v2.17.0/templates/links.md
@@ -1,7 +1,7 @@
 ## The `{{link-to}}` Component
 
 You create a link to a route using the
-[`{{link-to}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`{{link-to}}`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
 component.
 
 ```javascript {data-filename=app/router.js}
@@ -118,7 +118,7 @@ For more information on how to use query parameters see the [query parameters](.
 ### Using link-to as an inline component
 
 In addition to being used as a block expression, the
-[`link-to`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
 component can also be used in inline form by specifying the link text as the first
 argument to the component:
 
@@ -151,7 +151,7 @@ adding class names, Ember will also apply the standard `ember-view` and possibly
 ### Replacing history entries
 
 The default behavior for
-[`link-to`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
+[`link-to`](https://api.emberjs.com/ember/2.17/classes/Ember.Templates.helpers/methods/get?anchor=link-to)
 is to add entries to the browser's history when transitioning between the
 routes. However, to replace the current entry in the browser's history you
 can use the `replace=true` option:

--- a/guides/v2.17.0/templates/writing-helpers.md
+++ b/guides/v2.17.0/templates/writing-helpers.md
@@ -394,7 +394,7 @@ would see this:
 Welcome back! <b>&lt;script
 type="javascript"&gt;alert('pwned!');&lt;/script&gt;</b> has joined the channel.
 ```
-[1]: https://api.emberjs.com/ember/2.16/classes/Helper
-[2]: https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute
+[1]: https://api.emberjs.com/ember/2.17/classes/Helper
+[2]: https://api.emberjs.com/ember/2.17/classes/Helper/methods/compute?anchor=compute
 [3]: https://api.emberjs.com/classes/Ember.Helper.html#method_helper
-[4]: https://api.emberjs.com/ember/2.16/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe
+[4]: https://api.emberjs.com/ember/2.17/classes/@ember%2Fstring/methods/htmlSafe?anchor=htmlSafe

--- a/guides/v2.17.0/testing/testing-components.md
+++ b/guides/v2.17.0/testing/testing-components.md
@@ -395,7 +395,7 @@ Often, interacting with a component will cause asynchronous behavior to occur, s
 `wait` helper is designed to handle these scenarios, by providing a hook to ensure assertions are made after
 all Ajax requests and timers are complete.
 
-Imagine you have a typeahead component that uses [`Ember.run.debounce`](https://api.emberjs.com/ember/2.16/classes/@ember%2Frunloop/methods/debounce?anchor=debounce)
+Imagine you have a typeahead component that uses [`Ember.run.debounce`](https://api.emberjs.com/ember/2.17/classes/@ember%2Frunloop/methods/debounce?anchor=debounce)
 to limit requests to the server, and you want to verify that results are displayed after typing a character.
 
 > You can follow along by generating your own component with `ember generate

--- a/guides/v2.17.0/testing/unit-testing-basics.md
+++ b/guides/v2.17.0/testing/unit-testing-basics.md
@@ -3,7 +3,7 @@ is doing what was intended. Unlike acceptance tests, they are narrow in scope
 and do not require the Ember application to be running.
 
 As it is the basic object type in Ember, being able to test a simple
-[`EmberObject`](https://api.emberjs.com/ember/2.16/modules/@ember%2Fobject?show=inherited%2Cprotected%2Cprivate%2Cdeprecated) sets the foundation for testing more specific parts of your
+[`EmberObject`](https://api.emberjs.com/ember/2.17/modules/@ember%2Fobject?show=inherited%2Cprotected%2Cprivate%2Cdeprecated) sets the foundation for testing more specific parts of your
 Ember application such as controllers, components, etc. Testing an `EmberObject`
 is as simple as creating an instance of the object, setting its state, and
 running assertions against the object. By way of example, let's look at a few

--- a/guides/v2.17.0/tutorial/autocomplete-component.md
+++ b/guides/v2.17.0/tutorial/autocomplete-component.md
@@ -105,7 +105,7 @@ The `filter` function is passed in by the calling object. This is a pattern know
 
 Notice the `then` function called on the result of calling the `filter` function.
 The code expects the `filter` function to return a promise.
-A [promise](https://api.emberjs.com/ember/2.16/classes/Promise) is a JavaScript object that represents the result of an asynchronous function.
+A [promise](https://api.emberjs.com/ember/2.17/classes/Promise) is a JavaScript object that represents the result of an asynchronous function.
 A promise may or may not be executed at the time you receive it.
 To account for this, it provides functions, like `then` that let you give it code it will run when it eventually does receive a result.
 
@@ -279,7 +279,7 @@ The `value` property represents the latest state of the input field.
 Therefore we now check that results match the input field, ensuring that results will stay in sync with the last thing the user has typed.
 
 While this approach will keep our results order consistent, there are other things to consider when dealing with multiple concurrent tasks,
-such as [limiting the number of requests made to the server](https://api.emberjs.com/ember/2.16/classes/@ember%2Frunloop/methods/debounce?anchor=debounce).
+such as [limiting the number of requests made to the server](https://api.emberjs.com/ember/2.17/classes/@ember%2Frunloop/methods/debounce?anchor=debounce).
 To create effective and robust autocomplete behavior for your applications,
 we recommend considering the [`ember-concurrency`](http://ember-concurrency.com/#/docs/introduction) addon project.
 
@@ -340,7 +340,7 @@ Our `filterByCity` function is going to pretend to be the action function for ou
 We are not testing the actual filtering of rentals in this test, since it is focused on only the capability of the component.
 We will test the full logic of filtering in acceptance tests, described in the next section.
 
-Since our component is expecting the filter process to be asynchronous, we return promises from our filter, using [Ember's RSVP library](https://api.emberjs.com/ember/2.16/modules/rsvp).
+Since our component is expecting the filter process to be asynchronous, we return promises from our filter, using [Ember's RSVP library](https://api.emberjs.com/ember/2.17/classes/RSVP).
 
 Next, we'll add the call to render the component to show the cities we've provided above.
 

--- a/guides/v2.17.0/tutorial/ember-data.md
+++ b/guides/v2.17.0/tutorial/ember-data.md
@@ -3,7 +3,7 @@ As our application grows, we will want to persist our rental data on a server, a
 
 Ember comes with a data management library called [Ember Data](https://github.com/emberjs/data) to help deal with persistent application data.
 
-Ember Data requires you to define the structure of the data you wish to provide to your application by extending [`DS.Model`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model).
+Ember Data requires you to define the structure of the data you wish to provide to your application by extending [`DS.Model`](https://api.emberjs.com/ember-data/2.17/classes/DS.Model).
 
 You can generate an Ember Data Model using Ember CLI.
 We'll call our model `rental` and generate it as follows:
@@ -21,7 +21,7 @@ installing model-test
   create tests/unit/models/rental-test.js
 ```
 
-When we open the model file, we can see a blank class extending [`DS.Model`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model):
+When we open the model file, we can see a blank class extending [`DS.Model`](https://api.emberjs.com/ember-data/2.17/classes/DS.Model):
 
 ```javascript {data-filename=app/models/rental.js}
 import DS from 'ember-data';
@@ -33,7 +33,7 @@ export default DS.Model.extend({
 
 Let's define the structure of a rental object using the same attributes for our rental that we [previously used](../model-hook/) in our hard-coded array of JavaScript objects -
 _title_, _owner_, _city_, _property type_, _image_, _bedrooms_ and _description_.
-Define attributes by giving them the result of the function [`DS.attr()`](https://api.emberjs.com/ember-data/2.16/classes/DS/methods/attr?anchor=attr).
+Define attributes by giving them the result of the function [`DS.attr()`](https://api.emberjs.com/ember-data/2.17/classes/DS/methods/attr?anchor=attr).
 For more information on Ember Data Attributes, read the section called [Defining Attributes](../../models/defining-models/#toc_defining-attributes) in the guides.
 
 ```javascript {data-filename=app/models/rental.js data-diff="+4,+5,+6,+7,+8,+9,+10"}
@@ -56,9 +56,9 @@ We now have a model object that we can use for our Ember Data implementation.
 
 To use our new Ember Data Model object, we need to update the `model` function we [previously defined](../model-hook/) in our route handler.
 Delete the hard-coded JavaScript Array, and replace it with the following call to the [Ember Data Store service](../../models/#toc_the-store-and-a-single-source-of-truth).
-The [store service](https://api.emberjs.com/ember-data/2.16/classes/DS.Store) is injected into all routes and components in Ember.
+The [store service](https://api.emberjs.com/ember-data/2.17/classes/DS.Store) is injected into all routes and components in Ember.
 It is the main interface you use to interact with Ember Data.
-In this case, call the [`findAll`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/findAll?anchor=findAll) function on the store and provide it with the name of your newly created rental model class.
+In this case, call the [`findAll`](https://api.emberjs.com/ember-data/2.17/classes/DS.Store/methods/findAll?anchor=findAll) function on the store and provide it with the name of your newly created rental model class.
 
 ```javascript {data-filename=app/routes/rentals.js data-diff="+5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31,-32,-33"}
 import Route from '@ember/routing/route';

--- a/guides/v2.17.0/tutorial/installing-addons.md
+++ b/guides/v2.17.0/tutorial/installing-addons.md
@@ -143,7 +143,7 @@ For now, let's generate an adapter for our application:
 ember generate adapter application
 ```
 
-This adapter will extend the [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPIAdapter/) base class from Ember Data:
+This adapter will extend the [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/2.17/classes/DS.JSONAPIAdapter/) base class from Ember Data:
 
 ```javascript {data-filename=app/adapters/application.js data-diff="+4"}
 import DS from 'ember-data';

--- a/guides/v2.17.0/tutorial/model-hook.md
+++ b/guides/v2.17.0/tutorial/model-hook.md
@@ -11,7 +11,7 @@ Here's what our homepage will look like when we're done:
 ![super rentals homepage with rentals list](/images/model-hook/super-rentals-index-with-list.png)
 
 In Ember, route handlers are responsible for loading the model with data for the page.
-It loads the data in a function called [`model`](https://api.emberjs.com/ember/2.16/classes/Route/methods/model?anchor=model).
+It loads the data in a function called [`model`](https://api.emberjs.com/ember/2.17/classes/Route/methods/model?anchor=model).
 The `model` function acts as a **hook**, meaning that Ember will call it for us during different times in our app.
 The model function we've added to our `rentals` route handler will be called when a user navigates to the rentals route via root URL `http://localhost:4200`, or via `http://localhost:4200/rentals`.
 

--- a/guides/v2.17.0/tutorial/routes-and-templates.md
+++ b/guides/v2.17.0/tutorial/routes-and-templates.md
@@ -224,12 +224,12 @@ To do this we will add code to our index route handler by implementing a route l
 called `beforeModel`.
 
 Each route handler has a set of "lifecycle hooks", which are functions that are invoked at specific times during the loading of a page.
-The [`beforeModel`](https://api.emberjs.com/ember/2.16/classes/Route/methods/beforeModel?anchor=beforeModel)
+The [`beforeModel`](https://api.emberjs.com/ember/2.17/classes/Route/methods/beforeModel?anchor=beforeModel)
 hook gets executed before the data gets fetched from the model hook, and before the page is rendered.
 See [the next section](../model-hook/) for an explanation of the model hook.
 
-In our index route handler, we'll call the [`replaceWith`](https://api.emberjs.com/ember/2.16/classes/Route/methods/beforeModel?anchor=replaceWith) function.
-The `replaceWith` function is similar to the route's [`transitionTo()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/transitionTo?anchor=transitionTo) function,
+In our index route handler, we'll call the [`replaceWith`](https://api.emberjs.com/ember/2.17/classes/Route/methods/beforeModel?anchor=replaceWith) function.
+The `replaceWith` function is similar to the route's [`transitionTo()`](https://api.emberjs.com/ember/2.17/classes/Route/methods/transitionTo?anchor=transitionTo) function,
 the difference being that `replaceWith` will replace the current URL in the browser's history,
 while `transitionTo` will add to the history.
 Since we want our `rentals` route to serve as our home page, we will use the `replaceWith` function.

--- a/guides/v2.17.0/tutorial/service.md
+++ b/guides/v2.17.0/tutorial/service.md
@@ -289,7 +289,7 @@ In the second test, only one assert is expected (line 26), since the map element
 Also, note that the second test uses a dummy object as the returned map element (defined on line 4).
 Our map element can be substituted with any object because we are only asserting that the cache has been accessed (see line 32).
 
-The location in the cache has been [`camelized`](https://api.emberjs.com/ember/2.16/classes/String/methods/camelize?anchor=camelize) (line 30),
+The location in the cache has been [`camelized`](https://api.emberjs.com/ember/2.17/classes/String/methods/camelize?anchor=camelize) (line 30),
 so that it may be used as a key to look up our element.
 This matches the behavior in `getMapElement` when city has not yet been cached.
 

--- a/guides/v2.17.0/tutorial/subroutes.md
+++ b/guides/v2.17.0/tutorial/subroutes.md
@@ -339,7 +339,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `rental-listing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/2.16/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/2.17/classes/Route/methods/beforeModel?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Clicking on the title will load the detail page for that rental.

--- a/guides/v3.0.0/applications/applications-and-instances.md
+++ b/guides/v3.0.0/applications/applications-and-instances.md
@@ -1,8 +1,8 @@
-Every Ember application is represented by a class that extends [`Application`](https://api.emberjs.com/ember/2.16/classes/Application).
+Every Ember application is represented by a class that extends [`Application`](https://api.emberjs.com/ember/3.0/classes/Application).
 This class is used to declare and configure the many objects that make up your app.
 
 As your application boots,
-it creates an [`ApplicationInstance`](https://api.emberjs.com/ember/2.16/classes/ApplicationInstance) that is used to manage its stateful aspects.
+it creates an [`ApplicationInstance`](https://api.emberjs.com/ember/3.0/classes/ApplicationInstance) that is used to manage its stateful aspects.
 This instance acts as the "owner" of objects instantiated for your app.
 
 Essentially, the `Application` *defines your application*

--- a/guides/v3.0.0/applications/dependency-injection.md
+++ b/guides/v3.0.0/applications/dependency-injection.md
@@ -2,11 +2,11 @@ Ember applications utilize the [dependency injection](https://en.wikipedia.org/w
 ("DI") design pattern to declare and instantiate classes of objects and dependencies between them.
 Applications and application instances each serve a role in Ember's DI implementation.
 
-An [`Application`](https://api.emberjs.com/ember/2.16/classes/Application) serves as a "registry" for dependency declarations.
+An [`Application`](https://api.emberjs.com/ember/3.0/classes/Application) serves as a "registry" for dependency declarations.
 Factories (i.e. classes) are registered with an application,
 as well as rules about "injecting" dependencies that are applied when objects are instantiated.
 
-An [`ApplicationInstance`](https://api.emberjs.com/ember/2.16/classes/ApplicationInstance) serves as the "owner" for objects that are instantiated from registered factories.
+An [`ApplicationInstance`](https://api.emberjs.com/ember/3.0/classes/ApplicationInstance) serves as the "owner" for objects that are instantiated from registered factories.
 Application instances provide a means to "look up" (i.e. instantiate and / or retrieve) objects.
 
 > _Note: Although an `Application` serves as the primary registry for an app,
@@ -194,7 +194,7 @@ export default Component.extend({
 ## Factory Instance Lookups
 
 To fetch an instantiated factory from the running application you can call the
-[`lookup`](https://api.emberjs.com/ember/2.16/classes/ApplicationInstance/methods/lookup?anchor=lookup) method on an application instance. This method takes a string
+[`lookup`](https://api.emberjs.com/ember/3.0/classes/ApplicationInstance/methods/lookup?anchor=lookup) method on an application instance. This method takes a string
 to identify a factory and returns the appropriate object.
 
 ```javascript
@@ -225,9 +225,9 @@ export default {
 
 ### Getting an Application Instance from a Factory Instance
 
-[`Ember.getOwner`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) will retrieve the application instance that "owns" an
+[`Ember.getOwner`](https://api.emberjs.com/ember/3.0/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) will retrieve the application instance that "owns" an
 object. This means that framework objects like components, helpers, and routes
-can use [`Ember.getOwner`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) to perform lookups through their application
+can use [`Ember.getOwner`](https://api.emberjs.com/ember/3.0/classes/@ember%2Fapplication/methods/getOwner?anchor=getOwner) to perform lookups through their application
 instance at runtime.
 
 For example, this component plays songs with different audio services based

--- a/guides/v3.0.0/applications/run-loop.md
+++ b/guides/v3.0.0/applications/run-loop.md
@@ -197,9 +197,9 @@ $('a').click(() => {
 });
 ```
 
-The run loop API calls that _schedule_ work, i.e. [`run.schedule`](https://api.emberjs.com/ember/2.16/classes/@ember%2Frunloop/methods/schedule?anchor=schedule),
-[`run.scheduleOnce`](https://api.emberjs.com/ember/2.16/classes/@ember%2Frunloop/methods/scheduleOnce?anchor=scheduleOnce),
-[`run.once`](https://api.emberjs.com/ember/2.16/classes/@ember%2Frunloop/methods/once?anchor=once) have the property that they will approximate a run loop for you if one does not already exist.
+The run loop API calls that _schedule_ work, i.e. [`run.schedule`](https://api.emberjs.com/ember/3.0/classes/@ember%2Frunloop/methods/schedule?anchor=schedule),
+[`run.scheduleOnce`](https://api.emberjs.com/ember/3.0/classes/@ember%2Frunloop/methods/scheduleOnce?anchor=scheduleOnce),
+[`run.once`](https://api.emberjs.com/ember/3.0/classes/@ember%2Frunloop/methods/once?anchor=once) have the property that they will approximate a run loop for you if one does not already exist.
 These automatically created run loops we call _autoruns_.
 
 Here is some pseudocode to describe what happens using the example above:
@@ -264,5 +264,5 @@ Disabling autoruns help you identify these scenarios and helps both your testing
 
 ## Where can I find more information?
 
-Check out the [Ember.run](https://api.emberjs.com/ember/2.16/classes/@ember%2Frunloop) API documentation,
+Check out the [Ember.run](https://api.emberjs.com/ember/3.0/classes/@ember%2Frunloop) API documentation,
 as well as the [Backburner library](https://github.com/ebryn/backburner.js/) that powers the run loop.

--- a/guides/v3.0.0/components/defining-a-component.md
+++ b/guides/v3.0.0/components/defining-a-component.md
@@ -58,7 +58,7 @@ the Handlebars template as described above and use the component that is
 created.
 
 If you need to customize the behavior of the component you'll
-need to define a subclass of [`Component`](https://api.emberjs.com/ember/2.16/classes/Component). For example, you would
+need to define a subclass of [`Component`](https://api.emberjs.com/ember/3.0/classes/Component). For example, you would
 need a custom subclass if you wanted to change a component's element,
 respond to actions from the component's template, or manually make
 changes to the component's element using JavaScript.
@@ -71,7 +71,7 @@ file at `app/components/blog-post.js`. If your component was called
 
 ## Dynamically rendering a component
 
-The [`{{component}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/component?anchor=component) helper can be used to defer the selection of a component to
+The [`{{component}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/component?anchor=component) helper can be used to defer the selection of a component to
 run time. The `{{my-component}}` syntax always renders the same component,
 while using the `{{component}}` helper allows choosing a component to render on
 the fly. This is useful in cases where you want to interact with different
@@ -81,7 +81,7 @@ allow you to keep different logic well separated.
 The first parameter of the helper is the name of a component to render, as a
 string. So `{{component 'blog-post'}}` is the same as using `{{blog-post}}`.
 
-The real value of [`{{component}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/component?anchor=component) comes from being able to dynamically pick
+The real value of [`{{component}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/component?anchor=component) comes from being able to dynamically pick
 the component being rendered. Below is an example of using the helper as a
 means of choosing different components for displaying different kinds of posts:
 

--- a/guides/v3.0.0/components/handling-events.md
+++ b/guides/v3.0.0/components/handling-events.md
@@ -129,7 +129,7 @@ To utilize an `event` object as a function parameter:
 
 The event handling examples described above respond to one set of events.
 The names of the built-in events are listed below. Custom events can be
-registered by using [Application.customEvents](https://api.emberjs.com/ember/2.16/classes/Application/properties/customEvents?anchor=customEvents).
+registered by using [Application.customEvents](https://api.emberjs.com/ember/3.0/classes/Application/properties/customEvents?anchor=customEvents).
 
 Touch events:
 

--- a/guides/v3.0.0/components/passing-properties-to-a-component.md
+++ b/guides/v3.0.0/components/passing-properties-to-a-component.md
@@ -66,7 +66,7 @@ In other words, you can invoke the above component example like this:
 ```
 
 To set the component up to receive parameters this way, you need to
-set the [`positionalParams`](https://api.emberjs.com/ember/2.16/classes/Component/properties/positionalParams?anchor=positionalParams) attribute in your component class.
+set the [`positionalParams`](https://api.emberjs.com/ember/3.0/classes/Component/properties/positionalParams?anchor=positionalParams) attribute in your component class.
 
 ```javascript {data-filename=app/components/blog-post.js}
 import Component from '@ember/component';

--- a/guides/v3.0.0/components/the-component-lifecycle.md
+++ b/guides/v3.0.0/components/the-component-lifecycle.md
@@ -116,17 +116,17 @@ Suppose you want to integrate your favorite date picker library into an Ember pr
 Typically, 3rd party JS/jQuery libraries require a DOM element to bind to.
 So, where is the best place to initialize and attach the library?
 
-After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`](https://api.emberjs.com/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement) hook.
+After a component successfully renders its backing HTML element into the DOM, it will trigger its [`didInsertElement()`](https://api.emberjs.com/ember/3.0/classes/Component/events/didInsertElement?anchor=didInsertElement) hook.
 
 Ember guarantees that, by the time `didInsertElement()` is called:
 
 1. The component's element has been both created and inserted into the
    DOM.
 2. The component's element is accessible via the component's
-   [`$()`](https://api.emberjs.com/ember/2.16/classes/Component/methods/$?anchor=%24)
+   [`$()`](https://api.emberjs.com/ember/3.0/classes/Component/methods/$?anchor=%24)
    method.
 
-A component's [`$()`](https://api.emberjs.com/ember/2.16/classes/Component/methods/$?anchor=%24) method allows you to access the component's DOM element by returning a jQuery element.
+A component's [`$()`](https://api.emberjs.com/ember/3.0/classes/Component/methods/$?anchor=%24) method allows you to access the component's DOM element by returning a jQuery element.
 For example, you can set an attribute using jQuery's `attr()` method:
 
 ```javascript {data-filename=app/components/profile-editor.js}
@@ -140,7 +140,7 @@ export default Component.extend({
 });
 ```
 
-[`$()`](https://api.emberjs.com/ember/2.16/classes/Component/methods/$?anchor=%24) will, by default, return a jQuery object for the component's root element, but you can also target child elements within the component's template by passing a selector:
+[`$()`](https://api.emberjs.com/ember/3.0/classes/Component/methods/$?anchor=%24) will, by default, return a jQuery object for the component's root element, but you can also target child elements within the component's template by passing a selector:
 
 ```javascript {data-filename=app/components/profile-editor.js}
 import Component from '@ember/component';
@@ -153,7 +153,7 @@ export default Component.extend({
 });
 ```
 
-Let's initialize our date picker by overriding the [`didInsertElement()`](https://api.emberjs.com/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement) method.
+Let's initialize our date picker by overriding the [`didInsertElement()`](https://api.emberjs.com/ember/3.0/classes/Component/events/didInsertElement?anchor=didInsertElement) method.
 
 Date picker libraries usually attach to an `<input>` element, so we will use jQuery to find an appropriate input within our component's template.
 
@@ -168,7 +168,7 @@ export default Component.extend({
 });
 ```
 
-[`didInsertElement()`](https://api.emberjs.com/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement) is also a good place to
+[`didInsertElement()`](https://api.emberjs.com/ember/3.0/classes/Component/events/didInsertElement?anchor=didInsertElement) is also a good place to
 attach event listeners. This is particularly useful for custom events or
 other browser events which do not have a [built-in event
 handler](../handling-events/#toc_event-names).
@@ -193,9 +193,9 @@ There are a few things to note about the `didInsertElement()` hook:
 
 - It is only triggered once when the component element is first rendered.
 - In cases where you have components nested inside other components, the child component will always receive the `didInsertElement()` call before its parent does.
-- Setting properties on the component in [`didInsertElement()`](https://api.emberjs.com/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons,
+- Setting properties on the component in [`didInsertElement()`](https://api.emberjs.com/ember/3.0/classes/Component/events/didInsertElement?anchor=didInsertElement) triggers a re-render, and for performance reasons,
   is not allowed.
-- While [`didInsertElement()`](https://api.emberjs.com/ember/2.16/classes/Component/events/didInsertElement?anchor=didInsertElement) is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
+- While [`didInsertElement()`](https://api.emberjs.com/ember/3.0/classes/Component/events/didInsertElement?anchor=didInsertElement) is technically an event that can be listened for using `on()`, it is encouraged to override the default method itself,
   particularly when order of execution is important.
 
 ### Making Updates to the Rendered DOM with `didRender`
@@ -250,7 +250,7 @@ export default Component.extend({
 
 ### Detaching and Tearing Down Component Elements with `willDestroyElement`
 
-When a component detects that it is time to remove itself from the DOM, Ember will trigger the [`willDestroyElement()`](https://api.emberjs.com/ember/2.16/classes/Component/events/willDestroyElement?anchor=willDestroyElement) method,
+When a component detects that it is time to remove itself from the DOM, Ember will trigger the [`willDestroyElement()`](https://api.emberjs.com/ember/3.0/classes/Component/events/willDestroyElement?anchor=willDestroyElement) method,
 allowing for any teardown logic to be performed.
 
 Component teardown can be triggered by a number of different conditions.

--- a/guides/v3.0.0/components/wrapping-content-in-a-component.md
+++ b/guides/v3.0.0/components/wrapping-content-in-a-component.md
@@ -65,7 +65,7 @@ We will give them the option to specify either `markdown-style` or `html-style`.
 
 Supporting different editing styles will require different body components to provide special validation and highlighting.
 To load a different body component based on editing style,
-you can yield the component using the [`component helper`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/component?anchor=component) and [`hash helper`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/hash?anchor=hash).
+you can yield the component using the [`component helper`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/component?anchor=component) and [`hash helper`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/hash?anchor=hash).
 Here, the appropriate component is assigned to a hash using nested helpers and yielded to the template.
 Notice `editStyle` being used as an argument to the component helper.
 

--- a/guides/v3.0.0/configuring-ember/disabling-prototype-extensions.md
+++ b/guides/v3.0.0/configuring-ember/disabling-prototype-extensions.md
@@ -9,7 +9,7 @@ objects in the following ways:
 
 * `String` is extended to add convenience methods, such as
   `camelize()` and `w()`. You can find a list of these methods with the
-  [Ember.String documentation](https://api.emberjs.com/ember/2.16/classes/String).
+  [Ember.String documentation](https://api.emberjs.com/ember/3.0/classes/String).
 
 * `Function` is extended with methods to annotate functions as
   computed properties, via the `property()` method, and as observers,
@@ -90,7 +90,7 @@ islands.includes('Oahu');
 ### Strings
 
 Strings will no longer have the convenience methods described in the
-[`Ember.String` API reference](https://api.emberjs.com/ember/2.16/classes/String).
+[`Ember.String` API reference](https://api.emberjs.com/ember/3.0/classes/String).
 Instead,
 you can use the similarly-named methods of the `Ember.String` object and
 pass the string to use as the first parameter:

--- a/guides/v3.0.0/models/creating-updating-and-deleting-records.md
+++ b/guides/v3.0.0/models/creating-updating-and-deleting-records.md
@@ -1,7 +1,7 @@
 ## Creating Records
 
 You can create records by calling the
-[`createRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/createRecord?anchor=createRecord)
+[`createRecord()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Store/methods/createRecord?anchor=createRecord)
 method on the store.
 
 ```javascript
@@ -36,7 +36,7 @@ person.incrementProperty('age'); // Happy birthday!
 ## Persisting Records
 
 Records in Ember Data are persisted on a per-instance basis.
-Call [`save()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/methods/save?anchor=save)
+Call [`save()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Model/methods/save?anchor=save)
 on any instance of `DS.Model` and it will make a network request.
 
 Ember Data takes care of tracking the state of each record for
@@ -68,10 +68,10 @@ store.findRecord('post', 1).then(function(post) {
 
 You can tell if a record has outstanding changes that have not yet been
 saved by checking its
-[`hasDirtyAttributes`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/properties/hasDirtyAttributes?anchor=hasDirtyAttributes)
+[`hasDirtyAttributes`](https://api.emberjs.com/ember-data/3.0/classes/DS.Model/properties/hasDirtyAttributes?anchor=hasDirtyAttributes)
 property. You can also see what parts of
 the record were changed and what the original value was using the
-[`changedAttributes()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/methods/changedAttributes?anchor=changedAttributes)
+[`changedAttributes()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Model/methods/changedAttributes?anchor=changedAttributes)
 method. `changedAttributes` returns an object, whose keys are the changed
 properties and values are an array of values `[oldValue, newValue]`.
 
@@ -85,7 +85,7 @@ person.changedAttributes();       // => { isAdmin: [false, true] }
 
 At this point, you can either persist your changes via `save()` or you can roll
 back your changes. Calling
-[`rollbackAttributes()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/methods/rollbackAttributes?anchor=rollbackAttributes)
+[`rollbackAttributes()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Model/methods/rollbackAttributes?anchor=rollbackAttributes)
 for a saved record reverts all the `changedAttributes` to their original value.
 If the record `isNew` it will be removed from the store.
 
@@ -117,7 +117,7 @@ the errors from saving a blog post in your template:
 
 ## Promises
 
-[`save()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/methods/save?anchor=save) returns
+[`save()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Model/methods/save?anchor=save) returns
 a promise, which makes it easy to asynchronously handle success and failure
 scenarios.  Here's a common pattern:
 
@@ -145,7 +145,7 @@ post.save().then(transitionToPost).catch(failure);
 
 ## Deleting Records
 
-Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Model/methods/deleteRecord?anchor=deleteRecord)
+Deleting records is as straightforward as creating records. Call [`deleteRecord()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Model/methods/deleteRecord?anchor=deleteRecord)
 on any instance of `DS.Model`. This flags the record as `isDeleted`. The
 deletion can then be persisted using `save()`.  Alternatively, you can use
 the [`destroyRecord`](https://api.emberjs.com/ember-data/3.0/classes/DS.Model/methods/destroyRecord?anchor=destroyRecord) method to delete and persist at the same time.

--- a/guides/v3.0.0/models/defining-models.md
+++ b/guides/v3.0.0/models/defining-models.md
@@ -28,7 +28,7 @@ and [working with records](../creating-updating-and-deleting-records/) of that t
 ## Defining Attributes
 
 The `person` model we generated earlier didn't have any attributes. Let's
-add first and last name, as well as the birthday, using [`DS.attr`](https://api.emberjs.com/ember-data/2.16/classes/DS/methods/attr?anchor=attr):
+add first and last name, as well as the birthday, using [`DS.attr`](https://api.emberjs.com/ember-data/3.0/classes/DS/methods/attr?anchor=attr):
 
 ```javascript {data-filename=app/models/person.js}
 import DS from 'ember-data';

--- a/guides/v3.0.0/models/finding-records.md
+++ b/guides/v3.0.0/models/finding-records.md
@@ -2,14 +2,14 @@ The Ember Data store provides an interface for retrieving records of a single ty
 
 ### Retrieving a Single Record
 
-Use [`store.findRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/findRecord?anchor=findRecord) to retrieve a record by its type and ID.
+Use [`store.findRecord()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Store/methods/findRecord?anchor=findRecord) to retrieve a record by its type and ID.
 This will return a promise that fulfills with the requested record:
 
 ```javascript
 let blogPost = this.get('store').findRecord('blog-post', 1); // => GET /blog-posts/1
 ```
 
-Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/peekRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
+Use [`store.peekRecord()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Store/methods/peekRecord?anchor=peekRecord) to retrieve a record by its type and ID, without making a network request.
 This will return the record only if it is already present in the store:
 
 ```javascript
@@ -18,7 +18,7 @@ let blogPost = this.get('store').peekRecord('blog-post', 1); // => no network re
 
 ### Retrieving Multiple Records
 
-Use [`store.findAll()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/findAll?anchor=findAll) to retrieve all of the records for a given type:
+Use [`store.findAll()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Store/methods/findAll?anchor=findAll) to retrieve all of the records for a given type:
 
 ```javascript
 let blogPosts = this.get('store').findAll('blog-post'); // => GET /blog-posts
@@ -39,7 +39,7 @@ the `[]` notation will not work--you'll have to use `objectAt(index)` instead.
 ### Querying for Multiple Records
 
 Ember Data provides the ability to query for records that meet certain criteria.
-Calling [`store.query()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/query?anchor=query) will make a `GET` request with the passed object serialized as query params.
+Calling [`store.query()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Store/methods/query?anchor=query) will make a `GET` request with the passed object serialized as query params.
 This method returns a `DS.PromiseArray` in the same way as `findAll`.
 
 For example, we could search for all `person` models who have the name of
@@ -100,7 +100,7 @@ As in the case of `store.query()`, a query object can also be passed to `store.q
 However the adapter must return a single model object, not an array containing one element,
 otherwise Ember Data will throw an exception.
 
-Note that Ember's default [JSON API adapter](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPIAdapter) does not provide the functionality needed to support `queryRecord()` directly as it relies on REST request definitions that return result data in the form of an array.
+Note that Ember's default [JSON API adapter](https://api.emberjs.com/ember-data/3.0/classes/DS.JSONAPIAdapter) does not provide the functionality needed to support `queryRecord()` directly as it relies on REST request definitions that return result data in the form of an array.
 
 If your server API or your adapter only provides array responses but you wish to retrieve just a single record, you can alternatively use the `query()` method as follows:
 

--- a/guides/v3.0.0/models/pushing-records-into-the-store.md
+++ b/guides/v3.0.0/models/pushing-records-into-the-store.md
@@ -19,7 +19,7 @@ you want to update the UI immediately.
 
 ### Pushing Records
 
-To push a record into the store, call the store's [`push()`](https://api.emberjs.com/ember-data/2.16/classes/DS.Store/methods/push?anchor=push) method.
+To push a record into the store, call the store's [`push()`](https://api.emberjs.com/ember-data/3.0/classes/DS.Store/methods/push?anchor=push) method.
 
 For example, imagine we want to preload some data into the store when
 the application boots for the first time.

--- a/guides/v3.0.0/models/relationships.md
+++ b/guides/v3.0.0/models/relationships.md
@@ -340,7 +340,7 @@ include those related records in the response returned to the client.
 The value of the parameter should be a comma-separated list of names of the
 relationships required.
 
-If you are using an adapter that supports JSON API, such as Ember's default [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPIAdapter),
+If you are using an adapter that supports JSON API, such as Ember's default [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/3.0/classes/DS.JSONAPIAdapter),
 you can easily add the `include` parameter to the server requests created by
 the `findRecord()`, `findAll()`,
 `query()` and `queryRecord()` methods.

--- a/guides/v3.0.0/object-model/classes-and-instances.md
+++ b/guides/v3.0.0/object-model/classes-and-instances.md
@@ -4,8 +4,8 @@ as other major features of the Ember object model.
 
 ### Defining Classes
 
-To define a new Ember _class_, call the [`extend()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
-[`EmberObject`](https://api.emberjs.com/ember/2.16/modules/@ember%2Fobject):
+To define a new Ember _class_, call the [`extend()`](https://api.emberjs.com/ember/3.0/classes/@ember%2Fobject/methods/extend?anchor=extend) method on
+[`EmberObject`](https://api.emberjs.com/ember/3.0/modules/@ember%2Fobject):
 
 ```javascript
 import EmberObject from '@ember/object';
@@ -21,7 +21,7 @@ This defines a new `Person` class with a `say()` method.
 
 You can also create a _subclass_ from any existing class by calling
 its `extend()` method. For example, you might want to create a subclass
-of Ember's built-in [`Component`](https://api.emberjs.com/ember/2.16/classes/Component) class:
+of Ember's built-in [`Component`](https://api.emberjs.com/ember/3.0/classes/Component) class:
 
 
 ```javascript {data-filename=app/components/todo-item.js}
@@ -67,7 +67,7 @@ In certain cases, you will want to pass arguments to `_super()` before or after 
 
 This allows the original method to continue operating as it normally would.
 
-One common example is when overriding the [`normalizeResponse()`](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
+One common example is when overriding the [`normalizeResponse()`](https://api.emberjs.com/ember-data/3.0/classes/DS.JSONAPISerializer/methods/normalizeResponse?anchor=normalizeResponse) hook in one of Ember-Data's serializers.
 
 A handy shortcut for this is to use a "spread operator", like `...arguments`:
 
@@ -83,7 +83,7 @@ The above example returns the original arguments (after your customizations) bac
 ### Creating Instances
 
 Once you have defined a class, you can create new _instances_ of that
-class by calling its [`create()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
+class by calling its [`create()`](https://api.emberjs.com/ember/3.0/classes/@ember%2Fobject/methods/create?anchor=create) method. Any methods, properties and
 computed properties you defined on the class will be available to
 instances:
 
@@ -133,7 +133,7 @@ conventions in your Ember applications.
 
 ### Initializing Instances
 
-When a new instance is created, its [`init()`](https://api.emberjs.com/ember/2.16/classes/EmberObject/methods/init?anchor=init) method is invoked
+When a new instance is created, its [`init()`](https://api.emberjs.com/ember/3.0/classes/EmberObject/methods/init?anchor=init) method is invoked
 automatically. This is the ideal place to implement setup required on new
 instances:
 
@@ -216,8 +216,8 @@ Person.create({
 
 ### Accessing Object Properties
 
-When accessing the properties of an object, use the [`get()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/get?anchor=get)
-and [`set()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject/methods/set?anchor=set) accessor methods:
+When accessing the properties of an object, use the [`get()`](https://api.emberjs.com/ember/3.0/classes/@ember%2Fobject/methods/get?anchor=get)
+and [`set()`](https://api.emberjs.com/ember/3.0/classes/@ember%2Fobject/methods/set?anchor=set) accessor methods:
 
 
 ```javascript

--- a/guides/v3.0.0/object-model/computed-properties-and-aggregate-data.md
+++ b/guides/v3.0.0/object-model/computed-properties-and-aggregate-data.md
@@ -133,10 +133,10 @@ export default Component.extend({
 Here, `indexOfSelectedTodo` depends on `todos.[]`, so it will update if we add an item
 to `todos`, but won't update if the value of `isDone` on a `todo` changes.
 
-Several of the [Ember.computed](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject%2Fcomputed) macros
+Several of the [Ember.computed](https://api.emberjs.com/ember/3.0/classes/@ember%2Fobject%2Fcomputed) macros
 utilize the `[]` key to implement common use-cases. For instance, to
 create a computed property that mapped properties from an array, you could use
-[Ember.computed.map](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject%2Fcomputed/methods/map?anchor=map)
+[Ember.computed.map](https://api.emberjs.com/ember/3.0/classes/@ember%2Fobject%2Fcomputed/methods/map?anchor=map)
 or build the computed property yourself:
 
 ```javascript

--- a/guides/v3.0.0/object-model/computed-properties.md
+++ b/guides/v3.0.0/object-model/computed-properties.md
@@ -206,4 +206,4 @@ Person = EmberObject.extend({
 ```
 
 To see the full list of computed property macros, have a look at
-[the API documentation](https://api.emberjs.com/ember/2.16/modules/@ember%2Fobject)
+[the API documentation](https://api.emberjs.com/ember/3.0/modules/@ember%2Fobject)

--- a/guides/v3.0.0/object-model/index.md
+++ b/guides/v3.0.0/object-model/index.md
@@ -6,7 +6,7 @@ JavaScript objects don't support the observation of property value changes.
 Consequently, if an object is going to participate in Ember's binding
 system you may see an `Ember.Object` instead of a plain object.
 
-[Ember.Object](https://api.emberjs.com/ember/2.16/modules/@ember%2Fobject) also provides a class system, supporting features like mixins
+[Ember.Object](https://api.emberjs.com/ember/3.0/modules/@ember%2Fobject) also provides a class system, supporting features like mixins
 and constructor methods. Some features in Ember's object model are not present in
 JavaScript classes or common patterns, but all are aligned as much as possible
 with the language and proposed additions.
@@ -15,4 +15,4 @@ Ember also extends the JavaScript `Array` prototype with its
 [Ember.Enumerable](https://api.emberjs.com/classes/Ember.Enumerable.html) interface to provide change observation for arrays.
 
 Finally, Ember extends the `String` prototype with a few [formatting and
-localization methods](https://api.emberjs.com/ember/2.16/classes/String).
+localization methods](https://api.emberjs.com/ember/3.0/classes/String).

--- a/guides/v3.0.0/object-model/observers.md
+++ b/guides/v3.0.0/object-model/observers.md
@@ -79,7 +79,7 @@ person.set('firstName', 'John');
 person.set('lastName', 'Smith');
 ```
 
-To get around these problems, you should make use of [`Ember.run.once()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Frunloop/methods/once?anchor=once).
+To get around these problems, you should make use of [`Ember.run.once()`](https://api.emberjs.com/ember/3.0/classes/@ember%2Frunloop/methods/once?anchor=once).
 This will ensure that any processing you need to do only happens once, and
 happens in the next run loop once all bindings are synchronized:
 
@@ -145,7 +145,7 @@ get it in your `init()` method.
 ### Outside of class definitions
 
 You can also add observers to an object outside of a class definition
-using [`addObserver()`](https://api.emberjs.com/ember/2.16/classes/@ember%2Fobject%2Fobservers/methods/addObserver?anchor=addObserver):
+using [`addObserver()`](https://api.emberjs.com/ember/3.0/classes/@ember%2Fobject%2Fobservers/methods/addObserver?anchor=addObserver):
 
 
 ```javascript

--- a/guides/v3.0.0/routing/asynchronous-routing.md
+++ b/guides/v3.0.0/routing/asynchronous-routing.md
@@ -8,7 +8,7 @@ heavy use of the concept of Promises. In short, promises are objects that
 represent an eventual value. A promise can either _fulfill_
 (successfully resolve the value) or _reject_ (fail to resolve the
 value). The way to retrieve this eventual value, or handle the cases
-when the promise rejects, is via the promise's [`then()`](https://api.emberjs.com/ember/2.16/classes/Promise/methods/then?anchor=then) method, which
+when the promise rejects, is via the promise's [`then()`](https://api.emberjs.com/ember/3.0/classes/RSVP.Promise/methods/then?anchor=then) method, which
 accepts two optional callbacks, one for fulfillment and one for
 rejection. If the promise fulfills, the fulfillment handler gets called
 with the fulfilled value as its sole argument, and if the promise rejects,
@@ -74,7 +74,7 @@ defined on it to be a promise.
 If the promise fulfills, the transition will pick up where it left off and
 begin resolving the next (child) route's model, pausing if it too is a
 promise, and so on, until all destination route models have been
-resolved. The values passed to the [`setupController()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/setupController?anchor=setupController) hook for each route
+resolved. The values passed to the [`setupController()`](https://api.emberjs.com/ember/3.0/classes/Route/methods/setupController?anchor=setupController) hook for each route
 will be the fulfilled values from the promises.
 
 

--- a/guides/v3.0.0/routing/defining-your-routes.md
+++ b/guides/v3.0.0/routing/defining-your-routes.md
@@ -14,7 +14,7 @@ It also adds the route to the router.
 
 ## Basic Routes
 
-The [`map()`](https://api.emberjs.com/ember/2.16/classes/Router/methods/map?anchor=map) method
+The [`map()`](https://api.emberjs.com/ember/3.0/classes/EmberRouter/methods/map?anchor=map) method
 of your Ember application's router can be invoked to define URL mappings. When
 calling `map()`, you should pass a function that will be invoked with the value
 `this` set to an object which you can use to create routes.
@@ -39,7 +39,7 @@ Router.map(function() {
 });
 ```
 
-Inside your templates, you can use [`{{link-to}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
+Inside your templates, you can use [`{{link-to}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/link-to?anchor=link-to) to navigate between
 routes, using the name that you provided to the `route` method.
 
 ```handlebars

--- a/guides/v3.0.0/routing/loading-and-error-substates.md
+++ b/guides/v3.0.0/routing/loading-and-error-substates.md
@@ -88,7 +88,7 @@ It's important to note that `foo.bar.loading` is not considered now.
 ### The `loading` event
 
 If the various `beforeModel`/`model`/`afterModel` hooks
-don't immediately resolve, a [`loading`](https://api.emberjs.com/ember/2.16/classes/Route/events/loading?anchor=loading) event will be fired on that route.
+don't immediately resolve, a [`loading`](https://api.emberjs.com/ember/3.0/classes/Route/events/loading?anchor=loading) event will be fired on that route.
 
 ```javascript {data-filename=app/routes/foo-slow-model.js}
 import Route from '@ember/routing/route';
@@ -203,7 +203,7 @@ logged.
 
 If the `articles.overview` route's `model` hook returns a promise that rejects
 (for instance the server returned an error, the user isn't logged in,
-etc.), an [`error`](https://api.emberjs.com/ember/2.16/classes/Route/events/error?anchor=error) event will fire from that route and bubble upward.
+etc.), an [`error`](https://api.emberjs.com/ember/3.0/classes/Route/events/error?anchor=error) event will fire from that route and bubble upward.
 This `error` event can be handled and used to display an error message,
 redirect to a login page, etc.
 

--- a/guides/v3.0.0/routing/redirection.md
+++ b/guides/v3.0.0/routing/redirection.md
@@ -7,12 +7,12 @@ Usually you want to redirect them to the login page, and after they have success
 There are many other reasons you probably want to have the last word on whether a user can or cannot access a certain page.
 Ember allows you to control that access with a combination of hooks and methods in your route.
 
-One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/transitionTo?anchor=transitionTo).
+One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/3.0/classes/Route/methods/transitionTo?anchor=transitionTo).
 Calling `transitionTo()` from a route or
-[`transitionToRoute()`](https://api.emberjs.com/ember/2.16/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
+[`transitionToRoute()`](https://api.emberjs.com/ember/3.0/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
 `transitionTo()` behaves exactly like the [link-to](../../templates/links/) helper.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/3.0/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.
@@ -22,7 +22,7 @@ Passing a model will skip the route's `model()` hook since the model is already 
 
 ## Transitioning Before the Model is Known
 
-Since a route's [`beforeModel()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
+Since a route's [`beforeModel()`](https://api.emberjs.com/ember/3.0/classes/Route/methods/beforeModel?anchor=beforeModel) executes before the `model()` hook,
 it's a good place to do a redirect if you don't need any information that is contained in the model.
 
 ```javascript {data-filename=app/router.js}
@@ -53,7 +53,7 @@ you might use a [service](../../applications/services/).
 
 ## Transitioning After the Model is Known
 
-If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/afterModel?anchor=afterModel) hook.
+If you need information about the current model in order to decide about redirection, you can use the [`afterModel()`](https://api.emberjs.com/ember/3.0/classes/Route/methods/afterModel?anchor=afterModel) hook.
 It receives the resolved model as the first parameter and the transition as the second one.
 For example:
 
@@ -98,7 +98,7 @@ route's `beforeModel`, `model`, and `afterModel` hooks will fire again within
 the new, redirected transition. This is inefficient, since they just fired
 before the redirect.
 
-Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
+Instead, we can use the [`redirect()`](https://api.emberjs.com/ember/3.0/classes/Route/methods/redirect?anchor=redirect) method, which will leave the original
 transition validated, and not cause the parent route's hooks to fire again:
 
 ```javascript {data-filename=app/routes/posts.js}

--- a/guides/v3.0.0/routing/rendering-a-template.md
+++ b/guides/v3.0.0/routing/rendering-a-template.md
@@ -19,7 +19,7 @@ template. For example, the `posts.new` route will render its template into the
 `posts.hbs`'s `{{outlet}}`, and the `posts` route will render its template into
 the `application.hbs`'s `{{outlet}}`.
 
-If you want to render a template other than the default one, set the route's [`templateName`](https://api.emberjs.com/ember/2.16/classes/Route/properties/templateName?anchor=templateName) property to the name of
+If you want to render a template other than the default one, set the route's [`templateName`](https://api.emberjs.com/ember/3.0/classes/Route/properties/templateName?anchor=templateName) property to the name of
 the template you want to render instead.
 
 ```javascript {data-filename=app/routes/posts.js}
@@ -30,5 +30,5 @@ export default Route.extend({
 });
 ```
 
-You can override the [`renderTemplate()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/renderTemplate?anchor=renderTemplate) hook if you want finer control over template rendering.
+You can override the [`renderTemplate()`](https://api.emberjs.com/ember/3.0/classes/Route/methods/renderTemplate?anchor=renderTemplate) hook if you want finer control over template rendering.
 Among other things, it allows you to choose the controller used to configure the template and specific outlet to render it into.

--- a/guides/v3.0.0/routing/specifying-a-routes-model.md
+++ b/guides/v3.0.0/routing/specifying-a-routes-model.md
@@ -9,7 +9,7 @@ Router.map(function() {
 });
 ```
 
-To load a model for the `favorite-posts` route, you would use the [`model()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/model?anchor=model)
+To load a model for the `favorite-posts` route, you would use the [`model()`](https://api.emberjs.com/ember/3.0/classes/Route/methods/model?anchor=model)
 hook in the `favorite-posts` route handler:
 
 ```javascript {data-filename=app/routes/favorite-posts.js}
@@ -122,7 +122,7 @@ Routes without dynamic segments will always execute the model hook.
 ## Multiple Models
 
 Multiple models can be returned through an
-[RSVP.hash](https://api.emberjs.com/ember/2.16/classes/rsvp/methods/hash?anchor=hash).
+[RSVP.hash](https://api.emberjs.com/ember/3.0/classes/rsvp/methods/hash?anchor=hash).
 The `RSVP.hash` method takes an object with promises or values as properties as an argument, and returns a single promise.
 When all of the promises in the object resolve, the returned promise will resolve with an object of all of the promise values. For example:
 

--- a/guides/v3.0.0/templates/actions.md
+++ b/guides/v3.0.0/templates/actions.md
@@ -3,7 +3,7 @@ change application state. For example, imagine that you have a template
 that shows a blog title, and supports expanding the post to show the body.
 
 If you add the
-[`{{action}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/action?anchor=action)
+[`{{action}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/action?anchor=action)
 helper to any HTML DOM element, when a user clicks the element, the named event
 will be sent to the template's corresponding component or controller.
 
@@ -62,7 +62,7 @@ export default Component.extend({
 ## Specifying the Type of Event
 
 By default, the
-[`{{action}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/action?anchor=action)
+[`{{action}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/action?anchor=action)
 helper listens for click events and triggers the action when the user clicks
 on the element.
 
@@ -116,7 +116,7 @@ will trigger the action *and* the user will be directed to the new page.
 ## Modifying the action's first parameter
 
 If a `value` option for the
-[`{{action}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/action?anchor=action)
+[`{{action}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/action?anchor=action)
 helper is specified, its value will be considered a property path that will
 be read off of the first parameter of the action. This comes very handy with
 event listeners and enables to work with one-way bindings.

--- a/guides/v3.0.0/templates/binding-element-attributes.md
+++ b/guides/v3.0.0/templates/binding-element-attributes.md
@@ -59,8 +59,8 @@ renders the following HTML:
 
 To enable support for data attributes an attribute binding must be
 added to the component, e.g.
-[`Ember.LinkComponent`](https://api.emberjs.com/ember/2.16/classes/LinkComponent)
-or [`Ember.TextField`](https://api.emberjs.com/ember/2.16/classes/TextField)
+[`Ember.LinkComponent`](https://api.emberjs.com/ember/3.0/classes/LinkComponent)
+or [`Ember.TextField`](https://api.emberjs.com/ember/3.0/classes/TextField)
 for the specific attribute:
 
 ```javascript

--- a/guides/v3.0.0/templates/built-in-helpers.md
+++ b/guides/v3.0.0/templates/built-in-helpers.md
@@ -10,7 +10,7 @@ passing data to another helper or component.
 
 ### Using a helper to get a property dynamically
 
-The [`{{get}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=get) helper makes it easy to dynamically send the value of a
+The [`{{get}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/get?anchor=get) helper makes it easy to dynamically send the value of a
 variable to another helper or component.
 This can be useful if you want
 to output one of several values based on the result of a computed property.
@@ -26,7 +26,7 @@ if the `part` computed property returns "zip", this will display the result of
 
 In the last section it was discussed that helpers can be nested.
 This can be combined with these sorts of dynamic helpers.
-For example, the [`{{concat}}`](https://api.emberjs.com/ember/2.16/classes/Ember.Templates.helpers/methods/get?anchor=concat) helper makes it easy to dynamically send
+For example, the [`{{concat}}`](https://api.emberjs.com/ember/3.0/classes/Ember.Templates.helpers/methods/get?anchor=concat) helper makes it easy to dynamically send
 a number of parameters to a component or helper as a single parameter in the
 format of a concatenated string.
 

--- a/guides/v3.0.0/templates/writing-helpers.md
+++ b/guides/v3.0.0/templates/writing-helpers.md
@@ -248,7 +248,7 @@ although this is usually unnecessary and error-prone.
 
 To create a class-based helper, rather than exporting a simple function, you
 should export a subclass of [`Ember.Helper`](https://api.emberjs.com/ember/3.0/classes/Helper). Helper classes must contain a
-[`compute`](https://api.emberjs.com/ember/2.16/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
+[`compute`](https://api.emberjs.com/ember/3.0/classes/Helper/methods/compute?anchor=compute) method that behaves the same as the function passed to
 [`helper`](https://api.emberjs.com/ember/3.0/functions/@ember%2Fcomponent%2Fhelper/helper).  In order to access a service, you must first inject it
 into the class-based helper.  Once added, you can call the service's methods or
 access its properties from within the `compute()` method.

--- a/guides/v3.0.0/tutorial/installing-addons.md
+++ b/guides/v3.0.0/tutorial/installing-addons.md
@@ -142,7 +142,7 @@ For now, let's generate an adapter for our application:
 ember generate adapter application
 ```
 
-This adapter will extend the [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/2.16/classes/DS.JSONAPIAdapter/) base class from Ember Data:
+This adapter will extend the [`JSONAPIAdapter`](https://api.emberjs.com/ember-data/3.0/classes/DS.JSONAPIAdapter/) base class from Ember Data:
 
 ```javascript {data-filename="app/adapters/application.js" data-diff="+4"}
 import DS from 'ember-data';

--- a/guides/v3.0.0/tutorial/routes-and-templates.md
+++ b/guides/v3.0.0/tutorial/routes-and-templates.md
@@ -224,12 +224,12 @@ To do this we will add code to our index route handler by implementing a route l
 called `beforeModel`.
 
 Each route handler has a set of "lifecycle hooks", which are functions that are invoked at specific times during the loading of a page.
-The [`beforeModel`](https://api.emberjs.com/ember/2.16/classes/Route/methods/beforeModel?anchor=beforeModel)
+The [`beforeModel`](https://api.emberjs.com/ember/3.0/classes/Route/methods/beforeModel?anchor=beforeModel)
 hook gets executed before the data gets fetched from the model hook, and before the page is rendered.
 See [the next section](../model-hook/) for an explanation of the model hook.
 
 In our index route handler, we'll call the [`replaceWith`](https://api.emberjs.com/ember/3.0/classes/Route/methods/replaceWith?anchor=replaceWith) function.
-The `replaceWith` function is similar to the route's [`transitionTo()`](https://api.emberjs.com/ember/2.16/classes/Route/methods/transitionTo?anchor=transitionTo) function,
+The `replaceWith` function is similar to the route's [`transitionTo()`](https://api.emberjs.com/ember/3.0/classes/Route/methods/transitionTo?anchor=transitionTo) function,
 the difference being that `replaceWith` will replace the current URL in the browser's history,
 while `transitionTo` will add to the history.
 Since we want our `rentals` route to serve as our home page, we will use the `replaceWith` function.

--- a/guides/v3.0.0/tutorial/subroutes.md
+++ b/guides/v3.0.0/tutorial/subroutes.md
@@ -339,7 +339,7 @@ Now browse to `localhost:4200/rentals/grand-old-mansion` and you should see the 
 
 Now that we can load pages for individual rentals, we'll add a link (using the `link-to` helper) within our `rental-listing` component to navigate to individual pages.
 Here, the `link-to` helper takes the route name and the rental model object as arguments.
-When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/2.16/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
+When you pass an object as second argument into the `link-to` block helper, it will by default [serialize](https://api.emberjs.com/ember/3.0/classes/Route/methods/serialize?anchor=serialize) the object to the ID of the model into the URL.
 Alternately, you may just pass `rental.id` for clarity.
 
 Clicking on the title will load the detail page for that rental.


### PR DESCRIPTION
This PR addresses #1440 for Ember `v2.17.0` and `v3.0.0`.

## Process

1. Ran the script `npm run release:guides:links <guides-path> <version>`
2. Manually checked updated links
3. Ran `npm run test:node-local` to check all external links automatically