### PR TITLE
Add Unstable Language Server to IDE plugins

### DIFF
--- a/guides/release/code-editors/index.md
+++ b/guides/release/code-editors/index.md
@@ -6,6 +6,8 @@ Visual Studio Code is a code editor optimized for building and debugging modern 
 
 [Ember Language Server](https://marketplace.visualstudio.com/items?itemName=EmberTooling.vscode-ember) - Provides autocomplete in templates and allows go-to-definition behavior within Ember projects.
 
+[Ember Unstable Language Server](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable) - A popular fork of Ember Language Server with different features.
+
 [Ember JS (ES6) and Handlebars code snippets](https://marketplace.visualstudio.com/items?itemName=phanitejakomaravolu.EmberES6Snippets) - Enables Ember.js and Handlebars snippets to let you to type less and code more.
 
 [EditorConfig for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) - Attempts to override user/workspace settings with settings found in `.editorconfig` files. The `.editorconfig` file helps developers define and maintain consistent coding styles between different editors and IDEs.

--- a/guides/release/code-editors/index.md
+++ b/guides/release/code-editors/index.md
@@ -6,7 +6,7 @@ Visual Studio Code is a code editor optimized for building and debugging modern 
 
 [Ember Language Server](https://marketplace.visualstudio.com/items?itemName=EmberTooling.vscode-ember) - Provides autocomplete in templates and allows go-to-definition behavior within Ember projects.
 
-[Ember Unstable Language Server](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable) - A popular fork of Ember Language Server with different features.
+[Unstable Ember Language Server](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable) - A popular fork of Ember Language Server with different features.
 
 [Ember JS (ES6) and Handlebars code snippets](https://marketplace.visualstudio.com/items?itemName=phanitejakomaravolu.EmberES6Snippets) - Enables Ember.js and Handlebars snippets to let you to type less and code more.
 


### PR DESCRIPTION
I think we should show both Ember Language Server and Unstable Language Server in this list. This is a brand-new page for the Guides, just merged today, and this is a followup PR.

@lifeart are there any other differentiators to mention here?