### PR TITLE
Update routing/query-params.md

### DIFF
--- a/guides/release/routing/query-params.md
+++ b/guides/release/routing/query-params.md
@@ -172,7 +172,7 @@ export default class ArticlesController extends Controller {
   queryParams = ['category'];
   
   category = null;
-});
+}
 ```
 
 ### Update URL with `replaceState` instead


### PR DESCRIPTION
Fixes a syntax error in a controller's code example in the "Opting into a full transition" section