### PR TITLE
native-classes-in-depth.md edits #1613 and #1614 for more guide versions

### DIFF
--- a/guides/v3.15.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.15.0/in-depth-topics/native-classes-in-depth.md
@@ -557,7 +557,7 @@ airbus.move(); // flying!
 
 However, child classes can use the `super` keyword to access the parent, and use
 its methods and accessors. Class fields are always overwritten on the instance,
-so the values on the parent class cannot be accessed on by the child if they are
+so the values on the parent class cannot be accessed by the child if they are
 redefined.
 
 ### `constructor` in extends

--- a/guides/v3.15.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.15.0/in-depth-topics/native-classes-in-depth.md
@@ -426,7 +426,7 @@ directly on the class itself.
 ```js
 class Alert {
   static helloWorld() {
-    alert('Hello, world!');
+    return 'Hello, world!';
   }
 }
 

--- a/guides/v3.16.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.16.0/in-depth-topics/native-classes-in-depth.md
@@ -557,7 +557,7 @@ airbus.move(); // flying!
 
 However, child classes can use the `super` keyword to access the parent, and use
 its methods and accessors. Class fields are always overwritten on the instance,
-so the values on the parent class cannot be accessed on by the child if they are
+so the values on the parent class cannot be accessed by the child if they are
 redefined.
 
 ### `constructor` in extends

--- a/guides/v3.16.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.16.0/in-depth-topics/native-classes-in-depth.md
@@ -426,7 +426,7 @@ directly on the class itself.
 ```js
 class Alert {
   static helloWorld() {
-    alert('Hello, world!');
+    return 'Hello, world!';
   }
 }
 

--- a/guides/v3.17.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.17.0/in-depth-topics/native-classes-in-depth.md
@@ -557,7 +557,7 @@ airbus.move(); // flying!
 
 However, child classes can use the `super` keyword to access the parent, and use
 its methods and accessors. Class fields are always overwritten on the instance,
-so the values on the parent class cannot be accessed on by the child if they are
+so the values on the parent class cannot be accessed by the child if they are
 redefined.
 
 ### `constructor` in extends

--- a/guides/v3.17.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.17.0/in-depth-topics/native-classes-in-depth.md
@@ -426,7 +426,7 @@ directly on the class itself.
 ```js
 class Alert {
   static helloWorld() {
-    alert('Hello, world!');
+    return 'Hello, world!';
   }
 }
 

--- a/guides/v3.18.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.18.0/in-depth-topics/native-classes-in-depth.md
@@ -557,7 +557,7 @@ airbus.move(); // flying!
 
 However, child classes can use the `super` keyword to access the parent, and use
 its methods and accessors. Class fields are always overwritten on the instance,
-so the values on the parent class cannot be accessed on by the child if they are
+so the values on the parent class cannot be accessed by the child if they are
 redefined.
 
 ### `constructor` in extends

--- a/guides/v3.18.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.18.0/in-depth-topics/native-classes-in-depth.md
@@ -426,7 +426,7 @@ directly on the class itself.
 ```js
 class Alert {
   static helloWorld() {
-    alert('Hello, world!');
+    return 'Hello, world!';
   }
 }
 

--- a/guides/v3.19.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.19.0/in-depth-topics/native-classes-in-depth.md
@@ -557,7 +557,7 @@ airbus.move(); // flying!
 
 However, child classes can use the `super` keyword to access the parent, and use
 its methods and accessors. Class fields are always overwritten on the instance,
-so the values on the parent class cannot be accessed on by the child if they are
+so the values on the parent class cannot be accessed by the child if they are
 redefined.
 
 ### `constructor` in extends

--- a/guides/v3.19.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.19.0/in-depth-topics/native-classes-in-depth.md
@@ -426,7 +426,7 @@ directly on the class itself.
 ```js
 class Alert {
   static helloWorld() {
-    alert('Hello, world!');
+    return 'Hello, world!';
   }
 }
 

--- a/guides/v3.20.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.20.0/in-depth-topics/native-classes-in-depth.md
@@ -557,7 +557,7 @@ airbus.move(); // flying!
 
 However, child classes can use the `super` keyword to access the parent, and use
 its methods and accessors. Class fields are always overwritten on the instance,
-so the values on the parent class cannot be accessed on by the child if they are
+so the values on the parent class cannot be accessed by the child if they are
 redefined.
 
 ### `constructor` in extends

--- a/guides/v3.20.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.20.0/in-depth-topics/native-classes-in-depth.md
@@ -426,7 +426,7 @@ directly on the class itself.
 ```js
 class Alert {
   static helloWorld() {
-    alert('Hello, world!');
+    return 'Hello, world!';
   }
 }
 

--- a/guides/v3.21.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.21.0/in-depth-topics/native-classes-in-depth.md
@@ -557,7 +557,7 @@ airbus.move(); // flying!
 
 However, child classes can use the `super` keyword to access the parent, and use
 its methods and accessors. Class fields are always overwritten on the instance,
-so the values on the parent class cannot be accessed on by the child if they are
+so the values on the parent class cannot be accessed by the child if they are
 redefined.
 
 ### `constructor` in extends

--- a/guides/v3.21.0/in-depth-topics/native-classes-in-depth.md
+++ b/guides/v3.21.0/in-depth-topics/native-classes-in-depth.md
@@ -426,7 +426,7 @@ directly on the class itself.
 ```js
 class Alert {
   static helloWorld() {
-    alert('Hello, world!');
+    return 'Hello, world!';
   }
 }
 


### PR DESCRIPTION
Following on from #1613 (@ijlee2):

Sorry about the commit history mess! I did the other PRs on my iPad with the "Edit page" link at the top of the docs.
I didn't realise there were different directories with the different versions like this. I'll know for next time :)