### PR TITLE
upgrading / tracked properties / backwards-compatibility: use the locals

### DIFF
--- a/guides/release/upgrading/current-edition/tracked-properties.md
+++ b/guides/release/upgrading/current-edition/tracked-properties.md
@@ -233,7 +233,7 @@ class Image {
     let width = get(this, 'width');
     let height = get(this, 'height');
 
-    return this.width / this.height;
+    return width / height;
   }
 }
 

--- a/guides/v3.15.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.15.0/upgrading/current-edition/tracked-properties.md
@@ -228,7 +228,7 @@ class Image {
     let width = get(this, 'width');
     let height = get(this, 'height');
 
-    return this.width / this.height;
+    return width / height;
   }
 }
 

--- a/guides/v3.16.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.16.0/upgrading/current-edition/tracked-properties.md
@@ -228,7 +228,7 @@ class Image {
     let width = get(this, 'width');
     let height = get(this, 'height');
 
-    return this.width / this.height;
+    return width / height;
   }
 }
 

--- a/guides/v3.17.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.17.0/upgrading/current-edition/tracked-properties.md
@@ -233,7 +233,7 @@ class Image {
     let width = get(this, 'width');
     let height = get(this, 'height');
 
-    return this.width / this.height;
+    return width / height;
   }
 }
 

--- a/guides/v3.18.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.18.0/upgrading/current-edition/tracked-properties.md
@@ -233,7 +233,7 @@ class Image {
     let width = get(this, 'width');
     let height = get(this, 'height');
 
-    return this.width / this.height;
+    return width / height;
   }
 }
 

--- a/guides/v3.19.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.19.0/upgrading/current-edition/tracked-properties.md
@@ -233,7 +233,7 @@ class Image {
     let width = get(this, 'width');
     let height = get(this, 'height');
 
-    return this.width / this.height;
+    return width / height;
   }
 }
 

--- a/guides/v3.20.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.20.0/upgrading/current-edition/tracked-properties.md
@@ -233,7 +233,7 @@ class Image {
     let width = get(this, 'width');
     let height = get(this, 'height');
 
-    return this.width / this.height;
+    return width / height;
   }
 }
 

--- a/guides/v3.21.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.21.0/upgrading/current-edition/tracked-properties.md
@@ -233,7 +233,7 @@ class Image {
     let width = get(this, 'width');
     let height = get(this, 'height');
 
-    return this.width / this.height;
+    return width / height;
   }
 }
 


### PR DESCRIPTION
https://guides.emberjs.com/release/upgrading/current-edition/tracked-properties/#toc_backwards-compatibility

The example describes using get to read a property that isn't tracked, and how that achieves autotracking. 

The trouble is, the example loads the properties into locals then doesn't use them. That confused me: was the aim to side-effect the property (adding tracking to it), or was it to load tracked values with `get` and calculate the ratio with them?

I'm not sure if those semantics matter to people upgrading apps, but I was distracted by the variables being set then not used. It looks like a copy-paste leftover rather than a deliberate part of the example.

If it was deliberate, I'd suggest something like this instead: 

```
  get aspectRatio() {
    get(this, 'width');
    get(this, 'height');

    // calling get above turned on tracking
    return this.width / this.height;
  }
```

I'm not sure which is correct, so please do check that I'm right before merging.