### PR TITLE
DI: summarise name and subdirectory format

### DIFF
--- a/guides/release/applications/dependency-injection.md
+++ b/guides/release/applications/dependency-injection.md
@@ -63,6 +63,10 @@ export default {
 };
 ```
 
+### Naming Convention
+
+By default, factories are kebab-cased, and directories represented by a forward-slash. For example: a controller `app/controllers/users/primary-teachers` would be registered as `controllers:users/primary-teachers`.
+
 ### Registering Already Instantiated Objects
 
 By default, Ember will attempt to instantiate a registered factory when it is looked up.

--- a/guides/release/applications/dependency-injection.md
+++ b/guides/release/applications/dependency-injection.md
@@ -35,6 +35,23 @@ The first segment is the framework factory type, and the second is the name of t
 Hence, the `index` template has the key `template:index`.
 Ember has several built-in factory types, such as `service`, `route`, `template`, and `component`.
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          You might ask, how can I find the name of a factory?
+        </p>
+        <p>
+          Factories are kebab-cased and directories are followed by a forward slash. For example, a controller <code>app/controllers/users/primary-teachers</code> is registered as <code>controller:users/primary-teachers</code>.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
+
 You can create your own factory type by simply registering a factory with the new type.
 For example, to create a `user` type,
 you'd simply register your factory with `application.register('user:user-to-register')`.
@@ -62,10 +79,6 @@ export default {
   initialize: initialize
 };
 ```
-
-### Naming Convention
-
-By default, factories are kebab-cased, and directories represented by a forward-slash. For example: a controller `app/controllers/users/primary-teachers` would be registered as `controllers:users/primary-teachers`.
 
 ### Registering Already Instantiated Objects
 

--- a/guides/v3.15.0/applications/dependency-injection.md
+++ b/guides/v3.15.0/applications/dependency-injection.md
@@ -35,6 +35,23 @@ The first segment is the framework factory type, and the second is the name of t
 Hence, the `index` template has the key `template:index`.
 Ember has several built-in factory types, such as `service`, `route`, `template`, and `component`.
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          You might ask, how can I find the name of a factory?
+        </p>
+        <p>
+          Factories are kebab-cased and directories are followed by a forward slash. For example, a controller <code>app/controllers/users/primary-teachers</code> is registered as <code>controller:users/primary-teachers</code>.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
+
 You can create your own factory type by simply registering a factory with the new type.
 For example, to create a `user` type,
 you'd simply register your factory with `application.register('user:user-to-register')`.

--- a/guides/v3.16.0/applications/dependency-injection.md
+++ b/guides/v3.16.0/applications/dependency-injection.md
@@ -35,6 +35,23 @@ The first segment is the framework factory type, and the second is the name of t
 Hence, the `index` template has the key `template:index`.
 Ember has several built-in factory types, such as `service`, `route`, `template`, and `component`.
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          You might ask, how can I find the name of a factory?
+        </p>
+        <p>
+          Factories are kebab-cased and directories are followed by a forward slash. For example, a controller <code>app/controllers/users/primary-teachers</code> is registered as <code>controller:users/primary-teachers</code>.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
+
 You can create your own factory type by simply registering a factory with the new type.
 For example, to create a `user` type,
 you'd simply register your factory with `application.register('user:user-to-register')`.

--- a/guides/v3.17.0/applications/dependency-injection.md
+++ b/guides/v3.17.0/applications/dependency-injection.md
@@ -35,6 +35,23 @@ The first segment is the framework factory type, and the second is the name of t
 Hence, the `index` template has the key `template:index`.
 Ember has several built-in factory types, such as `service`, `route`, `template`, and `component`.
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          You might ask, how can I find the name of a factory?
+        </p>
+        <p>
+          Factories are kebab-cased and directories are followed by a forward slash. For example, a controller <code>app/controllers/users/primary-teachers</code> is registered as <code>controller:users/primary-teachers</code>.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
+
 You can create your own factory type by simply registering a factory with the new type.
 For example, to create a `user` type,
 you'd simply register your factory with `application.register('user:user-to-register')`.

--- a/guides/v3.18.0/applications/dependency-injection.md
+++ b/guides/v3.18.0/applications/dependency-injection.md
@@ -35,6 +35,23 @@ The first segment is the framework factory type, and the second is the name of t
 Hence, the `index` template has the key `template:index`.
 Ember has several built-in factory types, such as `service`, `route`, `template`, and `component`.
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          You might ask, how can I find the name of a factory?
+        </p>
+        <p>
+          Factories are kebab-cased and directories are followed by a forward slash. For example, a controller <code>app/controllers/users/primary-teachers</code> is registered as <code>controller:users/primary-teachers</code>.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
+
 You can create your own factory type by simply registering a factory with the new type.
 For example, to create a `user` type,
 you'd simply register your factory with `application.register('user:user-to-register')`.

--- a/guides/v3.19.0/applications/dependency-injection.md
+++ b/guides/v3.19.0/applications/dependency-injection.md
@@ -35,6 +35,23 @@ The first segment is the framework factory type, and the second is the name of t
 Hence, the `index` template has the key `template:index`.
 Ember has several built-in factory types, such as `service`, `route`, `template`, and `component`.
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          You might ask, how can I find the name of a factory?
+        </p>
+        <p>
+          Factories are kebab-cased and directories are followed by a forward slash. For example, a controller <code>app/controllers/users/primary-teachers</code> is registered as <code>controller:users/primary-teachers</code>.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
+
 You can create your own factory type by simply registering a factory with the new type.
 For example, to create a `user` type,
 you'd simply register your factory with `application.register('user:user-to-register')`.

--- a/guides/v3.20.0/applications/dependency-injection.md
+++ b/guides/v3.20.0/applications/dependency-injection.md
@@ -35,6 +35,23 @@ The first segment is the framework factory type, and the second is the name of t
 Hence, the `index` template has the key `template:index`.
 Ember has several built-in factory types, such as `service`, `route`, `template`, and `component`.
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          You might ask, how can I find the name of a factory?
+        </p>
+        <p>
+          Factories are kebab-cased and directories are followed by a forward slash. For example, a controller <code>app/controllers/users/primary-teachers</code> is registered as <code>controller:users/primary-teachers</code>.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
+
 You can create your own factory type by simply registering a factory with the new type.
 For example, to create a `user` type,
 you'd simply register your factory with `application.register('user:user-to-register')`.

--- a/guides/v3.21.0/applications/dependency-injection.md
+++ b/guides/v3.21.0/applications/dependency-injection.md
@@ -35,6 +35,23 @@ The first segment is the framework factory type, and the second is the name of t
 Hence, the `index` template has the key `template:index`.
 Ember has several built-in factory types, such as `service`, `route`, `template`, and `component`.
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          You might ask, how can I find the name of a factory?
+        </p>
+        <p>
+          Factories are kebab-cased and directories are followed by a forward slash. For example, a controller <code>app/controllers/users/primary-teachers</code> is registered as <code>controller:users/primary-teachers</code>.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
+
 You can create your own factory type by simply registering a factory with the new type.
 For example, to create a `user` type,
 you'd simply register your factory with `application.register('user:user-to-register')`.

--- a/guides/v3.22.0/applications/dependency-injection.md
+++ b/guides/v3.22.0/applications/dependency-injection.md
@@ -35,6 +35,23 @@ The first segment is the framework factory type, and the second is the name of t
 Hence, the `index` template has the key `template:index`.
 Ember has several built-in factory types, such as `service`, `route`, `template`, and `component`.
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          You might ask, how can I find the name of a factory?
+        </p>
+        <p>
+          Factories are kebab-cased and directories are followed by a forward slash. For example, a controller <code>app/controllers/users/primary-teachers</code> is registered as <code>controller:users/primary-teachers</code>.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
+
 You can create your own factory type by simply registering a factory with the new type.
 For example, to create a `user` type,
 you'd simply register your factory with `application.register('user:user-to-register')`.

--- a/guides/v3.23.0/applications/dependency-injection.md
+++ b/guides/v3.23.0/applications/dependency-injection.md
@@ -35,6 +35,23 @@ The first segment is the framework factory type, and the second is the name of t
 Hence, the `index` template has the key `template:index`.
 Ember has several built-in factory types, such as `service`, `route`, `template`, and `component`.
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          You might ask, how can I find the name of a factory?
+        </p>
+        <p>
+          Factories are kebab-cased and directories are followed by a forward slash. For example, a controller <code>app/controllers/users/primary-teachers</code> is registered as <code>controller:users/primary-teachers</code>.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
+
 You can create your own factory type by simply registering a factory with the new type.
 For example, to create a `user` type,
 you'd simply register your factory with `application.register('user:user-to-register')`.

--- a/guides/v3.24.0/applications/dependency-injection.md
+++ b/guides/v3.24.0/applications/dependency-injection.md
@@ -35,6 +35,23 @@ The first segment is the framework factory type, and the second is the name of t
 Hence, the `index` template has the key `template:index`.
 Ember has several built-in factory types, such as `service`, `route`, `template`, and `component`.
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          You might ask, how can I find the name of a factory?
+        </p>
+        <p>
+          Factories are kebab-cased and directories are followed by a forward slash. For example, a controller <code>app/controllers/users/primary-teachers</code> is registered as <code>controller:users/primary-teachers</code>.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
+
 You can create your own factory type by simply registering a factory with the new type.
 For example, to create a `user` type,
 you'd simply register your factory with `application.register('user:user-to-register')`.


### PR DESCRIPTION
I guess this will need work before it's usable, if it's good at all, but I found this difficult to learn & thought a PR would be more constructive than an issue?

 The DI registration syntax can be intimidating. It's fairly
 straightforward, but there's a lot to read and no brief summary
 of the expected or default syntax from an ember-cli app using the
 default file structure. Subdirectories are the main issue. There are
 no /s in the examples.

 This adds a subheading and an example with a subdirectory looking up a
 controller, as might be used in a controller unit test.