### PR TITLE
Add empty alternate text and role presentation to blog logo example

### DIFF
--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -271,7 +271,7 @@ to them.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postBody|>
-  <img src="./blog-logo.png" alt="Blog Logo">
+  <img alt="" role="presentation" src="./blog-logo.png">
 
   {{postBody}}
 
@@ -288,7 +288,7 @@ We can yield back multiple values as well, separated by spaces.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
-  <img src="./blog-logo.png" alt="Blog Logo">
+  <img alt="" role="presentation" src="./blog-logo.png">
   {{postTitle}}
 
   {{postBody}}

--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -271,7 +271,7 @@ to them.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postBody|>
-  <img src="./blog-logo.png">
+  <img src="./blog-logo.png" alt="Blog Logo">
 
   {{postBody}}
 
@@ -288,7 +288,7 @@ We can yield back multiple values as well, separated by spaces.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
-  <img src="./blog-logo.png" alt="Logo">
+  <img src="./blog-logo.png" alt="Blog Logo">
   {{postTitle}}
 
   {{postBody}}

--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -289,6 +289,7 @@ We can yield back multiple values as well, separated by spaces.
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
   <img alt="" role="presentation" src="./blog-logo.png">
+
   {{postTitle}}
 
   {{postBody}}

--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -288,7 +288,7 @@ We can yield back multiple values as well, separated by spaces.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
-  <img src="./blog-logo.png">
+  <img src="./blog-logo.png" alt="Logo">
   {{postTitle}}
 
   {{postBody}}

--- a/guides/v3.15.0/components/block-content.md
+++ b/guides/v3.15.0/components/block-content.md
@@ -271,7 +271,7 @@ to them.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
 
   {{postBody}}
 
@@ -288,7 +288,8 @@ We can yield back multiple values as well, separated by spaces.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
+
   {{postTitle}}
 
   {{postBody}}

--- a/guides/v3.16.0/components/block-content.md
+++ b/guides/v3.16.0/components/block-content.md
@@ -271,7 +271,7 @@ to them.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
 
   {{postBody}}
 
@@ -288,7 +288,8 @@ We can yield back multiple values as well, separated by spaces.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
+
   {{postTitle}}
 
   {{postBody}}

--- a/guides/v3.17.0/components/block-content.md
+++ b/guides/v3.17.0/components/block-content.md
@@ -271,7 +271,7 @@ to them.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
 
   {{postBody}}
 
@@ -288,7 +288,8 @@ We can yield back multiple values as well, separated by spaces.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
+
   {{postTitle}}
 
   {{postBody}}

--- a/guides/v3.18.0/components/block-content.md
+++ b/guides/v3.18.0/components/block-content.md
@@ -271,7 +271,7 @@ to them.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
 
   {{postBody}}
 
@@ -288,7 +288,8 @@ We can yield back multiple values as well, separated by spaces.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
+
   {{postTitle}}
 
   {{postBody}}

--- a/guides/v3.19.0/components/block-content.md
+++ b/guides/v3.19.0/components/block-content.md
@@ -271,7 +271,7 @@ to them.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
 
   {{postBody}}
 
@@ -288,7 +288,8 @@ We can yield back multiple values as well, separated by spaces.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
+
   {{postTitle}}
 
   {{postBody}}

--- a/guides/v3.20.0/components/block-content.md
+++ b/guides/v3.20.0/components/block-content.md
@@ -271,7 +271,7 @@ to them.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
 
   {{postBody}}
 
@@ -288,7 +288,8 @@ We can yield back multiple values as well, separated by spaces.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
+
   {{postTitle}}
 
   {{postBody}}

--- a/guides/v3.21.0/components/block-content.md
+++ b/guides/v3.21.0/components/block-content.md
@@ -271,7 +271,7 @@ to them.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
 
   {{postBody}}
 
@@ -288,7 +288,8 @@ We can yield back multiple values as well, separated by spaces.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
+
   {{postTitle}}
 
   {{postBody}}

--- a/guides/v3.22.0/components/block-content.md
+++ b/guides/v3.22.0/components/block-content.md
@@ -271,7 +271,7 @@ to them.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
 
   {{postBody}}
 
@@ -288,7 +288,8 @@ We can yield back multiple values as well, separated by spaces.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
+
   {{postTitle}}
 
   {{postBody}}

--- a/guides/v3.23.0/components/block-content.md
+++ b/guides/v3.23.0/components/block-content.md
@@ -271,7 +271,7 @@ to them.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
 
   {{postBody}}
 
@@ -288,7 +288,8 @@ We can yield back multiple values as well, separated by spaces.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
+
   {{postTitle}}
 
   {{postBody}}

--- a/guides/v3.24.0/components/block-content.md
+++ b/guides/v3.24.0/components/block-content.md
@@ -271,7 +271,7 @@ to them.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
 
   {{postBody}}
 
@@ -288,7 +288,8 @@ We can yield back multiple values as well, separated by spaces.
 ```handlebars
 <!-- usage -->
 <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
-  <img src="./blog-logo.png">
+  <img alt="" role="presentation" src="./blog-logo.png">
+
   {{postTitle}}
 
   {{postBody}}


### PR DESCRIPTION
This adds the missing `alt` attribute (needed for screen readers and accessibility).