### PR TITLE
[Docs] Correct some closing HTML tags

### DIFF
--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -246,7 +246,7 @@ function in JavaScript. Consider for instance a simple `BlogPost` component.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{@post.body}}
 ```
@@ -263,7 +263,7 @@ to them.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{yield @post.body}}
 ```

--- a/guides/v3.15.0/components/block-content.md
+++ b/guides/v3.15.0/components/block-content.md
@@ -246,7 +246,7 @@ function in JavaScript. Consider for instance a simple `BlogPost` component.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{@post.body}}
 ```
@@ -263,7 +263,7 @@ to them.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{yield @post.body}}
 ```

--- a/guides/v3.16.0/components/block-content.md
+++ b/guides/v3.16.0/components/block-content.md
@@ -246,7 +246,7 @@ function in JavaScript. Consider for instance a simple `BlogPost` component.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{@post.body}}
 ```
@@ -263,7 +263,7 @@ to them.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{yield @post.body}}
 ```

--- a/guides/v3.17.0/components/block-content.md
+++ b/guides/v3.17.0/components/block-content.md
@@ -246,7 +246,7 @@ function in JavaScript. Consider for instance a simple `BlogPost` component.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{@post.body}}
 ```
@@ -263,7 +263,7 @@ to them.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{yield @post.body}}
 ```

--- a/guides/v3.18.0/components/block-content.md
+++ b/guides/v3.18.0/components/block-content.md
@@ -246,7 +246,7 @@ function in JavaScript. Consider for instance a simple `BlogPost` component.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{@post.body}}
 ```
@@ -263,7 +263,7 @@ to them.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{yield @post.body}}
 ```

--- a/guides/v3.19.0/components/block-content.md
+++ b/guides/v3.19.0/components/block-content.md
@@ -246,7 +246,7 @@ function in JavaScript. Consider for instance a simple `BlogPost` component.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{@post.body}}
 ```
@@ -263,7 +263,7 @@ to them.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{yield @post.body}}
 ```

--- a/guides/v3.20.0/components/block-content.md
+++ b/guides/v3.20.0/components/block-content.md
@@ -246,7 +246,7 @@ function in JavaScript. Consider for instance a simple `BlogPost` component.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{@post.body}}
 ```
@@ -263,7 +263,7 @@ to them.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{yield @post.body}}
 ```

--- a/guides/v3.21.0/components/block-content.md
+++ b/guides/v3.21.0/components/block-content.md
@@ -246,7 +246,7 @@ function in JavaScript. Consider for instance a simple `BlogPost` component.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{@post.body}}
 ```
@@ -263,7 +263,7 @@ to them.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{yield @post.body}}
 ```

--- a/guides/v3.22.0/components/block-content.md
+++ b/guides/v3.22.0/components/block-content.md
@@ -246,7 +246,7 @@ function in JavaScript. Consider for instance a simple `BlogPost` component.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{@post.body}}
 ```
@@ -263,7 +263,7 @@ to them.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{yield @post.body}}
 ```

--- a/guides/v3.23.0/components/block-content.md
+++ b/guides/v3.23.0/components/block-content.md
@@ -246,7 +246,7 @@ function in JavaScript. Consider for instance a simple `BlogPost` component.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{@post.body}}
 ```
@@ -263,7 +263,7 @@ to them.
 
 ```handlebars {data-filename=app/components/blog-post.hbs}
 <h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h1>
+<h2>{{@post.author}}</h2>
 
 {{yield @post.body}}
 ```


### PR DESCRIPTION
- Fixed some incorrectly closed `<h2>` tags in block-content.md.
- Also made the same corrections in the previous versions of the
  docs (v3.15.0-v3.23.0).