### PR TITLE
Fix missing syntax highlighting for JS snippet

### DIFF
--- a/guides/release/tutorial/part-2/service-injection.md
+++ b/guides/release/tutorial/part-2/service-injection.md
@@ -193,7 +193,7 @@ With that, we should have a working share button!
 
 To be sure, let's add some tests! Let's start with an acceptance test:
 
-```handlebars { data-filename="tests/acceptance/super-rentals-test.js" data-diff="-2,+3,+39,+40,+41,+42,+43,+44,+45,+46,+47,+48,+49" }
+```js { data-filename="tests/acceptance/super-rentals-test.js" data-diff="-2,+3,+39,+40,+41,+42,+43,+44,+45,+46,+47,+48,+49" }
 import { module, test } from 'qunit';
 import { click, visit, currentURL } from '@ember/test-helpers';
 import { click, find, visit, currentURL } from '@ember/test-helpers';


### PR DESCRIPTION
In [this section of the Service Injection page](https://guides.emberjs.com/release/tutorial/part-2/service-injection/#toc_why-we-cant-test-windowlocationhref), the code snippet for the `super-rentals-test.js` file lacks syntax highlighting because the snippet language was set to Handlebars when it should be JavaScript:

<img width="755" alt="Screen Shot 2021-02-14 at 3 29 28 AM" src="https://user-images.githubusercontent.com/588690/107874171-e9a37f00-6e74-11eb-9c69-9ecdd2ff0331.png">


