### PR TITLE
fix: adds setupRouter to the documentation

### DIFF
--- a/guides/release/tutorial/part-2/route-params.md
+++ b/guides/release/tutorial/part-2/route-params.md
@@ -137,6 +137,7 @@ module('Integration | Component | rental', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders information about a rental property', async function (assert) {
+    this.owner.setupRouter();
     this.setProperties({
       rental: {
         id: 'grand-old-mansion',


### PR DESCRIPTION
The integration test does not load the router by default. It needs to be set up while the test is executing. It will make the documentation consistent.