### PR TITLE
Remove static meta description

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property="og:description" content="Ember.js helps developers be more productive out of the box. Designed with developer ergonomics in mind, its friendly APIs help you get your job done—fast." />
     <meta property="og:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@emberjs" />


### PR DESCRIPTION
We discussed https://github.com/ember-learn/guides-source/pull/1647 in the Learning meeting and the plan was to delete the descriptions from the index.html because they need to be dynamic based on each route in the app. 

This just removes the static description that crept in 👍 