### PR TITLE
changes to code examples of Input Components page (#1016)

### DIFF
--- a/guides/v3.10.0/templates/input-helpers.md
+++ b/guides/v3.10.0/templates/input-helpers.md
@@ -96,7 +96,7 @@ Which can be bound or set as described in the previous section.
 Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.10/classes/Component#event-handler-methods), you will always need to define the event name in camelCase format:
 
 ```handlebars
-<Input @type="checkbox" @keypress={{action "updateName"}} />
+<Input @id="admin-checkbox" @type="checkbox" @checked={{this.isAdmin}} @input={{this.validateRole}} />
 ```
 
 

--- a/guides/v3.11.0/templates/input-helpers.md
+++ b/guides/v3.11.0/templates/input-helpers.md
@@ -96,7 +96,7 @@ Which can be bound or set as described in the previous section.
 Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.11/classes/Component#event-handler-methods), you will always need to define the event name in camelCase format:
 
 ```handlebars
-<Input @type="checkbox" @keypress={{action "updateName"}} />
+<Input @id="admin-checkbox" @type="checkbox" @checked={{this.isAdmin}} @input={{this.validateRole}} />
 ```
 
 

--- a/guides/v3.12.0/templates/input-helpers.md
+++ b/guides/v3.12.0/templates/input-helpers.md
@@ -96,7 +96,7 @@ Which can be bound or set as described in the previous section.
 Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.12/classes/Component#event-handler-methods), you will always need to define the event name in camelCase format:
 
 ```handlebars
-<Input @type="checkbox" @keyPress={{action "updateName"}} />
+<Input @id="admin-checkbox" @type="checkbox" @checked={{this.isAdmin}} @input={{this.validateRole}} />
 ```
 
 

--- a/guides/v3.13.0/templates/input-helpers.md
+++ b/guides/v3.13.0/templates/input-helpers.md
@@ -96,7 +96,7 @@ Which can be bound or set as described in the previous section.
 Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.13/classes/Component#event-handler-methods), you will always need to define the event name in camelCase format:
 
 ```handlebars
-<Input @type="checkbox" @keyPress={{action "updateName"}} />
+<Input @id="admin-checkbox" @type="checkbox" @checked={{this.isAdmin}} @input={{this.validateRole}} />
 ```
 
 

--- a/guides/v3.14.0/templates/input-components.md
+++ b/guides/v3.14.0/templates/input-components.md
@@ -75,7 +75,7 @@ component to create a checkbox by setting its `type`:
 
 ```handlebars
 <label for="admin-checkbox">Is Admin?</label>
-<Input @id="admin-checkbox" @type="checkbox" @name="isAdmin" @checked={{this.isAdmin}} />
+<Input @id="admin-checkbox" @type="checkbox" @checked={{this.isAdmin}} />
 ```
 
 Checkboxes support the following properties:
@@ -93,7 +93,7 @@ Which can be bound or set as described in the previous section.
 If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.14/classes/Component#event-handler-methods), you will always need to define the event name in camelCase format:
 
 ```handlebars
-<Input @type="text" @keyPress={{action "updateName"}} />
+<Input @id="admin-checkbox" @type="checkbox" @checked={{this.isAdmin}} @input={{this.validateRole}} />
 ```
 
 ## Text Areas

--- a/guides/v3.7.0/templates/input-helpers.md
+++ b/guides/v3.7.0/templates/input-helpers.md
@@ -91,7 +91,7 @@ Which can be bound or set as described in the previous section.
 Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.7/classes/Component#event-names), you will always need to define the event name in camelCase format:
 
 ```handlebars
-{{input type="checkbox" keyPress=(action "updateName")}}
+{{input type="checkbox" name="isAdmin" checked=this.isAdmin input=(action "validateRole")}}
 ```
 
 

--- a/guides/v3.8.0/templates/input-helpers.md
+++ b/guides/v3.8.0/templates/input-helpers.md
@@ -91,7 +91,7 @@ Which can be bound or set as described in the previous section.
 Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.8/classes/Component#event-names), you will always need to define the event name in camelCase format:
 
 ```handlebars
-{{input type="checkbox" keyPress=(action "updateName")}}
+{{input type="checkbox" name="isAdmin" checked=this.isAdmin input=(action "validateRole")}}
 ```
 
 

--- a/guides/v3.9.0/templates/input-helpers.md
+++ b/guides/v3.9.0/templates/input-helpers.md
@@ -91,7 +91,7 @@ Which can be bound or set as described in the previous section.
 Checkboxes are a special input type. If you want to dispatch an action on a certain [event](https://api.emberjs.com/ember/3.9/classes/Component#event-names), you will always need to define the event name in camelCase format:
 
 ```handlebars
-{{input type="checkbox" keyPress=(action "updateName")}}
+{{input type="checkbox" name="isAdmin" checked=this.isAdmin input=(action "validateRole")}}
 ```
 
 


### PR DESCRIPTION
@ijlee2 Please review my first PR for the issue https://github.com/ember-learn/guides-source/issues/1016
 Let me know if you have any feedback! 

1) List of changes done to the Input Components page (v3.14)

- Remove the @name="isAdmin" in https://guides.emberjs.com/v3.14.0/templates/input-components/#toc_checkboxes. (This better matches the new code example in v3.15.)

- Update the code <Input @type="text" @keyPress={{action "updateName"}} /> to:

`<Input @id="admin-checkbox" @type="checkbox" @checked={{this.isAdmin}} @input={{this.validateRole}} />`

2) List of changes done to the Input Helpers page (v3.7 - v3.9)

-  Update the code {{input type="checkbox" keyPress=(action "updateName")}} to:

`{{input type="checkbox" name="isAdmin" checked=this.isAdmin input=(action "validateRole")}}`

3) List of changes done to the Input Helpers page (v3.10 - v3.13)

- Update the <Input @type="text" @keyPress={{action "updateName"}} /> to:

`<Input @id="admin-checkbox" @type="checkbox" @checked={{this.isAdmin}} @input={{this.validateRole}} />`

