### PR TITLE
Add default block content example at the top of the section

### DIFF
--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -1,5 +1,30 @@
-Component templates can leave a placeholder that users of the component can fill
-with their own HTML.
+Component templates can leave one or more placeholders that users can fill with their own HTML.
+This is called Block Content. Here's an example that provides a component with "default" Block Content.
+
+```handlebars
+<ExampleComponent>
+  This is the default <b>Block Content</b> that will
+  replace `{{yield}}` (or `{{yield to="default"}}`)
+  in the `ExampleComponent` template.
+</ExampleComponent>
+```
+
+This is equivalent to explicitly naming the block "default" using the named block syntax.
+
+```handlebars
+<ExampleComponent>
+  <:default>
+    This is the default <b>Block Content</b> that will
+    replace `{{yield}}` (or `{{yield to="default"}}`)
+    in the `ExampleComponent` template.
+  </:default>
+</ExampleComponent>
+```
+
+Block content can be both an easier and prettier way to provide a
+component with content, and it's also more functional. Through Block Content,
+users of the component can add additional styling and behavior by using HTML,
+modifiers, and other components within the block.
 
 To make that more concrete, let's take a look at two similar components
 representing different user's messages.

--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -22,10 +22,8 @@ This is equivalent to explicitly naming the default block using the named block 
 </ExampleComponent>
 ```
 
-Block content can be both an easier and prettier way to provide a
-component with content, and it's also more functional. Through Block Content,
-users of the component can add additional styling and behavior by using HTML,
-modifiers, and other components within the block.
+Through Block Content, users of the component can add additional styling and
+behavior by using HTML, modifiers, and other components within the block.
 
 To make that more concrete, let's take a look at two similar components
 representing different user's messages.

--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -4,7 +4,7 @@ Here's an example that provides a component with the implicit default block.
 
 ```handlebars
 <ExampleComponent>
-  This is the default <b>Block Content</b> that will
+  This is the default <b>block content</b> that will
   replace `{{yield}}` (or `{{yield to="default"}}`)
   in the `ExampleComponent` template.
 </ExampleComponent>

--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -10,7 +10,7 @@ Here's an example that provides a component with the implicit default block.
 </ExampleComponent>
 ```
 
-This is equivalent to explicitly naming the block "default" using the named block syntax.
+This is equivalent to explicitly naming the default block using the named block syntax.
 
 ```handlebars
 <ExampleComponent>

--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -1,5 +1,6 @@
 Component templates can leave one or more placeholders that users can fill with their own HTML.
-This is called Block Content. Here's an example that provides a component with "default" Block Content.
+These are called blocks.
+Here's an example that provides a component with the implicit default block.
 
 ```handlebars
 <ExampleComponent>

--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -15,7 +15,7 @@ This is equivalent to explicitly naming the default block using the named block 
 ```handlebars
 <ExampleComponent>
   <:default>
-    This is the default <b>Block Content</b> that will
+    This is the default <b>block content</b> that will
     replace `{{yield}}` (or `{{yield to="default"}}`)
     in the `ExampleComponent` template.
   </:default>


### PR DESCRIPTION
I added a simple example, but did so in a way that acknowledges named blocks and the "default" block. I think that named blocks are a valuable feature, and acknowledging the little bit of complexity can make it all seem a little less magical when the reader encounters named blocks later.

closes #1659