### PR TITLE
Continued - Create a short Contributing Overview guide

### DIFF
--- a/guides/release/contributing/adding-new-features.md
+++ b/guides/release/contributing/adding-new-features.md
@@ -1,3 +1,191 @@
----
-redirect: contributing/index
----
+Anyone can participate in adding new features to Ember. This guide will
+provide some background information for developers who want to
+contribute to the core [`ember.js` codebase](https://github.com/emberjs/ember.js).
+
+## RFCs
+
+New features begin as RFCs (Request for Comments).
+The RFC process is how community members and core team members
+propose changes, such as adding new features or
+making deprecations.
+
+You can see work-in-progress proposals in the
+[Ember RFCs repository Pull Requests](https://github.com/emberjs/rfcs/pulls),
+and participate in giving feedback.
+[Merged RFCs](https://emberjs.github.io/rfcs/) are proposals
+that can move forward with implementation.
+You can reach out to an RFC author to find out how to
+get involved.
+
+You can also [learn how to write your own RFC](https://github.com/emberjs/rfcs#ember-rfcs).
+
+## Background information
+
+Here are some tips for working in the [`ember.js` repository](https://github.com/emberjs/ember.js).
+
+To learn how to make a pull request, review the
+[`CONTRIBUTING.md`](https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md)
+instructions.
+
+In general, new feature development should be done on the `master` branch.
+
+Bugfixes should not introduce new APIs or break existing APIs, and do
+not need feature flags.
+
+Features can introduce new APIs, and need feature flags. They should not
+be applied to the release or beta branches, since SemVer requires
+bumping the minor version to introduce new features.
+
+Security fixes should not introduce new APIs, but may, if strictly
+necessary, break existing APIs. Such breakages should be as limited as
+possible.
+
+## Bug Fixes
+
+### Urgent Bug Fixes
+
+Urgent bugfixes are bugfixes that need to be applied to the existing
+release branch. If possible, they should be made on master and prefixed
+with `[BUGFIX release]`.
+
+### Beta Bug Fixes
+
+Beta bugfixes are bugfixes that need to be applied to the beta branch.
+If possible, they should be made on master and tagged with `[BUGFIX
+beta]`.
+
+### Security Fixes
+
+Security fixes need to be applied to the beta branch, the current
+release branch, and the previous tag. If possible, they should be made
+on master and tagged with `[SECURITY]`.
+
+## Features
+
+Features must always be wrapped in a feature flag. Tests for the feature
+must also be wrapped in a feature flag.
+
+Because the build-tools will process feature-flags, flags must use
+precisely this format. We are choosing conditionals rather than a block
+form because functions change the surrounding scope and may introduce
+problems with early return.
+
+```javascript
+if (Ember.FEATURES.isEnabled("feature")) {
+  // implementation
+}
+```
+
+Tests will always run with all features on, so make sure that any tests
+for the feature are passing against the current state of the feature.
+
+### Commits
+
+Commits related to a specific feature should include  a prefix like
+`[FEATURE htmlbars]`. This will allow us to quickly identify all commits
+for a specific feature in the future. Features will never be applied to
+beta or release branches. Once a beta or release branch has been cut, it
+contains all of the new features it will ever have.
+
+If a feature has made it into beta or release, and you make a commit to
+master that fixes a bug in the feature, treat it like a bugfix as
+described above.
+
+### Feature Naming Conventions
+
+```javascript {data-filename=config/environment.js}
+Ember.FEATURES['<packageName>-<feature>'] // if package specific
+Ember.FEATURES['container-factory-injections']
+Ember.FEATURES['htmlbars']
+```
+
+## Builds
+
+The Canary build, which is based off master, will include all features,
+guarded by the conditionals in the original source. This means that
+users of the canary build can enable whatever features they want by
+enabling them before creating their Ember.Application.
+
+```javascript {data-filename=config/environment.js}
+module.exports = function(environment) {
+  let ENV = {
+    EmberENV: {
+      FEATURES: {
+        htmlbars: true
+      }
+    },
+  }
+}
+```
+
+### `features.json`
+
+The root of the repository will contain a `features.json` file, which will
+contain a list of features that should be enabled for beta or release
+builds.
+
+This file is populated when branching, and may not gain additional
+features after the original branch. It may remove features.
+
+```javascript
+{
+  "htmlbars": true
+}
+```
+
+The build process will remove any features not included in the list, and
+remove the conditionals for features in the list.
+
+### Continuous Integration Tests
+
+For a new PR:
+
+1. Tests will run against master with all feature flags on.
+2. If a commit is tagged with `[BUGFIX beta]`, the commit will be
+   cherry-picked into beta, and the automated tests will be executed on that
+   branch. If the commit doesn't apply cleanly or the tests fail, the
+   build will fail.
+3. If a commit is tagged with `[BUGFIX release]`, the commit will be cherry-picked
+   into release, and the tests will be executed on the release branch. If the commit
+   doesn't apply cleanly or the tests fail, the build will fail.
+
+For a new commit to master:
+
+1. Tests will be executed as described above.
+2. If the build passes, the commits will be cherry-picked into the
+   appropriate branches.
+
+The idea is that new commits should be submitted as PRs to ensure they
+apply cleanly when a PR is merged.
+
+### Go/No-Go Process
+
+Every six weeks, the core team goes through the following process.
+
+#### Beta Branch
+
+All remaining features on the beta branch are vetted for readiness. If
+any feature isn't ready, it is removed from `features.json`.
+
+Once this is done, the beta branch is tagged and merged into release.
+
+#### Master Branch
+
+All features on the master branch are vetted for readiness. In order for
+a feature to be considered "ready" at this stage, it must be ready as-is
+with no blockers. Features are a no-go even if they are close and
+additional work on the beta branch would make it ready.
+
+Because this process happens every six weeks, there will be another
+opportunity for a feature to make it soon enough.
+
+Once this is done, the master branch is merged into beta. A
+`features.json` file is added with the features that are ready.
+
+### Beta Releases
+
+Every week, we repeat the Go/No-Go process for the features that remain
+on the beta branch. Any feature that has become unready is removed from
+the `features.json`.
+
+Once this is done, a Beta release is tagged and pushed.

--- a/guides/release/contributing/index.md
+++ b/guides/release/contributing/index.md
@@ -1,191 +1,33 @@
-Anyone can participate in adding new features to Ember. This guide will
-provide some background information for developers who want to
-contribute to the core [`ember.js` codebase](https://github.com/emberjs/ember.js).
+Ember is an open source project that succeeds thanks to the help of volunteers. Community members at any level are invited to help out with anything from bug reports to documentation. This guide will give you some tips on how to get started and where to ask for help if you want to get involved. Thanks in advance for your help!
 
-## RFCs
+# Types of contributions
 
-New features begin as RFCs (Request for Comments).
-The RFC process is how community members and core team members
-propose changes, such as adding new features or
-making deprecations.
+Any change that aims to make an improvement is very welcome!
 
-You can see work-in-progress proposals in the
-[Ember RFCs repository Pull Requests](https://github.com/emberjs/rfcs/pulls),
-and participate in giving feedback.
-[Merged RFCs](https://emberjs.github.io/rfcs/) are proposals
-that can move forward with implementation.
-You can reach out to an RFC author to find out how to
-get involved.
+You can create issues to document many things (list is not exhaustive!):
 
-You can also [learn how to write your own RFC](https://github.com/emberjs/rfcs#ember-rfcs).
+- Bugs
+- Ideas for enhancements
+- Code quality (e.g. refactoring)
+- Improving the documentation (clarifying, rephrasing, providing more examples, fixing typos, adding missing details)
 
-## Background information
+Creating an issue is a great way to start a discussion and gather opinions of other members of the Ember community. Once a decision has been made, you or someone else can volunteer to work on it, and create a pull request with their work.
 
-Here are some tips for working in the [`ember.js` repository](https://github.com/emberjs/ember.js).
+Apart from creating new issues and pull requests, another way to contribute is comment on existing issues and pull requests. The more reviewers we get for something, the lower the chance we'll overlook potential problems.
 
-To learn how to make a pull request, review the
-[`CONTRIBUTING.md`](https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md)
-instructions.
+# Where to get started
 
-In general, new feature development should be done on the `master` branch.
+A great place to start is helping improve something you personally ran into. E.g. if you found some of the documentation unclear yourself, please create an issue to highlight it, and optionally suggest how to simplify it.
 
-Bugfixes should not introduce new APIs or break existing APIs, and do
-not need feature flags.
+Have a look at the [list of main repositories](repositories) to learn about the different components of the Ember project.
 
-Features can introduce new APIs, and need feature flags. They should not
-be applied to the release or beta branches, since SemVer requires
-bumping the minor version to introduce new features.
+If you need some inspiration, you can check out the [Help Wanted](https://help-wanted.emberjs.com/) dashboard to browse for issues. If you are a beginner, look out for issues with the "Help wanted" and "Good first issue" labels.
 
-Security fixes should not introduce new APIs, but may, if strictly
-necessary, break existing APIs. Such breakages should be as limited as
-possible.
+# Asking for help
 
-## Bug Fixes
+Please comment directly on issues and PRs if you need help. This way others will see and can chime in to help.
+You can also visit the [Ember.js Community Page](https://emberjs.com/community) to join the Ember.js Discord server. Channels that start with `dev` are for contributors working on the corresponding projects, and they are a great place for questions.
 
-### Urgent Bug Fixes
+# In conclusion
 
-Urgent bugfixes are bugfixes that need to be applied to the existing
-release branch. If possible, they should be made on master and prefixed
-with `[BUGFIX release]`.
-
-### Beta Bug Fixes
-
-Beta bugfixes are bugfixes that need to be applied to the beta branch.
-If possible, they should be made on master and tagged with `[BUGFIX
-beta]`.
-
-### Security Fixes
-
-Security fixes need to be applied to the beta branch, the current
-release branch, and the previous tag. If possible, they should be made
-on master and tagged with `[SECURITY]`.
-
-## Features
-
-Features must always be wrapped in a feature flag. Tests for the feature
-must also be wrapped in a feature flag.
-
-Because the build-tools will process feature-flags, flags must use
-precisely this format. We are choosing conditionals rather than a block
-form because functions change the surrounding scope and may introduce
-problems with early return.
-
-```javascript
-if (Ember.FEATURES.isEnabled("feature")) {
-  // implementation
-}
-```
-
-Tests will always run with all features on, so make sure that any tests
-for the feature are passing against the current state of the feature.
-
-### Commits
-
-Commits related to a specific feature should include  a prefix like
-`[FEATURE htmlbars]`. This will allow us to quickly identify all commits
-for a specific feature in the future. Features will never be applied to
-beta or release branches. Once a beta or release branch has been cut, it
-contains all of the new features it will ever have.
-
-If a feature has made it into beta or release, and you make a commit to
-master that fixes a bug in the feature, treat it like a bugfix as
-described above.
-
-### Feature Naming Conventions
-
-```javascript {data-filename=config/environment.js}
-Ember.FEATURES['<packageName>-<feature>'] // if package specific
-Ember.FEATURES['container-factory-injections']
-Ember.FEATURES['htmlbars']
-```
-
-## Builds
-
-The Canary build, which is based off master, will include all features,
-guarded by the conditionals in the original source. This means that
-users of the canary build can enable whatever features they want by
-enabling them before creating their Ember.Application.
-
-```javascript {data-filename=config/environment.js}
-module.exports = function(environment) {
-  let ENV = {
-    EmberENV: {
-      FEATURES: {
-        htmlbars: true
-      }
-    },
-  }
-}
-```
-
-### `features.json`
-
-The root of the repository will contain a `features.json` file, which will
-contain a list of features that should be enabled for beta or release
-builds.
-
-This file is populated when branching, and may not gain additional
-features after the original branch. It may remove features.
-
-```javascript
-{
-  "htmlbars": true
-}
-```
-
-The build process will remove any features not included in the list, and
-remove the conditionals for features in the list.
-
-### Continuous Integration Tests
-
-For a new PR:
-
-1. Tests will run against master with all feature flags on.
-2. If a commit is tagged with `[BUGFIX beta]`, the commit will be
-   cherry-picked into beta, and the automated tests will be executed on that
-   branch. If the commit doesn't apply cleanly or the tests fail, the
-   build will fail.
-3. If a commit is tagged with `[BUGFIX release]`, the commit will be cherry-picked
-   into release, and the tests will be executed on the release branch. If the commit
-   doesn't apply cleanly or the tests fail, the build will fail.
-
-For a new commit to master:
-
-1. Tests will be executed as described above.
-2. If the build passes, the commits will be cherry-picked into the
-   appropriate branches.
-
-The idea is that new commits should be submitted as PRs to ensure they
-apply cleanly when a PR is merged.
-
-### Go/No-Go Process
-
-Every six weeks, the core team goes through the following process.
-
-#### Beta Branch
-
-All remaining features on the beta branch are vetted for readiness. If
-any feature isn't ready, it is removed from `features.json`.
-
-Once this is done, the beta branch is tagged and merged into release.
-
-#### Master Branch
-
-All features on the master branch are vetted for readiness. In order for
-a feature to be considered "ready" at this stage, it must be ready as-is
-with no blockers. Features are a no-go even if they are close and
-additional work on the beta branch would make it ready.
-
-Because this process happens every six weeks, there will be another
-opportunity for a feature to make it soon enough.
-
-Once this is done, the master branch is merged into beta. A
-`features.json` file is added with the features that are ready.
-
-### Beta Releases
-
-Every week, we repeat the Go/No-Go process for the features that remain
-on the beta branch. Any feature that has become unready is removed from
-the `features.json`.
-
-Once this is done, a Beta release is tagged and pushed.
+We would like to reiterate once again - anyone at any skill level can help out! If you have any ideas to improve anything whatsoever, we would love to see your contribution!

--- a/guides/release/pages.yml
+++ b/guides/release/pages.yml
@@ -310,8 +310,10 @@
   url: "contributing"
   isAdvanced: true
   pages:
-    - title: "Adding New Features"
+    - title: "Overview"
       url: "index"
+    - title: "Adding New Features"
+      url: "adding-new-features"
     - title: "Repositories"
       url: "repositories"
 - title: "Glossary"


### PR DESCRIPTION
This other PR had a bunch of merge conflicts since we moved some files around and also edited those files, as part of several contributors' workshop PRs: https://github.com/ember-learn/guides-source/pull/1665

This PR here squashes the commits from #1665, rebases them on `master`, and fixes the merge conflicts.

The new content was already reviewed, so I'll merge this as soon as I confirm that it all looks good and I didn't make any rebasing mistakes. 