### PR TITLE
Removed 3.16 from currently supported LTS versions

### DIFF
--- a/guides/versions.yml
+++ b/guides/versions.yml
@@ -50,6 +50,5 @@ allVersions:
   - "v3.25.0"
 currentVersion: "v3.25.0"
 ltsVersions:
-  - "v3.16.0"
   - "v3.20.0"
   - "v3.24.0"


### PR DESCRIPTION
## Description

Since [March 17, 2021](https://emberjs.com/releases/lts), 3.16 LTS is no longer supported.