### PR TITLE
Use test selectors instead of DOM selectors

### DIFF
--- a/guides/release/testing/testing-application.md
+++ b/guides/release/testing/testing-application.md
@@ -36,7 +36,7 @@ For example:
 
 ```javascript {data-filename=tests/acceptance/new-post-appears-first-test.js}
 import { module, test } from 'qunit';
-import { click, fillIn, visit } from '@ember/test-helpers';
+import { findAll, click, fillIn, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
 module('Acceptance | posts', function(hooks) {
@@ -46,7 +46,7 @@ module('Acceptance | posts', function(hooks) {
     await visit('/posts/new');
     await fillIn('input.title', 'My new post');
     await click('button.submit');
-    assert.equal(document.querySelector('ul.posts li').textContent, 'My new post');
+    assert.equal(findAll('ul.posts li').textContent, 'My new post');
   });
 });
 ```
@@ -119,7 +119,7 @@ Before making an assertion, wait for the execution of each asynchronous helper t
     await visit('/posts/new');
     await fillIn('input.title', 'My new post');
     await click('button.submit');
-    assert.equal(this.element.querySelector('ul.posts li').textContent, 'My new post');
+    assert.equal(findAll('ul.posts li').textContent, 'My new post');
   });
 ```
 

--- a/guides/release/testing/testing-application.md
+++ b/guides/release/testing/testing-application.md
@@ -44,8 +44,8 @@ module('Acceptance | posts', function(hooks) {
 
   test('should add new post', async function(assert) {
     await visit('/posts/new');
-    await fillIn('[data-test-post-input-title]', 'My new post');
-    await click('[data-test-post-save]');
+    await fillIn('[data-test-field="Title"]', 'My new post');
+    await click('[data-test-button="Save"]');
     assert
       .dom('[data-test-post-title]')
       .hasText('My new post', 'The user sees the correct title.');
@@ -119,8 +119,8 @@ Before making an assertion, wait for the execution of each asynchronous helper t
 ```javascript {data-filename=tests/acceptance/new-post-appears-first-test.js}
   test('should add new post', async function(assert) {
     await visit('/posts/new');
-    await fillIn('[data-test-post-input-title]', 'My new post');
-    await click('[data-test-post-save]');
+    await fillIn('[data-test-field="Title"]', 'My new post');
+    await click('[data-test-button="Save"]');
     assert.dom('[data-test-post-title]').hasText('My new post');
   });
 ```

--- a/guides/release/testing/testing-application.md
+++ b/guides/release/testing/testing-application.md
@@ -117,9 +117,9 @@ Before making an assertion, wait for the execution of each asynchronous helper t
 ```javascript {data-filename=tests/acceptance/new-post-appears-first-test.js}
   test('should add new post', async function(assert) {
     await visit('/posts/new');
-    await fillIn('input.title', 'My new post');
-    await click('button.submit');
-    assert.dom('ul.posts li').hasText('My new post');
+    await fillIn('[data-test-post-input-title]', 'My new post');
+    await click('[data-test-post-save]');
+    assert.dom('[data-test-post-title]').hasText('My new post');
   });
 ```
 

--- a/guides/release/testing/testing-application.md
+++ b/guides/release/testing/testing-application.md
@@ -44,9 +44,9 @@ module('Acceptance | posts', function(hooks) {
 
   test('should add new post', async function(assert) {
     await visit('/posts/new');
-    await fillIn('input.title', 'My new post');
-    await click('button.submit');
-    assert.dom('ul.posts li').hasText('My new post');
+    await fillIn('[data-test-post-input-title]', 'My new post');
+    await click('[data-test-post-save]');
+    assert.dom('[data-test-post-title]').hasText('My new post');
   });
 });
 ```

--- a/guides/release/testing/testing-application.md
+++ b/guides/release/testing/testing-application.md
@@ -36,7 +36,7 @@ For example:
 
 ```javascript {data-filename=tests/acceptance/new-post-appears-first-test.js}
 import { module, test } from 'qunit';
-import { findAll, click, fillIn, visit } from '@ember/test-helpers';
+import { click, fillIn, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
 module('Acceptance | posts', function(hooks) {
@@ -46,7 +46,7 @@ module('Acceptance | posts', function(hooks) {
     await visit('/posts/new');
     await fillIn('input.title', 'My new post');
     await click('button.submit');
-    assert.equal(findAll('ul.posts li').textContent, 'My new post');
+    assert.dom('ul.posts li').hasText('My new post');
   });
 });
 ```
@@ -119,7 +119,7 @@ Before making an assertion, wait for the execution of each asynchronous helper t
     await visit('/posts/new');
     await fillIn('input.title', 'My new post');
     await click('button.submit');
-    assert.equal(findAll('ul.posts li').textContent, 'My new post');
+    assert.dom('ul.posts li').hasText('My new post');
   });
 ```
 

--- a/guides/release/testing/testing-application.md
+++ b/guides/release/testing/testing-application.md
@@ -46,7 +46,9 @@ module('Acceptance | posts', function(hooks) {
     await visit('/posts/new');
     await fillIn('[data-test-post-input-title]', 'My new post');
     await click('[data-test-post-save]');
-    assert.dom('[data-test-post-title]').hasText('My new post');
+    assert
+      .dom('[data-test-post-title]')
+      .hasText('My new post', 'The user sees the correct title.');
   });
 });
 ```


### PR DESCRIPTION
I just ran into this today. trying to test a h1

```
document.querySelector('h1)
```

Is returning my app name... The code should be updated to use the helpers.