### PR TITLE
Make backburner docs more explicit

### DIFF
--- a/guides/release/configuring-ember/debugging.md
+++ b/guides/release/configuring-ember/debugging.md
@@ -106,8 +106,10 @@ this is quite slow and is not appropriate for production or even normal developm
 To enable full stacktrace mode in Backburner, and thus determine the stack of the task
 when it was scheduled onto the run loop, you can set:
 
-```javascript
-Ember.run.backburner.DEBUG = true;
+```javascript {data-filename=app/app.js}
+import { run } from '@ember/runloop';
+
+run.backburner.DEBUG = true;
 ```
 
 Once the `DEBUG` value is set to `true`, when you are at a breakpoint you can navigate


### PR DESCRIPTION
I'm not entirely sure that this is the right place to put it, but current wording is pretty vague.

Do I need to add it to my application code? To my tests? In `beforeEach` of my tests?

Also current version makes an assumption that the user knows that they need to import `Ember`.