### PR TITLE
Remove redundant import

### DIFF
--- a/guides/release/tutorial/part-1/reusable-components.md
+++ b/guides/release/tutorial/part-1/reusable-components.md
@@ -201,7 +201,6 @@ We just added a lot of behavior into a single component, so let's write some tes
 ```js { data-filename="tests/integration/components/map-test.js" data-diff="-3,+4,+6,-11,-12,-13,+14,+15,+16,+17,+18,+19,+20,+21,-23,+24,+25,+26,+27,+28,+29,+30,-32,+33,+34,-36,-37,-38,-39,-40,-41,+42,+43,+44,+45,-47,+48,+49,+50,+51,+52,+53,+54,+55,+56,+57,+58,+59,+60,+61,+62,+63,+64,+65,+66,+67,+68,+69,+70,+71,+72,+73,+74,+75,+76,+77,+78,+79,+80,+81,+82,+83,+84,+85,+86,+87,+88,+89,+90,+91,+92,+93" }
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
 import { render, find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import ENV from 'super-rentals/config/environment';


### PR DESCRIPTION
Merging this PR will:
- Remove line 204 in the _Overriding HTML Attributes in ...attributes_ example for `map-test.js`
`import { render } from '@ember/test-helpers';`

Reasoning:
- The following import statement includes the render and find which makes line 204 unnecessary
`import { render, find } from '@ember/test-helpers';`