### PR TITLE
add SPA netlify redirect

### DIFF
--- a/.netlifyredirects
+++ b/.netlifyredirects
@@ -1,2 +1,3 @@
 /                 /release/
 /current/*        /release/:splat
+/*                /index.html       200


### PR DESCRIPTION
I noticed when working on the design that the 404 page doesn't seem to be working on the guides for some reason 🙈  turns out we didn't setup the correct netlify redirects for SPAs 