### PR TITLE
Document in-element in the Guides (#1492)

### DIFF
--- a/.local.dic
+++ b/.local.dic
@@ -61,7 +61,7 @@ ember-cli-netlify
 ember-cli-mirage.
 ember-cli-tutorial-style
 ember-debug-handlers-polyfill
-ember-fast-cli 
+ember-fast-cli
 ember-intl
 erroring
 Evented
@@ -213,3 +213,4 @@ ZEIT
 yay
 template-lifecycle-dom-and-modifiers
 working-with-html-css-and-javascript
+dropdown

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -319,3 +319,67 @@ In the component's template, you can then use the `person` object:
 ```handlebars {data-filename=app/components/greeting/template.hbs}
 Hello, {{@person.givenName}} {{@person.familyName}}
 ```
+
+### The `in-element` helper
+
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
+to render a modal, tooltip or dropdown.
+
+Let's say I wanted to show a dropdown when a button is clicked on.
+
+We have the button we want to click on, a div element that will hold the dropdown and the dropdown component.
+```handlebars
+  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <div id="dropdown-destination" />
+
+  <MyDropdownComponent
+    @show={{this.showDropdown}}
+  />
+```
+
+When the user clicks on the button, the flag `showDropdown` will be set to true.
+```js
+  @tracked
+  showDropdown = false;
+
+  @action
+  onClickShowDropdown() {
+    this.showDropdown = true;
+  }
+```
+
+Once `showDropdown` is `true`, the `in-element` helper activates and we pass the `destinationElement` that contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+```handlebars {data-filename=app/components/myDropDownComponent.hbs}
+{{#if @show}}
+  {{#in-element this.destinationElement}}
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  {{/in-element}}
+{{/if}}
+```
+
+We need to make sure
+```js {data-filename=app/components/myDropDownComponent.js}
+  get destinationElement() {
+    return document.querySelector('#dropdown-destination');
+  }
+```
+
+After the user clicks on the button, the final HTML result for the div will be like this:
+```html
+  <div id="dropdown-destination">
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  </div>
+```
+
+Things to note:
+- The destination element needs to exist in the DOM before we use the helper.
+- When the destination element changes, the content will re-render completely.
+- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -315,7 +315,7 @@ components.
 ```
 
 In the component's template, you can then use the `person` object:
-
+test
 ```handlebars {data-filename=app/components/greeting/template.hbs}
 Hello, {{@person.givenName}} {{@person.familyName}}
 ```
@@ -327,8 +327,8 @@ to render a modal, tooltip or dropdown.
 
 Let's say I wanted to show a dropdown when a button is clicked on.
 
-We have the button we want to click on, a div element that will hold the dropdown and the dropdown component.
-```handlebars
+Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component.
+```handlebars {data-filename=app/components/some-component.hbs}
   <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
   <div id="dropdown-destination" />
 
@@ -337,8 +337,8 @@ We have the button we want to click on, a div element that will hold the dropdow
   />
 ```
 
-When the user clicks on the button, the flag `showDropdown` will be set to true.
-```js
+When the user clicks on the button, the flag `showDropdown` will be set to `true`.
+```js {data-filename=app/components/some-component.js}
   @tracked
   showDropdown = false;
 
@@ -349,7 +349,7 @@ When the user clicks on the button, the flag `showDropdown` will be set to true.
 ```
 
 Once `showDropdown` is `true`, the `in-element` helper activates and we pass the `destinationElement` that contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
-```handlebars {data-filename=app/components/myDropDownComponent.hbs}
+```handlebars {data-filename=app/components/my-dropdown-component.hbs}
 {{#if @show}}
   {{#in-element this.destinationElement}}
     <ul>
@@ -361,8 +361,7 @@ Once `showDropdown` is `true`, the `in-element` helper activates and we pass the
 {{/if}}
 ```
 
-We need to make sure
-```js {data-filename=app/components/myDropDownComponent.js}
+```js {data-filename=app/components/my-dropdown-component.js}
   get destinationElement() {
     return document.querySelector('#dropdown-destination');
   }
@@ -380,6 +379,6 @@ After the user clicks on the button, the final HTML result for the div will be l
 ```
 
 Things to note:
-- The destination element needs to exist in the DOM before we use the helper.
+- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
 - When the destination element changes, the content will re-render completely.
 - By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -379,5 +379,5 @@ After the user clicks on the button, the final HTML result for the div will be l
 
 Things to note:
 - The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
-- When the destination element changes, the content will re-render completely.
+- When the destination element changes, the contents defined in `in-element` will re-render completely.
 - By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -321,14 +321,17 @@ Hello, {{@person.givenName}} {{@person.familyName}}
 
 ### The `in-element` helper
 
-Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
-to render a modal, tooltip or dropdown.
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
+to render a modal, tooltip, or dropdown.
 
-Let's say I wanted to show a dropdown when a button is clicked on.
-
-Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+Suppose we want to show a dropdown menu when the user clicks on a button. The code below shows a `<button>` element, a placeholder `<div>` element, and a dropdown component. The argument `@show`, when set to `true`, will add the dropdown to the placeholder div.
 ```handlebars {data-filename=app/components/some-component.hbs}
-  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <button
+    type="button"
+    {{on "click" this.onClickShowDropdown}}
+  >
+    More Actions
+  </button>
   <div id="dropdown-destination" />
 
   <MyDropdownComponent
@@ -347,7 +350,7 @@ When the user clicks on the button, the flag `showDropdown` will be set to `true
   }
 ```
 
-Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+The dropdown component uses the argument `@show` to activate the `in-element` helper. We must **provide the destination DOM element** to the helper. In other words, where should the helper render its block content?
 ```handlebars {data-filename=app/components/my-dropdown-component.hbs}
 {{#if @show}}
   {{#in-element this.destinationElement}}
@@ -378,6 +381,6 @@ After the user clicks on the button, the final HTML result for the div will be l
 ```
 
 Things to note:
-- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
-- When the destination element changes, the contents defined in `in-element` will re-render completely.
-- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.
+- The destination element needs to exist in the DOM before we use the helper. Otherwise, an error will be thrown if you are in development mode. The error is not thrown in production.
+- When the destination element changes, the content defined in `in-element` will re-render completely.
+- By default, the `in-element` helper replaces the destination element's existing content with the helper's block content. If you want to instead append the block content, you can pass `insertBefore=null`.

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -315,7 +315,6 @@ components.
 ```
 
 In the component's template, you can then use the `person` object:
-test
 ```handlebars {data-filename=app/components/greeting/template.hbs}
 Hello, {{@person.givenName}} {{@person.familyName}}
 ```

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -326,7 +326,7 @@ to render a modal, tooltip or dropdown.
 
 Let's say I wanted to show a dropdown when a button is clicked on.
 
-Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component.
+Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
 ```handlebars {data-filename=app/components/some-component.hbs}
   <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
   <div id="dropdown-destination" />
@@ -347,7 +347,7 @@ When the user clicks on the button, the flag `showDropdown` will be set to `true
   }
 ```
 
-Once `showDropdown` is `true`, the `in-element` helper activates and we pass the `destinationElement` that contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
 ```handlebars {data-filename=app/components/my-dropdown-component.hbs}
 {{#if @show}}
   {{#in-element this.destinationElement}}

--- a/guides/v3.20.0/components/helper-functions.md
+++ b/guides/v3.20.0/components/helper-functions.md
@@ -321,14 +321,17 @@ To consult all available built-in helpers, you can check the [template helpers A
 
 ### The `in-element` helper
 
-Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
-to render a modal, tooltip or dropdown.
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.20/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
+to render a modal, tooltip, or dropdown.
 
-Let's say I wanted to show a dropdown when a button is clicked on.
-
-Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+Suppose we want to show a dropdown menu when the user clicks on a button. The code below shows a `<button>` element, a placeholder `<div>` element, and a dropdown component. The argument `@show`, when set to `true`, will add the dropdown to the placeholder div.
 ```handlebars {data-filename=app/components/some-component.hbs}
-  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <button
+    type="button"
+    {{on "click" this.onClickShowDropdown}}
+  >
+    More Actions
+  </button>
   <div id="dropdown-destination" />
 
   <MyDropdownComponent
@@ -347,7 +350,7 @@ When the user clicks on the button, the flag `showDropdown` will be set to `true
   }
 ```
 
-Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+The dropdown component uses the argument `@show` to activate the `in-element` helper. We must **provide the destination DOM element** to the helper. In other words, where should the helper render its block content?
 ```handlebars {data-filename=app/components/my-dropdown-component.hbs}
 {{#if @show}}
   {{#in-element this.destinationElement}}
@@ -378,6 +381,6 @@ After the user clicks on the button, the final HTML result for the div will be l
 ```
 
 Things to note:
-- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
-- When the destination element changes, the contents defined in `in-element` will re-render completely.
-- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.
+- The destination element needs to exist in the DOM before we use the helper. Otherwise, an error will be thrown if you are in development mode. The error is not thrown in production.
+- When the destination element changes, the content defined in `in-element` will re-render completely.
+- By default, the `in-element` helper replaces the destination element's existing content with the helper's block content. If you want to instead append the block content, you can pass `insertBefore=null`.

--- a/guides/v3.20.0/components/helper-functions.md
+++ b/guides/v3.20.0/components/helper-functions.md
@@ -318,3 +318,66 @@ Hello, {{@person.firstName}} {{@person.lastName}}
 ```
 
 To consult all available built-in helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/3.20/classes/Ember.Templates.helpers/).
+
+### The `in-element` helper
+
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
+to render a modal, tooltip or dropdown.
+
+Let's say I wanted to show a dropdown when a button is clicked on.
+
+Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+```handlebars {data-filename=app/components/some-component.hbs}
+  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <div id="dropdown-destination" />
+
+  <MyDropdownComponent
+    @show={{this.showDropdown}}
+  />
+```
+
+When the user clicks on the button, the flag `showDropdown` will be set to `true`.
+```js {data-filename=app/components/some-component.js}
+  @tracked
+  showDropdown = false;
+
+  @action
+  onClickShowDropdown() {
+    this.showDropdown = true;
+  }
+```
+
+Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+```handlebars {data-filename=app/components/my-dropdown-component.hbs}
+{{#if @show}}
+  {{#in-element this.destinationElement}}
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  {{/in-element}}
+{{/if}}
+```
+
+```js {data-filename=app/components/my-dropdown-component.js}
+  get destinationElement() {
+    return document.querySelector('#dropdown-destination');
+  }
+```
+
+After the user clicks on the button, the final HTML result for the div will be like this:
+```html
+  <div id="dropdown-destination">
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  </div>
+```
+
+Things to note:
+- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
+- When the destination element changes, the contents defined in `in-element` will re-render completely.
+- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.

--- a/guides/v3.21.0/components/helper-functions.md
+++ b/guides/v3.21.0/components/helper-functions.md
@@ -318,3 +318,66 @@ Hello, {{@person.givenName}} {{@person.familyName}}
 ```
 
 To consult all available built-in helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/).
+
+### The `in-element` helper
+
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
+to render a modal, tooltip or dropdown.
+
+Let's say I wanted to show a dropdown when a button is clicked on.
+
+Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+```handlebars {data-filename=app/components/some-component.hbs}
+  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <div id="dropdown-destination" />
+
+  <MyDropdownComponent
+    @show={{this.showDropdown}}
+  />
+```
+
+When the user clicks on the button, the flag `showDropdown` will be set to `true`.
+```js {data-filename=app/components/some-component.js}
+  @tracked
+  showDropdown = false;
+
+  @action
+  onClickShowDropdown() {
+    this.showDropdown = true;
+  }
+```
+
+Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+```handlebars {data-filename=app/components/my-dropdown-component.hbs}
+{{#if @show}}
+  {{#in-element this.destinationElement}}
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  {{/in-element}}
+{{/if}}
+```
+
+```js {data-filename=app/components/my-dropdown-component.js}
+  get destinationElement() {
+    return document.querySelector('#dropdown-destination');
+  }
+```
+
+After the user clicks on the button, the final HTML result for the div will be like this:
+```html
+  <div id="dropdown-destination">
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  </div>
+```
+
+Things to note:
+- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
+- When the destination element changes, the contents defined in `in-element` will re-render completely.
+- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.

--- a/guides/v3.21.0/components/helper-functions.md
+++ b/guides/v3.21.0/components/helper-functions.md
@@ -321,14 +321,17 @@ To consult all available built-in helpers, you can check the [template helpers A
 
 ### The `in-element` helper
 
-Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
-to render a modal, tooltip or dropdown.
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.21/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
+to render a modal, tooltip, or dropdown.
 
-Let's say I wanted to show a dropdown when a button is clicked on.
-
-Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+Suppose we want to show a dropdown menu when the user clicks on a button. The code below shows a `<button>` element, a placeholder `<div>` element, and a dropdown component. The argument `@show`, when set to `true`, will add the dropdown to the placeholder div.
 ```handlebars {data-filename=app/components/some-component.hbs}
-  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <button
+    type="button"
+    {{on "click" this.onClickShowDropdown}}
+  >
+    More Actions
+  </button>
   <div id="dropdown-destination" />
 
   <MyDropdownComponent
@@ -347,7 +350,7 @@ When the user clicks on the button, the flag `showDropdown` will be set to `true
   }
 ```
 
-Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+The dropdown component uses the argument `@show` to activate the `in-element` helper. We must **provide the destination DOM element** to the helper. In other words, where should the helper render its block content?
 ```handlebars {data-filename=app/components/my-dropdown-component.hbs}
 {{#if @show}}
   {{#in-element this.destinationElement}}
@@ -378,6 +381,6 @@ After the user clicks on the button, the final HTML result for the div will be l
 ```
 
 Things to note:
-- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
-- When the destination element changes, the contents defined in `in-element` will re-render completely.
-- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.
+- The destination element needs to exist in the DOM before we use the helper. Otherwise, an error will be thrown if you are in development mode. The error is not thrown in production.
+- When the destination element changes, the content defined in `in-element` will re-render completely.
+- By default, the `in-element` helper replaces the destination element's existing content with the helper's block content. If you want to instead append the block content, you can pass `insertBefore=null`.

--- a/guides/v3.22.0/components/helper-functions.md
+++ b/guides/v3.22.0/components/helper-functions.md
@@ -318,3 +318,66 @@ Hello, {{@person.givenName}} {{@person.familyName}}
 ```
 
 To consult all available built-in helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/3.22.0/classes/Ember.Templates.helpers/).
+
+### The `in-element` helper
+
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
+to render a modal, tooltip or dropdown.
+
+Let's say I wanted to show a dropdown when a button is clicked on.
+
+Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+```handlebars {data-filename=app/components/some-component.hbs}
+  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <div id="dropdown-destination" />
+
+  <MyDropdownComponent
+    @show={{this.showDropdown}}
+  />
+```
+
+When the user clicks on the button, the flag `showDropdown` will be set to `true`.
+```js {data-filename=app/components/some-component.js}
+  @tracked
+  showDropdown = false;
+
+  @action
+  onClickShowDropdown() {
+    this.showDropdown = true;
+  }
+```
+
+Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+```handlebars {data-filename=app/components/my-dropdown-component.hbs}
+{{#if @show}}
+  {{#in-element this.destinationElement}}
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  {{/in-element}}
+{{/if}}
+```
+
+```js {data-filename=app/components/my-dropdown-component.js}
+  get destinationElement() {
+    return document.querySelector('#dropdown-destination');
+  }
+```
+
+After the user clicks on the button, the final HTML result for the div will be like this:
+```html
+  <div id="dropdown-destination">
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  </div>
+```
+
+Things to note:
+- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
+- When the destination element changes, the contents defined in `in-element` will re-render completely.
+- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.

--- a/guides/v3.22.0/components/helper-functions.md
+++ b/guides/v3.22.0/components/helper-functions.md
@@ -321,14 +321,17 @@ To consult all available built-in helpers, you can check the [template helpers A
 
 ### The `in-element` helper
 
-Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
-to render a modal, tooltip or dropdown.
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.22/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
+to render a modal, tooltip, or dropdown.
 
-Let's say I wanted to show a dropdown when a button is clicked on.
-
-Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+Suppose we want to show a dropdown menu when the user clicks on a button. The code below shows a `<button>` element, a placeholder `<div>` element, and a dropdown component. The argument `@show`, when set to `true`, will add the dropdown to the placeholder div.
 ```handlebars {data-filename=app/components/some-component.hbs}
-  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <button
+    type="button"
+    {{on "click" this.onClickShowDropdown}}
+  >
+    More Actions
+  </button>
   <div id="dropdown-destination" />
 
   <MyDropdownComponent
@@ -347,7 +350,7 @@ When the user clicks on the button, the flag `showDropdown` will be set to `true
   }
 ```
 
-Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+The dropdown component uses the argument `@show` to activate the `in-element` helper. We must **provide the destination DOM element** to the helper. In other words, where should the helper render its block content?
 ```handlebars {data-filename=app/components/my-dropdown-component.hbs}
 {{#if @show}}
   {{#in-element this.destinationElement}}
@@ -378,6 +381,6 @@ After the user clicks on the button, the final HTML result for the div will be l
 ```
 
 Things to note:
-- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
-- When the destination element changes, the contents defined in `in-element` will re-render completely.
-- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.
+- The destination element needs to exist in the DOM before we use the helper. Otherwise, an error will be thrown if you are in development mode. The error is not thrown in production.
+- When the destination element changes, the content defined in `in-element` will re-render completely.
+- By default, the `in-element` helper replaces the destination element's existing content with the helper's block content. If you want to instead append the block content, you can pass `insertBefore=null`.

--- a/guides/v3.23.0/components/helper-functions.md
+++ b/guides/v3.23.0/components/helper-functions.md
@@ -318,3 +318,66 @@ Hello, {{@person.givenName}} {{@person.familyName}}
 ```
 
 To consult all available built-in helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/3.23.0/classes/Ember.Templates.helpers/).
+
+### The `in-element` helper
+
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
+to render a modal, tooltip or dropdown.
+
+Let's say I wanted to show a dropdown when a button is clicked on.
+
+Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+```handlebars {data-filename=app/components/some-component.hbs}
+  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <div id="dropdown-destination" />
+
+  <MyDropdownComponent
+    @show={{this.showDropdown}}
+  />
+```
+
+When the user clicks on the button, the flag `showDropdown` will be set to `true`.
+```js {data-filename=app/components/some-component.js}
+  @tracked
+  showDropdown = false;
+
+  @action
+  onClickShowDropdown() {
+    this.showDropdown = true;
+  }
+```
+
+Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+```handlebars {data-filename=app/components/my-dropdown-component.hbs}
+{{#if @show}}
+  {{#in-element this.destinationElement}}
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  {{/in-element}}
+{{/if}}
+```
+
+```js {data-filename=app/components/my-dropdown-component.js}
+  get destinationElement() {
+    return document.querySelector('#dropdown-destination');
+  }
+```
+
+After the user clicks on the button, the final HTML result for the div will be like this:
+```html
+  <div id="dropdown-destination">
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  </div>
+```
+
+Things to note:
+- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
+- When the destination element changes, the contents defined in `in-element` will re-render completely.
+- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.

--- a/guides/v3.23.0/components/helper-functions.md
+++ b/guides/v3.23.0/components/helper-functions.md
@@ -321,14 +321,17 @@ To consult all available built-in helpers, you can check the [template helpers A
 
 ### The `in-element` helper
 
-Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
-to render a modal, tooltip or dropdown.
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.23/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
+to render a modal, tooltip, or dropdown.
 
-Let's say I wanted to show a dropdown when a button is clicked on.
-
-Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+Suppose we want to show a dropdown menu when the user clicks on a button. The code below shows a `<button>` element, a placeholder `<div>` element, and a dropdown component. The argument `@show`, when set to `true`, will add the dropdown to the placeholder div.
 ```handlebars {data-filename=app/components/some-component.hbs}
-  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <button
+    type="button"
+    {{on "click" this.onClickShowDropdown}}
+  >
+    More Actions
+  </button>
   <div id="dropdown-destination" />
 
   <MyDropdownComponent
@@ -347,7 +350,7 @@ When the user clicks on the button, the flag `showDropdown` will be set to `true
   }
 ```
 
-Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+The dropdown component uses the argument `@show` to activate the `in-element` helper. We must **provide the destination DOM element** to the helper. In other words, where should the helper render its block content?
 ```handlebars {data-filename=app/components/my-dropdown-component.hbs}
 {{#if @show}}
   {{#in-element this.destinationElement}}
@@ -378,6 +381,6 @@ After the user clicks on the button, the final HTML result for the div will be l
 ```
 
 Things to note:
-- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
-- When the destination element changes, the contents defined in `in-element` will re-render completely.
-- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.
+- The destination element needs to exist in the DOM before we use the helper. Otherwise, an error will be thrown if you are in development mode. The error is not thrown in production.
+- When the destination element changes, the content defined in `in-element` will re-render completely.
+- By default, the `in-element` helper replaces the destination element's existing content with the helper's block content. If you want to instead append the block content, you can pass `insertBefore=null`.

--- a/guides/v3.24.0/components/helper-functions.md
+++ b/guides/v3.24.0/components/helper-functions.md
@@ -321,14 +321,17 @@ To consult all available built-in helpers, you can check the [template helpers A
 
 ### The `in-element` helper
 
-Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
-to render a modal, tooltip or dropdown.
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.24/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
+to render a modal, tooltip, or dropdown.
 
-Let's say I wanted to show a dropdown when a button is clicked on.
-
-Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+Suppose we want to show a dropdown menu when the user clicks on a button. The code below shows a `<button>` element, a placeholder `<div>` element, and a dropdown component. The argument `@show`, when set to `true`, will add the dropdown to the placeholder div.
 ```handlebars {data-filename=app/components/some-component.hbs}
-  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <button
+    type="button"
+    {{on "click" this.onClickShowDropdown}}
+  >
+    More Actions
+  </button>
   <div id="dropdown-destination" />
 
   <MyDropdownComponent
@@ -347,7 +350,7 @@ When the user clicks on the button, the flag `showDropdown` will be set to `true
   }
 ```
 
-Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+The dropdown component uses the argument `@show` to activate the `in-element` helper. We must **provide the destination DOM element** to the helper. In other words, where should the helper render its block content?
 ```handlebars {data-filename=app/components/my-dropdown-component.hbs}
 {{#if @show}}
   {{#in-element this.destinationElement}}
@@ -378,6 +381,6 @@ After the user clicks on the button, the final HTML result for the div will be l
 ```
 
 Things to note:
-- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
-- When the destination element changes, the contents defined in `in-element` will re-render completely.
-- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.
+- The destination element needs to exist in the DOM before we use the helper. Otherwise, an error will be thrown if you are in development mode. The error is not thrown in production.
+- When the destination element changes, the content defined in `in-element` will re-render completely.
+- By default, the `in-element` helper replaces the destination element's existing content with the helper's block content. If you want to instead append the block content, you can pass `insertBefore=null`.

--- a/guides/v3.24.0/components/helper-functions.md
+++ b/guides/v3.24.0/components/helper-functions.md
@@ -318,3 +318,66 @@ Hello, {{@person.givenName}} {{@person.familyName}}
 ```
 
 To consult all available built-in helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/3.24.0/classes/Ember.Templates.helpers/).
+
+### The `in-element` helper
+
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
+to render a modal, tooltip or dropdown.
+
+Let's say I wanted to show a dropdown when a button is clicked on.
+
+Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+```handlebars {data-filename=app/components/some-component.hbs}
+  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <div id="dropdown-destination" />
+
+  <MyDropdownComponent
+    @show={{this.showDropdown}}
+  />
+```
+
+When the user clicks on the button, the flag `showDropdown` will be set to `true`.
+```js {data-filename=app/components/some-component.js}
+  @tracked
+  showDropdown = false;
+
+  @action
+  onClickShowDropdown() {
+    this.showDropdown = true;
+  }
+```
+
+Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+```handlebars {data-filename=app/components/my-dropdown-component.hbs}
+{{#if @show}}
+  {{#in-element this.destinationElement}}
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  {{/in-element}}
+{{/if}}
+```
+
+```js {data-filename=app/components/my-dropdown-component.js}
+  get destinationElement() {
+    return document.querySelector('#dropdown-destination');
+  }
+```
+
+After the user clicks on the button, the final HTML result for the div will be like this:
+```html
+  <div id="dropdown-destination">
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  </div>
+```
+
+Things to note:
+- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
+- When the destination element changes, the contents defined in `in-element` will re-render completely.
+- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.

--- a/guides/v3.25.0/components/helper-functions.md
+++ b/guides/v3.25.0/components/helper-functions.md
@@ -322,14 +322,17 @@ Hello, {{@person.givenName}} {{@person.familyName}}
 
 ### The `in-element` helper
 
-Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
-to render a modal, tooltip or dropdown.
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.25/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
+to render a modal, tooltip, or dropdown.
 
-Let's say I wanted to show a dropdown when a button is clicked on.
-
-Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+Suppose we want to show a dropdown menu when the user clicks on a button. The code below shows a `<button>` element, a placeholder `<div>` element, and a dropdown component. The argument `@show`, when set to `true`, will add the dropdown to the placeholder div.
 ```handlebars {data-filename=app/components/some-component.hbs}
-  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <button
+    type="button"
+    {{on "click" this.onClickShowDropdown}}
+  >
+    More Actions
+  </button>
   <div id="dropdown-destination" />
 
   <MyDropdownComponent
@@ -348,7 +351,7 @@ When the user clicks on the button, the flag `showDropdown` will be set to `true
   }
 ```
 
-Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+The dropdown component uses the argument `@show` to activate the `in-element` helper. We must **provide the destination DOM element** to the helper. In other words, where should the helper render its block content?
 ```handlebars {data-filename=app/components/my-dropdown-component.hbs}
 {{#if @show}}
   {{#in-element this.destinationElement}}
@@ -379,6 +382,6 @@ After the user clicks on the button, the final HTML result for the div will be l
 ```
 
 Things to note:
-- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
-- When the destination element changes, the contents defined in `in-element` will re-render completely.
-- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.
+- The destination element needs to exist in the DOM before we use the helper. Otherwise, an error will be thrown if you are in development mode. The error is not thrown in production.
+- When the destination element changes, the content defined in `in-element` will re-render completely.
+- By default, the `in-element` helper replaces the destination element's existing content with the helper's block content. If you want to instead append the block content, you can pass `insertBefore=null`.

--- a/guides/v3.25.0/components/helper-functions.md
+++ b/guides/v3.25.0/components/helper-functions.md
@@ -319,3 +319,66 @@ In the component's template, you can then use the `person` object:
 ```handlebars {data-filename=app/components/greeting/template.hbs}
 Hello, {{@person.givenName}} {{@person.familyName}}
 ```
+
+### The `in-element` helper
+
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
+to render a modal, tooltip or dropdown.
+
+Let's say I wanted to show a dropdown when a button is clicked on.
+
+Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+```handlebars {data-filename=app/components/some-component.hbs}
+  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <div id="dropdown-destination" />
+
+  <MyDropdownComponent
+    @show={{this.showDropdown}}
+  />
+```
+
+When the user clicks on the button, the flag `showDropdown` will be set to `true`.
+```js {data-filename=app/components/some-component.js}
+  @tracked
+  showDropdown = false;
+
+  @action
+  onClickShowDropdown() {
+    this.showDropdown = true;
+  }
+```
+
+Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+```handlebars {data-filename=app/components/my-dropdown-component.hbs}
+{{#if @show}}
+  {{#in-element this.destinationElement}}
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  {{/in-element}}
+{{/if}}
+```
+
+```js {data-filename=app/components/my-dropdown-component.js}
+  get destinationElement() {
+    return document.querySelector('#dropdown-destination');
+  }
+```
+
+After the user clicks on the button, the final HTML result for the div will be like this:
+```html
+  <div id="dropdown-destination">
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  </div>
+```
+
+Things to note:
+- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
+- When the destination element changes, the contents defined in `in-element` will re-render completely.
+- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.

--- a/guides/v3.26.0/components/helper-functions.md
+++ b/guides/v3.26.0/components/helper-functions.md
@@ -322,14 +322,17 @@ Hello, {{@person.givenName}} {{@person.familyName}}
 
 ### The `in-element` helper
 
-Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
-to render a modal, tooltip or dropdown.
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.26/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
+to render a modal, tooltip, or dropdown.
 
-Let's say I wanted to show a dropdown when a button is clicked on.
-
-Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+Suppose we want to show a dropdown menu when the user clicks on a button. The code below shows a `<button>` element, a placeholder `<div>` element, and a dropdown component. The argument `@show`, when set to `true`, will add the dropdown to the placeholder div.
 ```handlebars {data-filename=app/components/some-component.hbs}
-  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <button
+    type="button"
+    {{on "click" this.onClickShowDropdown}}
+  >
+    More Actions
+  </button>
   <div id="dropdown-destination" />
 
   <MyDropdownComponent
@@ -348,7 +351,7 @@ When the user clicks on the button, the flag `showDropdown` will be set to `true
   }
 ```
 
-Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+The dropdown component uses the argument `@show` to activate the `in-element` helper. We must **provide the destination DOM element** to the helper. In other words, where should the helper render its block content?
 ```handlebars {data-filename=app/components/my-dropdown-component.hbs}
 {{#if @show}}
   {{#in-element this.destinationElement}}
@@ -379,6 +382,6 @@ After the user clicks on the button, the final HTML result for the div will be l
 ```
 
 Things to note:
-- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
-- When the destination element changes, the contents defined in `in-element` will re-render completely.
-- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.
+- The destination element needs to exist in the DOM before we use the helper. Otherwise, an error will be thrown if you are in development mode. The error is not thrown in production.
+- When the destination element changes, the content defined in `in-element` will re-render completely.
+- By default, the `in-element` helper replaces the destination element's existing content with the helper's block content. If you want to instead append the block content, you can pass `insertBefore=null`.

--- a/guides/v3.26.0/components/helper-functions.md
+++ b/guides/v3.26.0/components/helper-functions.md
@@ -319,3 +319,66 @@ In the component's template, you can then use the `person` object:
 ```handlebars {data-filename=app/components/greeting/template.hbs}
 Hello, {{@person.givenName}} {{@person.familyName}}
 ```
+
+### The `in-element` helper
+
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a specific DOM element that is in a different part of the page. For instance, we might want
+to render a modal, tooltip or dropdown.
+
+Let's say I wanted to show a dropdown when a button is clicked on.
+
+Below, we have the button we want to click on, a div element that will hold the dropdown and the dropdown component. We pass in `showDropdown` that will add the dropdown into our div.
+```handlebars {data-filename=app/components/some-component.hbs}
+  <button type="button" {{on "click" this.onClickShowDropdown}}>More Actions</button>
+  <div id="dropdown-destination" />
+
+  <MyDropdownComponent
+    @show={{this.showDropdown}}
+  />
+```
+
+When the user clicks on the button, the flag `showDropdown` will be set to `true`.
+```js {data-filename=app/components/some-component.js}
+  @tracked
+  showDropdown = false;
+
+  @action
+  onClickShowDropdown() {
+    this.showDropdown = true;
+  }
+```
+
+Since `showDropdown` is passed into `MyDropdownComponent` as `show`, when `show` is `true`, the `in-element` helper is activated. We pass in `destinationElement` into `in-element` which contains the destination DOM element. The `in-element` helper will take the content block and render into the destination element.
+```handlebars {data-filename=app/components/my-dropdown-component.hbs}
+{{#if @show}}
+  {{#in-element this.destinationElement}}
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  {{/in-element}}
+{{/if}}
+```
+
+```js {data-filename=app/components/my-dropdown-component.js}
+  get destinationElement() {
+    return document.querySelector('#dropdown-destination');
+  }
+```
+
+After the user clicks on the button, the final HTML result for the div will be like this:
+```html
+  <div id="dropdown-destination">
+    <ul>
+      <li>Archive</li>
+      <li>Mark as Read</li>
+      <li>Report</li>
+    </ul>
+  </div>
+```
+
+Things to note:
+- The destination element needs to exist in the DOM before we use the helper. If not, an error will be thrown in development mode, but not in production.
+- When the destination element changes, the contents defined in `in-element` will re-render completely.
+- By default, the `in-element` helper will replace the entire contents of the destination element. If we want it to just append, we need to pass `insertBefore=null`.


### PR DESCRIPTION
This PR looks to resolve #1492.

We are adding an example and documentation to the `in-element` helper on the [Built in helper](https://guides.emberjs.com/release/components/helper-functions/#toc_built-in-helpers) section. I added the same into the version of the guides that have the `in-element` helper. 