### PR TITLE
Backport code block indentation

### DIFF
--- a/guides/v3.15.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.15.0/upgrading/current-edition/native-classes.md
@@ -450,11 +450,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use `class` when defining a class, and `class ... extends` when extending a
   class.
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  class Actress extends Person {}
-  ```
+    class Actress extends Person {}
+    ```
 
 - Always give your class a name, e.g. ✅ `class MyClass {}` and not 🛑 `class {}`
 
@@ -463,11 +463,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use the [`extend`][1] static method to define a class, with
   [`EmberObject`][2] as the root base class.
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  const Actress = Person.extend({});
-  ```
+    const Actress = Person.extend({});
+    ```
 
 [1]: https://api.emberjs.com/ember/3.15/functions/@ember%2Fobject/extend
 [2]: https://api.emberjs.com/ember/3.15/classes/EmberObject
@@ -478,25 +478,25 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `new` keyword to create instances of the class
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  let jen = new Person();
-  ```
+    let jen = new Person();
+    ```
 
 - Arguments passed when using `new` will be accessible in the `constructor` of
   the class:
 
-  ```js
-  class Person {
-    constructor(name) {
-      this.name = name;
+    ```js
+    class Person {
+      constructor(name) {
+        this.name = name;
+      }
     }
-  }
 
-  let jen = new Person('Jen Weber');
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = new Person('Jen Weber');
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Prefer the `constructor` function, unless the class extends `EmberObject`,
   in which case prefer `init`.
@@ -505,21 +505,21 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the [`create`][3] static method to create instances of the class:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create();
-  ```
+    let jen = Person.create();
+    ```
 
 - You can pass an object of values to `create`, and they'll be assigned to the
   instance:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create({ name: 'Jen Weber' });
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = Person.create({ name: 'Jen Weber' });
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Use the `init` method instead of the `constructor`.
 
@@ -556,42 +556,42 @@ const Person = EmberObject.extend({
 - Native classes have _fields_. Fields are created and assigned for every
   instance:
 
-  ```js
-  class Person {
-    name = 'Chad Hietala';
-  }
-  ```
+    ```js
+    class Person {
+      name = 'Chad Hietala';
+    }
+    ```
 
 - It is okay to assign objects and arrays in class fields:
 
-  ```js
-  // ok ✅
-  class Person {
-    shoppingList = [];
-  }
-  ```
+    ```js
+    // ok ✅
+    class Person {
+      shoppingList = [];
+    }
+    ```
 
 - Avoid using class state in field definitions, use the constructor instead:
 
-  ```js
-  // bad 🛑
-  class Image {
-    width = 0;
-    height = 0;
+    ```js
+    // bad 🛑
+    class Image {
+      width = 0;
+      height = 0;
 
-    aspectRatio = this.width / this.height;
-  }
-
-  // good ✅
-  class Image {
-    constructor() {
-      this.aspectRatio = this.width / this.height;
+      aspectRatio = this.width / this.height;
     }
 
-    width = 0;
-    height = 0;
-  }
-  ```
+    // good ✅
+    class Image {
+      constructor() {
+        this.aspectRatio = this.width / this.height;
+      }
+
+      width = 0;
+      height = 0;
+    }
+    ```
 
 - Fields are assigned before any constructor code is run, so you can access
   their values in the `constructor` function.
@@ -601,21 +601,21 @@ const Person = EmberObject.extend({
 - Classic classes have _properties_. Properties are created and assigned once to
   the _prototype_ of the class, and are shared between every instance:
 
-  ```js
-  const Person = EmberObject.extend({
-    name: 'Chad Hietala',
-  });
-  ```
+    ```js
+    const Person = EmberObject.extend({
+      name: 'Chad Hietala',
+    });
+    ```
 
 - It is _not_ okay to assign objects or arrays as properties, because they are
   shared between instances:
 
-  ```js
-  // not ok 🛑
-  const Person = EmberObject.extend({
-    shoppingList: [],
-  });
-  ```
+    ```js
+    // not ok 🛑
+    const Person = EmberObject.extend({
+      shoppingList: [],
+    });
+    ```
 
 ### Accessors
 
@@ -623,19 +623,19 @@ These are also mostly the same between native and classic classes.
 
 - Accessors can be defined with the `get` and `set` keywords:
 
-  ```js
-  class Person {
-    _name = 'Mel Sumner';
+    ```js
+    class Person {
+      _name = 'Mel Sumner';
 
-    get name() {
-      return this._name;
-    }
+      get name() {
+        return this._name;
+      }
 
-    set name(newName) {
-      this._name = newName;
+      set name(newName) {
+        this._name = newName;
+      }
     }
-  }
-  ```
+    ```
 
 - Getters run every time the property is read, setters run every time the
   property is set.
@@ -650,13 +650,13 @@ These are also mostly the same between native and classic classes.
   class.
 - Native decorators are functions that get applied using the `@` symbol:
 
-  ```js
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import { tracked } from '@glimmer/tracking';
 
-  class Person {
-    @tracked name = 'Ed Faulkner';
-  }
-  ```
+    class Person {
+      @tracked name = 'Ed Faulkner';
+    }
+    ```
 
 - Native decorators can be applied to class fields, methods, accessors, or
   classes themselves. Generally, specific decorators are only meant to be
@@ -669,14 +669,14 @@ These are also mostly the same between native and classic classes.
 
 - Classic decorators are assigned like properties in classic class definitions:
 
-  ```js
-  import EmberObject from '@ember/object';
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import EmberObject from '@ember/object';
+    import { tracked } from '@glimmer/tracking';
 
-  const Person = EmberObject.extend({
-    name: tracked({ value: 'Ed Faulkner' }),
-  });
-  ```
+    const Person = EmberObject.extend({
+      name: tracked({ value: 'Ed Faulkner' }),
+    });
+    ```
 
 - Only specific decorators provided by Ember can be applied this way in classic
   classes.
@@ -688,29 +688,29 @@ These are also mostly the same between native and classic classes.
 - Adding the `static` keyword to a class element definition puts it on the
   _class_ itself, instead of instances:
 
-  ```js
-  class Person {
-    static name = 'Ed Faulkner';
-  }
+    ```js
+    class Person {
+      static name = 'Ed Faulkner';
+    }
 
-  console.log(Person.name); // Ed Faulkner
+    console.log(Person.name); // Ed Faulkner
 
-  let person = new Person();
+    let person = new Person();
 
-  console.log(person.name); // undefined
-  ```
+    console.log(person.name); // undefined
+    ```
 
 **Classic**
 
 - Use `reopenClass` to add static elements to the constructor:
 
-  ```js
-  const Person = EmberObject.extend();
+    ```js
+    const Person = EmberObject.extend();
 
-  Person.reopenClass({
-    name: 'Ed Faulkner',
-  });
-  ```
+    Person.reopenClass({
+      name: 'Ed Faulkner',
+    });
+    ```
 
 ### Super
 
@@ -720,38 +720,38 @@ These are also mostly the same between native and classic classes.
 - In constructors, use the keyword by itself (this is required). Generally pass
   any arguments along as well:
 
-  ```js
-  class TodoComponent extends Component {
-    constructor() {
-      super(...arguments);
+    ```js
+    class TodoComponent extends Component {
+      constructor() {
+        super(...arguments);
 
-      // setup the component...
+        // setup the component...
+      }
     }
-  }
-  ```
+    ```
 
 - In all other cases, specify the _method_ you want to call when using `super`:
 
-  ```js
-  class Vehicle {
-    moveType = 'moving';
+    ```js
+    class Vehicle {
+      moveType = 'moving';
 
-    move() {
-      console.log(`${this.moveType}!`);
+      move() {
+        console.log(`${this.moveType}!`);
+      }
     }
-  }
 
-  class Aircraft extends Vehicle {
-    moveType = 'flying';
+    class Aircraft extends Vehicle {
+      moveType = 'flying';
 
-    fly() {
-      super.move();
+      fly() {
+        super.move();
+      }
     }
-  }
 
-  let airbus = new Aircraft();
-  airbus.fly(); // flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.fly(); // flying!
+    ```
 
 - If the method does not exist on the parent class, it will throw an error.
 
@@ -760,23 +760,23 @@ These are also mostly the same between native and classic classes.
 - Use the `_super()` function to call the super method with the same name as the
   current method that is executing:
 
-  ```js
-  const Vehicle = EmberObject.extend({
-    move() {
-      console.log(`moving!`);
-    },
-  });
+    ```js
+    const Vehicle = EmberObject.extend({
+      move() {
+        console.log(`moving!`);
+      },
+    });
 
-  const Aircraft = Vehicle.extend({
-    move() {
-      this._super();
-      console.log('flying!');
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      move() {
+        this._super();
+        console.log('flying!');
+      },
+    });
 
-  let airbus = new Aircraft();
-  airbus.move(); // moving! flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.move(); // moving! flying!
+    ```
 
 - Calling `_super()` is _required_ for `init` to function properly. It should
   generally be done before you do anything else in `init`.
@@ -787,27 +787,27 @@ These are also mostly the same between native and classic classes.
 - It is possible to extend classic classes with native syntax, and to toggle
   back and forth between the two:
 
-  ```js
-  class Vehicle extends EmberObject {
-    move() {
-      // ...
+    ```js
+    class Vehicle extends EmberObject {
+      move() {
+        // ...
+      }
     }
-  }
 
-  const Aircraft = Vehicle.extend({
-    fly() {
-      // ...
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      fly() {
+        // ...
+      },
+    });
 
-  class Helicopter extends Aircraft {
-    hover() {
-      // ...
+    class Helicopter extends Aircraft {
+      hover() {
+        // ...
+      }
     }
-  }
 
-  let blackHawk = Helicopter.create();
-  ```
+    let blackHawk = Helicopter.create();
+    ```
 
 - Use `init` instead of `constructor`
 - Use `create` instead of `new`

--- a/guides/v3.16.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.16.0/upgrading/current-edition/native-classes.md
@@ -450,11 +450,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use `class` when defining a class, and `class ... extends` when extending a
   class.
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  class Actress extends Person {}
-  ```
+    class Actress extends Person {}
+    ```
 
 - Always give your class a name, e.g. ✅ `class MyClass {}` and not 🛑 `class {}`
 
@@ -463,11 +463,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use the [`extend`][1] static method to define a class, with
   [`EmberObject`][2] as the root base class.
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  const Actress = Person.extend({});
-  ```
+    const Actress = Person.extend({});
+    ```
 
 [1]: https://api.emberjs.com/ember/3.16/functions/@ember%2Fobject/extend
 [2]: https://api.emberjs.com/ember/3.16/classes/EmberObject
@@ -478,25 +478,25 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `new` keyword to create instances of the class
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  let jen = new Person();
-  ```
+    let jen = new Person();
+    ```
 
 - Arguments passed when using `new` will be accessible in the `constructor` of
   the class:
 
-  ```js
-  class Person {
-    constructor(name) {
-      this.name = name;
+    ```js
+    class Person {
+      constructor(name) {
+        this.name = name;
+      }
     }
-  }
 
-  let jen = new Person('Jen Weber');
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = new Person('Jen Weber');
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Prefer the `constructor` function, unless the class extends `EmberObject`,
   in which case prefer `init`.
@@ -505,21 +505,21 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the [`create`][3] static method to create instances of the class:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create();
-  ```
+    let jen = Person.create();
+    ```
 
 - You can pass an object of values to `create`, and they'll be assigned to the
   instance:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create({ name: 'Jen Weber' });
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = Person.create({ name: 'Jen Weber' });
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Use the `init` method instead of the `constructor`.
 
@@ -556,42 +556,42 @@ const Person = EmberObject.extend({
 - Native classes have _fields_. Fields are created and assigned for every
   instance:
 
-  ```js
-  class Person {
-    name = 'Chad Hietala';
-  }
-  ```
+    ```js
+    class Person {
+      name = 'Chad Hietala';
+    }
+    ```
 
 - It is okay to assign objects and arrays in class fields:
 
-  ```js
-  // ok ✅
-  class Person {
-    shoppingList = [];
-  }
-  ```
+    ```js
+    // ok ✅
+    class Person {
+      shoppingList = [];
+    }
+    ```
 
 - Avoid using class state in field definitions, use the constructor instead:
 
-  ```js
-  // bad 🛑
-  class Image {
-    width = 0;
-    height = 0;
+    ```js
+    // bad 🛑
+    class Image {
+      width = 0;
+      height = 0;
 
-    aspectRatio = this.width / this.height;
-  }
-
-  // good ✅
-  class Image {
-    constructor() {
-      this.aspectRatio = this.width / this.height;
+      aspectRatio = this.width / this.height;
     }
 
-    width = 0;
-    height = 0;
-  }
-  ```
+    // good ✅
+    class Image {
+      constructor() {
+        this.aspectRatio = this.width / this.height;
+      }
+
+      width = 0;
+      height = 0;
+    }
+    ```
 
 - Fields are assigned before any constructor code is run, so you can access
   their values in the `constructor` function.
@@ -601,21 +601,21 @@ const Person = EmberObject.extend({
 - Classic classes have _properties_. Properties are created and assigned once to
   the _prototype_ of the class, and are shared between every instance:
 
-  ```js
-  const Person = EmberObject.extend({
-    name: 'Chad Hietala',
-  });
-  ```
+    ```js
+    const Person = EmberObject.extend({
+      name: 'Chad Hietala',
+    });
+    ```
 
 - It is _not_ okay to assign objects or arrays as properties, because they are
   shared between instances:
 
-  ```js
-  // not ok 🛑
-  const Person = EmberObject.extend({
-    shoppingList: [],
-  });
-  ```
+    ```js
+    // not ok 🛑
+    const Person = EmberObject.extend({
+      shoppingList: [],
+    });
+    ```
 
 ### Accessors
 
@@ -623,19 +623,19 @@ These are also mostly the same between native and classic classes.
 
 - Accessors can be defined with the `get` and `set` keywords:
 
-  ```js
-  class Person {
-    _name = 'Mel Sumner';
+    ```js
+    class Person {
+      _name = 'Mel Sumner';
 
-    get name() {
-      return this._name;
-    }
+      get name() {
+        return this._name;
+      }
 
-    set name(newName) {
-      this._name = newName;
+      set name(newName) {
+        this._name = newName;
+      }
     }
-  }
-  ```
+    ```
 
 - Getters run every time the property is read, setters run every time the
   property is set.
@@ -650,13 +650,13 @@ These are also mostly the same between native and classic classes.
   class.
 - Native decorators are functions that get applied using the `@` symbol:
 
-  ```js
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import { tracked } from '@glimmer/tracking';
 
-  class Person {
-    @tracked name = 'Ed Faulkner';
-  }
-  ```
+    class Person {
+      @tracked name = 'Ed Faulkner';
+    }
+    ```
 
 - Native decorators can be applied to class fields, methods, accessors, or
   classes themselves. Generally, specific decorators are only meant to be
@@ -669,14 +669,14 @@ These are also mostly the same between native and classic classes.
 
 - Classic decorators are assigned like properties in classic class definitions:
 
-  ```js
-  import EmberObject from '@ember/object';
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import EmberObject from '@ember/object';
+    import { tracked } from '@glimmer/tracking';
 
-  const Person = EmberObject.extend({
-    name: tracked({ value: 'Ed Faulkner' }),
-  });
-  ```
+    const Person = EmberObject.extend({
+      name: tracked({ value: 'Ed Faulkner' }),
+    });
+    ```
 
 - Only specific decorators provided by Ember can be applied this way in classic
   classes.
@@ -688,29 +688,29 @@ These are also mostly the same between native and classic classes.
 - Adding the `static` keyword to a class element definition puts it on the
   _class_ itself, instead of instances:
 
-  ```js
-  class Person {
-    static name = 'Ed Faulkner';
-  }
+    ```js
+    class Person {
+      static name = 'Ed Faulkner';
+    }
 
-  console.log(Person.name); // Ed Faulkner
+    console.log(Person.name); // Ed Faulkner
 
-  let person = new Person();
+    let person = new Person();
 
-  console.log(person.name); // undefined
-  ```
+    console.log(person.name); // undefined
+    ```
 
 **Classic**
 
 - Use `reopenClass` to add static elements to the constructor:
 
-  ```js
-  const Person = EmberObject.extend();
+    ```js
+    const Person = EmberObject.extend();
 
-  Person.reopenClass({
-    name: 'Ed Faulkner',
-  });
-  ```
+    Person.reopenClass({
+      name: 'Ed Faulkner',
+    });
+    ```
 
 ### Super
 
@@ -720,38 +720,38 @@ These are also mostly the same between native and classic classes.
 - In constructors, use the keyword by itself (this is required). Generally pass
   any arguments along as well:
 
-  ```js
-  class TodoComponent extends Component {
-    constructor() {
-      super(...arguments);
+    ```js
+    class TodoComponent extends Component {
+      constructor() {
+        super(...arguments);
 
-      // setup the component...
+        // setup the component...
+      }
     }
-  }
-  ```
+    ```
 
 - In all other cases, specify the _method_ you want to call when using `super`:
 
-  ```js
-  class Vehicle {
-    moveType = 'moving';
+    ```js
+    class Vehicle {
+      moveType = 'moving';
 
-    move() {
-      console.log(`${this.moveType}!`);
+      move() {
+        console.log(`${this.moveType}!`);
+      }
     }
-  }
 
-  class Aircraft extends Vehicle {
-    moveType = 'flying';
+    class Aircraft extends Vehicle {
+      moveType = 'flying';
 
-    fly() {
-      super.move();
+      fly() {
+        super.move();
+      }
     }
-  }
 
-  let airbus = new Aircraft();
-  airbus.fly(); // flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.fly(); // flying!
+    ```
 
 - If the method does not exist on the parent class, it will throw an error.
 
@@ -760,23 +760,23 @@ These are also mostly the same between native and classic classes.
 - Use the `_super()` function to call the super method with the same name as the
   current method that is executing:
 
-  ```js
-  const Vehicle = EmberObject.extend({
-    move() {
-      console.log(`moving!`);
-    },
-  });
+    ```js
+    const Vehicle = EmberObject.extend({
+      move() {
+        console.log(`moving!`);
+      },
+    });
 
-  const Aircraft = Vehicle.extend({
-    move() {
-      this._super();
-      console.log('flying!');
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      move() {
+        this._super();
+        console.log('flying!');
+      },
+    });
 
-  let airbus = new Aircraft();
-  airbus.move(); // moving! flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.move(); // moving! flying!
+    ```
 
 - Calling `_super()` is _required_ for `init` to function properly. It should
   generally be done before you do anything else in `init`.
@@ -787,27 +787,27 @@ These are also mostly the same between native and classic classes.
 - It is possible to extend classic classes with native syntax, and to toggle
   back and forth between the two:
 
-  ```js
-  class Vehicle extends EmberObject {
-    move() {
-      // ...
+    ```js
+    class Vehicle extends EmberObject {
+      move() {
+        // ...
+      }
     }
-  }
 
-  const Aircraft = Vehicle.extend({
-    fly() {
-      // ...
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      fly() {
+        // ...
+      },
+    });
 
-  class Helicopter extends Aircraft {
-    hover() {
-      // ...
+    class Helicopter extends Aircraft {
+      hover() {
+        // ...
+      }
     }
-  }
 
-  let blackHawk = Helicopter.create();
-  ```
+    let blackHawk = Helicopter.create();
+    ```
 
 - Use `init` instead of `constructor`
 - Use `create` instead of `new`

--- a/guides/v3.17.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.17.0/upgrading/current-edition/native-classes.md
@@ -450,11 +450,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use `class` when defining a class, and `class ... extends` when extending a
   class.
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  class Actress extends Person {}
-  ```
+    class Actress extends Person {}
+    ```
 
 - Always give your class a name, e.g. ✅ `class MyClass {}` and not 🛑 `class {}`
 
@@ -463,11 +463,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use the [`extend`][1] static method to define a class, with
   [`EmberObject`][2] as the root base class.
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  const Actress = Person.extend({});
-  ```
+    const Actress = Person.extend({});
+    ```
 
 [1]: https://api.emberjs.com/ember/3.17/functions/@ember%2Fobject/extend
 [2]: https://api.emberjs.com/ember/3.17/classes/EmberObject
@@ -478,25 +478,25 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `new` keyword to create instances of the class
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  let jen = new Person();
-  ```
+    let jen = new Person();
+    ```
 
 - Arguments passed when using `new` will be accessible in the `constructor` of
   the class:
 
-  ```js
-  class Person {
-    constructor(name) {
-      this.name = name;
+    ```js
+    class Person {
+      constructor(name) {
+        this.name = name;
+      }
     }
-  }
 
-  let jen = new Person('Jen Weber');
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = new Person('Jen Weber');
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Prefer the `constructor` function, unless the class extends `EmberObject`,
   in which case prefer `init`.
@@ -505,21 +505,21 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the [`create`][3] static method to create instances of the class:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create();
-  ```
+    let jen = Person.create();
+    ```
 
 - You can pass an object of values to `create`, and they'll be assigned to the
   instance:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create({ name: 'Jen Weber' });
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = Person.create({ name: 'Jen Weber' });
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Use the `init` method instead of the `constructor`.
 
@@ -556,42 +556,42 @@ const Person = EmberObject.extend({
 - Native classes have _fields_. Fields are created and assigned for every
   instance:
 
-  ```js
-  class Person {
-    name = 'Chad Hietala';
-  }
-  ```
+    ```js
+    class Person {
+      name = 'Chad Hietala';
+    }
+    ```
 
 - It is okay to assign objects and arrays in class fields:
 
-  ```js
-  // ok ✅
-  class Person {
-    shoppingList = [];
-  }
-  ```
+    ```js
+    // ok ✅
+    class Person {
+      shoppingList = [];
+    }
+    ```
 
 - Avoid using class state in field definitions, use the constructor instead:
 
-  ```js
-  // bad 🛑
-  class Image {
-    width = 0;
-    height = 0;
+    ```js
+    // bad 🛑
+    class Image {
+      width = 0;
+      height = 0;
 
-    aspectRatio = this.width / this.height;
-  }
-
-  // good ✅
-  class Image {
-    constructor() {
-      this.aspectRatio = this.width / this.height;
+      aspectRatio = this.width / this.height;
     }
 
-    width = 0;
-    height = 0;
-  }
-  ```
+    // good ✅
+    class Image {
+      constructor() {
+        this.aspectRatio = this.width / this.height;
+      }
+
+      width = 0;
+      height = 0;
+    }
+    ```
 
 - Fields are assigned before any constructor code is run, so you can access
   their values in the `constructor` function.
@@ -601,21 +601,21 @@ const Person = EmberObject.extend({
 - Classic classes have _properties_. Properties are created and assigned once to
   the _prototype_ of the class, and are shared between every instance:
 
-  ```js
-  const Person = EmberObject.extend({
-    name: 'Chad Hietala',
-  });
-  ```
+    ```js
+    const Person = EmberObject.extend({
+      name: 'Chad Hietala',
+    });
+    ```
 
 - It is _not_ okay to assign objects or arrays as properties, because they are
   shared between instances:
 
-  ```js
-  // not ok 🛑
-  const Person = EmberObject.extend({
-    shoppingList: [],
-  });
-  ```
+    ```js
+    // not ok 🛑
+    const Person = EmberObject.extend({
+      shoppingList: [],
+    });
+    ```
 
 ### Accessors
 
@@ -623,19 +623,19 @@ These are also mostly the same between native and classic classes.
 
 - Accessors can be defined with the `get` and `set` keywords:
 
-  ```js
-  class Person {
-    _name = 'Mel Sumner';
+    ```js
+    class Person {
+      _name = 'Mel Sumner';
 
-    get name() {
-      return this._name;
-    }
+      get name() {
+        return this._name;
+      }
 
-    set name(newName) {
-      this._name = newName;
+      set name(newName) {
+        this._name = newName;
+      }
     }
-  }
-  ```
+    ```
 
 - Getters run every time the property is read, setters run every time the
   property is set.
@@ -650,13 +650,13 @@ These are also mostly the same between native and classic classes.
   class.
 - Native decorators are functions that get applied using the `@` symbol:
 
-  ```js
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import { tracked } from '@glimmer/tracking';
 
-  class Person {
-    @tracked name = 'Ed Faulkner';
-  }
-  ```
+    class Person {
+      @tracked name = 'Ed Faulkner';
+    }
+    ```
 
 - Native decorators can be applied to class fields, methods, accessors, or
   classes themselves. Generally, specific decorators are only meant to be
@@ -669,14 +669,14 @@ These are also mostly the same between native and classic classes.
 
 - Classic decorators are assigned like properties in classic class definitions:
 
-  ```js
-  import EmberObject from '@ember/object';
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import EmberObject from '@ember/object';
+    import { tracked } from '@glimmer/tracking';
 
-  const Person = EmberObject.extend({
-    name: tracked({ value: 'Ed Faulkner' }),
-  });
-  ```
+    const Person = EmberObject.extend({
+      name: tracked({ value: 'Ed Faulkner' }),
+    });
+    ```
 
 - Only specific decorators provided by Ember can be applied this way in classic
   classes.
@@ -688,29 +688,29 @@ These are also mostly the same between native and classic classes.
 - Adding the `static` keyword to a class element definition puts it on the
   _class_ itself, instead of instances:
 
-  ```js
-  class Person {
-    static name = 'Ed Faulkner';
-  }
+    ```js
+    class Person {
+      static name = 'Ed Faulkner';
+    }
 
-  console.log(Person.name); // Ed Faulkner
+    console.log(Person.name); // Ed Faulkner
 
-  let person = new Person();
+    let person = new Person();
 
-  console.log(person.name); // undefined
-  ```
+    console.log(person.name); // undefined
+    ```
 
 **Classic**
 
 - Use `reopenClass` to add static elements to the constructor:
 
-  ```js
-  const Person = EmberObject.extend();
+    ```js
+    const Person = EmberObject.extend();
 
-  Person.reopenClass({
-    name: 'Ed Faulkner',
-  });
-  ```
+    Person.reopenClass({
+      name: 'Ed Faulkner',
+    });
+    ```
 
 ### Super
 
@@ -720,38 +720,38 @@ These are also mostly the same between native and classic classes.
 - In constructors, use the keyword by itself (this is required). Generally pass
   any arguments along as well:
 
-  ```js
-  class TodoComponent extends Component {
-    constructor() {
-      super(...arguments);
+    ```js
+    class TodoComponent extends Component {
+      constructor() {
+        super(...arguments);
 
-      // setup the component...
+        // setup the component...
+      }
     }
-  }
-  ```
+    ```
 
 - In all other cases, specify the _method_ you want to call when using `super`:
 
-  ```js
-  class Vehicle {
-    moveType = 'moving';
+    ```js
+    class Vehicle {
+      moveType = 'moving';
 
-    move() {
-      console.log(`${this.moveType}!`);
+      move() {
+        console.log(`${this.moveType}!`);
+      }
     }
-  }
 
-  class Aircraft extends Vehicle {
-    moveType = 'flying';
+    class Aircraft extends Vehicle {
+      moveType = 'flying';
 
-    fly() {
-      super.move();
+      fly() {
+        super.move();
+      }
     }
-  }
 
-  let airbus = new Aircraft();
-  airbus.fly(); // flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.fly(); // flying!
+    ```
 
 - If the method does not exist on the parent class, it will throw an error.
 
@@ -760,23 +760,23 @@ These are also mostly the same between native and classic classes.
 - Use the `_super()` function to call the super method with the same name as the
   current method that is executing:
 
-  ```js
-  const Vehicle = EmberObject.extend({
-    move() {
-      console.log(`moving!`);
-    },
-  });
+    ```js
+    const Vehicle = EmberObject.extend({
+      move() {
+        console.log(`moving!`);
+      },
+    });
 
-  const Aircraft = Vehicle.extend({
-    move() {
-      this._super();
-      console.log('flying!');
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      move() {
+        this._super();
+        console.log('flying!');
+      },
+    });
 
-  let airbus = new Aircraft();
-  airbus.move(); // moving! flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.move(); // moving! flying!
+    ```
 
 - Calling `_super()` is _required_ for `init` to function properly. It should
   generally be done before you do anything else in `init`.
@@ -787,27 +787,27 @@ These are also mostly the same between native and classic classes.
 - It is possible to extend classic classes with native syntax, and to toggle
   back and forth between the two:
 
-  ```js
-  class Vehicle extends EmberObject {
-    move() {
-      // ...
+    ```js
+    class Vehicle extends EmberObject {
+      move() {
+        // ...
+      }
     }
-  }
 
-  const Aircraft = Vehicle.extend({
-    fly() {
-      // ...
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      fly() {
+        // ...
+      },
+    });
 
-  class Helicopter extends Aircraft {
-    hover() {
-      // ...
+    class Helicopter extends Aircraft {
+      hover() {
+        // ...
+      }
     }
-  }
 
-  let blackHawk = Helicopter.create();
-  ```
+    let blackHawk = Helicopter.create();
+    ```
 
 - Use `init` instead of `constructor`
 - Use `create` instead of `new`

--- a/guides/v3.18.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.18.0/upgrading/current-edition/native-classes.md
@@ -450,11 +450,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use `class` when defining a class, and `class ... extends` when extending a
   class.
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  class Actress extends Person {}
-  ```
+    class Actress extends Person {}
+    ```
 
 - Always give your class a name, e.g. ✅ `class MyClass {}` and not 🛑 `class {}`
 
@@ -463,11 +463,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use the [`extend`][1] static method to define a class, with
   [`EmberObject`][2] as the root base class.
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  const Actress = Person.extend({});
-  ```
+    const Actress = Person.extend({});
+    ```
 
 [1]: https://api.emberjs.com/ember/3.18/functions/@ember%2Fobject/extend
 [2]: https://api.emberjs.com/ember/3.18/classes/EmberObject
@@ -478,25 +478,25 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `new` keyword to create instances of the class
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  let jen = new Person();
-  ```
+    let jen = new Person();
+    ```
 
 - Arguments passed when using `new` will be accessible in the `constructor` of
   the class:
 
-  ```js
-  class Person {
-    constructor(name) {
-      this.name = name;
+    ```js
+    class Person {
+      constructor(name) {
+        this.name = name;
+      }
     }
-  }
 
-  let jen = new Person('Jen Weber');
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = new Person('Jen Weber');
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Prefer the `constructor` function, unless the class extends `EmberObject`,
   in which case prefer `init`.
@@ -505,21 +505,21 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the [`create`][3] static method to create instances of the class:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create();
-  ```
+    let jen = Person.create();
+    ```
 
 - You can pass an object of values to `create`, and they'll be assigned to the
   instance:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create({ name: 'Jen Weber' });
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = Person.create({ name: 'Jen Weber' });
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Use the `init` method instead of the `constructor`.
 
@@ -556,42 +556,42 @@ const Person = EmberObject.extend({
 - Native classes have _fields_. Fields are created and assigned for every
   instance:
 
-  ```js
-  class Person {
-    name = 'Chad Hietala';
-  }
-  ```
+    ```js
+    class Person {
+      name = 'Chad Hietala';
+    }
+    ```
 
 - It is okay to assign objects and arrays in class fields:
 
-  ```js
-  // ok ✅
-  class Person {
-    shoppingList = [];
-  }
-  ```
+    ```js
+    // ok ✅
+    class Person {
+      shoppingList = [];
+    }
+    ```
 
 - Avoid using class state in field definitions, use the constructor instead:
 
-  ```js
-  // bad 🛑
-  class Image {
-    width = 0;
-    height = 0;
+    ```js
+    // bad 🛑
+    class Image {
+      width = 0;
+      height = 0;
 
-    aspectRatio = this.width / this.height;
-  }
-
-  // good ✅
-  class Image {
-    constructor() {
-      this.aspectRatio = this.width / this.height;
+      aspectRatio = this.width / this.height;
     }
 
-    width = 0;
-    height = 0;
-  }
-  ```
+    // good ✅
+    class Image {
+      constructor() {
+        this.aspectRatio = this.width / this.height;
+      }
+
+      width = 0;
+      height = 0;
+    }
+    ```
 
 - Fields are assigned before any constructor code is run, so you can access
   their values in the `constructor` function.
@@ -601,21 +601,21 @@ const Person = EmberObject.extend({
 - Classic classes have _properties_. Properties are created and assigned once to
   the _prototype_ of the class, and are shared between every instance:
 
-  ```js
-  const Person = EmberObject.extend({
-    name: 'Chad Hietala',
-  });
-  ```
+    ```js
+    const Person = EmberObject.extend({
+      name: 'Chad Hietala',
+    });
+    ```
 
 - It is _not_ okay to assign objects or arrays as properties, because they are
   shared between instances:
 
-  ```js
-  // not ok 🛑
-  const Person = EmberObject.extend({
-    shoppingList: [],
-  });
-  ```
+    ```js
+    // not ok 🛑
+    const Person = EmberObject.extend({
+      shoppingList: [],
+    });
+    ```
 
 ### Accessors
 
@@ -623,19 +623,19 @@ These are also mostly the same between native and classic classes.
 
 - Accessors can be defined with the `get` and `set` keywords:
 
-  ```js
-  class Person {
-    _name = 'Mel Sumner';
+    ```js
+    class Person {
+      _name = 'Mel Sumner';
 
-    get name() {
-      return this._name;
-    }
+      get name() {
+        return this._name;
+      }
 
-    set name(newName) {
-      this._name = newName;
+      set name(newName) {
+        this._name = newName;
+      }
     }
-  }
-  ```
+    ```
 
 - Getters run every time the property is read, setters run every time the
   property is set.
@@ -650,13 +650,13 @@ These are also mostly the same between native and classic classes.
   class.
 - Native decorators are functions that get applied using the `@` symbol:
 
-  ```js
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import { tracked } from '@glimmer/tracking';
 
-  class Person {
-    @tracked name = 'Ed Faulkner';
-  }
-  ```
+    class Person {
+      @tracked name = 'Ed Faulkner';
+    }
+    ```
 
 - Native decorators can be applied to class fields, methods, accessors, or
   classes themselves. Generally, specific decorators are only meant to be
@@ -669,14 +669,14 @@ These are also mostly the same between native and classic classes.
 
 - Classic decorators are assigned like properties in classic class definitions:
 
-  ```js
-  import EmberObject from '@ember/object';
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import EmberObject from '@ember/object';
+    import { tracked } from '@glimmer/tracking';
 
-  const Person = EmberObject.extend({
-    name: tracked({ value: 'Ed Faulkner' }),
-  });
-  ```
+    const Person = EmberObject.extend({
+      name: tracked({ value: 'Ed Faulkner' }),
+    });
+    ```
 
 - Only specific decorators provided by Ember can be applied this way in classic
   classes.
@@ -688,29 +688,29 @@ These are also mostly the same between native and classic classes.
 - Adding the `static` keyword to a class element definition puts it on the
   _class_ itself, instead of instances:
 
-  ```js
-  class Person {
-    static name = 'Ed Faulkner';
-  }
+    ```js
+    class Person {
+      static name = 'Ed Faulkner';
+    }
 
-  console.log(Person.name); // Ed Faulkner
+    console.log(Person.name); // Ed Faulkner
 
-  let person = new Person();
+    let person = new Person();
 
-  console.log(person.name); // undefined
-  ```
+    console.log(person.name); // undefined
+    ```
 
 **Classic**
 
 - Use `reopenClass` to add static elements to the constructor:
 
-  ```js
-  const Person = EmberObject.extend();
+    ```js
+    const Person = EmberObject.extend();
 
-  Person.reopenClass({
-    name: 'Ed Faulkner',
-  });
-  ```
+    Person.reopenClass({
+      name: 'Ed Faulkner',
+    });
+    ```
 
 ### Super
 
@@ -720,38 +720,38 @@ These are also mostly the same between native and classic classes.
 - In constructors, use the keyword by itself (this is required). Generally pass
   any arguments along as well:
 
-  ```js
-  class TodoComponent extends Component {
-    constructor() {
-      super(...arguments);
+    ```js
+    class TodoComponent extends Component {
+      constructor() {
+        super(...arguments);
 
-      // setup the component...
+        // setup the component...
+      }
     }
-  }
-  ```
+    ```
 
 - In all other cases, specify the _method_ you want to call when using `super`:
 
-  ```js
-  class Vehicle {
-    moveType = 'moving';
+    ```js
+    class Vehicle {
+      moveType = 'moving';
 
-    move() {
-      console.log(`${this.moveType}!`);
+      move() {
+        console.log(`${this.moveType}!`);
+      }
     }
-  }
 
-  class Aircraft extends Vehicle {
-    moveType = 'flying';
+    class Aircraft extends Vehicle {
+      moveType = 'flying';
 
-    fly() {
-      super.move();
+      fly() {
+        super.move();
+      }
     }
-  }
 
-  let airbus = new Aircraft();
-  airbus.fly(); // flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.fly(); // flying!
+    ```
 
 - If the method does not exist on the parent class, it will throw an error.
 
@@ -760,23 +760,23 @@ These are also mostly the same between native and classic classes.
 - Use the `_super()` function to call the super method with the same name as the
   current method that is executing:
 
-  ```js
-  const Vehicle = EmberObject.extend({
-    move() {
-      console.log(`moving!`);
-    },
-  });
+    ```js
+    const Vehicle = EmberObject.extend({
+      move() {
+        console.log(`moving!`);
+      },
+    });
 
-  const Aircraft = Vehicle.extend({
-    move() {
-      this._super();
-      console.log('flying!');
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      move() {
+        this._super();
+        console.log('flying!');
+      },
+    });
 
-  let airbus = new Aircraft();
-  airbus.move(); // moving! flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.move(); // moving! flying!
+    ```
 
 - Calling `_super()` is _required_ for `init` to function properly. It should
   generally be done before you do anything else in `init`.
@@ -787,27 +787,27 @@ These are also mostly the same between native and classic classes.
 - It is possible to extend classic classes with native syntax, and to toggle
   back and forth between the two:
 
-  ```js
-  class Vehicle extends EmberObject {
-    move() {
-      // ...
+    ```js
+    class Vehicle extends EmberObject {
+      move() {
+        // ...
+      }
     }
-  }
 
-  const Aircraft = Vehicle.extend({
-    fly() {
-      // ...
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      fly() {
+        // ...
+      },
+    });
 
-  class Helicopter extends Aircraft {
-    hover() {
-      // ...
+    class Helicopter extends Aircraft {
+      hover() {
+        // ...
+      }
     }
-  }
 
-  let blackHawk = Helicopter.create();
-  ```
+    let blackHawk = Helicopter.create();
+    ```
 
 - Use `init` instead of `constructor`
 - Use `create` instead of `new`

--- a/guides/v3.19.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.19.0/upgrading/current-edition/native-classes.md
@@ -450,11 +450,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use `class` when defining a class, and `class ... extends` when extending a
   class.
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  class Actress extends Person {}
-  ```
+    class Actress extends Person {}
+    ```
 
 - Always give your class a name, e.g. ✅ `class MyClass {}` and not 🛑 `class {}`
 
@@ -463,11 +463,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use the [`extend`][1] static method to define a class, with
   [`EmberObject`][2] as the root base class.
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  const Actress = Person.extend({});
-  ```
+    const Actress = Person.extend({});
+    ```
 
 [1]: https://api.emberjs.com/ember/3.19/functions/@ember%2Fobject/extend
 [2]: https://api.emberjs.com/ember/3.19/classes/EmberObject
@@ -478,25 +478,25 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `new` keyword to create instances of the class
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  let jen = new Person();
-  ```
+    let jen = new Person();
+    ```
 
 - Arguments passed when using `new` will be accessible in the `constructor` of
   the class:
 
-  ```js
-  class Person {
-    constructor(name) {
-      this.name = name;
+    ```js
+    class Person {
+      constructor(name) {
+        this.name = name;
+      }
     }
-  }
 
-  let jen = new Person('Jen Weber');
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = new Person('Jen Weber');
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Prefer the `constructor` function, unless the class extends `EmberObject`,
   in which case prefer `init`.
@@ -505,21 +505,21 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the [`create`][3] static method to create instances of the class:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create();
-  ```
+    let jen = Person.create();
+    ```
 
 - You can pass an object of values to `create`, and they'll be assigned to the
   instance:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create({ name: 'Jen Weber' });
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = Person.create({ name: 'Jen Weber' });
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Use the `init` method instead of the `constructor`.
 
@@ -556,42 +556,42 @@ const Person = EmberObject.extend({
 - Native classes have _fields_. Fields are created and assigned for every
   instance:
 
-  ```js
-  class Person {
-    name = 'Chad Hietala';
-  }
-  ```
+    ```js
+    class Person {
+      name = 'Chad Hietala';
+    }
+    ```
 
 - It is okay to assign objects and arrays in class fields:
 
-  ```js
-  // ok ✅
-  class Person {
-    shoppingList = [];
-  }
-  ```
+    ```js
+    // ok ✅
+    class Person {
+      shoppingList = [];
+    }
+    ```
 
 - Avoid using class state in field definitions, use the constructor instead:
 
-  ```js
-  // bad 🛑
-  class Image {
-    width = 0;
-    height = 0;
+    ```js
+    // bad 🛑
+    class Image {
+      width = 0;
+      height = 0;
 
-    aspectRatio = this.width / this.height;
-  }
-
-  // good ✅
-  class Image {
-    constructor() {
-      this.aspectRatio = this.width / this.height;
+      aspectRatio = this.width / this.height;
     }
 
-    width = 0;
-    height = 0;
-  }
-  ```
+    // good ✅
+    class Image {
+      constructor() {
+        this.aspectRatio = this.width / this.height;
+      }
+
+      width = 0;
+      height = 0;
+    }
+    ```
 
 - Fields are assigned before any constructor code is run, so you can access
   their values in the `constructor` function.
@@ -601,21 +601,21 @@ const Person = EmberObject.extend({
 - Classic classes have _properties_. Properties are created and assigned once to
   the _prototype_ of the class, and are shared between every instance:
 
-  ```js
-  const Person = EmberObject.extend({
-    name: 'Chad Hietala',
-  });
-  ```
+    ```js
+    const Person = EmberObject.extend({
+      name: 'Chad Hietala',
+    });
+    ```
 
 - It is _not_ okay to assign objects or arrays as properties, because they are
   shared between instances:
 
-  ```js
-  // not ok 🛑
-  const Person = EmberObject.extend({
-    shoppingList: [],
-  });
-  ```
+    ```js
+    // not ok 🛑
+    const Person = EmberObject.extend({
+      shoppingList: [],
+    });
+    ```
 
 ### Accessors
 
@@ -623,19 +623,19 @@ These are also mostly the same between native and classic classes.
 
 - Accessors can be defined with the `get` and `set` keywords:
 
-  ```js
-  class Person {
-    _name = 'Mel Sumner';
+    ```js
+    class Person {
+      _name = 'Mel Sumner';
 
-    get name() {
-      return this._name;
-    }
+      get name() {
+        return this._name;
+      }
 
-    set name(newName) {
-      this._name = newName;
+      set name(newName) {
+        this._name = newName;
+      }
     }
-  }
-  ```
+    ```
 
 - Getters run every time the property is read, setters run every time the
   property is set.
@@ -650,13 +650,13 @@ These are also mostly the same between native and classic classes.
   class.
 - Native decorators are functions that get applied using the `@` symbol:
 
-  ```js
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import { tracked } from '@glimmer/tracking';
 
-  class Person {
-    @tracked name = 'Ed Faulkner';
-  }
-  ```
+    class Person {
+      @tracked name = 'Ed Faulkner';
+    }
+    ```
 
 - Native decorators can be applied to class fields, methods, accessors, or
   classes themselves. Generally, specific decorators are only meant to be
@@ -669,14 +669,14 @@ These are also mostly the same between native and classic classes.
 
 - Classic decorators are assigned like properties in classic class definitions:
 
-  ```js
-  import EmberObject from '@ember/object';
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import EmberObject from '@ember/object';
+    import { tracked } from '@glimmer/tracking';
 
-  const Person = EmberObject.extend({
-    name: tracked({ value: 'Ed Faulkner' }),
-  });
-  ```
+    const Person = EmberObject.extend({
+      name: tracked({ value: 'Ed Faulkner' }),
+    });
+    ```
 
 - Only specific decorators provided by Ember can be applied this way in classic
   classes.
@@ -688,29 +688,29 @@ These are also mostly the same between native and classic classes.
 - Adding the `static` keyword to a class element definition puts it on the
   _class_ itself, instead of instances:
 
-  ```js
-  class Person {
-    static name = 'Ed Faulkner';
-  }
+    ```js
+    class Person {
+      static name = 'Ed Faulkner';
+    }
 
-  console.log(Person.name); // Ed Faulkner
+    console.log(Person.name); // Ed Faulkner
 
-  let person = new Person();
+    let person = new Person();
 
-  console.log(person.name); // undefined
-  ```
+    console.log(person.name); // undefined
+    ```
 
 **Classic**
 
 - Use `reopenClass` to add static elements to the constructor:
 
-  ```js
-  const Person = EmberObject.extend();
+    ```js
+    const Person = EmberObject.extend();
 
-  Person.reopenClass({
-    name: 'Ed Faulkner',
-  });
-  ```
+    Person.reopenClass({
+      name: 'Ed Faulkner',
+    });
+    ```
 
 ### Super
 
@@ -720,38 +720,38 @@ These are also mostly the same between native and classic classes.
 - In constructors, use the keyword by itself (this is required). Generally pass
   any arguments along as well:
 
-  ```js
-  class TodoComponent extends Component {
-    constructor() {
-      super(...arguments);
+    ```js
+    class TodoComponent extends Component {
+      constructor() {
+        super(...arguments);
 
-      // setup the component...
+        // setup the component...
+      }
     }
-  }
-  ```
+    ```
 
 - In all other cases, specify the _method_ you want to call when using `super`:
 
-  ```js
-  class Vehicle {
-    moveType = 'moving';
+    ```js
+    class Vehicle {
+      moveType = 'moving';
 
-    move() {
-      console.log(`${this.moveType}!`);
+      move() {
+        console.log(`${this.moveType}!`);
+      }
     }
-  }
 
-  class Aircraft extends Vehicle {
-    moveType = 'flying';
+    class Aircraft extends Vehicle {
+      moveType = 'flying';
 
-    fly() {
-      super.move();
+      fly() {
+        super.move();
+      }
     }
-  }
 
-  let airbus = new Aircraft();
-  airbus.fly(); // flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.fly(); // flying!
+    ```
 
 - If the method does not exist on the parent class, it will throw an error.
 
@@ -760,23 +760,23 @@ These are also mostly the same between native and classic classes.
 - Use the `_super()` function to call the super method with the same name as the
   current method that is executing:
 
-  ```js
-  const Vehicle = EmberObject.extend({
-    move() {
-      console.log(`moving!`);
-    },
-  });
+    ```js
+    const Vehicle = EmberObject.extend({
+      move() {
+        console.log(`moving!`);
+      },
+    });
 
-  const Aircraft = Vehicle.extend({
-    move() {
-      this._super();
-      console.log('flying!');
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      move() {
+        this._super();
+        console.log('flying!');
+      },
+    });
 
-  let airbus = new Aircraft();
-  airbus.move(); // moving! flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.move(); // moving! flying!
+    ```
 
 - Calling `_super()` is _required_ for `init` to function properly. It should
   generally be done before you do anything else in `init`.
@@ -787,27 +787,27 @@ These are also mostly the same between native and classic classes.
 - It is possible to extend classic classes with native syntax, and to toggle
   back and forth between the two:
 
-  ```js
-  class Vehicle extends EmberObject {
-    move() {
-      // ...
+    ```js
+    class Vehicle extends EmberObject {
+      move() {
+        // ...
+      }
     }
-  }
 
-  const Aircraft = Vehicle.extend({
-    fly() {
-      // ...
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      fly() {
+        // ...
+      },
+    });
 
-  class Helicopter extends Aircraft {
-    hover() {
-      // ...
+    class Helicopter extends Aircraft {
+      hover() {
+        // ...
+      }
     }
-  }
 
-  let blackHawk = Helicopter.create();
-  ```
+    let blackHawk = Helicopter.create();
+    ```
 
 - Use `init` instead of `constructor`
 - Use `create` instead of `new`

--- a/guides/v3.20.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.20.0/upgrading/current-edition/native-classes.md
@@ -450,11 +450,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use `class` when defining a class, and `class ... extends` when extending a
   class.
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  class Actress extends Person {}
-  ```
+    class Actress extends Person {}
+    ```
 
 - Always give your class a name, e.g. ✅ `class MyClass {}` and not 🛑 `class {}`
 
@@ -463,11 +463,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use the [`extend`][1] static method to define a class, with
   [`EmberObject`][2] as the root base class.
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  const Actress = Person.extend({});
-  ```
+    const Actress = Person.extend({});
+    ```
 
 [1]: https://api.emberjs.com/ember/3.20/functions/@ember%2Fobject/extend
 [2]: https://api.emberjs.com/ember/3.20/classes/EmberObject
@@ -478,25 +478,25 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `new` keyword to create instances of the class
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  let jen = new Person();
-  ```
+    let jen = new Person();
+    ```
 
 - Arguments passed when using `new` will be accessible in the `constructor` of
   the class:
 
-  ```js
-  class Person {
-    constructor(name) {
-      this.name = name;
+    ```js
+    class Person {
+      constructor(name) {
+        this.name = name;
+      }
     }
-  }
 
-  let jen = new Person('Jen Weber');
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = new Person('Jen Weber');
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Prefer the `constructor` function, unless the class extends `EmberObject`,
   in which case prefer `init`.
@@ -505,21 +505,21 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the [`create`][3] static method to create instances of the class:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create();
-  ```
+    let jen = Person.create();
+    ```
 
 - You can pass an object of values to `create`, and they'll be assigned to the
   instance:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create({ name: 'Jen Weber' });
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = Person.create({ name: 'Jen Weber' });
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Use the `init` method instead of the `constructor`.
 
@@ -556,42 +556,42 @@ const Person = EmberObject.extend({
 - Native classes have _fields_. Fields are created and assigned for every
   instance:
 
-  ```js
-  class Person {
-    name = 'Chad Hietala';
-  }
-  ```
+    ```js
+    class Person {
+      name = 'Chad Hietala';
+    }
+    ```
 
 - It is okay to assign objects and arrays in class fields:
 
-  ```js
-  // ok ✅
-  class Person {
-    shoppingList = [];
-  }
-  ```
+    ```js
+    // ok ✅
+    class Person {
+      shoppingList = [];
+    }
+    ```
 
 - Avoid using class state in field definitions, use the constructor instead:
 
-  ```js
-  // bad 🛑
-  class Image {
-    width = 0;
-    height = 0;
+    ```js
+    // bad 🛑
+    class Image {
+      width = 0;
+      height = 0;
 
-    aspectRatio = this.width / this.height;
-  }
-
-  // good ✅
-  class Image {
-    constructor() {
-      this.aspectRatio = this.width / this.height;
+      aspectRatio = this.width / this.height;
     }
 
-    width = 0;
-    height = 0;
-  }
-  ```
+    // good ✅
+    class Image {
+      constructor() {
+        this.aspectRatio = this.width / this.height;
+      }
+
+      width = 0;
+      height = 0;
+    }
+    ```
 
 - Fields are assigned before any constructor code is run, so you can access
   their values in the `constructor` function.
@@ -601,21 +601,21 @@ const Person = EmberObject.extend({
 - Classic classes have _properties_. Properties are created and assigned once to
   the _prototype_ of the class, and are shared between every instance:
 
-  ```js
-  const Person = EmberObject.extend({
-    name: 'Chad Hietala',
-  });
-  ```
+    ```js
+    const Person = EmberObject.extend({
+      name: 'Chad Hietala',
+    });
+    ```
 
 - It is _not_ okay to assign objects or arrays as properties, because they are
   shared between instances:
 
-  ```js
-  // not ok 🛑
-  const Person = EmberObject.extend({
-    shoppingList: [],
-  });
-  ```
+    ```js
+    // not ok 🛑
+    const Person = EmberObject.extend({
+      shoppingList: [],
+    });
+    ```
 
 ### Accessors
 
@@ -623,19 +623,19 @@ These are also mostly the same between native and classic classes.
 
 - Accessors can be defined with the `get` and `set` keywords:
 
-  ```js
-  class Person {
-    _name = 'Mel Sumner';
+    ```js
+    class Person {
+      _name = 'Mel Sumner';
 
-    get name() {
-      return this._name;
-    }
+      get name() {
+        return this._name;
+      }
 
-    set name(newName) {
-      this._name = newName;
+      set name(newName) {
+        this._name = newName;
+      }
     }
-  }
-  ```
+    ```
 
 - Getters run every time the property is read, setters run every time the
   property is set.
@@ -650,13 +650,13 @@ These are also mostly the same between native and classic classes.
   class.
 - Native decorators are functions that get applied using the `@` symbol:
 
-  ```js
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import { tracked } from '@glimmer/tracking';
 
-  class Person {
-    @tracked name = 'Ed Faulkner';
-  }
-  ```
+    class Person {
+      @tracked name = 'Ed Faulkner';
+    }
+    ```
 
 - Native decorators can be applied to class fields, methods, accessors, or
   classes themselves. Generally, specific decorators are only meant to be
@@ -669,14 +669,14 @@ These are also mostly the same between native and classic classes.
 
 - Classic decorators are assigned like properties in classic class definitions:
 
-  ```js
-  import EmberObject from '@ember/object';
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import EmberObject from '@ember/object';
+    import { tracked } from '@glimmer/tracking';
 
-  const Person = EmberObject.extend({
-    name: tracked({ value: 'Ed Faulkner' }),
-  });
-  ```
+    const Person = EmberObject.extend({
+      name: tracked({ value: 'Ed Faulkner' }),
+    });
+    ```
 
 - Only specific decorators provided by Ember can be applied this way in classic
   classes.
@@ -688,29 +688,29 @@ These are also mostly the same between native and classic classes.
 - Adding the `static` keyword to a class element definition puts it on the
   _class_ itself, instead of instances:
 
-  ```js
-  class Person {
-    static name = 'Ed Faulkner';
-  }
+    ```js
+    class Person {
+      static name = 'Ed Faulkner';
+    }
 
-  console.log(Person.name); // Ed Faulkner
+    console.log(Person.name); // Ed Faulkner
 
-  let person = new Person();
+    let person = new Person();
 
-  console.log(person.name); // undefined
-  ```
+    console.log(person.name); // undefined
+    ```
 
 **Classic**
 
 - Use `reopenClass` to add static elements to the constructor:
 
-  ```js
-  const Person = EmberObject.extend();
+    ```js
+    const Person = EmberObject.extend();
 
-  Person.reopenClass({
-    name: 'Ed Faulkner',
-  });
-  ```
+    Person.reopenClass({
+      name: 'Ed Faulkner',
+    });
+    ```
 
 ### Super
 
@@ -720,38 +720,38 @@ These are also mostly the same between native and classic classes.
 - In constructors, use the keyword by itself (this is required). Generally pass
   any arguments along as well:
 
-  ```js
-  class TodoComponent extends Component {
-    constructor() {
-      super(...arguments);
+    ```js
+    class TodoComponent extends Component {
+      constructor() {
+        super(...arguments);
 
-      // setup the component...
+        // setup the component...
+      }
     }
-  }
-  ```
+    ```
 
 - In all other cases, specify the _method_ you want to call when using `super`:
 
-  ```js
-  class Vehicle {
-    moveType = 'moving';
+    ```js
+    class Vehicle {
+      moveType = 'moving';
 
-    move() {
-      console.log(`${this.moveType}!`);
+      move() {
+        console.log(`${this.moveType}!`);
+      }
     }
-  }
 
-  class Aircraft extends Vehicle {
-    moveType = 'flying';
+    class Aircraft extends Vehicle {
+      moveType = 'flying';
 
-    fly() {
-      super.move();
+      fly() {
+        super.move();
+      }
     }
-  }
 
-  let airbus = new Aircraft();
-  airbus.fly(); // flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.fly(); // flying!
+    ```
 
 - If the method does not exist on the parent class, it will throw an error.
 
@@ -760,23 +760,23 @@ These are also mostly the same between native and classic classes.
 - Use the `_super()` function to call the super method with the same name as the
   current method that is executing:
 
-  ```js
-  const Vehicle = EmberObject.extend({
-    move() {
-      console.log(`moving!`);
-    },
-  });
+    ```js
+    const Vehicle = EmberObject.extend({
+      move() {
+        console.log(`moving!`);
+      },
+    });
 
-  const Aircraft = Vehicle.extend({
-    move() {
-      this._super();
-      console.log('flying!');
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      move() {
+        this._super();
+        console.log('flying!');
+      },
+    });
 
-  let airbus = new Aircraft();
-  airbus.move(); // moving! flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.move(); // moving! flying!
+    ```
 
 - Calling `_super()` is _required_ for `init` to function properly. It should
   generally be done before you do anything else in `init`.
@@ -787,27 +787,27 @@ These are also mostly the same between native and classic classes.
 - It is possible to extend classic classes with native syntax, and to toggle
   back and forth between the two:
 
-  ```js
-  class Vehicle extends EmberObject {
-    move() {
-      // ...
+    ```js
+    class Vehicle extends EmberObject {
+      move() {
+        // ...
+      }
     }
-  }
 
-  const Aircraft = Vehicle.extend({
-    fly() {
-      // ...
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      fly() {
+        // ...
+      },
+    });
 
-  class Helicopter extends Aircraft {
-    hover() {
-      // ...
+    class Helicopter extends Aircraft {
+      hover() {
+        // ...
+      }
     }
-  }
 
-  let blackHawk = Helicopter.create();
-  ```
+    let blackHawk = Helicopter.create();
+    ```
 
 - Use `init` instead of `constructor`
 - Use `create` instead of `new`

--- a/guides/v3.21.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.21.0/upgrading/current-edition/native-classes.md
@@ -450,11 +450,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use `class` when defining a class, and `class ... extends` when extending a
   class.
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  class Actress extends Person {}
-  ```
+    class Actress extends Person {}
+    ```
 
 - Always give your class a name, e.g. ✅ `class MyClass {}` and not 🛑 `class {}`
 
@@ -463,11 +463,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use the [`extend`][1] static method to define a class, with
   [`EmberObject`][2] as the root base class.
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  const Actress = Person.extend({});
-  ```
+    const Actress = Person.extend({});
+    ```
 
 [1]: https://api.emberjs.com/ember/3.21/functions/@ember%2Fobject/extend
 [2]: https://api.emberjs.com/ember/3.21/classes/EmberObject
@@ -478,25 +478,25 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `new` keyword to create instances of the class
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  let jen = new Person();
-  ```
+    let jen = new Person();
+    ```
 
 - Arguments passed when using `new` will be accessible in the `constructor` of
   the class:
 
-  ```js
-  class Person {
-    constructor(name) {
-      this.name = name;
+    ```js
+    class Person {
+      constructor(name) {
+        this.name = name;
+      }
     }
-  }
 
-  let jen = new Person('Jen Weber');
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = new Person('Jen Weber');
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Prefer the `constructor` function, unless the class extends `EmberObject`,
   in which case prefer `init`.
@@ -505,21 +505,21 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the [`create`][3] static method to create instances of the class:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create();
-  ```
+    let jen = Person.create();
+    ```
 
 - You can pass an object of values to `create`, and they'll be assigned to the
   instance:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create({ name: 'Jen Weber' });
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = Person.create({ name: 'Jen Weber' });
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Use the `init` method instead of the `constructor`.
 
@@ -556,42 +556,42 @@ const Person = EmberObject.extend({
 - Native classes have _fields_. Fields are created and assigned for every
   instance:
 
-  ```js
-  class Person {
-    name = 'Chad Hietala';
-  }
-  ```
+    ```js
+    class Person {
+      name = 'Chad Hietala';
+    }
+    ```
 
 - It is okay to assign objects and arrays in class fields:
 
-  ```js
-  // ok ✅
-  class Person {
-    shoppingList = [];
-  }
-  ```
+    ```js
+    // ok ✅
+    class Person {
+      shoppingList = [];
+    }
+    ```
 
 - Avoid using class state in field definitions, use the constructor instead:
 
-  ```js
-  // bad 🛑
-  class Image {
-    width = 0;
-    height = 0;
+    ```js
+    // bad 🛑
+    class Image {
+      width = 0;
+      height = 0;
 
-    aspectRatio = this.width / this.height;
-  }
-
-  // good ✅
-  class Image {
-    constructor() {
-      this.aspectRatio = this.width / this.height;
+      aspectRatio = this.width / this.height;
     }
 
-    width = 0;
-    height = 0;
-  }
-  ```
+    // good ✅
+    class Image {
+      constructor() {
+        this.aspectRatio = this.width / this.height;
+      }
+
+      width = 0;
+      height = 0;
+    }
+    ```
 
 - Fields are assigned before any constructor code is run, so you can access
   their values in the `constructor` function.
@@ -601,21 +601,21 @@ const Person = EmberObject.extend({
 - Classic classes have _properties_. Properties are created and assigned once to
   the _prototype_ of the class, and are shared between every instance:
 
-  ```js
-  const Person = EmberObject.extend({
-    name: 'Chad Hietala',
-  });
-  ```
+    ```js
+    const Person = EmberObject.extend({
+      name: 'Chad Hietala',
+    });
+    ```
 
 - It is _not_ okay to assign objects or arrays as properties, because they are
   shared between instances:
 
-  ```js
-  // not ok 🛑
-  const Person = EmberObject.extend({
-    shoppingList: [],
-  });
-  ```
+    ```js
+    // not ok 🛑
+    const Person = EmberObject.extend({
+      shoppingList: [],
+    });
+    ```
 
 ### Accessors
 
@@ -623,19 +623,19 @@ These are also mostly the same between native and classic classes.
 
 - Accessors can be defined with the `get` and `set` keywords:
 
-  ```js
-  class Person {
-    _name = 'Mel Sumner';
+    ```js
+    class Person {
+      _name = 'Mel Sumner';
 
-    get name() {
-      return this._name;
-    }
+      get name() {
+        return this._name;
+      }
 
-    set name(newName) {
-      this._name = newName;
+      set name(newName) {
+        this._name = newName;
+      }
     }
-  }
-  ```
+    ```
 
 - Getters run every time the property is read, setters run every time the
   property is set.
@@ -650,13 +650,13 @@ These are also mostly the same between native and classic classes.
   class.
 - Native decorators are functions that get applied using the `@` symbol:
 
-  ```js
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import { tracked } from '@glimmer/tracking';
 
-  class Person {
-    @tracked name = 'Ed Faulkner';
-  }
-  ```
+    class Person {
+      @tracked name = 'Ed Faulkner';
+    }
+    ```
 
 - Native decorators can be applied to class fields, methods, accessors, or
   classes themselves. Generally, specific decorators are only meant to be
@@ -669,14 +669,14 @@ These are also mostly the same between native and classic classes.
 
 - Classic decorators are assigned like properties in classic class definitions:
 
-  ```js
-  import EmberObject from '@ember/object';
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import EmberObject from '@ember/object';
+    import { tracked } from '@glimmer/tracking';
 
-  const Person = EmberObject.extend({
-    name: tracked({ value: 'Ed Faulkner' }),
-  });
-  ```
+    const Person = EmberObject.extend({
+      name: tracked({ value: 'Ed Faulkner' }),
+    });
+    ```
 
 - Only specific decorators provided by Ember can be applied this way in classic
   classes.
@@ -688,29 +688,29 @@ These are also mostly the same between native and classic classes.
 - Adding the `static` keyword to a class element definition puts it on the
   _class_ itself, instead of instances:
 
-  ```js
-  class Person {
-    static name = 'Ed Faulkner';
-  }
+    ```js
+    class Person {
+      static name = 'Ed Faulkner';
+    }
 
-  console.log(Person.name); // Ed Faulkner
+    console.log(Person.name); // Ed Faulkner
 
-  let person = new Person();
+    let person = new Person();
 
-  console.log(person.name); // undefined
-  ```
+    console.log(person.name); // undefined
+    ```
 
 **Classic**
 
 - Use `reopenClass` to add static elements to the constructor:
 
-  ```js
-  const Person = EmberObject.extend();
+    ```js
+    const Person = EmberObject.extend();
 
-  Person.reopenClass({
-    name: 'Ed Faulkner',
-  });
-  ```
+    Person.reopenClass({
+      name: 'Ed Faulkner',
+    });
+    ```
 
 ### Super
 
@@ -720,38 +720,38 @@ These are also mostly the same between native and classic classes.
 - In constructors, use the keyword by itself (this is required). Generally pass
   any arguments along as well:
 
-  ```js
-  class TodoComponent extends Component {
-    constructor() {
-      super(...arguments);
+    ```js
+    class TodoComponent extends Component {
+      constructor() {
+        super(...arguments);
 
-      // setup the component...
+        // setup the component...
+      }
     }
-  }
-  ```
+    ```
 
 - In all other cases, specify the _method_ you want to call when using `super`:
 
-  ```js
-  class Vehicle {
-    moveType = 'moving';
+    ```js
+    class Vehicle {
+      moveType = 'moving';
 
-    move() {
-      console.log(`${this.moveType}!`);
+      move() {
+        console.log(`${this.moveType}!`);
+      }
     }
-  }
 
-  class Aircraft extends Vehicle {
-    moveType = 'flying';
+    class Aircraft extends Vehicle {
+      moveType = 'flying';
 
-    fly() {
-      super.move();
+      fly() {
+        super.move();
+      }
     }
-  }
 
-  let airbus = new Aircraft();
-  airbus.fly(); // flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.fly(); // flying!
+    ```
 
 - If the method does not exist on the parent class, it will throw an error.
 
@@ -760,23 +760,23 @@ These are also mostly the same between native and classic classes.
 - Use the `_super()` function to call the super method with the same name as the
   current method that is executing:
 
-  ```js
-  const Vehicle = EmberObject.extend({
-    move() {
-      console.log(`moving!`);
-    },
-  });
+    ```js
+    const Vehicle = EmberObject.extend({
+      move() {
+        console.log(`moving!`);
+      },
+    });
 
-  const Aircraft = Vehicle.extend({
-    move() {
-      this._super();
-      console.log('flying!');
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      move() {
+        this._super();
+        console.log('flying!');
+      },
+    });
 
-  let airbus = new Aircraft();
-  airbus.move(); // moving! flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.move(); // moving! flying!
+    ```
 
 - Calling `_super()` is _required_ for `init` to function properly. It should
   generally be done before you do anything else in `init`.
@@ -787,27 +787,27 @@ These are also mostly the same between native and classic classes.
 - It is possible to extend classic classes with native syntax, and to toggle
   back and forth between the two:
 
-  ```js
-  class Vehicle extends EmberObject {
-    move() {
-      // ...
+    ```js
+    class Vehicle extends EmberObject {
+      move() {
+        // ...
+      }
     }
-  }
 
-  const Aircraft = Vehicle.extend({
-    fly() {
-      // ...
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      fly() {
+        // ...
+      },
+    });
 
-  class Helicopter extends Aircraft {
-    hover() {
-      // ...
+    class Helicopter extends Aircraft {
+      hover() {
+        // ...
+      }
     }
-  }
 
-  let blackHawk = Helicopter.create();
-  ```
+    let blackHawk = Helicopter.create();
+    ```
 
 - Use `init` instead of `constructor`
 - Use `create` instead of `new`

--- a/guides/v3.22.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.22.0/upgrading/current-edition/native-classes.md
@@ -450,11 +450,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use `class` when defining a class, and `class ... extends` when extending a
   class.
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  class Actress extends Person {}
-  ```
+    class Actress extends Person {}
+    ```
 
 - Always give your class a name, e.g. ✅ `class MyClass {}` and not 🛑 `class {}`
 
@@ -463,11 +463,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use the [`extend`][1] static method to define a class, with
   [`EmberObject`][2] as the root base class.
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  const Actress = Person.extend({});
-  ```
+    const Actress = Person.extend({});
+    ```
 
 [1]: https://api.emberjs.com/ember/3.22.0/functions/@ember%2Fobject/extend
 [2]: https://api.emberjs.com/ember/3.22.0/classes/EmberObject
@@ -478,25 +478,25 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `new` keyword to create instances of the class
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  let jen = new Person();
-  ```
+    let jen = new Person();
+    ```
 
 - Arguments passed when using `new` will be accessible in the `constructor` of
   the class:
 
-  ```js
-  class Person {
-    constructor(name) {
-      this.name = name;
+    ```js
+    class Person {
+      constructor(name) {
+        this.name = name;
+      }
     }
-  }
 
-  let jen = new Person('Jen Weber');
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = new Person('Jen Weber');
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Prefer the `constructor` function, unless the class extends `EmberObject`,
   in which case prefer `init`.
@@ -505,21 +505,21 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the [`create`][3] static method to create instances of the class:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create();
-  ```
+    let jen = Person.create();
+    ```
 
 - You can pass an object of values to `create`, and they'll be assigned to the
   instance:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create({ name: 'Jen Weber' });
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = Person.create({ name: 'Jen Weber' });
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Use the `init` method instead of the `constructor`.
 
@@ -556,42 +556,42 @@ const Person = EmberObject.extend({
 - Native classes have _fields_. Fields are created and assigned for every
   instance:
 
-  ```js
-  class Person {
-    name = 'Chad Hietala';
-  }
-  ```
+    ```js
+    class Person {
+      name = 'Chad Hietala';
+    }
+    ```
 
 - It is okay to assign objects and arrays in class fields:
 
-  ```js
-  // ok ✅
-  class Person {
-    shoppingList = [];
-  }
-  ```
+    ```js
+    // ok ✅
+    class Person {
+      shoppingList = [];
+    }
+    ```
 
 - Avoid using class state in field definitions, use the constructor instead:
 
-  ```js
-  // bad 🛑
-  class Image {
-    width = 0;
-    height = 0;
+    ```js
+    // bad 🛑
+    class Image {
+      width = 0;
+      height = 0;
 
-    aspectRatio = this.width / this.height;
-  }
-
-  // good ✅
-  class Image {
-    constructor() {
-      this.aspectRatio = this.width / this.height;
+      aspectRatio = this.width / this.height;
     }
 
-    width = 0;
-    height = 0;
-  }
-  ```
+    // good ✅
+    class Image {
+      constructor() {
+        this.aspectRatio = this.width / this.height;
+      }
+
+      width = 0;
+      height = 0;
+    }
+    ```
 
 - Fields are assigned before any constructor code is run, so you can access
   their values in the `constructor` function.
@@ -601,21 +601,21 @@ const Person = EmberObject.extend({
 - Classic classes have _properties_. Properties are created and assigned once to
   the _prototype_ of the class, and are shared between every instance:
 
-  ```js
-  const Person = EmberObject.extend({
-    name: 'Chad Hietala',
-  });
-  ```
+    ```js
+    const Person = EmberObject.extend({
+      name: 'Chad Hietala',
+    });
+    ```
 
 - It is _not_ okay to assign objects or arrays as properties, because they are
   shared between instances:
 
-  ```js
-  // not ok 🛑
-  const Person = EmberObject.extend({
-    shoppingList: [],
-  });
-  ```
+    ```js
+    // not ok 🛑
+    const Person = EmberObject.extend({
+      shoppingList: [],
+    });
+    ```
 
 ### Accessors
 
@@ -623,19 +623,19 @@ These are also mostly the same between native and classic classes.
 
 - Accessors can be defined with the `get` and `set` keywords:
 
-  ```js
-  class Person {
-    _name = 'Mel Sumner';
+    ```js
+    class Person {
+      _name = 'Mel Sumner';
 
-    get name() {
-      return this._name;
-    }
+      get name() {
+        return this._name;
+      }
 
-    set name(newName) {
-      this._name = newName;
+      set name(newName) {
+        this._name = newName;
+      }
     }
-  }
-  ```
+    ```
 
 - Getters run every time the property is read, setters run every time the
   property is set.
@@ -650,13 +650,13 @@ These are also mostly the same between native and classic classes.
   class.
 - Native decorators are functions that get applied using the `@` symbol:
 
-  ```js
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import { tracked } from '@glimmer/tracking';
 
-  class Person {
-    @tracked name = 'Ed Faulkner';
-  }
-  ```
+    class Person {
+      @tracked name = 'Ed Faulkner';
+    }
+    ```
 
 - Native decorators can be applied to class fields, methods, accessors, or
   classes themselves. Generally, specific decorators are only meant to be
@@ -669,14 +669,14 @@ These are also mostly the same between native and classic classes.
 
 - Classic decorators are assigned like properties in classic class definitions:
 
-  ```js
-  import EmberObject from '@ember/object';
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import EmberObject from '@ember/object';
+    import { tracked } from '@glimmer/tracking';
 
-  const Person = EmberObject.extend({
-    name: tracked({ value: 'Ed Faulkner' }),
-  });
-  ```
+    const Person = EmberObject.extend({
+      name: tracked({ value: 'Ed Faulkner' }),
+    });
+    ```
 
 - Only specific decorators provided by Ember can be applied this way in classic
   classes.
@@ -688,29 +688,29 @@ These are also mostly the same between native and classic classes.
 - Adding the `static` keyword to a class element definition puts it on the
   _class_ itself, instead of instances:
 
-  ```js
-  class Person {
-    static name = 'Ed Faulkner';
-  }
+    ```js
+    class Person {
+      static name = 'Ed Faulkner';
+    }
 
-  console.log(Person.name); // Ed Faulkner
+    console.log(Person.name); // Ed Faulkner
 
-  let person = new Person();
+    let person = new Person();
 
-  console.log(person.name); // undefined
-  ```
+    console.log(person.name); // undefined
+    ```
 
 **Classic**
 
 - Use `reopenClass` to add static elements to the constructor:
 
-  ```js
-  const Person = EmberObject.extend();
+    ```js
+    const Person = EmberObject.extend();
 
-  Person.reopenClass({
-    name: 'Ed Faulkner',
-  });
-  ```
+    Person.reopenClass({
+      name: 'Ed Faulkner',
+    });
+    ```
 
 ### Super
 
@@ -720,38 +720,38 @@ These are also mostly the same between native and classic classes.
 - In constructors, use the keyword by itself (this is required). Generally pass
   any arguments along as well:
 
-  ```js
-  class TodoComponent extends Component {
-    constructor() {
-      super(...arguments);
+    ```js
+    class TodoComponent extends Component {
+      constructor() {
+        super(...arguments);
 
-      // setup the component...
+        // setup the component...
+      }
     }
-  }
-  ```
+    ```
 
 - In all other cases, specify the _method_ you want to call when using `super`:
 
-  ```js
-  class Vehicle {
-    moveType = 'moving';
+    ```js
+    class Vehicle {
+      moveType = 'moving';
 
-    move() {
-      console.log(`${this.moveType}!`);
+      move() {
+        console.log(`${this.moveType}!`);
+      }
     }
-  }
 
-  class Aircraft extends Vehicle {
-    moveType = 'flying';
+    class Aircraft extends Vehicle {
+      moveType = 'flying';
 
-    fly() {
-      super.move();
+      fly() {
+        super.move();
+      }
     }
-  }
 
-  let airbus = new Aircraft();
-  airbus.fly(); // flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.fly(); // flying!
+    ```
 
 - If the method does not exist on the parent class, it will throw an error.
 
@@ -760,23 +760,23 @@ These are also mostly the same between native and classic classes.
 - Use the `_super()` function to call the super method with the same name as the
   current method that is executing:
 
-  ```js
-  const Vehicle = EmberObject.extend({
-    move() {
-      console.log(`moving!`);
-    },
-  });
+    ```js
+    const Vehicle = EmberObject.extend({
+      move() {
+        console.log(`moving!`);
+      },
+    });
 
-  const Aircraft = Vehicle.extend({
-    move() {
-      this._super();
-      console.log('flying!');
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      move() {
+        this._super();
+        console.log('flying!');
+      },
+    });
 
-  let airbus = new Aircraft();
-  airbus.move(); // moving! flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.move(); // moving! flying!
+    ```
 
 - Calling `_super()` is _required_ for `init` to function properly. It should
   generally be done before you do anything else in `init`.
@@ -787,27 +787,27 @@ These are also mostly the same between native and classic classes.
 - It is possible to extend classic classes with native syntax, and to toggle
   back and forth between the two:
 
-  ```js
-  class Vehicle extends EmberObject {
-    move() {
-      // ...
+    ```js
+    class Vehicle extends EmberObject {
+      move() {
+        // ...
+      }
     }
-  }
 
-  const Aircraft = Vehicle.extend({
-    fly() {
-      // ...
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      fly() {
+        // ...
+      },
+    });
 
-  class Helicopter extends Aircraft {
-    hover() {
-      // ...
+    class Helicopter extends Aircraft {
+      hover() {
+        // ...
+      }
     }
-  }
 
-  let blackHawk = Helicopter.create();
-  ```
+    let blackHawk = Helicopter.create();
+    ```
 
 - Use `init` instead of `constructor`
 - Use `create` instead of `new`

--- a/guides/v3.23.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.23.0/upgrading/current-edition/native-classes.md
@@ -450,11 +450,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use `class` when defining a class, and `class ... extends` when extending a
   class.
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  class Actress extends Person {}
-  ```
+    class Actress extends Person {}
+    ```
 
 - Always give your class a name, e.g. ✅ `class MyClass {}` and not 🛑 `class {}`
 
@@ -463,11 +463,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use the [`extend`][1] static method to define a class, with
   [`EmberObject`][2] as the root base class.
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  const Actress = Person.extend({});
-  ```
+    const Actress = Person.extend({});
+    ```
 
 [1]: https://api.emberjs.com/ember/3.23.0/functions/@ember%2Fobject/extend
 [2]: https://api.emberjs.com/ember/3.23.0/classes/EmberObject
@@ -478,25 +478,25 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `new` keyword to create instances of the class
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  let jen = new Person();
-  ```
+    let jen = new Person();
+    ```
 
 - Arguments passed when using `new` will be accessible in the `constructor` of
   the class:
 
-  ```js
-  class Person {
-    constructor(name) {
-      this.name = name;
+    ```js
+    class Person {
+      constructor(name) {
+        this.name = name;
+      }
     }
-  }
 
-  let jen = new Person('Jen Weber');
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = new Person('Jen Weber');
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Prefer the `constructor` function, unless the class extends `EmberObject`,
   in which case prefer `init`.
@@ -505,21 +505,21 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the [`create`][3] static method to create instances of the class:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create();
-  ```
+    let jen = Person.create();
+    ```
 
 - You can pass an object of values to `create`, and they'll be assigned to the
   instance:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create({ name: 'Jen Weber' });
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = Person.create({ name: 'Jen Weber' });
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Use the `init` method instead of the `constructor`.
 
@@ -556,42 +556,42 @@ const Person = EmberObject.extend({
 - Native classes have _fields_. Fields are created and assigned for every
   instance:
 
-  ```js
-  class Person {
-    name = 'Chad Hietala';
-  }
-  ```
+    ```js
+    class Person {
+      name = 'Chad Hietala';
+    }
+    ```
 
 - It is okay to assign objects and arrays in class fields:
 
-  ```js
-  // ok ✅
-  class Person {
-    shoppingList = [];
-  }
-  ```
+    ```js
+    // ok ✅
+    class Person {
+      shoppingList = [];
+    }
+    ```
 
 - Avoid using class state in field definitions, use the constructor instead:
 
-  ```js
-  // bad 🛑
-  class Image {
-    width = 0;
-    height = 0;
+    ```js
+    // bad 🛑
+    class Image {
+      width = 0;
+      height = 0;
 
-    aspectRatio = this.width / this.height;
-  }
-
-  // good ✅
-  class Image {
-    constructor() {
-      this.aspectRatio = this.width / this.height;
+      aspectRatio = this.width / this.height;
     }
 
-    width = 0;
-    height = 0;
-  }
-  ```
+    // good ✅
+    class Image {
+      constructor() {
+        this.aspectRatio = this.width / this.height;
+      }
+
+      width = 0;
+      height = 0;
+    }
+    ```
 
 - Fields are assigned before any constructor code is run, so you can access
   their values in the `constructor` function.
@@ -601,21 +601,21 @@ const Person = EmberObject.extend({
 - Classic classes have _properties_. Properties are created and assigned once to
   the _prototype_ of the class, and are shared between every instance:
 
-  ```js
-  const Person = EmberObject.extend({
-    name: 'Chad Hietala',
-  });
-  ```
+    ```js
+    const Person = EmberObject.extend({
+      name: 'Chad Hietala',
+    });
+    ```
 
 - It is _not_ okay to assign objects or arrays as properties, because they are
   shared between instances:
 
-  ```js
-  // not ok 🛑
-  const Person = EmberObject.extend({
-    shoppingList: [],
-  });
-  ```
+    ```js
+    // not ok 🛑
+    const Person = EmberObject.extend({
+      shoppingList: [],
+    });
+    ```
 
 ### Accessors
 
@@ -623,19 +623,19 @@ These are also mostly the same between native and classic classes.
 
 - Accessors can be defined with the `get` and `set` keywords:
 
-  ```js
-  class Person {
-    _name = 'Mel Sumner';
+    ```js
+    class Person {
+      _name = 'Mel Sumner';
 
-    get name() {
-      return this._name;
-    }
+      get name() {
+        return this._name;
+      }
 
-    set name(newName) {
-      this._name = newName;
+      set name(newName) {
+        this._name = newName;
+      }
     }
-  }
-  ```
+    ```
 
 - Getters run every time the property is read, setters run every time the
   property is set.
@@ -650,13 +650,13 @@ These are also mostly the same between native and classic classes.
   class.
 - Native decorators are functions that get applied using the `@` symbol:
 
-  ```js
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import { tracked } from '@glimmer/tracking';
 
-  class Person {
-    @tracked name = 'Ed Faulkner';
-  }
-  ```
+    class Person {
+      @tracked name = 'Ed Faulkner';
+    }
+    ```
 
 - Native decorators can be applied to class fields, methods, accessors, or
   classes themselves. Generally, specific decorators are only meant to be
@@ -669,14 +669,14 @@ These are also mostly the same between native and classic classes.
 
 - Classic decorators are assigned like properties in classic class definitions:
 
-  ```js
-  import EmberObject from '@ember/object';
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import EmberObject from '@ember/object';
+    import { tracked } from '@glimmer/tracking';
 
-  const Person = EmberObject.extend({
-    name: tracked({ value: 'Ed Faulkner' }),
-  });
-  ```
+    const Person = EmberObject.extend({
+      name: tracked({ value: 'Ed Faulkner' }),
+    });
+    ```
 
 - Only specific decorators provided by Ember can be applied this way in classic
   classes.
@@ -688,29 +688,29 @@ These are also mostly the same between native and classic classes.
 - Adding the `static` keyword to a class element definition puts it on the
   _class_ itself, instead of instances:
 
-  ```js
-  class Person {
-    static name = 'Ed Faulkner';
-  }
+    ```js
+    class Person {
+      static name = 'Ed Faulkner';
+    }
 
-  console.log(Person.name); // Ed Faulkner
+    console.log(Person.name); // Ed Faulkner
 
-  let person = new Person();
+    let person = new Person();
 
-  console.log(person.name); // undefined
-  ```
+    console.log(person.name); // undefined
+    ```
 
 **Classic**
 
 - Use `reopenClass` to add static elements to the constructor:
 
-  ```js
-  const Person = EmberObject.extend();
+    ```js
+    const Person = EmberObject.extend();
 
-  Person.reopenClass({
-    name: 'Ed Faulkner',
-  });
-  ```
+    Person.reopenClass({
+      name: 'Ed Faulkner',
+    });
+    ```
 
 ### Super
 
@@ -720,38 +720,38 @@ These are also mostly the same between native and classic classes.
 - In constructors, use the keyword by itself (this is required). Generally pass
   any arguments along as well:
 
-  ```js
-  class TodoComponent extends Component {
-    constructor() {
-      super(...arguments);
+    ```js
+    class TodoComponent extends Component {
+      constructor() {
+        super(...arguments);
 
-      // setup the component...
+        // setup the component...
+      }
     }
-  }
-  ```
+    ```
 
 - In all other cases, specify the _method_ you want to call when using `super`:
 
-  ```js
-  class Vehicle {
-    moveType = 'moving';
+    ```js
+    class Vehicle {
+      moveType = 'moving';
 
-    move() {
-      console.log(`${this.moveType}!`);
+      move() {
+        console.log(`${this.moveType}!`);
+      }
     }
-  }
 
-  class Aircraft extends Vehicle {
-    moveType = 'flying';
+    class Aircraft extends Vehicle {
+      moveType = 'flying';
 
-    fly() {
-      super.move();
+      fly() {
+        super.move();
+      }
     }
-  }
 
-  let airbus = new Aircraft();
-  airbus.fly(); // flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.fly(); // flying!
+    ```
 
 - If the method does not exist on the parent class, it will throw an error.
 
@@ -760,23 +760,23 @@ These are also mostly the same between native and classic classes.
 - Use the `_super()` function to call the super method with the same name as the
   current method that is executing:
 
-  ```js
-  const Vehicle = EmberObject.extend({
-    move() {
-      console.log(`moving!`);
-    },
-  });
+    ```js
+    const Vehicle = EmberObject.extend({
+      move() {
+        console.log(`moving!`);
+      },
+    });
 
-  const Aircraft = Vehicle.extend({
-    move() {
-      this._super();
-      console.log('flying!');
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      move() {
+        this._super();
+        console.log('flying!');
+      },
+    });
 
-  let airbus = new Aircraft();
-  airbus.move(); // moving! flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.move(); // moving! flying!
+    ```
 
 - Calling `_super()` is _required_ for `init` to function properly. It should
   generally be done before you do anything else in `init`.
@@ -787,27 +787,27 @@ These are also mostly the same between native and classic classes.
 - It is possible to extend classic classes with native syntax, and to toggle
   back and forth between the two:
 
-  ```js
-  class Vehicle extends EmberObject {
-    move() {
-      // ...
+    ```js
+    class Vehicle extends EmberObject {
+      move() {
+        // ...
+      }
     }
-  }
 
-  const Aircraft = Vehicle.extend({
-    fly() {
-      // ...
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      fly() {
+        // ...
+      },
+    });
 
-  class Helicopter extends Aircraft {
-    hover() {
-      // ...
+    class Helicopter extends Aircraft {
+      hover() {
+        // ...
+      }
     }
-  }
 
-  let blackHawk = Helicopter.create();
-  ```
+    let blackHawk = Helicopter.create();
+    ```
 
 - Use `init` instead of `constructor`
 - Use `create` instead of `new`

--- a/guides/v3.24.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.24.0/upgrading/current-edition/native-classes.md
@@ -450,11 +450,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use `class` when defining a class, and `class ... extends` when extending a
   class.
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  class Actress extends Person {}
-  ```
+    class Actress extends Person {}
+    ```
 
 - Always give your class a name, e.g. ✅ `class MyClass {}` and not 🛑 `class {}`
 
@@ -463,11 +463,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use the [`extend`][1] static method to define a class, with
   [`EmberObject`][2] as the root base class.
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  const Actress = Person.extend({});
-  ```
+    const Actress = Person.extend({});
+    ```
 
 [1]: https://api.emberjs.com/ember/3.24.0/functions/@ember%2Fobject/extend
 [2]: https://api.emberjs.com/ember/3.24.0/classes/EmberObject
@@ -478,25 +478,25 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `new` keyword to create instances of the class
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  let jen = new Person();
-  ```
+    let jen = new Person();
+    ```
 
 - Arguments passed when using `new` will be accessible in the `constructor` of
   the class:
 
-  ```js
-  class Person {
-    constructor(name) {
-      this.name = name;
+    ```js
+    class Person {
+      constructor(name) {
+        this.name = name;
+      }
     }
-  }
 
-  let jen = new Person('Jen Weber');
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = new Person('Jen Weber');
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Prefer the `constructor` function, unless the class extends `EmberObject`,
   in which case prefer `init`.
@@ -505,21 +505,21 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the [`create`][3] static method to create instances of the class:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create();
-  ```
+    let jen = Person.create();
+    ```
 
 - You can pass an object of values to `create`, and they'll be assigned to the
   instance:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create({ name: 'Jen Weber' });
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = Person.create({ name: 'Jen Weber' });
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Use the `init` method instead of the `constructor`.
 
@@ -556,42 +556,42 @@ const Person = EmberObject.extend({
 - Native classes have _fields_. Fields are created and assigned for every
   instance:
 
-  ```js
-  class Person {
-    name = 'Chad Hietala';
-  }
-  ```
+    ```js
+    class Person {
+      name = 'Chad Hietala';
+    }
+    ```
 
 - It is okay to assign objects and arrays in class fields:
 
-  ```js
-  // ok ✅
-  class Person {
-    shoppingList = [];
-  }
-  ```
+    ```js
+    // ok ✅
+    class Person {
+      shoppingList = [];
+    }
+    ```
 
 - Avoid using class state in field definitions, use the constructor instead:
 
-  ```js
-  // bad 🛑
-  class Image {
-    width = 0;
-    height = 0;
+    ```js
+    // bad 🛑
+    class Image {
+      width = 0;
+      height = 0;
 
-    aspectRatio = this.width / this.height;
-  }
-
-  // good ✅
-  class Image {
-    constructor() {
-      this.aspectRatio = this.width / this.height;
+      aspectRatio = this.width / this.height;
     }
 
-    width = 0;
-    height = 0;
-  }
-  ```
+    // good ✅
+    class Image {
+      constructor() {
+        this.aspectRatio = this.width / this.height;
+      }
+
+      width = 0;
+      height = 0;
+    }
+    ```
 
 - Fields are assigned before any constructor code is run, so you can access
   their values in the `constructor` function.
@@ -601,21 +601,21 @@ const Person = EmberObject.extend({
 - Classic classes have _properties_. Properties are created and assigned once to
   the _prototype_ of the class, and are shared between every instance:
 
-  ```js
-  const Person = EmberObject.extend({
-    name: 'Chad Hietala',
-  });
-  ```
+    ```js
+    const Person = EmberObject.extend({
+      name: 'Chad Hietala',
+    });
+    ```
 
 - It is _not_ okay to assign objects or arrays as properties, because they are
   shared between instances:
 
-  ```js
-  // not ok 🛑
-  const Person = EmberObject.extend({
-    shoppingList: [],
-  });
-  ```
+    ```js
+    // not ok 🛑
+    const Person = EmberObject.extend({
+      shoppingList: [],
+    });
+    ```
 
 ### Accessors
 
@@ -623,19 +623,19 @@ These are also mostly the same between native and classic classes.
 
 - Accessors can be defined with the `get` and `set` keywords:
 
-  ```js
-  class Person {
-    _name = 'Mel Sumner';
+    ```js
+    class Person {
+      _name = 'Mel Sumner';
 
-    get name() {
-      return this._name;
-    }
+      get name() {
+        return this._name;
+      }
 
-    set name(newName) {
-      this._name = newName;
+      set name(newName) {
+        this._name = newName;
+      }
     }
-  }
-  ```
+    ```
 
 - Getters run every time the property is read, setters run every time the
   property is set.
@@ -650,13 +650,13 @@ These are also mostly the same between native and classic classes.
   class.
 - Native decorators are functions that get applied using the `@` symbol:
 
-  ```js
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import { tracked } from '@glimmer/tracking';
 
-  class Person {
-    @tracked name = 'Ed Faulkner';
-  }
-  ```
+    class Person {
+      @tracked name = 'Ed Faulkner';
+    }
+    ```
 
 - Native decorators can be applied to class fields, methods, accessors, or
   classes themselves. Generally, specific decorators are only meant to be
@@ -669,14 +669,14 @@ These are also mostly the same between native and classic classes.
 
 - Classic decorators are assigned like properties in classic class definitions:
 
-  ```js
-  import EmberObject from '@ember/object';
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import EmberObject from '@ember/object';
+    import { tracked } from '@glimmer/tracking';
 
-  const Person = EmberObject.extend({
-    name: tracked({ value: 'Ed Faulkner' }),
-  });
-  ```
+    const Person = EmberObject.extend({
+      name: tracked({ value: 'Ed Faulkner' }),
+    });
+    ```
 
 - Only specific decorators provided by Ember can be applied this way in classic
   classes.
@@ -688,29 +688,29 @@ These are also mostly the same between native and classic classes.
 - Adding the `static` keyword to a class element definition puts it on the
   _class_ itself, instead of instances:
 
-  ```js
-  class Person {
-    static name = 'Ed Faulkner';
-  }
+    ```js
+    class Person {
+      static name = 'Ed Faulkner';
+    }
 
-  console.log(Person.name); // Ed Faulkner
+    console.log(Person.name); // Ed Faulkner
 
-  let person = new Person();
+    let person = new Person();
 
-  console.log(person.name); // undefined
-  ```
+    console.log(person.name); // undefined
+    ```
 
 **Classic**
 
 - Use `reopenClass` to add static elements to the constructor:
 
-  ```js
-  const Person = EmberObject.extend();
+    ```js
+    const Person = EmberObject.extend();
 
-  Person.reopenClass({
-    name: 'Ed Faulkner',
-  });
-  ```
+    Person.reopenClass({
+      name: 'Ed Faulkner',
+    });
+    ```
 
 ### Super
 
@@ -720,38 +720,38 @@ These are also mostly the same between native and classic classes.
 - In constructors, use the keyword by itself (this is required). Generally pass
   any arguments along as well:
 
-  ```js
-  class TodoComponent extends Component {
-    constructor() {
-      super(...arguments);
+    ```js
+    class TodoComponent extends Component {
+      constructor() {
+        super(...arguments);
 
-      // setup the component...
+        // setup the component...
+      }
     }
-  }
-  ```
+    ```
 
 - In all other cases, specify the _method_ you want to call when using `super`:
 
-  ```js
-  class Vehicle {
-    moveType = 'moving';
+    ```js
+    class Vehicle {
+      moveType = 'moving';
 
-    move() {
-      console.log(`${this.moveType}!`);
+      move() {
+        console.log(`${this.moveType}!`);
+      }
     }
-  }
 
-  class Aircraft extends Vehicle {
-    moveType = 'flying';
+    class Aircraft extends Vehicle {
+      moveType = 'flying';
 
-    fly() {
-      super.move();
+      fly() {
+        super.move();
+      }
     }
-  }
 
-  let airbus = new Aircraft();
-  airbus.fly(); // flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.fly(); // flying!
+    ```
 
 - If the method does not exist on the parent class, it will throw an error.
 
@@ -760,23 +760,23 @@ These are also mostly the same between native and classic classes.
 - Use the `_super()` function to call the super method with the same name as the
   current method that is executing:
 
-  ```js
-  const Vehicle = EmberObject.extend({
-    move() {
-      console.log(`moving!`);
-    },
-  });
+    ```js
+    const Vehicle = EmberObject.extend({
+      move() {
+        console.log(`moving!`);
+      },
+    });
 
-  const Aircraft = Vehicle.extend({
-    move() {
-      this._super();
-      console.log('flying!');
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      move() {
+        this._super();
+        console.log('flying!');
+      },
+    });
 
-  let airbus = new Aircraft();
-  airbus.move(); // moving! flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.move(); // moving! flying!
+    ```
 
 - Calling `_super()` is _required_ for `init` to function properly. It should
   generally be done before you do anything else in `init`.
@@ -787,27 +787,27 @@ These are also mostly the same between native and classic classes.
 - It is possible to extend classic classes with native syntax, and to toggle
   back and forth between the two:
 
-  ```js
-  class Vehicle extends EmberObject {
-    move() {
-      // ...
+    ```js
+    class Vehicle extends EmberObject {
+      move() {
+        // ...
+      }
     }
-  }
 
-  const Aircraft = Vehicle.extend({
-    fly() {
-      // ...
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      fly() {
+        // ...
+      },
+    });
 
-  class Helicopter extends Aircraft {
-    hover() {
-      // ...
+    class Helicopter extends Aircraft {
+      hover() {
+        // ...
+      }
     }
-  }
 
-  let blackHawk = Helicopter.create();
-  ```
+    let blackHawk = Helicopter.create();
+    ```
 
 - Use `init` instead of `constructor`
 - Use `create` instead of `new`

--- a/guides/v3.25.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.25.0/upgrading/current-edition/native-classes.md
@@ -450,11 +450,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use `class` when defining a class, and `class ... extends` when extending a
   class.
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  class Actress extends Person {}
-  ```
+    class Actress extends Person {}
+    ```
 
 - Always give your class a name, e.g. ✅ `class MyClass {}` and not 🛑 `class {}`
 
@@ -463,11 +463,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use the [`extend`][1] static method to define a class, with
   [`EmberObject`][2] as the root base class.
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  const Actress = Person.extend({});
-  ```
+    const Actress = Person.extend({});
+    ```
 
 [1]: https://api.emberjs.com/ember/3.25.0/functions/@ember%2Fobject/extend
 [2]: https://api.emberjs.com/ember/3.25.0/classes/EmberObject
@@ -478,25 +478,25 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `new` keyword to create instances of the class
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  let jen = new Person();
-  ```
+    let jen = new Person();
+    ```
 
 - Arguments passed when using `new` will be accessible in the `constructor` of
   the class:
 
-  ```js
-  class Person {
-    constructor(name) {
-      this.name = name;
+    ```js
+    class Person {
+      constructor(name) {
+        this.name = name;
+      }
     }
-  }
 
-  let jen = new Person('Jen Weber');
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = new Person('Jen Weber');
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Prefer the `constructor` function, unless the class extends `EmberObject`,
   in which case prefer `init`.
@@ -505,21 +505,21 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the [`create`][3] static method to create instances of the class:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create();
-  ```
+    let jen = Person.create();
+    ```
 
 - You can pass an object of values to `create`, and they'll be assigned to the
   instance:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create({ name: 'Jen Weber' });
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = Person.create({ name: 'Jen Weber' });
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Use the `init` method instead of the `constructor`.
 
@@ -556,42 +556,42 @@ const Person = EmberObject.extend({
 - Native classes have _fields_. Fields are created and assigned for every
   instance:
 
-  ```js
-  class Person {
-    name = 'Chad Hietala';
-  }
-  ```
+    ```js
+    class Person {
+      name = 'Chad Hietala';
+    }
+    ```
 
 - It is okay to assign objects and arrays in class fields:
 
-  ```js
-  // ok ✅
-  class Person {
-    shoppingList = [];
-  }
-  ```
+    ```js
+    // ok ✅
+    class Person {
+      shoppingList = [];
+    }
+    ```
 
 - Avoid using class state in field definitions, use the constructor instead:
 
-  ```js
-  // bad 🛑
-  class Image {
-    width = 0;
-    height = 0;
+    ```js
+    // bad 🛑
+    class Image {
+      width = 0;
+      height = 0;
 
-    aspectRatio = this.width / this.height;
-  }
-
-  // good ✅
-  class Image {
-    constructor() {
-      this.aspectRatio = this.width / this.height;
+      aspectRatio = this.width / this.height;
     }
 
-    width = 0;
-    height = 0;
-  }
-  ```
+    // good ✅
+    class Image {
+      constructor() {
+        this.aspectRatio = this.width / this.height;
+      }
+
+      width = 0;
+      height = 0;
+    }
+    ```
 
 - Fields are assigned before any constructor code is run, so you can access
   their values in the `constructor` function.
@@ -601,21 +601,21 @@ const Person = EmberObject.extend({
 - Classic classes have _properties_. Properties are created and assigned once to
   the _prototype_ of the class, and are shared between every instance:
 
-  ```js
-  const Person = EmberObject.extend({
-    name: 'Chad Hietala',
-  });
-  ```
+    ```js
+    const Person = EmberObject.extend({
+      name: 'Chad Hietala',
+    });
+    ```
 
 - It is _not_ okay to assign objects or arrays as properties, because they are
   shared between instances:
 
-  ```js
-  // not ok 🛑
-  const Person = EmberObject.extend({
-    shoppingList: [],
-  });
-  ```
+    ```js
+    // not ok 🛑
+    const Person = EmberObject.extend({
+      shoppingList: [],
+    });
+    ```
 
 ### Accessors
 
@@ -623,19 +623,19 @@ These are also mostly the same between native and classic classes.
 
 - Accessors can be defined with the `get` and `set` keywords:
 
-  ```js
-  class Person {
-    _name = 'Mel Sumner';
+    ```js
+    class Person {
+      _name = 'Mel Sumner';
 
-    get name() {
-      return this._name;
-    }
+      get name() {
+        return this._name;
+      }
 
-    set name(newName) {
-      this._name = newName;
+      set name(newName) {
+        this._name = newName;
+      }
     }
-  }
-  ```
+    ```
 
 - Getters run every time the property is read, setters run every time the
   property is set.
@@ -650,13 +650,13 @@ These are also mostly the same between native and classic classes.
   class.
 - Native decorators are functions that get applied using the `@` symbol:
 
-  ```js
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import { tracked } from '@glimmer/tracking';
 
-  class Person {
-    @tracked name = 'Ed Faulkner';
-  }
-  ```
+    class Person {
+      @tracked name = 'Ed Faulkner';
+    }
+    ```
 
 - Native decorators can be applied to class fields, methods, accessors, or
   classes themselves. Generally, specific decorators are only meant to be
@@ -669,14 +669,14 @@ These are also mostly the same between native and classic classes.
 
 - Classic decorators are assigned like properties in classic class definitions:
 
-  ```js
-  import EmberObject from '@ember/object';
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import EmberObject from '@ember/object';
+    import { tracked } from '@glimmer/tracking';
 
-  const Person = EmberObject.extend({
-    name: tracked({ value: 'Ed Faulkner' }),
-  });
-  ```
+    const Person = EmberObject.extend({
+      name: tracked({ value: 'Ed Faulkner' }),
+    });
+    ```
 
 - Only specific decorators provided by Ember can be applied this way in classic
   classes.
@@ -688,29 +688,29 @@ These are also mostly the same between native and classic classes.
 - Adding the `static` keyword to a class element definition puts it on the
   _class_ itself, instead of instances:
 
-  ```js
-  class Person {
-    static name = 'Ed Faulkner';
-  }
+    ```js
+    class Person {
+      static name = 'Ed Faulkner';
+    }
 
-  console.log(Person.name); // Ed Faulkner
+    console.log(Person.name); // Ed Faulkner
 
-  let person = new Person();
+    let person = new Person();
 
-  console.log(person.name); // undefined
-  ```
+    console.log(person.name); // undefined
+    ```
 
 **Classic**
 
 - Use `reopenClass` to add static elements to the constructor:
 
-  ```js
-  const Person = EmberObject.extend();
+    ```js
+    const Person = EmberObject.extend();
 
-  Person.reopenClass({
-    name: 'Ed Faulkner',
-  });
-  ```
+    Person.reopenClass({
+      name: 'Ed Faulkner',
+    });
+    ```
 
 ### Super
 
@@ -720,38 +720,38 @@ These are also mostly the same between native and classic classes.
 - In constructors, use the keyword by itself (this is required). Generally pass
   any arguments along as well:
 
-  ```js
-  class TodoComponent extends Component {
-    constructor() {
-      super(...arguments);
+    ```js
+    class TodoComponent extends Component {
+      constructor() {
+        super(...arguments);
 
-      // setup the component...
+        // setup the component...
+      }
     }
-  }
-  ```
+    ```
 
 - In all other cases, specify the _method_ you want to call when using `super`:
 
-  ```js
-  class Vehicle {
-    moveType = 'moving';
+    ```js
+    class Vehicle {
+      moveType = 'moving';
 
-    move() {
-      console.log(`${this.moveType}!`);
+      move() {
+        console.log(`${this.moveType}!`);
+      }
     }
-  }
 
-  class Aircraft extends Vehicle {
-    moveType = 'flying';
+    class Aircraft extends Vehicle {
+      moveType = 'flying';
 
-    fly() {
-      super.move();
+      fly() {
+        super.move();
+      }
     }
-  }
 
-  let airbus = new Aircraft();
-  airbus.fly(); // flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.fly(); // flying!
+    ```
 
 - If the method does not exist on the parent class, it will throw an error.
 
@@ -760,23 +760,23 @@ These are also mostly the same between native and classic classes.
 - Use the `_super()` function to call the super method with the same name as the
   current method that is executing:
 
-  ```js
-  const Vehicle = EmberObject.extend({
-    move() {
-      console.log(`moving!`);
-    },
-  });
+    ```js
+    const Vehicle = EmberObject.extend({
+      move() {
+        console.log(`moving!`);
+      },
+    });
 
-  const Aircraft = Vehicle.extend({
-    move() {
-      this._super();
-      console.log('flying!');
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      move() {
+        this._super();
+        console.log('flying!');
+      },
+    });
 
-  let airbus = new Aircraft();
-  airbus.move(); // moving! flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.move(); // moving! flying!
+    ```
 
 - Calling `_super()` is _required_ for `init` to function properly. It should
   generally be done before you do anything else in `init`.
@@ -787,27 +787,27 @@ These are also mostly the same between native and classic classes.
 - It is possible to extend classic classes with native syntax, and to toggle
   back and forth between the two:
 
-  ```js
-  class Vehicle extends EmberObject {
-    move() {
-      // ...
+    ```js
+    class Vehicle extends EmberObject {
+      move() {
+        // ...
+      }
     }
-  }
 
-  const Aircraft = Vehicle.extend({
-    fly() {
-      // ...
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      fly() {
+        // ...
+      },
+    });
 
-  class Helicopter extends Aircraft {
-    hover() {
-      // ...
+    class Helicopter extends Aircraft {
+      hover() {
+        // ...
+      }
     }
-  }
 
-  let blackHawk = Helicopter.create();
-  ```
+    let blackHawk = Helicopter.create();
+    ```
 
 - Use `init` instead of `constructor`
 - Use `create` instead of `new`

--- a/guides/v3.26.0/upgrading/current-edition/native-classes.md
+++ b/guides/v3.26.0/upgrading/current-edition/native-classes.md
@@ -450,11 +450,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use `class` when defining a class, and `class ... extends` when extending a
   class.
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  class Actress extends Person {}
-  ```
+    class Actress extends Person {}
+    ```
 
 - Always give your class a name, e.g. ✅ `class MyClass {}` and not 🛑 `class {}`
 
@@ -463,11 +463,11 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 - Use the [`extend`][1] static method to define a class, with
   [`EmberObject`][2] as the root base class.
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  const Actress = Person.extend({});
-  ```
+    const Actress = Person.extend({});
+    ```
 
 [1]: https://api.emberjs.com/ember/3.26.0/functions/@ember%2Fobject/extend
 [2]: https://api.emberjs.com/ember/3.26.0/classes/EmberObject
@@ -478,25 +478,25 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the `new` keyword to create instances of the class
 
-  ```js
-  class Person {}
+    ```js
+    class Person {}
 
-  let jen = new Person();
-  ```
+    let jen = new Person();
+    ```
 
 - Arguments passed when using `new` will be accessible in the `constructor` of
   the class:
 
-  ```js
-  class Person {
-    constructor(name) {
-      this.name = name;
+    ```js
+    class Person {
+      constructor(name) {
+        this.name = name;
+      }
     }
-  }
 
-  let jen = new Person('Jen Weber');
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = new Person('Jen Weber');
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Prefer the `constructor` function, unless the class extends `EmberObject`,
   in which case prefer `init`.
@@ -505,21 +505,21 @@ syntax and _not_ extending from `EmberObject` at all in your apps.
 
 - Use the [`create`][3] static method to create instances of the class:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create();
-  ```
+    let jen = Person.create();
+    ```
 
 - You can pass an object of values to `create`, and they'll be assigned to the
   instance:
 
-  ```js
-  const Person = EmberObject.extend({});
+    ```js
+    const Person = EmberObject.extend({});
 
-  let jen = Person.create({ name: 'Jen Weber' });
-  console.log(jen.name); // Jen Weber
-  ```
+    let jen = Person.create({ name: 'Jen Weber' });
+    console.log(jen.name); // Jen Weber
+    ```
 
 - Use the `init` method instead of the `constructor`.
 
@@ -556,42 +556,42 @@ const Person = EmberObject.extend({
 - Native classes have _fields_. Fields are created and assigned for every
   instance:
 
-  ```js
-  class Person {
-    name = 'Chad Hietala';
-  }
-  ```
+    ```js
+    class Person {
+      name = 'Chad Hietala';
+    }
+    ```
 
 - It is okay to assign objects and arrays in class fields:
 
-  ```js
-  // ok ✅
-  class Person {
-    shoppingList = [];
-  }
-  ```
+    ```js
+    // ok ✅
+    class Person {
+      shoppingList = [];
+    }
+    ```
 
 - Avoid using class state in field definitions, use the constructor instead:
 
-  ```js
-  // bad 🛑
-  class Image {
-    width = 0;
-    height = 0;
+    ```js
+    // bad 🛑
+    class Image {
+      width = 0;
+      height = 0;
 
-    aspectRatio = this.width / this.height;
-  }
-
-  // good ✅
-  class Image {
-    constructor() {
-      this.aspectRatio = this.width / this.height;
+      aspectRatio = this.width / this.height;
     }
 
-    width = 0;
-    height = 0;
-  }
-  ```
+    // good ✅
+    class Image {
+      constructor() {
+        this.aspectRatio = this.width / this.height;
+      }
+
+      width = 0;
+      height = 0;
+    }
+    ```
 
 - Fields are assigned before any constructor code is run, so you can access
   their values in the `constructor` function.
@@ -601,21 +601,21 @@ const Person = EmberObject.extend({
 - Classic classes have _properties_. Properties are created and assigned once to
   the _prototype_ of the class, and are shared between every instance:
 
-  ```js
-  const Person = EmberObject.extend({
-    name: 'Chad Hietala',
-  });
-  ```
+    ```js
+    const Person = EmberObject.extend({
+      name: 'Chad Hietala',
+    });
+    ```
 
 - It is _not_ okay to assign objects or arrays as properties, because they are
   shared between instances:
 
-  ```js
-  // not ok 🛑
-  const Person = EmberObject.extend({
-    shoppingList: [],
-  });
-  ```
+    ```js
+    // not ok 🛑
+    const Person = EmberObject.extend({
+      shoppingList: [],
+    });
+    ```
 
 ### Accessors
 
@@ -623,19 +623,19 @@ These are also mostly the same between native and classic classes.
 
 - Accessors can be defined with the `get` and `set` keywords:
 
-  ```js
-  class Person {
-    _name = 'Mel Sumner';
+    ```js
+    class Person {
+      _name = 'Mel Sumner';
 
-    get name() {
-      return this._name;
-    }
+      get name() {
+        return this._name;
+      }
 
-    set name(newName) {
-      this._name = newName;
+      set name(newName) {
+        this._name = newName;
+      }
     }
-  }
-  ```
+    ```
 
 - Getters run every time the property is read, setters run every time the
   property is set.
@@ -650,13 +650,13 @@ These are also mostly the same between native and classic classes.
   class.
 - Native decorators are functions that get applied using the `@` symbol:
 
-  ```js
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import { tracked } from '@glimmer/tracking';
 
-  class Person {
-    @tracked name = 'Ed Faulkner';
-  }
-  ```
+    class Person {
+      @tracked name = 'Ed Faulkner';
+    }
+    ```
 
 - Native decorators can be applied to class fields, methods, accessors, or
   classes themselves. Generally, specific decorators are only meant to be
@@ -669,14 +669,14 @@ These are also mostly the same between native and classic classes.
 
 - Classic decorators are assigned like properties in classic class definitions:
 
-  ```js
-  import EmberObject from '@ember/object';
-  import { tracked } from '@glimmer/tracking';
+    ```js
+    import EmberObject from '@ember/object';
+    import { tracked } from '@glimmer/tracking';
 
-  const Person = EmberObject.extend({
-    name: tracked({ value: 'Ed Faulkner' }),
-  });
-  ```
+    const Person = EmberObject.extend({
+      name: tracked({ value: 'Ed Faulkner' }),
+    });
+    ```
 
 - Only specific decorators provided by Ember can be applied this way in classic
   classes.
@@ -688,29 +688,29 @@ These are also mostly the same between native and classic classes.
 - Adding the `static` keyword to a class element definition puts it on the
   _class_ itself, instead of instances:
 
-  ```js
-  class Person {
-    static name = 'Ed Faulkner';
-  }
+    ```js
+    class Person {
+      static name = 'Ed Faulkner';
+    }
 
-  console.log(Person.name); // Ed Faulkner
+    console.log(Person.name); // Ed Faulkner
 
-  let person = new Person();
+    let person = new Person();
 
-  console.log(person.name); // undefined
-  ```
+    console.log(person.name); // undefined
+    ```
 
 **Classic**
 
 - Use `reopenClass` to add static elements to the constructor:
 
-  ```js
-  const Person = EmberObject.extend();
+    ```js
+    const Person = EmberObject.extend();
 
-  Person.reopenClass({
-    name: 'Ed Faulkner',
-  });
-  ```
+    Person.reopenClass({
+      name: 'Ed Faulkner',
+    });
+    ```
 
 ### Super
 
@@ -720,38 +720,38 @@ These are also mostly the same between native and classic classes.
 - In constructors, use the keyword by itself (this is required). Generally pass
   any arguments along as well:
 
-  ```js
-  class TodoComponent extends Component {
-    constructor() {
-      super(...arguments);
+    ```js
+    class TodoComponent extends Component {
+      constructor() {
+        super(...arguments);
 
-      // setup the component...
+        // setup the component...
+      }
     }
-  }
-  ```
+    ```
 
 - In all other cases, specify the _method_ you want to call when using `super`:
 
-  ```js
-  class Vehicle {
-    moveType = 'moving';
+    ```js
+    class Vehicle {
+      moveType = 'moving';
 
-    move() {
-      console.log(`${this.moveType}!`);
+      move() {
+        console.log(`${this.moveType}!`);
+      }
     }
-  }
 
-  class Aircraft extends Vehicle {
-    moveType = 'flying';
+    class Aircraft extends Vehicle {
+      moveType = 'flying';
 
-    fly() {
-      super.move();
+      fly() {
+        super.move();
+      }
     }
-  }
 
-  let airbus = new Aircraft();
-  airbus.fly(); // flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.fly(); // flying!
+    ```
 
 - If the method does not exist on the parent class, it will throw an error.
 
@@ -760,23 +760,23 @@ These are also mostly the same between native and classic classes.
 - Use the `_super()` function to call the super method with the same name as the
   current method that is executing:
 
-  ```js
-  const Vehicle = EmberObject.extend({
-    move() {
-      console.log(`moving!`);
-    },
-  });
+    ```js
+    const Vehicle = EmberObject.extend({
+      move() {
+        console.log(`moving!`);
+      },
+    });
 
-  const Aircraft = Vehicle.extend({
-    move() {
-      this._super();
-      console.log('flying!');
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      move() {
+        this._super();
+        console.log('flying!');
+      },
+    });
 
-  let airbus = new Aircraft();
-  airbus.move(); // moving! flying!
-  ```
+    let airbus = new Aircraft();
+    airbus.move(); // moving! flying!
+    ```
 
 - Calling `_super()` is _required_ for `init` to function properly. It should
   generally be done before you do anything else in `init`.
@@ -787,27 +787,27 @@ These are also mostly the same between native and classic classes.
 - It is possible to extend classic classes with native syntax, and to toggle
   back and forth between the two:
 
-  ```js
-  class Vehicle extends EmberObject {
-    move() {
-      // ...
+    ```js
+    class Vehicle extends EmberObject {
+      move() {
+        // ...
+      }
     }
-  }
 
-  const Aircraft = Vehicle.extend({
-    fly() {
-      // ...
-    },
-  });
+    const Aircraft = Vehicle.extend({
+      fly() {
+        // ...
+      },
+    });
 
-  class Helicopter extends Aircraft {
-    hover() {
-      // ...
+    class Helicopter extends Aircraft {
+      hover() {
+        // ...
+      }
     }
-  }
 
-  let blackHawk = Helicopter.create();
-  ```
+    let blackHawk = Helicopter.create();
+    ```
 
 - Use `init` instead of `constructor`
 - Use `create` instead of `new`


### PR DESCRIPTION
A follow-up to https://github.com/ember-learn/guides-source/pull/1703, backporting the change made in `current-edition` to `v3.15`, ..., `v3.26`.

> Some code blocks on the `native-classes` page are nested inside an unordered list.

> For the code block indentation to work correctly, an indentation of `4` spaces is needed for every level of the list - there are currently `2`, which is causing the first degree of indentation in each code block to be lost (example shown below):