### PR TITLE
Template-only components fixes

### DIFF
--- a/guides/release/upgrading/current-edition/glimmer-components.md
+++ b/guides/release/upgrading/current-edition/glimmer-components.md
@@ -864,6 +864,6 @@ Additionally, the `mut` helper generally can't be used for the same reason:
 />
 ```
 
-Since Octane template-only components shares a subset of the features available
-to `@glimmer/component`, they can be "upgraded" seamless to a Glimmer component
-by adding a JavaScript file alongside the template when the need arises.
+Since Octane, a template-only component shares a subset of features that are available
+in `@glimmer/component`. Such component can be seamlessly "upgraded" to a Glimmer component,
+when you add a JavaScript file alongside the template.

--- a/guides/release/upgrading/current-edition/glimmer-components.md
+++ b/guides/release/upgrading/current-edition/glimmer-components.md
@@ -841,12 +841,6 @@ it with `on`:
 ## Template-Only Components
 
 In Octane, template-only components have only an `hbs` file and no `JavaScript` file.
-Behind the scenes, template-only components inherit from `'@glimmer/component'`.
-
-They can be thought of as _functional_ components, in the sense that their
-output (the rendered template) is a pure function of their inputs (their
-arguments). The fact that they can't have state makes them much easier to reason
-about in general, and less prone to errors.
 
 Template-only components have no backing class instance, so `this` in their
 templates is `null`. This means that you can only reference passed in arguments
@@ -870,4 +864,6 @@ Additionally, the `mut` helper generally can't be used for the same reason:
 />
 ```
 
-<!-- eof - needed for pages that end in a code block  -->
+Since Octane template-only components shares a subset of the features available
+to `@glimmer/component`, they can be "upgraded" seamless to a Glimmer component
+by adding a JavaScript file alongside the template when the need arises.


### PR DESCRIPTION
* Template-only components don't inherit from `@glimmer/component`.
* Also removed the "pure function" verbiage which felt a bit jargon-y without adding much information, and isn't consistent with how we teach/describe components in the rest of the guides.