### PR TITLE
Remove tmp  during search index creation

### DIFF
--- a/scripts/update-search-index
+++ b/scripts/update-search-index
@@ -62,6 +62,11 @@ rm -r dist
 echo "  DONE"
 
 echo
+echo "🤖 Deleting tmp folder"
+rm -r tmp
+echo "  DONE"
+
+echo
 echo "🤖 Deploying"
 ember deploy production
 echo "  DONE"


### PR DESCRIPTION
The script was creating too many indices for algolia.
We discovered that a tmp dir was holding all the old
versions. You can reproduce this bug by deleting dist,
deleting some versions, and running ember build.
The resulting dist had all the versions, including
those that were deleted.

Co-authored by @mansona 