### PR TITLE
Fix default glimmer args example

### DIFF
--- a/guides/release/upgrading/current-edition/glimmer-components.md
+++ b/guides/release/upgrading/current-edition/glimmer-components.md
@@ -443,7 +443,7 @@ export default class ImageComponent extends Component {
   }
 
   get aspectRatio() {
-    return this.args.width / this.args.height;
+    return this.width / this.height;
   }
 }
 ```

--- a/guides/v3.15.0/upgrading/current-edition/glimmer-components.md
+++ b/guides/v3.15.0/upgrading/current-edition/glimmer-components.md
@@ -443,7 +443,7 @@ export default class ImageComponent extends Component {
   }
 
   get aspectRatio() {
-    return this.args.width / this.args.height;
+    return this.width / this.height;
   }
 }
 ```

--- a/guides/v3.16.0/upgrading/current-edition/glimmer-components.md
+++ b/guides/v3.16.0/upgrading/current-edition/glimmer-components.md
@@ -443,7 +443,7 @@ export default class ImageComponent extends Component {
   }
 
   get aspectRatio() {
-    return this.args.width / this.args.height;
+    return this.width / this.height;
   }
 }
 ```

--- a/guides/v3.17.0/upgrading/current-edition/glimmer-components.md
+++ b/guides/v3.17.0/upgrading/current-edition/glimmer-components.md
@@ -443,7 +443,7 @@ export default class ImageComponent extends Component {
   }
 
   get aspectRatio() {
-    return this.args.width / this.args.height;
+    return this.width / this.height;
   }
 }
 ```

--- a/guides/v3.18.0/upgrading/current-edition/glimmer-components.md
+++ b/guides/v3.18.0/upgrading/current-edition/glimmer-components.md
@@ -443,7 +443,7 @@ export default class ImageComponent extends Component {
   }
 
   get aspectRatio() {
-    return this.args.width / this.args.height;
+    return this.width / this.height;
   }
 }
 ```

--- a/guides/v3.19.0/upgrading/current-edition/glimmer-components.md
+++ b/guides/v3.19.0/upgrading/current-edition/glimmer-components.md
@@ -443,7 +443,7 @@ export default class ImageComponent extends Component {
   }
 
   get aspectRatio() {
-    return this.args.width / this.args.height;
+    return this.width / this.height;
   }
 }
 ```

--- a/guides/v3.20.0/upgrading/current-edition/glimmer-components.md
+++ b/guides/v3.20.0/upgrading/current-edition/glimmer-components.md
@@ -443,7 +443,7 @@ export default class ImageComponent extends Component {
   }
 
   get aspectRatio() {
-    return this.args.width / this.args.height;
+    return this.width / this.height;
   }
 }
 ```

--- a/guides/v3.21.0/upgrading/current-edition/glimmer-components.md
+++ b/guides/v3.21.0/upgrading/current-edition/glimmer-components.md
@@ -443,7 +443,7 @@ export default class ImageComponent extends Component {
   }
 
   get aspectRatio() {
-    return this.args.width / this.args.height;
+    return this.width / this.height;
   }
 }
 ```

--- a/guides/v3.22.0/upgrading/current-edition/glimmer-components.md
+++ b/guides/v3.22.0/upgrading/current-edition/glimmer-components.md
@@ -443,7 +443,7 @@ export default class ImageComponent extends Component {
   }
 
   get aspectRatio() {
-    return this.args.width / this.args.height;
+    return this.width / this.height;
   }
 }
 ```

--- a/guides/v3.23.0/upgrading/current-edition/glimmer-components.md
+++ b/guides/v3.23.0/upgrading/current-edition/glimmer-components.md
@@ -443,7 +443,7 @@ export default class ImageComponent extends Component {
   }
 
   get aspectRatio() {
-    return this.args.width / this.args.height;
+    return this.width / this.height;
   }
 }
 ```

--- a/guides/v3.24.0/upgrading/current-edition/glimmer-components.md
+++ b/guides/v3.24.0/upgrading/current-edition/glimmer-components.md
@@ -443,7 +443,7 @@ export default class ImageComponent extends Component {
   }
 
   get aspectRatio() {
-    return this.args.width / this.args.height;
+    return this.width / this.height;
   }
 }
 ```

--- a/guides/v3.25.0/upgrading/current-edition/glimmer-components.md
+++ b/guides/v3.25.0/upgrading/current-edition/glimmer-components.md
@@ -443,7 +443,7 @@ export default class ImageComponent extends Component {
   }
 
   get aspectRatio() {
-    return this.args.width / this.args.height;
+    return this.width / this.height;
   }
 }
 ```

--- a/guides/v3.26.0/upgrading/current-edition/glimmer-components.md
+++ b/guides/v3.26.0/upgrading/current-edition/glimmer-components.md
@@ -443,7 +443,7 @@ export default class ImageComponent extends Component {
   }
 
   get aspectRatio() {
-    return this.args.width / this.args.height;
+    return this.width / this.height;
   }
 }
 ```

--- a/guides/v3.27.0/upgrading/current-edition/glimmer-components.md
+++ b/guides/v3.27.0/upgrading/current-edition/glimmer-components.md
@@ -443,7 +443,7 @@ export default class ImageComponent extends Component {
   }
 
   get aspectRatio() {
-    return this.args.width / this.args.height;
+    return this.width / this.height;
   }
 }
 ```


### PR DESCRIPTION
[This section](https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/#toc_arguments) of the guides provides an example of how to use getters for default Glimmer component args, but in the example the original immutable args are used to compute `aspectRatio` rather than the getters that provide default values. This could be confusing because it could imply that the getters somehow provide defaults to the args when accessed via `this.args`. Instead, IMHO, the arg-consuming getter (`aspectRatio`) should demonstrate using the getters rather than the original args. This PR makes that change for all versions that include this example (all Octane versions).