### PR TITLE
Update documentation for get helper

### DIFF
--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -208,9 +208,21 @@ For the full list of available helpers, you can check the [template helpers API 
 ### The `get` helper
 
 The [`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
-helper makes it easy to dynamically send the value of a variable to another
-helper or component. This can be useful if you want to output one of several
-values based on the result of a getter.
+helper makes it easy to dynamically look up a property on an object. The second argument to `{{get}}` can be a string or an integer depending on the object being accessed.
+
+
+accessing properties on an object with string keys:
+```handlebars
+{{get this.someObject "object_key"}}
+```
+accessing via indices:
+
+```handlebars
+{{get this.someObjectWithNumericKeys 0}}
+
+{{get this.someArray 0}}
+```
+or outputting one of several values based on result of a getter:
 
 ```handlebars
 {{get this.address this.part}}
@@ -218,6 +230,7 @@ values based on the result of a getter.
 
 If the `part` getter returns "zip", this will display the result of `this.address.zip`.
 If it returns "city", you get `this.address.city`.
+
 
 ### The `concat` helper
 

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -208,20 +208,24 @@ For the full list of available helpers, you can check the [template helpers API 
 ### The `get` helper
 
 The [`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
-helper makes it easy to dynamically look up a property on an object. The second argument to `{{get}}` can be a string or an integer depending on the object being accessed.
+helper makes it easy to dynamically look up a property on an object or an element in an array. The second argument to `{{get}}` can be a string or an integer depending on the object being accessed.
 
 
 accessing properties on an object with string keys:
 ```handlebars
 {{get this.someObject "object_key"}}
 ```
-accessing via indices:
+accessing properties on an object with numeric keys:
 
 ```handlebars
 {{get this.someObjectWithNumericKeys 0}}
+` ` `
 
+accessing elements in an array:
+
+```handlebars
 {{get this.someArray 0}}
-```
+` ` `
 or outputting one of several values based on result of a getter:
 
 ```handlebars

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -208,25 +208,22 @@ For the full list of available helpers, you can check the [template helpers API 
 ### The `get` helper
 
 The [`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
-helper makes it easy to dynamically look up a property on an object or an element in an array. The second argument to `{{get}}` can be a string or an integer depending on the object being accessed.
+helper makes it easy to dynamically look up a property on an object or an element in an array. The second argument to `{{get}}` can be a string or a number, depending on the object being accessed.
 
 
-accessing properties on an object with string keys:
+To access a property on an object with a string key:
+
 ```handlebars
 {{get this.someObject "object_key"}}
 ```
-accessing properties on an object with numeric keys:
 
-```handlebars
-{{get this.someObjectWithNumericKeys 0}}
-` ` `
-
-accessing elements in an array:
+To access the first element in an array:
 
 ```handlebars
 {{get this.someArray 0}}
-` ` `
-or outputting one of several values based on result of a getter:
+```
+
+To access a property on an object with a dynamic key:
 
 ```handlebars
 {{get this.address this.part}}


### PR DESCRIPTION
This PR is motivated by a question that was surfaced by [this issue](https://github.com/emberjs/ember.js/issues/19519) in the [emberjs repo ](https://github.com/emberjs/ember.js).  

The `get` helper use can be extended to objects with string or numeric keys, so arrays can also make use of the helper. This PR updates the docs to have examples of all of these use cases and have a more generic definition of what the `get` helper can do. 