### PR TITLE
Fix backing class in Template Lifecycle, DOM, and Modifiers

### DIFF
--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -266,10 +266,10 @@ The simplest way to accomplish this is by using the `did-insert` modifier from [
 ```
 
 ```js {app/components/edit-form.js}
-import Component from "@glimmer/component";
-import { action } from "@ember/object";
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
-export default class EditForm extends Component {
+export default class EditFormComponent extends Component {
   @action
   focus(element) {
     element.focus();

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -266,7 +266,11 @@ The simplest way to accomplish this is by using the `did-insert` modifier from [
 ```
 
 ```js {app/components/edit-form.js}
-export default class EditForm {
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+
+export default class EditForm extends Component {
+  @action
   focus(element) {
     element.focus();
   }


### PR DESCRIPTION
The previous version of this example was lacking the imports and used a bare class instead of one which `extends Component`, and also did not include the `@action` binding, so would simply not have worked.