### PR TITLE
Remove Prettier for Handlebars recommendation

### DIFF
--- a/guides/release/code-editors/index.md
+++ b/guides/release/code-editors/index.md
@@ -25,10 +25,6 @@ and maintain consistent coding styles between different editors and IDEs.
 [Glimmer Templates Syntax](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-glimmer-syntax) -
 Syntax formatting for glimmer templates.
 
-[Prettier for Handlebars](https://marketplace.visualstudio.com/items?itemName=Alonski.prettier-for-handlebars-vscode) -
-Format your handlebars files with Prettier ...that's it! 
-Note, because this uses the currently unreleased Prettier, it may break with future changes to Prettier.
-
 ## Vim and Neovim
 
 Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient.


### PR DESCRIPTION
This extension isn't needed anymore to use Prettier with Templates anymore.
The recommendation now (at least from me) is to use Ember Template Lint with the [Prettier Plugin](https://github.com/ember-template-lint/ember-template-lint-plugin-prettier)

To auto fix on save in VSCode it is possible to use the `emeraldwalk.runonsave` extension with these settings:
```
  // Settings for `RunOnSave` extension
  "emeraldwalk.runonsave": {
    "commands": [
      {
        // For every `.hbs` run the template linter in fix mode
        "match": "\\.hbs$",
        "cmd": "yarn run ember-template-lint ${file} --fix"
      }
    ]
  },
```