### PR TITLE
Remove references to Bower

### DIFF
--- a/guides/release/addons-and-dependencies/index.md
+++ b/guides/release/addons-and-dependencies/index.md
@@ -44,8 +44,7 @@ Your own assets (such as `robots.txt`, `favicon`, custom fonts, etc) should be p
 When you're using dependencies that are not included in an addon,
 you will have to instruct Ember CLI to include your assets in the build.
 This is done using the asset manifest file `ember-cli-build.js`.
-You should only try to import assets located in the `node_modules` and `vendor` folders. `bower_components` also still
-works, but is recommended against, unless you have no other choice. Even bower recommends not to use itself anymore.
+You should only try to import assets located in the `node_modules` and `vendor` folders.
 
 ### Globals provided by JavaScript assets
 


### PR DESCRIPTION
Since the [Bower RFC implementation](https://github.com/ember-cli/ember-cli/pull/9707) has been merged (I assume it will be part of the upcoming `v4.2` release), I think we can start removing references to Bower from the guides?