### PR TITLE
add get and set imports to tracked backwards compat examples

### DIFF
--- a/guides/release/upgrading/current-edition/tracked-properties.md
+++ b/guides/release/upgrading/current-edition/tracked-properties.md
@@ -228,6 +228,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -247,6 +249,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v3.15.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.15.0/upgrading/current-edition/tracked-properties.md
@@ -223,6 +223,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -242,6 +244,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v3.16.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.16.0/upgrading/current-edition/tracked-properties.md
@@ -223,6 +223,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -242,6 +244,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v3.17.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.17.0/upgrading/current-edition/tracked-properties.md
@@ -228,6 +228,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -247,6 +249,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v3.18.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.18.0/upgrading/current-edition/tracked-properties.md
@@ -228,6 +228,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -247,6 +249,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v3.19.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.19.0/upgrading/current-edition/tracked-properties.md
@@ -228,6 +228,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -247,6 +249,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v3.20.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.20.0/upgrading/current-edition/tracked-properties.md
@@ -228,6 +228,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -247,6 +249,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v3.21.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.21.0/upgrading/current-edition/tracked-properties.md
@@ -228,6 +228,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -247,6 +249,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v3.22.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.22.0/upgrading/current-edition/tracked-properties.md
@@ -228,6 +228,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -247,6 +249,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v3.23.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.23.0/upgrading/current-edition/tracked-properties.md
@@ -228,6 +228,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -247,6 +249,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v3.24.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.24.0/upgrading/current-edition/tracked-properties.md
@@ -228,6 +228,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -247,6 +249,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v3.25.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.25.0/upgrading/current-edition/tracked-properties.md
@@ -228,6 +228,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -247,6 +249,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v3.26.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.26.0/upgrading/current-edition/tracked-properties.md
@@ -228,6 +228,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -247,6 +249,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v3.27.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.27.0/upgrading/current-edition/tracked-properties.md
@@ -228,6 +228,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -247,6 +249,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v3.28.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v3.28.0/upgrading/current-edition/tracked-properties.md
@@ -228,6 +228,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -247,6 +249,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;

--- a/guides/v4.0.0/upgrading/current-edition/tracked-properties.md
+++ b/guides/v4.0.0/upgrading/current-edition/tracked-properties.md
@@ -228,6 +228,8 @@ Likewise, properties that are not decorated with `@tracked` that you get using
 them:
 
 ```js
+import { get, set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     let width = get(this, 'width');
@@ -247,6 +249,8 @@ and there is no way to know in advance that they might be changed with `set`.
 For instance, this will not work:
 
 ```js
+import { set } from '@ember/object';
+
 class Image {
   get aspectRatio() {
     return this.width / this.height;


### PR DESCRIPTION
I have pointed developers at these docs and they had some uncertainty over where `get` and `set` come from. I've added the `get` and `set` imports to the examples for clarity.