### PR TITLE
Bugfix - search index script omits prebuilt guides

### DIFF
--- a/scripts/update-search-index
+++ b/scripts/update-search-index
@@ -25,6 +25,11 @@ rm -rf ./guides/v?.*
 echo "  DONE"
 
 echo
+echo "🤖 Removing pre-built guides."
+rm -rf ./public/v?.*
+echo "  DONE"
+
+echo
 echo "👩‍💻 Go to https://www.algolia.com/apps/Y1OMR4C7MF/api-keys/all"
 read -sp "Algolia Write API Key: " write_api_key
 


### PR DESCRIPTION
This fixes a bug in search index deploy scripts.
We pre-build some older versions of the guides to make our
builds faster. Our search index scripts were picking up on
these, making everything slow and overwriting a lot of our
indexes every time we deployed. Now, we delete
those pre-built versions before running the index.

#1777