### PR TITLE
revise instructions for runloop debugging

### DIFF
--- a/guides/release/configuring-ember/debugging.md
+++ b/guides/release/configuring-ember/debugging.md
@@ -107,9 +107,9 @@ To enable full stacktrace mode in Backburner, and thus determine the stack of th
 when it was scheduled onto the run loop, you can set:
 
 ```javascript {data-filename=app/app.js}
-import { run } from '@ember/runloop';
+import runloop from '@ember/runloop';
 
-run.backburner.DEBUG = true;
+runloop._backburner.DEBUG = true;
 ```
 
 Once the `DEBUG` value is set to `true`, when you are at a breakpoint you can navigate


### PR DESCRIPTION
I haven't used the feature so don't know if it's working, or whether accessing an _variable is a good idea, but the previous steps didn't work for me during/after an Ember/cli 4.1 upgrade.