### PR TITLE
Remove Ember Language Server from the list of Visual Studio Code's extensions

### DIFF
--- a/guides/release/code-editors/index.md
+++ b/guides/release/code-editors/index.md
@@ -8,7 +8,7 @@ Visual Studio Code is a code editor optimized for building and debugging modern 
 Visual Studio Code is one of the most popular text editors among Ember developers.
 
 [Unstable Ember Language Server](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable) -
-Unstable Ember Language Server is full-featured fork of Ember Language Server. It's stable and extremely power-featured.
+Despite its name, Unstable Ember Language Server is a stable, full-featured language server. Its name comes from its history as a fork of Ember Language Server and the efforts to keep up with changes in Ember.
 
 [Ember JS (ES6) and Handlebars code snippets](https://marketplace.visualstudio.com/items?itemName=phanitejakomaravolu.EmberES6Snippets) -
 Enables Ember.js and Handlebars snippets to let you to type less and code more.

--- a/guides/release/code-editors/index.md
+++ b/guides/release/code-editors/index.md
@@ -7,12 +7,11 @@ many of which are created and maintained by the developer community:
 Visual Studio Code is a code editor optimized for building and debugging modern web applications. 
 Visual Studio Code is one of the most popular text editors among Ember developers.
 
-[Ember Language Server](https://marketplace.visualstudio.com/items?itemName=EmberTooling.vscode-ember) -
-Provides autocomplete in templates and allows go-to-definition behavior within Ember projects.
-
 [Unstable Ember Language Server](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable) -
-A popular fork of Ember Language Server with different features.
-Don't let the 'unstable' name confuse you - it's safe to use!
+Unstable Ember Language Server is full-featured fork of Ember Language Server. It's stable and extremely power-featured.
+
+[Ember Language Server](https://marketplace.visualstudio.com/items?itemName=EmberTooling.vscode-ember) -
+Provides autocomplete in templates and allows go-to-definition behavior within Ember projects. *It is not under active maintaining.*
 
 [Ember JS (ES6) and Handlebars code snippets](https://marketplace.visualstudio.com/items?itemName=phanitejakomaravolu.EmberES6Snippets) -
 Enables Ember.js and Handlebars snippets to let you to type less and code more.

--- a/guides/release/code-editors/index.md
+++ b/guides/release/code-editors/index.md
@@ -4,14 +4,11 @@ many of which are created and maintained by the developer community:
 
 ## Visual Studio Code
 
-Visual Studio Code is a code editor optimized for building and debugging modern web applications. 
+Visual Studio Code is a code editor optimized for building and debugging modern web applications.
 Visual Studio Code is one of the most popular text editors among Ember developers.
 
 [Unstable Ember Language Server](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable) -
 Unstable Ember Language Server is full-featured fork of Ember Language Server. It's stable and extremely power-featured.
-
-[Ember Language Server](https://marketplace.visualstudio.com/items?itemName=EmberTooling.vscode-ember) -
-Provides autocomplete in templates and allows go-to-definition behavior within Ember projects. *It is not under active maintaining.*
 
 [Ember JS (ES6) and Handlebars code snippets](https://marketplace.visualstudio.com/items?itemName=phanitejakomaravolu.EmberES6Snippets) -
 Enables Ember.js and Handlebars snippets to let you to type less and code more.
@@ -29,8 +26,8 @@ Syntax formatting for glimmer templates.
 Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient.
 It is included as "vi" with most UNIX systems and with Apple OS X.
 Alternatively, Neovim is a hyper-extensible Vim-based text editor.
-Both editors share a range of cross-compatible extensions listed below. 
-  
+Both editors share a range of cross-compatible extensions listed below.
+
 You'll want to remove any linter / completion manager you currently have installed
 (or disable them for `.js`, `.ts` or `.hbs` files), and follow the install guides for the following packages:
 
@@ -47,7 +44,7 @@ Various tools for working with Ember.js projects.
 An Intellisense engine which takes control over all linting, hinting, and language-server integration.
 
 [coc-ember](https://github.com/NullVoxPopuli/coc-ember) -
-Ember.js language server extension including useful configuration instructions. 
+Ember.js language server extension including useful configuration instructions.
 Optional addons for Ember language server:
 - [vim-ember-hbs](https://github.com/joukevandermaas/vim-ember-hbs)
 - [vim-javascript](https://github.com/pangloss/vim-javascript)


### PR DESCRIPTION
`Ember Language Server` is not under active maintaining, but `Unstable Ember Language Server` is. 
`UELS` includes all `ELS` features and has a lot [more](https://github.com/lifeart/ember-language-server#features).
Right now `UELS` is the main `VSCode` extension for Ember developers.

If `UELS` will be in the first place, new Ember developers will use it and have more comfortable experience.