### PR TITLE
guides: fix "tools for deprecations" links

### DIFF
--- a/guides/release/upgrading/index.md
+++ b/guides/release/upgrading/index.md
@@ -32,7 +32,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v3.15.0/upgrading/index.md
+++ b/guides/v3.15.0/upgrading/index.md
@@ -27,7 +27,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v3.16.0/upgrading/index.md
+++ b/guides/v3.16.0/upgrading/index.md
@@ -27,7 +27,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v3.17.0/upgrading/index.md
+++ b/guides/v3.17.0/upgrading/index.md
@@ -27,7 +27,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v3.18.0/upgrading/index.md
+++ b/guides/v3.18.0/upgrading/index.md
@@ -27,7 +27,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v3.19.0/upgrading/index.md
+++ b/guides/v3.19.0/upgrading/index.md
@@ -27,7 +27,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v3.20.0/upgrading/index.md
+++ b/guides/v3.20.0/upgrading/index.md
@@ -27,7 +27,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v3.21.0/upgrading/index.md
+++ b/guides/v3.21.0/upgrading/index.md
@@ -27,7 +27,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v3.22.0/upgrading/index.md
+++ b/guides/v3.22.0/upgrading/index.md
@@ -27,7 +27,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v3.23.0/upgrading/index.md
+++ b/guides/v3.23.0/upgrading/index.md
@@ -27,7 +27,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v3.24.0/upgrading/index.md
+++ b/guides/v3.24.0/upgrading/index.md
@@ -27,7 +27,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v3.25.0/upgrading/index.md
+++ b/guides/v3.25.0/upgrading/index.md
@@ -27,7 +27,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v3.26.0/upgrading/index.md
+++ b/guides/v3.26.0/upgrading/index.md
@@ -27,7 +27,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v3.27.0/upgrading/index.md
+++ b/guides/v3.27.0/upgrading/index.md
@@ -27,7 +27,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v3.28.0/upgrading/index.md
+++ b/guides/v3.28.0/upgrading/index.md
@@ -27,7 +27,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v4.0.0/upgrading/index.md
+++ b/guides/v4.0.0/upgrading/index.md
@@ -32,7 +32,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v4.1.0/upgrading/index.md
+++ b/guides/v4.1.0/upgrading/index.md
@@ -32,7 +32,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 

--- a/guides/v4.2.0/upgrading/index.md
+++ b/guides/v4.2.0/upgrading/index.md
@@ -32,7 +32,7 @@ When they are available, they can save a lot of time that you would spend making
 If an API you are using will be going away in the next major version of Ember, you will see a deprecation warning in the developer console.
 Sometimes, they will be deprecation warnings caused by code in your app, and other times, they may be caused by an addon.
 
-For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](release/ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
+For more guidance on what to do with deprecations, visit [Handling Deprecations](../configuring-ember/handling-deprecations/), check out the Ember Inspector [tools for deprecations](../ember-inspector/deprecations/), or read about the specifics in the [Deprecations Guides](https://deprecations.emberjs.com/).
 
 ## Upgrading to Octane
 


### PR DESCRIPTION
Throughout all of the guides since v3.15.0, we have a broken link to the
"/ember-inspector/deprecations" page. Let's go through and fix this
retroactively so consumers of the guides can find the content that they're
looking for a little bit easier.