### PR TITLE
guides: Fix diff lines for adding NewMessageInput

### DIFF
--- a/guides/release/components/introducing-components.md
+++ b/guides/release/components/introducing-components.md
@@ -282,7 +282,7 @@ We have one last component to extract. Let's pull out the new message input.
 
 And include it in our `application.hbs` file.
 
-```handlebars {data-filename="app/templates/application.hbs" data-diff="-6,-7,-8,-9,-10,-11,+12"}
+```handlebars {data-filename="app/templates/application.hbs" data-diff="-6,-7,-8,-9,-10,-11,-12,+13"}
 <div class="messages">
   <ReceivedMessage />
 

--- a/guides/v4.2.0/components/introducing-components.md
+++ b/guides/v4.2.0/components/introducing-components.md
@@ -282,7 +282,7 @@ We have one last component to extract. Let's pull out the new message input.
 
 And include it in our `application.hbs` file.
 
-```handlebars {data-filename="app/templates/application.hbs" data-diff="-6,-7,-8,-9,-10,-11,+12"}
+```handlebars {data-filename="app/templates/application.hbs" data-diff="-6,-7,-8,-9,-10,-11,-12,+13"}
 <div class="messages">
   <ReceivedMessage />
 


### PR DESCRIPTION
A very minor issue I noticed while reading https://guides.emberjs.com/release/components/introducing-components/

Previously the + appeared on the /form line - it should appear on the NewMessageInput.