### PR TITLE
Backport code sample diff

### DIFF
--- a/guides/v3.28.0/components/introducing-components.md
+++ b/guides/v3.28.0/components/introducing-components.md
@@ -282,7 +282,7 @@ We have one last component to extract. Let's pull out the new message input.
 
 And include it in our `application.hbs` file.
 
-```handlebars {data-filename="app/templates/application.hbs" data-diff="-6,-7,-8,-9,-10,-11,+12"}
+```handlebars {data-filename="app/templates/application.hbs" data-diff="-6,-7,-8,-9,-10,-11,-12,+13"}
 <div class="messages">
   <ReceivedMessage />
 

--- a/guides/v4.0.0/components/introducing-components.md
+++ b/guides/v4.0.0/components/introducing-components.md
@@ -282,7 +282,7 @@ We have one last component to extract. Let's pull out the new message input.
 
 And include it in our `application.hbs` file.
 
-```handlebars {data-filename="app/templates/application.hbs" data-diff="-6,-7,-8,-9,-10,-11,+12"}
+```handlebars {data-filename="app/templates/application.hbs" data-diff="-6,-7,-8,-9,-10,-11,-12,+13"}
 <div class="messages">
   <ReceivedMessage />
 

--- a/guides/v4.1.0/components/introducing-components.md
+++ b/guides/v4.1.0/components/introducing-components.md
@@ -282,7 +282,7 @@ We have one last component to extract. Let's pull out the new message input.
 
 And include it in our `application.hbs` file.
 
-```handlebars {data-filename="app/templates/application.hbs" data-diff="-6,-7,-8,-9,-10,-11,+12"}
+```handlebars {data-filename="app/templates/application.hbs" data-diff="-6,-7,-8,-9,-10,-11,-12,+13"}
 <div class="messages">
   <ReceivedMessage />
 


### PR DESCRIPTION
A code sample diff was fixed in https://github.com/ember-learn/guides-source/pull/1816 for a couple of versions. This PR backports the fix to the remaining applicable versions.