### PR TITLE
Remove some outdated route method references

### DIFF
--- a/guides/release/models/creating-updating-and-deleting-records.md
+++ b/guides/release/models/creating-updating-and-deleting-records.md
@@ -110,28 +110,18 @@ a promise, which makes it easy to asynchronously handle success and failure
 scenarios. Here's a common pattern:
 
 ```javascript
-let post = store.createRecord('post', {
+// Assumed to have already injected the router and store services
+const newPost = this.store.createRecord('post', {
   title: 'Rails is Omakase',
   body: 'Lorem ipsum'
 });
 
-let self = this;
-
-function transitionToPost(post) {
-  this.router.transitionTo('posts.show', post);
+try {
+  await newPost.save();
+  this.router.transitionTo('posts.show', newPost.id);
+} catch (error) {
+  // Handle error
 }
-
-function failure(reason) {
-  // handle the error
-}
-
-post
-  .save()
-  .then(transitionToPost)
-  .catch(failure);
-
-// => POST to '/posts'
-// => transitioning to posts.show route
 ```
 
 ## Deleting Records

--- a/guides/release/models/creating-updating-and-deleting-records.md
+++ b/guides/release/models/creating-updating-and-deleting-records.md
@@ -118,7 +118,7 @@ let post = store.createRecord('post', {
 let self = this;
 
 function transitionToPost(post) {
-  self.transitionToRoute('posts.show', post);
+  this.router.transitionTo('posts.show', post);
 }
 
 function failure(reason) {

--- a/guides/release/routing/redirection.md
+++ b/guides/release/routing/redirection.md
@@ -7,12 +7,10 @@ Usually you want to redirect them to the login page, and after they have success
 There are many other reasons you probably want to have the last word on whether a user can or cannot access a certain page.
 Ember allows you to control that access with a combination of hooks and methods in your route.
 
-One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/release/classes/Route/methods/transitionTo?anchor=transitionTo).
-Calling `transitionTo()` from a route or
-[`transitionToRoute()`](https://api.emberjs.com/ember/release/classes/Controller/methods/transitionToRoute?anchor=transitionToRoute) from a controller will stop any transitions currently in progress and start a new one, functioning as a redirect.
-`transitionTo()` behaves exactly like the [`LinkTo`](../../templates/links/) helper.
+One of the methods is [`transitionTo()`](https://api.emberjs.com/ember/release/classes/RouterService/methods/transitionTo?anchor=transitionTo).
+Calling `transitionTo()` on the router service will stop any transitions currently in progress and start a new one, functioning as a redirect.
 
-The other one is [`replaceWith()`](https://api.emberjs.com/ember/release/classes/Route/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
+The other one is [`replaceWith()`](https://api.emberjs.com/ember/release/classes/RouterService/methods/replaceWith?anchor=replaceWith) which works the same way as `transitionTo()`.
 The only difference between them is how they manage history.
 `replaceWith()` substitutes the current route entry and replaces it with that of the route we are redirecting to,
 while `transitionTo()` leaves the entry for the current route and creates a new one for the redirection.


### PR DESCRIPTION
Closes #1754

We mostly replaced the outdated uses of transitionToRoute/replaceWithRoute, but there were a couple links hanging around. The code samples already use the service, like they are supposed to.

Only 1 reviewer is needed, from any team member.