### PR TITLE
Rename `ENABLE_ALL_FEATURES` flag to `ENABLE_OPTIONAL_FEATURES` for versions v2.3.0 and up

### DIFF
--- a/guides/release/configuring-ember/feature-flags.md
+++ b/guides/release/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.10.0/configuring-ember/feature-flags.md
+++ b/guides/v2.10.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ var ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.11.0/configuring-ember/feature-flags.md
+++ b/guides/v2.11.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.12.0/configuring-ember/feature-flags.md
+++ b/guides/v2.12.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.13.0/configuring-ember/feature-flags.md
+++ b/guides/v2.13.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.14.0/configuring-ember/feature-flags.md
+++ b/guides/v2.14.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.15.0/configuring-ember/feature-flags.md
+++ b/guides/v2.15.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.16.0/configuring-ember/feature-flags.md
+++ b/guides/v2.16.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.17.0/configuring-ember/feature-flags.md
+++ b/guides/v2.17.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.18.0/configuring-ember/feature-flags.md
+++ b/guides/v2.18.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.3.0/configuring-ember/feature-flags.md
+++ b/guides/v2.3.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ var ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.4.0/configuring-ember/feature-flags.md
+++ b/guides/v2.4.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ var ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.5.0/configuring-ember/feature-flags.md
+++ b/guides/v2.5.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ var ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.6.0/configuring-ember/feature-flags.md
+++ b/guides/v2.6.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ var ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.7.0/configuring-ember/feature-flags.md
+++ b/guides/v2.7.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ var ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.8.0/configuring-ember/feature-flags.md
+++ b/guides/v2.8.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ var ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v2.9.0/configuring-ember/feature-flags.md
+++ b/guides/v2.9.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ var ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.0.0/configuring-ember/feature-flags.md
+++ b/guides/v3.0.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.1.0/configuring-ember/feature-flags.md
+++ b/guides/v3.1.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.10.0/configuring-ember/feature-flags.md
+++ b/guides/v3.10.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.11.0/configuring-ember/feature-flags.md
+++ b/guides/v3.11.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.12.0/configuring-ember/feature-flags.md
+++ b/guides/v3.12.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.13.0/configuring-ember/feature-flags.md
+++ b/guides/v3.13.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.14.0/configuring-ember/feature-flags.md
+++ b/guides/v3.14.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.15.0/configuring-ember/feature-flags.md
+++ b/guides/v3.15.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.16.0/configuring-ember/feature-flags.md
+++ b/guides/v3.16.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.17.0/configuring-ember/feature-flags.md
+++ b/guides/v3.17.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.18.0/configuring-ember/feature-flags.md
+++ b/guides/v3.18.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.19.0/configuring-ember/feature-flags.md
+++ b/guides/v3.19.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.2.0/configuring-ember/feature-flags.md
+++ b/guides/v3.2.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.20.0/configuring-ember/feature-flags.md
+++ b/guides/v3.20.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.21.0/configuring-ember/feature-flags.md
+++ b/guides/v3.21.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.22.0/configuring-ember/feature-flags.md
+++ b/guides/v3.22.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.23.0/configuring-ember/feature-flags.md
+++ b/guides/v3.23.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.24.0/configuring-ember/feature-flags.md
+++ b/guides/v3.24.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.25.0/configuring-ember/feature-flags.md
+++ b/guides/v3.25.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.26.0/configuring-ember/feature-flags.md
+++ b/guides/v3.26.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.27.0/configuring-ember/feature-flags.md
+++ b/guides/v3.27.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.28.0/configuring-ember/feature-flags.md
+++ b/guides/v3.28.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.3.0/configuring-ember/feature-flags.md
+++ b/guides/v3.3.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.4.0/configuring-ember/feature-flags.md
+++ b/guides/v3.4.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.5.0/configuring-ember/feature-flags.md
+++ b/guides/v3.5.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.6.0/configuring-ember/feature-flags.md
+++ b/guides/v3.6.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.7.0/configuring-ember/feature-flags.md
+++ b/guides/v3.7.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.8.0/configuring-ember/feature-flags.md
+++ b/guides/v3.8.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v3.9.0/configuring-ember/feature-flags.md
+++ b/guides/v3.9.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v4.0.0/configuring-ember/feature-flags.md
+++ b/guides/v4.0.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v4.1.0/configuring-ember/feature-flags.md
+++ b/guides/v4.1.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v4.2.0/configuring-ember/feature-flags.md
+++ b/guides/v4.2.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.

--- a/guides/v4.3.0/configuring-ember/feature-flags.md
+++ b/guides/v4.3.0/configuring-ember/feature-flags.md
@@ -58,5 +58,5 @@ let ENV = {
 };
 ```
 
-For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_ALL_FEATURES` to `true` will enable all
+For the truly ambitious developer, setting `ENV.EmberENV.ENABLE_OPTIONAL_FEATURES` to `true` will enable all
 experimental features.


### PR DESCRIPTION
The `ENABLE_ALL_FEATURES` flag was removed in [v2.3.0](https://github.com/emberjs/ember.js/blob/5a77a4312accd672f29b48b73db2b78745335ae7/CHANGELOG.md#230-january-17-2016) in favour of `ENABLE_OPTIONAL_FEATURES`:
https://github.com/emberjs/ember.js/pull/12627