### PR TITLE
Update modifiers related sections to be accurate to what we've been able to do since 3.25

### DIFF
--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -243,7 +243,7 @@ On the other hand, if you're looking at JavaScript documentation that tells you 
 
 If you want to set a property, you can use the `prop` element modifier.
 
-## Calling Methods On First Render
+## Calling Methods On Render
 
 So far, we've talked about web APIs that work by setting attributes as well as web APIs that work by setting properties. But what about web APIs that work by calling methods, like setting focus on an element?
 
@@ -253,35 +253,30 @@ For example, let's say we want to focus an `<input>` in a form as soon as the fo
 inputElement.focus();
 ```
 
-This code needs to run after the element is rendered.
-
-The simplest way to accomplish this is by using the `did-insert` modifier from [@ember/render-modifiers][render-modifiers].
-
-[render-modifiers]: https://github.com/emberjs/ember-render-modifiers
+This code needs to run after the element is rendered, and modifiers provided that capability.
 
 ```handlebars {app/components/edit-form.hbs}
 <form>
-  <input {{did-insert this.focus}}>
+  <input {{this.autofocus}}>
 </form>
 ```
 
+Here we define a local modifier right on the component class.
+
 ```js {app/components/edit-form.js}
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
+import { modifier } from 'ember-modifier';
 
 export default class EditFormComponent extends Component {
-  @action
-  focus(element) {
-    element.focus();
-  }
+  autofocus = modifier((element) => element.focus());
 }
 ```
 
-The `did-insert` modifier will call a function after its element is added to the DOM. That function receives the element as a parameter.
+More information about `ember-modifier` can be found [on the README](https://github.com/ember-modifier/ember-modifier) as well as philosophy, how to think about modifiers, etc.
 
-### Abstracting the Logic Into a Custom Modifier
+### Abstracting the Logic Into a Shareable Modifier
 
-Using the `did-insert` modifier works well for one-off cases, but if you want to pull this logic into reusable functionality that you can use throughout your app, you can make your _own_ modifier.
+Using the local modifier sworks well for one-off cases, but if you want to pull this logic into reusable functionality that you can use throughout your app, you can move the modifier to a globally accessible place
 
 The modifier that we're going to build will allow us to say:
 
@@ -291,9 +286,9 @@ The modifier that we're going to build will allow us to say:
 </form>
 ```
 
-Pretty nice, right?
+No need for `this`, or to define anything on your component class.
 
-To accomplish that, we'll create a modifier in `app/modifiers/autofocus.js`. First, install [`ember-modifier`](https://github.com/ember-modifier/ember-modifier) and then generate an `autofocus` modifier for your app:
+To accomplish that, we'll create a file at `app/modifiers/autofocus.js`. First, ensure that [`ember-modifier`](https://github.com/ember-modifier/ember-modifier) is installed and then generate an `autofocus` modifier for your app:
 
 ```bash
 ember install ember-modifier
@@ -448,7 +443,7 @@ document.addEventListener("click", event => {
 
 The most important difference between this example and the cases we've seen so far is that we need to remove the `click` event handler from the document when this element is destroyed.
 
-To accomplish this, we can use [`ember-modifier`](https://github.com/ember-modifier/ember-modifier) to create a `on-click-outside` modifier that sets up the event listener after the element is first inserted and removes the event listener when the element is removed. 
+To accomplish this, we can use [`ember-modifier`](https://github.com/ember-modifier/ember-modifier) to create a `on-click-outside` modifier that sets up the event listener after the element is first inserted and removes the event listener when the element is removed.
 
 Run the following commands to install the addon and generate a new modifier:
 

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -253,7 +253,8 @@ For example, let's say we want to focus an `<input>` in a form as soon as the fo
 inputElement.focus();
 ```
 
-This code needs to run after the element is rendered, and modifiers provided that capability.
+We can use a modifier to run a method immediately after an element has rendered.
+In this example, we add an `autofocus` method to the component class, and use it in a template:
 
 ```handlebars {app/components/edit-form.hbs}
 <form>
@@ -272,11 +273,11 @@ export default class EditFormComponent extends Component {
 }
 ```
 
-More information about `ember-modifier` can be found [on the README](https://github.com/ember-modifier/ember-modifier) as well as philosophy, how to think about modifiers, etc.
+Modifiers can be used in many other ways! For API documentation and more examples, visit the [the `ember-modifier` README](https://github.com/ember-modifier/ember-modifier).
 
 ### Abstracting the Logic Into a Shareable Modifier
 
-Using the local modifier sworks well for one-off cases, but if you want to pull this logic into reusable functionality that you can use throughout your app, you can move the modifier to a globally accessible place
+Writing a modifier in a component class works well for one-time use cases, but if you want to reuse the modifier in other places within your app, you can move the modifier to a globally accessible place.
 
 The modifier that we're going to build will allow us to say:
 

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -245,7 +245,7 @@ If you want to set a property, you can use the `prop` element modifier.
 
 ## Calling Methods On Render
 
-So far, we've talked about web APIs that work by setting attributes as well as web APIs that work by setting properties. But what about web APIs that work by calling methods, like setting focus on an element?
+So far, we've talked about web APIs that work by setting attributes as well as web APIs that work by setting properties. But what about web APIs that work by calling methods, like setting focus on an element? 
 
 For example, let's say we want to focus an `<input>` in a form as soon as the form is rendered. The web API for focusing an element is:
 
@@ -254,15 +254,9 @@ inputElement.focus();
 ```
 
 We can use a modifier to run a method immediately after an element has rendered.
-In this example, we add an `autofocus` method to the component class, and use it in a template:
-
-```handlebars {app/components/edit-form.hbs}
-<form>
-  <input {{this.autofocus}}>
-</form>
-```
-
-Here we define a local modifier right on the component class.
+To follow along with the examples below, make sure you have `ember-modifier` installed in your app.
+Import `modifier` from `ember-modfier`, add an `autofocus` method to the component class,
+and then use it in a component template.
 
 ```js {app/components/edit-form.js}
 import Component from '@glimmer/component';
@@ -271,6 +265,14 @@ import { modifier } from 'ember-modifier';
 export default class EditFormComponent extends Component {
   autofocus = modifier((element) => element.focus());
 }
+```
+
+Here is how we can use our new modifier in a template:
+
+```handlebars {app/components/edit-form.hbs}
+<form>
+  <input {{this.autofocus}}>
+</form>
 ```
 
 Modifiers can be used in many other ways! For API documentation and more examples, visit the [the `ember-modifier` README](https://github.com/ember-modifier/ember-modifier).

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -271,7 +271,10 @@ Here is how we can use our new modifier in a template:
 
 ```handlebars {app/components/edit-form.hbs}
 <form>
-  <input {{this.autofocus}}>
+  <label>
+    Name:
+    <input {{this.autofocus}}>
+  <label>
 </form>
 ```
 

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -257,7 +257,7 @@ We can use a modifier to run a method immediately after an element has rendered.
 To follow along with the examples below, make sure you have `ember-modifier` installed in your app:
 
 ```
-npx ember install ember-modifier
+ember install ember-modifier
 ```
 
 Import `modifier` from `ember-modfier`, add an `autofocus` method to the component class,

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -254,7 +254,12 @@ inputElement.focus();
 ```
 
 We can use a modifier to run a method immediately after an element has rendered.
-To follow along with the examples below, make sure you have `ember-modifier` installed in your app.
+To follow along with the examples below, make sure you have `ember-modifier` installed in your app:
+
+```
+npx ember install ember-modifier
+```
+
 Import `modifier` from `ember-modfier`, add an `autofocus` method to the component class,
 and then use it in a component template.
 
@@ -263,7 +268,7 @@ import Component from '@glimmer/component';
 import { modifier } from 'ember-modifier';
 
 export default class EditFormComponent extends Component {
-  autofocus = modifier((element) => element.focus());
+  autofocus = modifier((element) => element.focus(), { eager: false });
 }
 ```
 


### PR DESCRIPTION
This will

- [x] Update existing modifier language in the `release` docs
- [ ] once approved, I'll back port it all the way to 3.25
- [ ] removes mentions of `@ember/render-modifiers` as those modifiers were meant for migration from the old paradigms, and not exactly reflective of how the Octane mental model works.

Prior to 3.25, all modifiers had to be globally available in `app/modifiers/*` -- this is very awkward, and kind of unfortunate from a teaching perspective that we had such a big gap between modifiers being "the thing" and when they can be freely used -- so I'll be ignoring everything prior to 3.25 for these updates.