### PR TITLE
Add missing period to features list

### DIFF
--- a/guides/v4.5.0/getting-started/index.md
+++ b/guides/v4.5.0/getting-started/index.md
@@ -11,7 +11,7 @@ Some of these features that you'll learn about in the guides are:
 * [Components](../components/) - The fundamental construct used in Ember applications, used to create reusable UI elements and define the layout and the functionality of the app.
 * [Routing](../routing/) - A central part of an Ember application. Enables developers to drive the application state from the URL.
 * [Services](../services/) - The way to store long-term state in your application and pass it around.
-* [Ember Data](../models/) - Ember Data provides a consistent way to communicate with external APIs and manage application state
+* [Ember Data](../models/) - Ember Data provides a consistent way to communicate with external APIs and manage application state.
 * [Ember Inspector](../ember-inspector/) - A browser extension, or bookmarklet, to inspect your application live. It's also useful for spotting Ember applications in the wild, try to install it and open up the [NASA website](https://www.nasa.gov/)!
 
 ## Organization


### PR DESCRIPTION
In maybe the most pedantic correction ever, add a period to the features list on the one bullet point missing it, for stylistic consistency in the guides.