### PR TITLE
updated "ember server" references to "ember serve"

### DIFF
--- a/guides/release/tutorial/part-1/orientation.md
+++ b/guides/release/tutorial/part-1/orientation.md
@@ -165,10 +165,10 @@ We'll learn about the purposes of these files and folders as we go. For now, jus
 
 ## Starting and Stopping the Development Server
 
-Ember CLI comes with a lot of different commands for a variety of development tasks, such as the `ember new` command that we saw earlier. It also comes with a _development server_, which we can launch with the `ember server` command:
+Ember CLI comes with a lot of different commands for a variety of development tasks, such as the `ember new` command that we saw earlier. It also comes with a _development server_, which we can launch with the `ember serve` command:
 
 ```shell
-$ ember server
+$ ember serve
 building... 
 
 Build successful (9761ms) – Serving on http://localhost:4200/
@@ -190,7 +190,7 @@ The development server is responsible for compiling our app and serving it to th
   </div>
 </div>
 
-You can exit out of the development server at any time by typing `Ctrl + C` into the terminal window where `ember server` is running. That is, typing the "C" key on your keyboard _while_ holding down the "Ctrl" key at the same time. Once it has stopped, you can start it back up again with the same `ember server` command. We recommend having two terminal windows open: one to run the server in background, another to type other Ember CLI commands.
+You can exit out of the development server at any time by typing `Ctrl + C` into the terminal window where `ember serve` is running. That is, typing the "C" key on your keyboard _while_ holding down the "Ctrl" key at the same time. Once it has stopped, you can start it back up again with the same `ember serve` command. We recommend having two terminal windows open: one to run the server in background, another to type other Ember CLI commands.
 
 ## Editing Files and Live Reload
 

--- a/guides/release/tutorial/part-1/reusable-components.md
+++ b/guides/release/tutorial/part-1/reusable-components.md
@@ -95,10 +95,10 @@ After saving the changes to our configuration file, we will need to restart our 
 
 <!-- TODO: https://github.com/ember-cli/ember-cli/issues/8782 -->
 
-You can stop the server by finding the terminal window where `ember server` is running, then type `Ctrl + C`. That is, typing the "C" key on your keyboard _while_ holding down the "Ctrl" key at the same time. Once it has stopped, you can start it back up again with the same `ember server` command.
+You can stop the server by finding the terminal window where `ember serve` is running, then type `Ctrl + C`. That is, typing the "C" key on your keyboard _while_ holding down the "Ctrl" key at the same time. Once it has stopped, you can start it back up again with the same `ember serve` command.
 
 ```shell
-$ ember server
+$ ember serve
 building... 
 
 Build successful (13286ms) – Serving on http://localhost:4200/


### PR DESCRIPTION
Was going through the tutorial and noticed they were telling us to use the "ember server" command to run the dev server. This was inconsistent with the quickstart and what's documented in the CLI, so I updated it.

Also noticed the CLI says to run "npm start", which is an alias to "ember serve", but just wondering if that should be updated as well.

Thanks!