### PR TITLE
Update linking-between-routes.md

### DIFF
--- a/guides/release/routing/linking-between-routes.md
+++ b/guides/release/routing/linking-between-routes.md
@@ -205,12 +205,6 @@ simply pass them along with the invocation:
 CSS classes passed this way will be _in addition to_ the standard `ember-view`
 and possibly `active` classes.
 
-Note that the `<LinkTo />` component uses the element's `id` HTML attribute
-internally for event dispatching purposes. For that reason, if you would like
-to customize its HTML `id`, you must pass it as the `@id` argument instead.
-Overriding the components `id` attribute directly will stop the link from
-functioning correctly.
-
 ### Replacing history entries
 
 The default behavior for the `<LinkTo />` component is to add entries to the


### PR DESCRIPTION
Remove the legacy `@id` argument note of `<LinkTo />` component according to https://deprecations.emberjs.com/v3.x/#toc_ember-built-in-components-legacy-arguments, using the `id` HTML attribute should be fine now.