### PR TITLE
Remove `ember-gestures` addon recommendation

### DIFF
--- a/guides/release/accessibility/application-considerations.md
+++ b/guides/release/accessibility/application-considerations.md
@@ -46,7 +46,6 @@ Here are some examples of accessibility-focused addons created by many people th
 
 - [ember-a11y-landmarks](https://github.com/ember-a11y/ember-a11y-landmarks) - Ember addon to help with landmark roles for better accessibility
 - [ember-component-focus](https://github.com/ember-a11y/ember-component-focus) - A mixin for adding methods to your Ember components that help you manage the currently focused element.
-- [ember-gestures](https://github.com/html-next/ember-gestures) - Ember Gestures provides an easy way to use gestures by making it simple to define and use HammerJS managers and recognizers throughout your app.
 - [ember-steps](https://github.com/rwjblue/ember-steps) - Declarative create wizards, tabbed UIs, and more
 - [ember-page-title](https://github.com/tim-evans/ember-page-title) - Page title management for Ember.js Apps
 - [ember-self-focused](https://github.com/linkedin/self-focused/tree/master/packages/ember-self-focused) - Focus on route on transition


### PR DESCRIPTION
`ember-gestures` and its dependency, `ember-hammertime`, are no longer maintained and do not function at all on recent versions of Ember.

Refs:
- https://github.com/html-next/ember-gestures/issues/139
- https://github.com/html-next/ember-hammertime/issues/103