### PR TITLE
Update autotracking in-depth guides to use @cached decorator (#1886)

### DIFF
--- a/guides/release/in-depth-topics/autotracking-in-depth.md
+++ b/guides/release/in-depth-topics/autotracking-in-depth.md
@@ -362,17 +362,13 @@ getter is very expensive, however, you will want to cache the value and
 retrieve it when the dependencies haven't changed. You want to recompute only
 if a dependency has been updated.
 
-Ember's [cache API](https://github.com/ember-polyfills/ember-cache-primitive-polyfill) lets
-you cache a getter in 2 steps:
+Ember's [@cached decorator](https://github.com/ember-polyfills/ember-cache-primitive-polyfill) lets
+you cache (or "memoize") a getter by simply marking it as `@cached`.
 
-1. Pass a function that is costly to compute to `createCache`.
-1. In the getter, call the function with `getValue` and return its value.
-
-With these steps in mind, let's introduce caching to `aspectRatio`:
+With this in mind, let's introduce caching to `aspectRatio`:
 
 ```js
-import { tracked } from '@glimmer/tracking';
-import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
+import { cached, tracked } from '@glimmer/tracking';
 
 let count = 0;
 
@@ -380,12 +376,7 @@ class Photo {
   @tracked width = 600;
   @tracked height = 400;
 
-  // `#` indicates a private field on the class
-  #aspectRatioCache = createCache(() => {
-    count++;
-    return this.width / this.height;
-  });
-
+  @cached
   get aspectRatio() {
     return getValue(this.#aspectRatioCache);
   }
@@ -407,6 +398,8 @@ console.log(count); // 2
 From the value of `count`, we see that, this time, `aspectRatio` was calculated
 only twice.
 
-The cache API was released in Ember 3.22. If you want to leverage this API between versions 3.13 and 3.21, you can install [ember-cache-primitive-polyfill](https://github.com/ember-polyfills/ember-cache-primitive-polyfill) to your project.
+In general, you should avoid using @cached unless you have confirmed that the getter you are decorating is computationally expensive, since @cached adds a small amount of overhead to the getter.
+
+The @cached decorator was released in Ember 4.1. If you want to leverage this API between versions 3.13 and 4.1, you can install [ember-cached-decorator-polyfill](https://github.com/ember-polyfills/ember-cached-decorator-polyfill) to your project.
 
 <!-- eof - needed for pages that end in a code block  -->


### PR DESCRIPTION
Changes the "Caching of tracked properties" section of the Autotracking In-Depth guides page to use the `@cached` decorator instead of the lower-level caching primitives APIs.