### PR TITLE
Update setupTest function imports

### DIFF
--- a/guides/release/accessibility/page-template-considerations.md
+++ b/guides/release/accessibility/page-template-considerations.md
@@ -48,7 +48,7 @@ You can test that page titles are generated correctly by asserting on the value 
 ```javascript {data-filename=tests/acceptance/posts-test.js}
 import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'my-app-name/tests/helpers';
 
 module('Acceptance | posts', function(hooks) {
   setupApplicationTest(hooks);

--- a/guides/release/testing/test-types.md
+++ b/guides/release/testing/test-types.md
@@ -73,7 +73,7 @@ When unit tests involve the Ember framework, you must import and call [`setupTes
 For example, consider a service that keeps an array of messages, to be shown to the user at a later time:
 
 ```javascript {data-filename=tests/unit/services/flash-messages-test.js}
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'my-app-name/tests/helpers';
 import { module, test } from 'qunit';
 
 module('Unit | Service | flash-messages', function(hooks) {
@@ -113,7 +113,7 @@ Consider a button component. For simplicity, assume that the component keeps tra
 
 ```javascript {data-filename=tests/integration/components/simple-button-test.js}
 import { click, render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'my-app-name/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 
@@ -174,7 +174,7 @@ Let's continue with the blog post example from [Rendering Tests](../test-types/#
 
 ```javascript {data-filename=tests/acceptance/posts-test.js}
 import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'my-app-name/tests/helpers';
 import { module, test } from 'qunit';
 
 module('Acceptance | posts', function(hooks) {

--- a/guides/release/testing/testing-application.md
+++ b/guides/release/testing/testing-application.md
@@ -10,7 +10,7 @@ This generates this file:
 ```javascript {data-filename=tests/acceptance/login-test.js}
 import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'my-app-name/tests/helpers';
 
 module('Acceptance | login', function(hooks) {
   setupApplicationTest(hooks);
@@ -37,7 +37,7 @@ For example:
 ```javascript {data-filename=tests/acceptance/new-post-appears-first-test.js}
 import { module, test } from 'qunit';
 import { click, fillIn, visit } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'my-app-name/tests/helpers';
 
 module('Acceptance | posts', function(hooks) {
   setupApplicationTest(hooks);

--- a/guides/release/testing/testing-components.md
+++ b/guides/release/testing/testing-components.md
@@ -31,7 +31,7 @@ and cleaning up once your tests in this module are finished.
 
 ```javascript {data-filename="tests/integration/components/pretty-color-test.js"}
 import { module } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'my-app-name/tests/helpers';
 
 module('Integration | Component | pretty-color', function(hooks) {
   setupRenderingTest(hooks);
@@ -44,7 +44,7 @@ Here, we can use the `QUnit.test` helper and we can give it a descriptive name:
 
 ```javascript {data-filename="tests/integration/components/pretty-color-test.js"}
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'my-app-name/tests/helpers';
 
 module('Integration | Component | pretty-color', function(hooks) {
   setupRenderingTest(hooks);
@@ -63,7 +63,7 @@ We can better see what this means, once we start writing out our first test case
 
 ```javascript {data-filename="tests/integration/components/pretty-color-test.js"}
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'my-app-name/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -94,7 +94,7 @@ component's `style` attribute and is reflected in the rendered HTML:
 
 ```javascript {data-filename="tests/integration/components/pretty-color-test.js"}
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'my-app-name/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -121,7 +121,7 @@ We might also test this component to ensure that the content of its template is 
 
 ```javascript {data-filename="tests/integration/components/pretty-color-test.js"}
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'my-app-name/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -181,7 +181,7 @@ And our test might look like this:
 
 ```javascript {data-filename="tests/integration/components/magic-title-test.js"}
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'my-app-name/tests/helpers';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -246,7 +246,7 @@ external action is called:
 
 ```javascript {data-filename="tests/integration/components/comment-form-test.js"}
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'my-app-name/tests/helpers';
 import { click, fillIn, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -324,7 +324,7 @@ In this case we initially force location to "New York".
 
 ```javascript {data-filename="tests/integration/components/location-indicator-test.js"}
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'my-app-name/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
@@ -361,7 +361,7 @@ the test needs to check that the stub data from the service is reflected in the 
 
 ```javascript {data-filename="tests/integration/components/location-indicator-test.js" data-diff="+30,+31,+32,+33,+34,+35"}
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'my-app-name/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
@@ -403,7 +403,7 @@ In the next example, we'll add another test that validates that the display chan
 
 ```javascript {data-filename="tests/integration/components/location-indicator-test.js" data-diff="+36,+37,+38,+39,+40,+41,+42,+43,+44,+45,+46,+47,+48,+49,+50"}
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'my-app-name/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
@@ -509,7 +509,7 @@ In your test, use the `settled` helper to wait until your debounce timer is up a
 
 ```javascript {data-filename="tests/integration/components/delayed-typeahead-test.js"}
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'my-app-name/tests/helpers';
 import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/guides/release/testing/testing-controllers.md
+++ b/guides/release/testing/testing-controllers.md
@@ -38,7 +38,7 @@ container:
 
 ```javascript {data-filename=tests/unit/controllers/posts-test.js}
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'my-app-name/tests/helpers';
 
 module('Unit | Controller | posts', function(hooks) {
   setupTest(hooks);
@@ -52,7 +52,7 @@ and is also exposed in tests for your usage. Here it will return a singleton ins
 
 ```javascript {data-filename=tests/unit/controllers/posts-test.js}
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'my-app-name/tests/helpers';
 
 module('Unit | Controller | posts', function(hooks) {
   setupTest(hooks);

--- a/guides/release/testing/testing-helpers.md
+++ b/guides/release/testing/testing-helpers.md
@@ -53,7 +53,7 @@ in [Testing Components](../testing-components/).
 
 ```javascript {data-filename=tests/integration/helpers/format-currency-test.js}
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'my-app-name/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -75,7 +75,7 @@ We can now also properly test if a helper will respond to property changes.
 
 ```javascript {data-filename=tests/integration/helpers/format-currency-test.js}
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'my-app-name/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/guides/release/testing/testing-models.md
+++ b/guides/release/testing/testing-models.md
@@ -30,7 +30,7 @@ level 4 to assert that the `levelName` changes. We will use `module` together wi
 
 ```javascript {data-filename=tests/unit/models/player-test.js}
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'my-app-name/tests/helpers';
 import { run } from '@ember/runloop';
 
 module('Unit | Model | player', function(hooks) {
@@ -85,7 +85,7 @@ Then you could test that the relationship by looking it up on the `user` model w
 
 ```javascript {data-filename=tests/unit/models/user-test.js}
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'my-app-name/tests/helpers';
 import { get } from '@ember/object';
 
 module('Unit | Model | user', function(hooks) {

--- a/guides/release/testing/testing-routes.md
+++ b/guides/release/testing/testing-routes.md
@@ -45,7 +45,7 @@ Here is an example of test this route in an isolated test case:
 
 ```javascript {data-filename=tests/unit/routes/application-test.js}
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'my-app-name/tests/helpers';
 
 let originalAlert;
 

--- a/guides/release/testing/unit-testing-basics.md
+++ b/guides/release/testing/unit-testing-basics.md
@@ -31,7 +31,7 @@ computed property is working correctly.
 
 ```javascript {data-filename=tests/unit/service/some-thing-test.js}
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'my-app-name/tests/helpers';
 
 module('Unit | Service | some thing', function(hooks) {
   setupTest(hooks);
@@ -80,7 +80,7 @@ result of the method call.
 
 ```javascript {data-filename=tests/unit/services/some-thing-test.js}
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'my-app-name/tests/helpers';
 
 module('Unit | Service | some thing', function(hooks) {
   setupTest(hooks);
@@ -117,7 +117,7 @@ The test would call the `calc` method and assert it gets back the correct value.
 
 ```javascript {data-filename=tests/unit/services/some-thing-test.js}
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'my-app-name/tests/helpers';
 
 module('Unit | Service | some thing', function(hooks) {
   setupTest(hooks);
@@ -179,7 +179,7 @@ out which method the error is in. In we stub the other method:
 
 ```javascript {data-filename=tests/unit/services/some-thing-test.js}
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'my-app-name/tests/helpers';
 
 module('Unit | Service | some thing', function(hooks) {
   setupTest(hooks);
@@ -223,7 +223,7 @@ Instead, create a simple object and pass it instead.
 
 ```javascript {data-filename=tests/unit/services/employees-test.js}
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'my-app-name/tests/helpers';
 
 module('Unit | Service | employees', function(hooks) {
   setupTest(hooks);


### PR DESCRIPTION
Implementing RFC https://github.com/emberjs/rfcs/pull/637 changed the import paths for setupTest functions (setupTest, setupRenderingTest, setupApplicationTest). This change is live - if someone has the latest ember version installed and runs `ember g component my-component` they will see this syntax at the top of the new tests:

```
import { module, test } from 'qunit';
import { setupRenderingTest } from 'my-app-name/tests/helpers';
import { render } from '@ember/test-helpers';
import { hbs } from 'ember-cli-htmlbars';
```

This PR is a find-replace to reflect those changes. 