### PR TITLE
Add helper function changes to other guides versions

### DIFF
--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -1,8 +1,8 @@
 Helper functions are JavaScript functions that you can call from your template.
 
-Ember's template syntax limits what you can express to keep the structure of your application clear at a glance. When you need to compute something using JavaScript, you can use helper functions. It's possible to create your own helpers or just [use the built-in ones](./#toc_built-in-helpers).
+Ember's template syntax limits what you can express to keep the structure of your application clear at a glance. When you need to compute something using JavaScript, you can use helper functions. It's possible to create your own helpers, locally or just [use the built-in ones](./#toc_built-in-helpers).
 
-For instance, let's take a look at a generic message component from a messaging app.
+Let's take a look at a generic message component from a messaging app.
 
 ```handlebars {data-filename="app/components/message.hbs"}
 <Message::Avatar
@@ -62,11 +62,127 @@ Since the title is just the `@username` plus some extra stuff, we can replace `@
 
 However, to get the first initial of the string, we'll need to use JavaScript. To do that, we'll write a helper function.
 
-## Writing a Helper Function
-
-We define helper functions in the `app/helpers` folder.
-
 In this case we want a helper function that takes three arguments: a string, a starting position, and a length. The function will return a substring of the original string.
+
+## Local Helper Functions
+
+It's possible to use plain functions for helpers and modifiers. A plain helper function can be "local" to or defined on components and controllers.
+
+```js {data-filename="app/components/message.js"}
+import Component from '@glimmer/component';
+import { setComponentTemplate } from '@ember/component';
+import { hbs } from 'ember-cli-htmlbars';
+
+export default class Message extends Component {
+  substring = (string, start, end) => string.substring(start, end);
+}
+```
+
+We can then use this helper in the component's template to get the first letter of the username.
+
+```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4"}
+<Message::Avatar
+  @title="{{@username}}'s avatar"
+  @initial={{@avatarTitle}}
+  @initial={{this.substring @username 0 1}}
+  @isActive={{@userIsActive}}
+  class={{if @isCurrentUser "current-user"}}
+/>
+<section>
+  <Message::Username
+    @name={{@username}}
+    @localTime={{@userLocalTime}}
+  />
+
+  {{yield}}
+</section>
+```
+
+### Named Arguments
+
+Helpers default to using positional arguments, but sometimes it can make the corresponding syntax `{{substring @username 0 1}}` a little hard to read. We see some numbers at the end but can't tell what exactly they mean. We can use _named arguments_ to make the `substring` helper easier to read.
+
+Using named arguments, we could make our template a lot clearer.
+
+```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4,+5"}
+<Message::Avatar
+  @title="{{@username}}'s avatar"
+  @initial={{substring @username 0 1}}
+  {{! This won't work yet! We need to update the substring helper }}
+  @initial={{substring @username start=0 end=1}}
+  @isActive={{@userIsActive}}
+  class={{if @isCurrentUser "current-user"}}
+/>
+<section>
+  <Message::Username
+    @name={{@username}}
+    @localTime={{@userLocalTime}}
+  />
+
+  {{yield}}
+</section>
+```
+
+Helpers take _named arguments_ as a JavaScript object. All named arguments are grouped into an "options object" as the last parameter.
+
+```js {data-filename="app/components/message.js" data-diff="-6,+7"}
+import Component from '@glimmer/component';
+import { setComponentTemplate } from '@ember/component';
+import { hbs } from 'ember-cli-htmlbars';
+
+export default class Message extends Component {
+  substring = (string, start, end) => string.substring(start, end);
+  substring = (string, options) => string.substring(options.start, options.end);
+}
+```
+
+You can mix positional and named arguments to make your templates easy to read:
+
+```handlebars {data-filename="app/components/calculator.hbs"}
+{{this.calculate 1 2 op="add"}}
+```
+
+```js {data-filename="app/components/calculator.js"}
+export default class Calculator extends Component {
+  calculate(first, second, options) {
+    // ...
+  }
+}
+```
+
+### Nested Helpers
+
+Sometimes, you might see helpers invoked by placing them inside parentheses,
+`()`. This means that a Helper is being used inside of another Helper or
+Component. This is referred to as a "nested" Helper Invocation. Parentheses must be used because curly braces `{{}}` cannot be nested.
+
+```handlebars {data-filename=app/templates/application.hbs}
+{{this.sum (this.multiply 2 4) 2}}
+```
+
+In this example, we are using a helper to multiply `2` and `4` _before_ passing the value into `{{sum}}`.
+
+Thus, the output of these combined helpers is `10`.
+
+As you move forward with these template guides, keep in mind that a helper can be used anywhere a normal value can be used.
+
+Many of Ember's built-in helpers (as well as your custom helpers) can be used in nested form.
+
+## Global Helper Functions
+
+Next to local helpers, ember provides a way to use global helpers. We define global helper functions in the `app/helpers` folder. Once defined, they will be available to use directly inside all templates in your app.
+
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        Before Ember 4.5, using global helpers was the only way to define helpers.
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
 
 To implement the helper, we write a JavaScript function that takes its arguments as an _array_. This is because helpers can also receive _named_
 arguments, which we'll discuss next.
@@ -96,8 +212,6 @@ function substring(args) {
 export default helper(substring);
 ```
 
-**This is how we normally write helpers in Ember**.
-
 We can then use this helper in the component's template to get the first letter of the username.
 
 ```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4"}
@@ -118,11 +232,9 @@ We can then use this helper in the component's template to get the first letter 
 </section>
 ```
 
-### Named Arguments
+### Named arguments
 
-The syntax `{{substring @username 0 1}}` is a little hard to read. We see some numbers at the end but can't tell what exactly they mean. We can use _named arguments_ to make the `substring` helper easier to read.
-
-Using named arguments, we could make our template a lot clearer.
+Similar to local helpers, global helpers also can mix positional and named arguments.
 
 ```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4,+5"}
 <Message::Avatar
@@ -143,8 +255,6 @@ Using named arguments, we could make our template a lot clearer.
 </section>
 ```
 
-In addition to taking _positional arguments_ as an array, helpers take _named arguments_ as a JavaScript object. Here's what that looks like using [destructuring syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Unpacking_fields_from_objects_passed_as_function_parameter).
-
 ```js {data-filename="app/helpers/substring.js"}
 import { helper } from '@ember/component/helper';
 
@@ -155,31 +265,7 @@ function substring([string], { start, end }) {
 export default helper(substring);
 ```
 
-You can mix positional and named arguments to make your templates easy to read.
-
-### Nested Helpers
-
-Sometimes, you might see helpers invoked by placing them inside parentheses,
-`()`. This means that a Helper is being used inside of another Helper or
-Component. This is referred to as a "nested" Helper Invocation. Parentheses must
-be used because curly braces `{{}}` cannot be nested.
-
-```handlebars {data-filename=app/templates/application.hbs}
-{{sum (multiply 2 4) 2}}
-```
-
-In this example, we are using a helper to multiply `2` and `4` _before_ passing
-the value into `{{sum}}`.
-
-Thus, the output of these combined helpers is `10`.
-
-As you move forward with these template guides, keep in mind that a helper can
-be used anywhere a normal value can be used.
-
-Many of Ember's built-in helpers (as well as your custom helpers) can be used in
-nested form.
-
-## Advanced: Class Helpers
+### Class Helpers
 
 Helpers can also be defined using class syntax. For instance, we could define
 the substring helper using classes instead.
@@ -203,11 +289,11 @@ discussing state in the next chapter).
 ## Built-in Helpers
 
 Below you will find some useful template helpers documented.
-For the full list of available helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/).
+For the full list of available helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/).
 
 ### The `get` helper
 
-The [`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
+The [`{{get}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/get?anchor=get)
 helper makes it easy to dynamically look up a property on an object or an element in an array. The second argument to `{{get}}` can be a string or a number, depending on the object being accessed.
 
 
@@ -237,7 +323,7 @@ If it returns "city", you get `this.address.city`.
 
 We mentioned above that helpers can be nested. This can be
 combined with different dynamic helpers. For example, the
-[`{{concat}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
+[`{{concat}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
 helper makes it easy to dynamically send a number of parameters to a component
 or helper as a single parameter in the format of a concatenated string.
 
@@ -253,7 +339,7 @@ This will display the result of `this.foo.item1` when index is 1, and
 Now let's say your template is starting to get a bit cluttered and you want
 to clean up the logic in your templates. This can be achieved with the `let`
 block helper.
-The [`{{let}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/let?anchor=let)
+The [`{{let}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/let?anchor=let)
 helper lets you create new bindings (or temporary variables) in your template.
 
 Say your template now looks like this:
@@ -290,7 +376,7 @@ capitalized given name and family name as `givenName` and `familyName` instead o
 
 ### The `array` helper
 
-Using the [`{{array}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
+Using the [`{{array}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
 you can pass arrays directly from the template as an argument to your components.
 
 ```handlebars
@@ -315,7 +401,7 @@ In the component's template, you can then use the `people` argument as an array:
 
 ### The `hash` helper
 
-Using the [`{{hash}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
+Using the [`{{hash}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
 helper, you can pass objects directly from the template as an argument to your
 components.
 
@@ -335,7 +421,7 @@ Hello, {{@person.givenName}} {{@person.familyName}}
 
 ### The `in-element` helper
 
-Using the [`{{in-element}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
 to render a modal, tooltip, or dropdown.
 
 Suppose we want to show a dropdown menu when the user clicks on a button. The code below shows a `<button>` element, a placeholder `<div>` element, and a dropdown component. The argument `@show`, when set to `true`, will add the dropdown to the placeholder div.

--- a/guides/v4.6.0/components/helper-functions.md
+++ b/guides/v4.6.0/components/helper-functions.md
@@ -1,8 +1,8 @@
 Helper functions are JavaScript functions that you can call from your template.
 
-Ember's template syntax limits what you can express to keep the structure of your application clear at a glance. When you need to compute something using JavaScript, you can use helper functions. It's possible to create your own helpers or just [use the built-in ones](./#toc_built-in-helpers).
+Ember's template syntax limits what you can express to keep the structure of your application clear at a glance. When you need to compute something using JavaScript, you can use helper functions. It's possible to create your own helpers, locally or just [use the built-in ones](./#toc_built-in-helpers).
 
-For instance, let's take a look at a generic message component from a messaging app.
+Let's take a look at a generic message component from a messaging app.
 
 ```handlebars {data-filename="app/components/message.hbs"}
 <Message::Avatar
@@ -62,11 +62,127 @@ Since the title is just the `@username` plus some extra stuff, we can replace `@
 
 However, to get the first initial of the string, we'll need to use JavaScript. To do that, we'll write a helper function.
 
-## Writing a Helper Function
-
-We define helper functions in the `app/helpers` folder.
-
 In this case we want a helper function that takes three arguments: a string, a starting position, and a length. The function will return a substring of the original string.
+
+## Local Helper Functions
+
+It's possible to use plain functions for helpers and modifiers. A plain helper function can be "local" to or defined on components and controllers.
+
+```js {data-filename="app/components/message.js"}
+import Component from '@glimmer/component';
+import { setComponentTemplate } from '@ember/component';
+import { hbs } from 'ember-cli-htmlbars';
+
+export default class Message extends Component {
+  substring = (string, start, end) => string.substring(start, end);
+}
+```
+
+We can then use this helper in the component's template to get the first letter of the username.
+
+```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4"}
+<Message::Avatar
+  @title="{{@username}}'s avatar"
+  @initial={{@avatarTitle}}
+  @initial={{this.substring @username 0 1}}
+  @isActive={{@userIsActive}}
+  class={{if @isCurrentUser "current-user"}}
+/>
+<section>
+  <Message::Username
+    @name={{@username}}
+    @localTime={{@userLocalTime}}
+  />
+
+  {{yield}}
+</section>
+```
+
+### Named Arguments
+
+Helpers default to using positional arguments, but sometimes it can make the corresponding syntax `{{substring @username 0 1}}` a little hard to read. We see some numbers at the end but can't tell what exactly they mean. We can use _named arguments_ to make the `substring` helper easier to read.
+
+Using named arguments, we could make our template a lot clearer.
+
+```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4,+5"}
+<Message::Avatar
+  @title="{{@username}}'s avatar"
+  @initial={{substring @username 0 1}}
+  {{! This won't work yet! We need to update the substring helper }}
+  @initial={{substring @username start=0 end=1}}
+  @isActive={{@userIsActive}}
+  class={{if @isCurrentUser "current-user"}}
+/>
+<section>
+  <Message::Username
+    @name={{@username}}
+    @localTime={{@userLocalTime}}
+  />
+
+  {{yield}}
+</section>
+```
+
+Helpers take _named arguments_ as a JavaScript object. All named arguments are grouped into an "options object" as the last parameter.
+
+```js {data-filename="app/components/message.js" data-diff="-6,+7"}
+import Component from '@glimmer/component';
+import { setComponentTemplate } from '@ember/component';
+import { hbs } from 'ember-cli-htmlbars';
+
+export default class Message extends Component {
+  substring = (string, start, end) => string.substring(start, end);
+  substring = (string, options) => string.substring(options.start, options.end);
+}
+```
+
+You can mix positional and named arguments to make your templates easy to read:
+
+```handlebars {data-filename="app/components/calculator.hbs"}
+{{this.calculate 1 2 op="add"}}
+```
+
+```js {data-filename="app/components/calculator.js"}
+export default class Calculator extends Component {
+  calculate(first, second, options) {
+    // ...
+  }
+}
+```
+
+### Nested Helpers
+
+Sometimes, you might see helpers invoked by placing them inside parentheses,
+`()`. This means that a Helper is being used inside of another Helper or
+Component. This is referred to as a "nested" Helper Invocation. Parentheses must be used because curly braces `{{}}` cannot be nested.
+
+```handlebars {data-filename=app/templates/application.hbs}
+{{this.sum (this.multiply 2 4) 2}}
+```
+
+In this example, we are using a helper to multiply `2` and `4` _before_ passing the value into `{{sum}}`.
+
+Thus, the output of these combined helpers is `10`.
+
+As you move forward with these template guides, keep in mind that a helper can be used anywhere a normal value can be used.
+
+Many of Ember's built-in helpers (as well as your custom helpers) can be used in nested form.
+
+## Global Helper Functions
+
+Next to local helpers, ember provides a way to use global helpers. We define global helper functions in the `app/helpers` folder. Once defined, they will be available to use directly inside all templates in your app.
+
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        Before Ember 4.5, using global helpers was the only way to define helpers.
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
 
 To implement the helper, we write a JavaScript function that takes its arguments as an _array_. This is because helpers can also receive _named_
 arguments, which we'll discuss next.
@@ -96,8 +212,6 @@ function substring(args) {
 export default helper(substring);
 ```
 
-**This is how we normally write helpers in Ember**.
-
 We can then use this helper in the component's template to get the first letter of the username.
 
 ```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4"}
@@ -118,11 +232,9 @@ We can then use this helper in the component's template to get the first letter 
 </section>
 ```
 
-### Named Arguments
+### Named arguments
 
-The syntax `{{substring @username 0 1}}` is a little hard to read. We see some numbers at the end but can't tell what exactly they mean. We can use _named arguments_ to make the `substring` helper easier to read.
-
-Using named arguments, we could make our template a lot clearer.
+Similar to local helpers, global helpers also can mix positional and named arguments.
 
 ```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4,+5"}
 <Message::Avatar
@@ -143,8 +255,6 @@ Using named arguments, we could make our template a lot clearer.
 </section>
 ```
 
-In addition to taking _positional arguments_ as an array, helpers take _named arguments_ as a JavaScript object. Here's what that looks like using [destructuring syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Unpacking_fields_from_objects_passed_as_function_parameter).
-
 ```js {data-filename="app/helpers/substring.js"}
 import { helper } from '@ember/component/helper';
 
@@ -155,31 +265,7 @@ function substring([string], { start, end }) {
 export default helper(substring);
 ```
 
-You can mix positional and named arguments to make your templates easy to read.
-
-### Nested Helpers
-
-Sometimes, you might see helpers invoked by placing them inside parentheses,
-`()`. This means that a Helper is being used inside of another Helper or
-Component. This is referred to as a "nested" Helper Invocation. Parentheses must
-be used because curly braces `{{}}` cannot be nested.
-
-```handlebars {data-filename=app/templates/application.hbs}
-{{sum (multiply 2 4) 2}}
-```
-
-In this example, we are using a helper to multiply `2` and `4` _before_ passing
-the value into `{{sum}}`.
-
-Thus, the output of these combined helpers is `10`.
-
-As you move forward with these template guides, keep in mind that a helper can
-be used anywhere a normal value can be used.
-
-Many of Ember's built-in helpers (as well as your custom helpers) can be used in
-nested form.
-
-## Advanced: Class Helpers
+### Class Helpers
 
 Helpers can also be defined using class syntax. For instance, we could define
 the substring helper using classes instead.
@@ -203,11 +289,11 @@ discussing state in the next chapter).
 ## Built-in Helpers
 
 Below you will find some useful template helpers documented.
-For the full list of available helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/4.6.0/classes/Ember.Templates.helpers/).
+For the full list of available helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/).
 
 ### The `get` helper
 
-The [`{{get}}`](https://api.emberjs.com/ember/4.6.0/classes/Ember.Templates.helpers/methods/get?anchor=get)
+The [`{{get}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/get?anchor=get)
 helper makes it easy to dynamically look up a property on an object or an element in an array. The second argument to `{{get}}` can be a string or a number, depending on the object being accessed.
 
 
@@ -237,7 +323,7 @@ If it returns "city", you get `this.address.city`.
 
 We mentioned above that helpers can be nested. This can be
 combined with different dynamic helpers. For example, the
-[`{{concat}}`](https://api.emberjs.com/ember/4.6.0/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
+[`{{concat}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
 helper makes it easy to dynamically send a number of parameters to a component
 or helper as a single parameter in the format of a concatenated string.
 
@@ -253,7 +339,7 @@ This will display the result of `this.foo.item1` when index is 1, and
 Now let's say your template is starting to get a bit cluttered and you want
 to clean up the logic in your templates. This can be achieved with the `let`
 block helper.
-The [`{{let}}`](https://api.emberjs.com/ember/4.6.0/classes/Ember.Templates.helpers/methods/let?anchor=let)
+The [`{{let}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/let?anchor=let)
 helper lets you create new bindings (or temporary variables) in your template.
 
 Say your template now looks like this:
@@ -290,7 +376,7 @@ capitalized given name and family name as `givenName` and `familyName` instead o
 
 ### The `array` helper
 
-Using the [`{{array}}`](https://api.emberjs.com/ember/4.6.0/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
+Using the [`{{array}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
 you can pass arrays directly from the template as an argument to your components.
 
 ```handlebars
@@ -315,7 +401,7 @@ In the component's template, you can then use the `people` argument as an array:
 
 ### The `hash` helper
 
-Using the [`{{hash}}`](https://api.emberjs.com/ember/4.6.0/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
+Using the [`{{hash}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
 helper, you can pass objects directly from the template as an argument to your
 components.
 
@@ -335,7 +421,7 @@ Hello, {{@person.givenName}} {{@person.familyName}}
 
 ### The `in-element` helper
 
-Using the [`{{in-element}}`](https://api.emberjs.com/ember/4.6.0/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
 to render a modal, tooltip, or dropdown.
 
 Suppose we want to show a dropdown menu when the user clicks on a button. The code below shows a `<button>` element, a placeholder `<div>` element, and a dropdown component. The argument `@show`, when set to `true`, will add the dropdown to the placeholder div.

--- a/guides/v4.7.0/components/helper-functions.md
+++ b/guides/v4.7.0/components/helper-functions.md
@@ -1,8 +1,8 @@
 Helper functions are JavaScript functions that you can call from your template.
 
-Ember's template syntax limits what you can express to keep the structure of your application clear at a glance. When you need to compute something using JavaScript, you can use helper functions. It's possible to create your own helpers or just [use the built-in ones](./#toc_built-in-helpers).
+Ember's template syntax limits what you can express to keep the structure of your application clear at a glance. When you need to compute something using JavaScript, you can use helper functions. It's possible to create your own helpers, locally or just [use the built-in ones](./#toc_built-in-helpers).
 
-For instance, let's take a look at a generic message component from a messaging app.
+Let's take a look at a generic message component from a messaging app.
 
 ```handlebars {data-filename="app/components/message.hbs"}
 <Message::Avatar
@@ -62,11 +62,127 @@ Since the title is just the `@username` plus some extra stuff, we can replace `@
 
 However, to get the first initial of the string, we'll need to use JavaScript. To do that, we'll write a helper function.
 
-## Writing a Helper Function
-
-We define helper functions in the `app/helpers` folder.
-
 In this case we want a helper function that takes three arguments: a string, a starting position, and a length. The function will return a substring of the original string.
+
+## Local Helper Functions
+
+It's possible to use plain functions for helpers and modifiers. A plain helper function can be "local" to or defined on components and controllers.
+
+```js {data-filename="app/components/message.js"}
+import Component from '@glimmer/component';
+import { setComponentTemplate } from '@ember/component';
+import { hbs } from 'ember-cli-htmlbars';
+
+export default class Message extends Component {
+  substring = (string, start, end) => string.substring(start, end);
+}
+```
+
+We can then use this helper in the component's template to get the first letter of the username.
+
+```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4"}
+<Message::Avatar
+  @title="{{@username}}'s avatar"
+  @initial={{@avatarTitle}}
+  @initial={{this.substring @username 0 1}}
+  @isActive={{@userIsActive}}
+  class={{if @isCurrentUser "current-user"}}
+/>
+<section>
+  <Message::Username
+    @name={{@username}}
+    @localTime={{@userLocalTime}}
+  />
+
+  {{yield}}
+</section>
+```
+
+### Named Arguments
+
+Helpers default to using positional arguments, but sometimes it can make the corresponding syntax `{{substring @username 0 1}}` a little hard to read. We see some numbers at the end but can't tell what exactly they mean. We can use _named arguments_ to make the `substring` helper easier to read.
+
+Using named arguments, we could make our template a lot clearer.
+
+```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4,+5"}
+<Message::Avatar
+  @title="{{@username}}'s avatar"
+  @initial={{substring @username 0 1}}
+  {{! This won't work yet! We need to update the substring helper }}
+  @initial={{substring @username start=0 end=1}}
+  @isActive={{@userIsActive}}
+  class={{if @isCurrentUser "current-user"}}
+/>
+<section>
+  <Message::Username
+    @name={{@username}}
+    @localTime={{@userLocalTime}}
+  />
+
+  {{yield}}
+</section>
+```
+
+Helpers take _named arguments_ as a JavaScript object. All named arguments are grouped into an "options object" as the last parameter.
+
+```js {data-filename="app/components/message.js" data-diff="-6,+7"}
+import Component from '@glimmer/component';
+import { setComponentTemplate } from '@ember/component';
+import { hbs } from 'ember-cli-htmlbars';
+
+export default class Message extends Component {
+  substring = (string, start, end) => string.substring(start, end);
+  substring = (string, options) => string.substring(options.start, options.end);
+}
+```
+
+You can mix positional and named arguments to make your templates easy to read:
+
+```handlebars {data-filename="app/components/calculator.hbs"}
+{{this.calculate 1 2 op="add"}}
+```
+
+```js {data-filename="app/components/calculator.js"}
+export default class Calculator extends Component {
+  calculate(first, second, options) {
+    // ...
+  }
+}
+```
+
+### Nested Helpers
+
+Sometimes, you might see helpers invoked by placing them inside parentheses,
+`()`. This means that a Helper is being used inside of another Helper or
+Component. This is referred to as a "nested" Helper Invocation. Parentheses must be used because curly braces `{{}}` cannot be nested.
+
+```handlebars {data-filename=app/templates/application.hbs}
+{{this.sum (this.multiply 2 4) 2}}
+```
+
+In this example, we are using a helper to multiply `2` and `4` _before_ passing the value into `{{sum}}`.
+
+Thus, the output of these combined helpers is `10`.
+
+As you move forward with these template guides, keep in mind that a helper can be used anywhere a normal value can be used.
+
+Many of Ember's built-in helpers (as well as your custom helpers) can be used in nested form.
+
+## Global Helper Functions
+
+Next to local helpers, ember provides a way to use global helpers. We define global helper functions in the `app/helpers` folder. Once defined, they will be available to use directly inside all templates in your app.
+
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        Before Ember 4.5, using global helpers was the only way to define helpers.
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
 
 To implement the helper, we write a JavaScript function that takes its arguments as an _array_. This is because helpers can also receive _named_
 arguments, which we'll discuss next.
@@ -96,8 +212,6 @@ function substring(args) {
 export default helper(substring);
 ```
 
-**This is how we normally write helpers in Ember**.
-
 We can then use this helper in the component's template to get the first letter of the username.
 
 ```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4"}
@@ -118,11 +232,9 @@ We can then use this helper in the component's template to get the first letter 
 </section>
 ```
 
-### Named Arguments
+### Named arguments
 
-The syntax `{{substring @username 0 1}}` is a little hard to read. We see some numbers at the end but can't tell what exactly they mean. We can use _named arguments_ to make the `substring` helper easier to read.
-
-Using named arguments, we could make our template a lot clearer.
+Similar to local helpers, global helpers also can mix positional and named arguments.
 
 ```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4,+5"}
 <Message::Avatar
@@ -143,8 +255,6 @@ Using named arguments, we could make our template a lot clearer.
 </section>
 ```
 
-In addition to taking _positional arguments_ as an array, helpers take _named arguments_ as a JavaScript object. Here's what that looks like using [destructuring syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Unpacking_fields_from_objects_passed_as_function_parameter).
-
 ```js {data-filename="app/helpers/substring.js"}
 import { helper } from '@ember/component/helper';
 
@@ -155,31 +265,7 @@ function substring([string], { start, end }) {
 export default helper(substring);
 ```
 
-You can mix positional and named arguments to make your templates easy to read.
-
-### Nested Helpers
-
-Sometimes, you might see helpers invoked by placing them inside parentheses,
-`()`. This means that a Helper is being used inside of another Helper or
-Component. This is referred to as a "nested" Helper Invocation. Parentheses must
-be used because curly braces `{{}}` cannot be nested.
-
-```handlebars {data-filename=app/templates/application.hbs}
-{{sum (multiply 2 4) 2}}
-```
-
-In this example, we are using a helper to multiply `2` and `4` _before_ passing
-the value into `{{sum}}`.
-
-Thus, the output of these combined helpers is `10`.
-
-As you move forward with these template guides, keep in mind that a helper can
-be used anywhere a normal value can be used.
-
-Many of Ember's built-in helpers (as well as your custom helpers) can be used in
-nested form.
-
-## Advanced: Class Helpers
+### Class Helpers
 
 Helpers can also be defined using class syntax. For instance, we could define
 the substring helper using classes instead.
@@ -203,11 +289,11 @@ discussing state in the next chapter).
 ## Built-in Helpers
 
 Below you will find some useful template helpers documented.
-For the full list of available helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/4.7.0/classes/Ember.Templates.helpers/).
+For the full list of available helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/).
 
 ### The `get` helper
 
-The [`{{get}}`](https://api.emberjs.com/ember/4.7.0/classes/Ember.Templates.helpers/methods/get?anchor=get)
+The [`{{get}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/get?anchor=get)
 helper makes it easy to dynamically look up a property on an object or an element in an array. The second argument to `{{get}}` can be a string or a number, depending on the object being accessed.
 
 
@@ -237,7 +323,7 @@ If it returns "city", you get `this.address.city`.
 
 We mentioned above that helpers can be nested. This can be
 combined with different dynamic helpers. For example, the
-[`{{concat}}`](https://api.emberjs.com/ember/4.7.0/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
+[`{{concat}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
 helper makes it easy to dynamically send a number of parameters to a component
 or helper as a single parameter in the format of a concatenated string.
 
@@ -253,7 +339,7 @@ This will display the result of `this.foo.item1` when index is 1, and
 Now let's say your template is starting to get a bit cluttered and you want
 to clean up the logic in your templates. This can be achieved with the `let`
 block helper.
-The [`{{let}}`](https://api.emberjs.com/ember/4.7.0/classes/Ember.Templates.helpers/methods/let?anchor=let)
+The [`{{let}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/let?anchor=let)
 helper lets you create new bindings (or temporary variables) in your template.
 
 Say your template now looks like this:
@@ -290,7 +376,7 @@ capitalized given name and family name as `givenName` and `familyName` instead o
 
 ### The `array` helper
 
-Using the [`{{array}}`](https://api.emberjs.com/ember/4.7.0/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
+Using the [`{{array}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
 you can pass arrays directly from the template as an argument to your components.
 
 ```handlebars
@@ -315,7 +401,7 @@ In the component's template, you can then use the `people` argument as an array:
 
 ### The `hash` helper
 
-Using the [`{{hash}}`](https://api.emberjs.com/ember/4.7.0/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
+Using the [`{{hash}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
 helper, you can pass objects directly from the template as an argument to your
 components.
 
@@ -335,7 +421,7 @@ Hello, {{@person.givenName}} {{@person.familyName}}
 
 ### The `in-element` helper
 
-Using the [`{{in-element}}`](https://api.emberjs.com/ember/4.7.0/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
 to render a modal, tooltip, or dropdown.
 
 Suppose we want to show a dropdown menu when the user clicks on a button. The code below shows a `<button>` element, a placeholder `<div>` element, and a dropdown component. The argument `@show`, when set to `true`, will add the dropdown to the placeholder div.

--- a/guides/v4.8.0/components/helper-functions.md
+++ b/guides/v4.8.0/components/helper-functions.md
@@ -1,8 +1,8 @@
 Helper functions are JavaScript functions that you can call from your template.
 
-Ember's template syntax limits what you can express to keep the structure of your application clear at a glance. When you need to compute something using JavaScript, you can use helper functions. It's possible to create your own helpers or just [use the built-in ones](./#toc_built-in-helpers).
+Ember's template syntax limits what you can express to keep the structure of your application clear at a glance. When you need to compute something using JavaScript, you can use helper functions. It's possible to create your own helpers, locally or just [use the built-in ones](./#toc_built-in-helpers).
 
-For instance, let's take a look at a generic message component from a messaging app.
+Let's take a look at a generic message component from a messaging app.
 
 ```handlebars {data-filename="app/components/message.hbs"}
 <Message::Avatar
@@ -62,11 +62,127 @@ Since the title is just the `@username` plus some extra stuff, we can replace `@
 
 However, to get the first initial of the string, we'll need to use JavaScript. To do that, we'll write a helper function.
 
-## Writing a Helper Function
-
-We define helper functions in the `app/helpers` folder.
-
 In this case we want a helper function that takes three arguments: a string, a starting position, and a length. The function will return a substring of the original string.
+
+## Local Helper Functions
+
+It's possible to use plain functions for helpers and modifiers. A plain helper function can be "local" to or defined on components and controllers.
+
+```js {data-filename="app/components/message.js"}
+import Component from '@glimmer/component';
+import { setComponentTemplate } from '@ember/component';
+import { hbs } from 'ember-cli-htmlbars';
+
+export default class Message extends Component {
+  substring = (string, start, end) => string.substring(start, end);
+}
+```
+
+We can then use this helper in the component's template to get the first letter of the username.
+
+```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4"}
+<Message::Avatar
+  @title="{{@username}}'s avatar"
+  @initial={{@avatarTitle}}
+  @initial={{this.substring @username 0 1}}
+  @isActive={{@userIsActive}}
+  class={{if @isCurrentUser "current-user"}}
+/>
+<section>
+  <Message::Username
+    @name={{@username}}
+    @localTime={{@userLocalTime}}
+  />
+
+  {{yield}}
+</section>
+```
+
+### Named Arguments
+
+Helpers default to using positional arguments, but sometimes it can make the corresponding syntax `{{substring @username 0 1}}` a little hard to read. We see some numbers at the end but can't tell what exactly they mean. We can use _named arguments_ to make the `substring` helper easier to read.
+
+Using named arguments, we could make our template a lot clearer.
+
+```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4,+5"}
+<Message::Avatar
+  @title="{{@username}}'s avatar"
+  @initial={{substring @username 0 1}}
+  {{! This won't work yet! We need to update the substring helper }}
+  @initial={{substring @username start=0 end=1}}
+  @isActive={{@userIsActive}}
+  class={{if @isCurrentUser "current-user"}}
+/>
+<section>
+  <Message::Username
+    @name={{@username}}
+    @localTime={{@userLocalTime}}
+  />
+
+  {{yield}}
+</section>
+```
+
+Helpers take _named arguments_ as a JavaScript object. All named arguments are grouped into an "options object" as the last parameter.
+
+```js {data-filename="app/components/message.js" data-diff="-6,+7"}
+import Component from '@glimmer/component';
+import { setComponentTemplate } from '@ember/component';
+import { hbs } from 'ember-cli-htmlbars';
+
+export default class Message extends Component {
+  substring = (string, start, end) => string.substring(start, end);
+  substring = (string, options) => string.substring(options.start, options.end);
+}
+```
+
+You can mix positional and named arguments to make your templates easy to read:
+
+```handlebars {data-filename="app/components/calculator.hbs"}
+{{this.calculate 1 2 op="add"}}
+```
+
+```js {data-filename="app/components/calculator.js"}
+export default class Calculator extends Component {
+  calculate(first, second, options) {
+    // ...
+  }
+}
+```
+
+### Nested Helpers
+
+Sometimes, you might see helpers invoked by placing them inside parentheses,
+`()`. This means that a Helper is being used inside of another Helper or
+Component. This is referred to as a "nested" Helper Invocation. Parentheses must be used because curly braces `{{}}` cannot be nested.
+
+```handlebars {data-filename=app/templates/application.hbs}
+{{this.sum (this.multiply 2 4) 2}}
+```
+
+In this example, we are using a helper to multiply `2` and `4` _before_ passing the value into `{{sum}}`.
+
+Thus, the output of these combined helpers is `10`.
+
+As you move forward with these template guides, keep in mind that a helper can be used anywhere a normal value can be used.
+
+Many of Ember's built-in helpers (as well as your custom helpers) can be used in nested form.
+
+## Global Helper Functions
+
+Next to local helpers, ember provides a way to use global helpers. We define global helper functions in the `app/helpers` folder. Once defined, they will be available to use directly inside all templates in your app.
+
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        Before Ember 4.5, using global helpers was the only way to define helpers.
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
 
 To implement the helper, we write a JavaScript function that takes its arguments as an _array_. This is because helpers can also receive _named_
 arguments, which we'll discuss next.
@@ -96,8 +212,6 @@ function substring(args) {
 export default helper(substring);
 ```
 
-**This is how we normally write helpers in Ember**.
-
 We can then use this helper in the component's template to get the first letter of the username.
 
 ```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4"}
@@ -118,11 +232,9 @@ We can then use this helper in the component's template to get the first letter 
 </section>
 ```
 
-### Named Arguments
+### Named arguments
 
-The syntax `{{substring @username 0 1}}` is a little hard to read. We see some numbers at the end but can't tell what exactly they mean. We can use _named arguments_ to make the `substring` helper easier to read.
-
-Using named arguments, we could make our template a lot clearer.
+Similar to local helpers, global helpers also can mix positional and named arguments.
 
 ```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4,+5"}
 <Message::Avatar
@@ -143,8 +255,6 @@ Using named arguments, we could make our template a lot clearer.
 </section>
 ```
 
-In addition to taking _positional arguments_ as an array, helpers take _named arguments_ as a JavaScript object. Here's what that looks like using [destructuring syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Unpacking_fields_from_objects_passed_as_function_parameter).
-
 ```js {data-filename="app/helpers/substring.js"}
 import { helper } from '@ember/component/helper';
 
@@ -155,31 +265,7 @@ function substring([string], { start, end }) {
 export default helper(substring);
 ```
 
-You can mix positional and named arguments to make your templates easy to read.
-
-### Nested Helpers
-
-Sometimes, you might see helpers invoked by placing them inside parentheses,
-`()`. This means that a Helper is being used inside of another Helper or
-Component. This is referred to as a "nested" Helper Invocation. Parentheses must
-be used because curly braces `{{}}` cannot be nested.
-
-```handlebars {data-filename=app/templates/application.hbs}
-{{sum (multiply 2 4) 2}}
-```
-
-In this example, we are using a helper to multiply `2` and `4` _before_ passing
-the value into `{{sum}}`.
-
-Thus, the output of these combined helpers is `10`.
-
-As you move forward with these template guides, keep in mind that a helper can
-be used anywhere a normal value can be used.
-
-Many of Ember's built-in helpers (as well as your custom helpers) can be used in
-nested form.
-
-## Advanced: Class Helpers
+### Class Helpers
 
 Helpers can also be defined using class syntax. For instance, we could define
 the substring helper using classes instead.
@@ -203,11 +289,11 @@ discussing state in the next chapter).
 ## Built-in Helpers
 
 Below you will find some useful template helpers documented.
-For the full list of available helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/4.8.0/classes/Ember.Templates.helpers/).
+For the full list of available helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/).
 
 ### The `get` helper
 
-The [`{{get}}`](https://api.emberjs.com/ember/4.8.0/classes/Ember.Templates.helpers/methods/get?anchor=get)
+The [`{{get}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/get?anchor=get)
 helper makes it easy to dynamically look up a property on an object or an element in an array. The second argument to `{{get}}` can be a string or a number, depending on the object being accessed.
 
 
@@ -237,7 +323,7 @@ If it returns "city", you get `this.address.city`.
 
 We mentioned above that helpers can be nested. This can be
 combined with different dynamic helpers. For example, the
-[`{{concat}}`](https://api.emberjs.com/ember/4.8.0/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
+[`{{concat}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
 helper makes it easy to dynamically send a number of parameters to a component
 or helper as a single parameter in the format of a concatenated string.
 
@@ -253,7 +339,7 @@ This will display the result of `this.foo.item1` when index is 1, and
 Now let's say your template is starting to get a bit cluttered and you want
 to clean up the logic in your templates. This can be achieved with the `let`
 block helper.
-The [`{{let}}`](https://api.emberjs.com/ember/4.8.0/classes/Ember.Templates.helpers/methods/let?anchor=let)
+The [`{{let}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/let?anchor=let)
 helper lets you create new bindings (or temporary variables) in your template.
 
 Say your template now looks like this:
@@ -290,7 +376,7 @@ capitalized given name and family name as `givenName` and `familyName` instead o
 
 ### The `array` helper
 
-Using the [`{{array}}`](https://api.emberjs.com/ember/4.8.0/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
+Using the [`{{array}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
 you can pass arrays directly from the template as an argument to your components.
 
 ```handlebars
@@ -315,7 +401,7 @@ In the component's template, you can then use the `people` argument as an array:
 
 ### The `hash` helper
 
-Using the [`{{hash}}`](https://api.emberjs.com/ember/4.8.0/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
+Using the [`{{hash}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
 helper, you can pass objects directly from the template as an argument to your
 components.
 
@@ -335,7 +421,7 @@ Hello, {{@person.givenName}} {{@person.familyName}}
 
 ### The `in-element` helper
 
-Using the [`{{in-element}}`](https://api.emberjs.com/ember/4.8.0/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
 to render a modal, tooltip, or dropdown.
 
 Suppose we want to show a dropdown menu when the user clicks on a button. The code below shows a `<button>` element, a placeholder `<div>` element, and a dropdown component. The argument `@show`, when set to `true`, will add the dropdown to the placeholder div.


### PR DESCRIPTION
@SkoebaSteve updated the helpers content for v4.5 to cover how to use local helpers in https://github.com/ember-learn/guides-source/pull/1888. This PR copies those changes into more recent guides versions as well. The prose/changes were previously reviewed - this is copy-paste.

@SkoebaSteve if there's ever any other changes you want to make to the guides that do not need to go on older versions, you can make your changes in the `release` folder. I think the helper functions made sense to include on older versions as well, though!