### PR TITLE
Remove use of @ember/string

### DIFF
--- a/guides/release/models/customizing-adapters.md
+++ b/guides/release/models/customizing-adapters.md
@@ -188,11 +188,10 @@ underscore_case instead of dash-case you could override the
 
 ```javascript {data-filename=app/adapters/application.js}
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
-import { underscore } from '@ember/string';
 
 export default class ApplicationAdapter extends JSONAPIAdapter {
   pathForType(type) {
-    return underscore(type);
+    return type.replace(/-/g, '_'); // blog-post-comment becomes blog_post_comment 
   }
 }
 ```

--- a/guides/release/models/customizing-serializers.md
+++ b/guides/release/models/customizing-serializers.md
@@ -318,12 +318,11 @@ payload. For example, if your backend returned attributes that are
 method like this.
 
 ```javascript {data-filename=app/serializers/application.js}
-import { underscore } from '@ember/string';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 
 export default class ApplicationSerializer extends JSONAPISerializer {
   keyForAttribute(attr) {
-    return underscore(attr);
+    return attr.replace(/_/g, '-'); // blog_post_comment becomes blog-post-comment 
   }
 }
 ```


### PR DESCRIPTION
Replace it with plain old regex `replace`.

`replaceAll` would be easier to read, but may not be available in people's projects or node environments.

Similarly I decided not to escape the _ or -, since it's all by itself, but I could add an escape if preferred.

This addresses a blocker for https://github.com/emberjs/rfcs/pull/898