### PR TITLE
docs fix: Replace dead link with updated w3c on web components

### DIFF
--- a/guides/v1.10.0/components/index.md
+++ b/guides/v1.10.0/components/index.md
@@ -11,7 +11,8 @@ JavaScript?
 
 That's exactly what components let you do. In fact, it's such a good
 idea that the W3C is currently working on the [Custom
-Elements](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements) spec.
+Elements](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements)
+spec.
 
 Ember's implementation of components hews as closely to the [Web
 Components specification](http://www.w3.org/TR/components-intro/) as possible.

--- a/guides/v1.10.0/components/index.md
+++ b/guides/v1.10.0/components/index.md
@@ -11,8 +11,7 @@ JavaScript?
 
 That's exactly what components let you do. In fact, it's such a good
 idea that the W3C is currently working on the [Custom
-Elements](https://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/custom/index.html)
-spec.
+Elements](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements) spec.
 
 Ember's implementation of components hews as closely to the [Web
 Components specification](http://www.w3.org/TR/components-intro/) as possible.


### PR DESCRIPTION
- Dead link https://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/custom/index.html -> http://w3c.github.io/webcomponents/spec/custom/ looks like this updated spec
- looks like it's in a few places in the codebase; not sure what the strategy is for mass-updating older docs https://github.com/search?q=repo%3Aember-learn%2Fguides-source%20https%3A%2F%2Fdvcs.w3.org%2Fhg%2Fwebcomponents%2Fraw-file%2Ftip%2Fspec%2Fcustom%2Findex.html&type=code

# Before 

dead link 
<img width="1161" alt="Screenshot 2023-04-21 at 12 08 01 PM" src="https://user-images.githubusercontent.com/5950956/233621384-22564a5a-9db6-4551-831c-8a6aed9931bc.png">

What link used to look like via wayback machine https://web.archive.org/web/20170306082720/http://w3c.github.io/webcomponents/spec/custom/

<img width="1389" alt="Screenshot 2023-04-21 at 12 09 15 PM" src="https://user-images.githubusercontent.com/5950956/233621604-41ea1e59-8efc-44c3-93b9-7f7ff480d133.png">

# Now 

<img width="1299" alt="Screenshot 2023-04-21 at 12 08 26 PM" src="https://user-images.githubusercontent.com/5950956/233621431-f19ef4d7-63e7-4566-aad7-14c4669c89be.png">

