### PR TITLE
Use avatarInitial instead of avatarTitle in diff

### DIFF
--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -83,7 +83,7 @@ We can then use this helper in the component's template to get the first letter 
 ```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4"}
 <Message::Avatar
   @title="{{@username}}'s avatar"
-  @initial={{@avatarTitle}}
+  @initial={{@avatarInitial}}
   @initial={{this.substring @username 0 1}}
   @isActive={{@userIsActive}}
   class={{if @isCurrentUser "current-user"}}

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -197,7 +197,7 @@ We can then use this helper in the component's template to get the first letter 
 ```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4"}
 <Message::Avatar
   @title="{{@username}}'s avatar"
-  @initial={{@avatarTitle}}
+  @initial={{@avatarInitial}}
   @initial={{substring @username 0 1}}
   @isActive={{@userIsActive}}
   class={{if @isCurrentUser "current-user"}}


### PR DESCRIPTION
The diff mentioned that the old initial was the @avatarTitle which confused me for a while.

I changed it to @avatarInitial which I assume is what's intended