### PR TITLE
Remove deprecated Ember Data usage of firstObject

### DIFF
--- a/guides/release/models/finding-records.md
+++ b/guides/release/models/finding-records.md
@@ -119,7 +119,7 @@ tom = store.query('user', {
     email: 'tomster@example.com'
   }
 }).then(function(users) {
-  return users.get('firstObject');
+  return users[0]; // the first object
 });
 ```
 

--- a/guides/release/models/relationships.md
+++ b/guides/release/models/relationships.md
@@ -425,7 +425,7 @@ export default class AdeleRoute extends Route {
         include: 'albums'
       })
       .then(function(artists) {
-        return artists.firstObject;
+        return artists[0];
       });
   }
 }

--- a/guides/release/routing/redirection.md
+++ b/guides/release/routing/redirection.md
@@ -74,7 +74,7 @@ export default class PostsRoute extends Route {
 
   afterModel(model, transition) {
     if (model.get('length') === 1) {
-      this.router.transitionTo('post', model.get('firstObject'));
+      this.router.transitionTo('post', model[0]);
     }
   }
 }
@@ -128,7 +128,7 @@ export default class PostsRoute extends Route {
 
   redirect(model, transition) {
     if (model.get('length') === 1) {
-      this.router.transitionTo('posts.post', model.get('firstObject'));
+      this.router.transitionTo('posts.post', model[0]);
     }
   }
 }


### PR DESCRIPTION
Partially addresses #1921

firstObject is removed in 5.0.