### PR TITLE
Fix `<LinkTo />` in title

### DIFF
--- a/guides/release/routing/query-params.md
+++ b/guides/release/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v1.10.0/testing/test-runners.md
+++ b/guides/v1.10.0/testing/test-runners.md
@@ -1,6 +1,6 @@
 When it comes to running your tests there are multiple approaches that you can take depending on what best suits your workflow. Finding a low friction method of running your tests is important because it is something that you will be doing quite often.
 
-### <a name="browser"></a>The Browser
+### The Browser
 
 The simplest way of running your tests is just opening a page in the browser. The following is how to put a test "harness" around your app with qunit so you can run tests against it:
 

--- a/guides/v3.15.0/routing/query-params.md
+++ b/guides/v3.15.0/routing/query-params.md
@@ -81,7 +81,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v3.16.0/routing/query-params.md
+++ b/guides/v3.16.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v3.17.0/routing/query-params.md
+++ b/guides/v3.17.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v3.18.0/routing/query-params.md
+++ b/guides/v3.18.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v3.19.0/routing/query-params.md
+++ b/guides/v3.19.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v3.20.0/routing/query-params.md
+++ b/guides/v3.20.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v3.21.0/routing/query-params.md
+++ b/guides/v3.21.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v3.22.0/routing/query-params.md
+++ b/guides/v3.22.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v3.23.0/routing/query-params.md
+++ b/guides/v3.23.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v3.24.0/routing/query-params.md
+++ b/guides/v3.24.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v3.25.0/routing/query-params.md
+++ b/guides/v3.25.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v3.26.0/routing/query-params.md
+++ b/guides/v3.26.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v3.27.0/routing/query-params.md
+++ b/guides/v3.27.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v3.28.0/routing/query-params.md
+++ b/guides/v3.28.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v4.0.0/routing/query-params.md
+++ b/guides/v4.0.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v4.1.0/routing/query-params.md
+++ b/guides/v4.1.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v4.10.0/routing/query-params.md
+++ b/guides/v4.10.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v4.11.0/routing/query-params.md
+++ b/guides/v4.11.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v4.12.0/routing/query-params.md
+++ b/guides/v4.12.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v4.2.0/routing/query-params.md
+++ b/guides/v4.2.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v4.3.0/routing/query-params.md
+++ b/guides/v4.3.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v4.4.0/routing/query-params.md
+++ b/guides/v4.4.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v4.5.0/routing/query-params.md
+++ b/guides/v4.5.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v4.6.0/routing/query-params.md
+++ b/guides/v4.6.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v4.7.0/routing/query-params.md
+++ b/guides/v4.7.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v4.8.0/routing/query-params.md
+++ b/guides/v4.8.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:

--- a/guides/v4.9.0/routing/query-params.md
+++ b/guides/v4.9.0/routing/query-params.md
@@ -84,7 +84,7 @@ With this code, we have established the following behaviors:
    full router transition (i.e. it won't call `model` hooks and
    `setupController`, etc.); it will only update the URL.
 
-### <LinkTo /> component
+### `<LinkTo />` component
 
 The `<LinkTo />` component supports specifying query params using the `@query`
 argument, along with the `{{hash}}` helper:


### PR DESCRIPTION
@locks brought the issue below to our attention and this fixes it. I've also checked is this happend in other places but that was not the case, except for one weird `<a>` tag in v1.10, so I removed that one too :)

![Screenshot 2023-07-05 at 09 48 13](https://github.com/ember-learn/guides-source/assets/5811560/b95ebe7d-d5f7-473f-ac5e-6f95b0e88bf6)

**After**
![Screenshot 2023-07-05 at 09 55 10](https://github.com/ember-learn/guides-source/assets/5811560/1e94eda0-4245-4dea-b2d6-93f4f2e4e087)