### PR TITLE
Add SPA fallback

### DIFF
--- a/.netlifyredirects
+++ b/.netlifyredirects
@@ -1,2 +1,4 @@
 /                 /release/
 /current/*        /release/:splat
+
+/*                /index.html       200


### PR DESCRIPTION
This means that going to a non-existent URL like https://guides.emberjs.com/release/sdfsdf will give us a nicer error page