### PR TITLE
Update quick-start.md

### DIFF
--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -254,7 +254,7 @@ In the rest of the code examples in this tutorial, whenever we add or remove cod
 
 Let's replace all our old code with our new componentized version:
 
-```handlebars {data-filename="app/templates/scientists.hbs" data-diff="-1,-2,-3,-4,-5,-6,-7,+8,+9,+10,+11"}
+```handlebars {data-filename="app/templates/scientists.hbs" data-diff="-0,-1,-2,-3,-4,-5,-6,-7,+8,+9,+10,+11"}
 <h2>List of Scientists</h2>
 
 <ul>


### PR DESCRIPTION
In the "diff" portion, it doesn't include deleting the h2; however, in the next paragraph, it says that the page should look identical. If you don't delete the h2, then it will display "List of Scientists" twice in 2 different h2s.