### PR TITLE
⬆️ Dep on ember-test-selectors@6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "ember-resolver": "^8.0.3",
         "ember-source": "~3.28.8",
         "ember-template-lint": "^3.15.0",
-        "ember-test-selectors": "^5.0.0",
+        "ember-test-selectors": "^6.0.0",
         "eslint": "^7.32.0",
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-config-prettier": "^8.3.0",
@@ -22945,17 +22945,17 @@
       "dev": true
     },
     "node_modules/ember-test-selectors": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ember-test-selectors/-/ember-test-selectors-5.0.0.tgz",
-      "integrity": "sha512-hqAPqyJLEGBYcQ9phOKvHhSCyvcSbUL8Yj2si8OASsQWxwRqbxrtk5YlkN2aZiZdp9PAd2wErS8uClG0U7tNpA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ember-test-selectors/-/ember-test-selectors-6.0.0.tgz",
+      "integrity": "sha512-PgYcI9PeNvtKaF0QncxfbS68olMYM1idwuI8v/WxsjOGqUx5bmsu6V17vy/d9hX4mwmjgsBhEghrVasGSuaIgw==",
       "dev": true,
       "dependencies": {
         "calculate-cache-key-for-tree": "^2.0.0",
-        "ember-cli-babel": "^7.22.1",
-        "ember-cli-version-checker": "^5.1.1"
+        "ember-cli-babel": "^7.26.4",
+        "ember-cli-version-checker": "^5.1.2"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": "12.* || 14.* || >= 16.*"
       }
     },
     "node_modules/ember-test-selectors/node_modules/ember-cli-version-checker": {
@@ -58762,14 +58762,14 @@
       }
     },
     "ember-test-selectors": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ember-test-selectors/-/ember-test-selectors-5.0.0.tgz",
-      "integrity": "sha512-hqAPqyJLEGBYcQ9phOKvHhSCyvcSbUL8Yj2si8OASsQWxwRqbxrtk5YlkN2aZiZdp9PAd2wErS8uClG0U7tNpA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ember-test-selectors/-/ember-test-selectors-6.0.0.tgz",
+      "integrity": "sha512-PgYcI9PeNvtKaF0QncxfbS68olMYM1idwuI8v/WxsjOGqUx5bmsu6V17vy/d9hX4mwmjgsBhEghrVasGSuaIgw==",
       "dev": true,
       "requires": {
         "calculate-cache-key-for-tree": "^2.0.0",
-        "ember-cli-babel": "^7.22.1",
-        "ember-cli-version-checker": "^5.1.1"
+        "ember-cli-babel": "^7.26.4",
+        "ember-cli-version-checker": "^5.1.2"
       },
       "dependencies": {
         "ember-cli-version-checker": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "ember-resolver": "^8.0.3",
     "ember-source": "~3.28.8",
     "ember-template-lint": "^3.15.0",
-    "ember-test-selectors": "^5.0.0",
+    "ember-test-selectors": "^6.0.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
ember-test-selectors@5 was triggering the following deprecations:

- ember-global
- ember.component.reopen
- template-compiler.registerPlugin