### PR TITLE
Update engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "walk-sync": "^2.0.2"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "16.* || 18.* || >= 20"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
addresses:
```
❯ npm i
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'ember-showdown-prism@4.4.0',
npm WARN EBADENGINE   required: { node: '16.* || >= 18' },
npm WARN EBADENGINE   current: { node: 'v14.21.3', npm: '9.6.3' }
npm WARN EBADENGINE }
```