### PR TITLE
fix: allow EmberData version to be set on release:minor script

### DIFF
--- a/scripts/create-new-minor-version
+++ b/scripts/create-new-minor-version
@@ -66,9 +66,12 @@ sed -i .bak -e "/currentVersion/i \\
 rm guides/versions.yml.bak
 echo "  DONE"
 
+echo "What version of EmberData is being released (e.g. 5.3.0)? Double check this as it might not be the same version as Ember."
+read -r EMBER_DATA_CURRENT_VERSION
+
 # Update version numbers in links
 echo "🤖 Updating version number for links in /guides/$CURRENT_VERSION/**/*.md"
-node scripts/update-version-links guides/$CURRENT_VERSION $(echo $CURRENT_VERSION | cut -d "v" -f2) --silent
+node scripts/update-version-links guides/$CURRENT_VERSION $(echo $CURRENT_VERSION | cut -d "v" -f2) $(echo $EMBER_DATA_CURRENT_VERSION | cut -d "v" -f2) --silent
 echo "  DONE"
 
 echo

--- a/scripts/create-new-minor-version
+++ b/scripts/create-new-minor-version
@@ -48,6 +48,8 @@ NEXT_VERSION=$MAJOR_VERSION.$(($MINOR_VERSION+1)).$PATCH_VERSION
 
 # Copy the current release guides into the appropriate version-numbered folder.
 # `-r` is for recursive, so all directory content is copied.
+echo "🤖 Removing any directories for $CURRENT_VERSION"
+rm -rf guides/$CURRENT_VERSION
 echo "🤖 Copying release to $CURRENT_VERSION"
 cp -r guides/release guides/$CURRENT_VERSION
 echo "  DONE"

--- a/scripts/update-version-links
+++ b/scripts/update-version-links
@@ -26,7 +26,7 @@
  */
 
 const fs = require('fs');
-const replaceURLsVersions = require('./helpers/replace-url-versions')
+const replaceURLVersions = require('./helpers/replace-url-versions');
 const { Command } = require('commander');
 const program = new Command();
       program.option('--dry-run')
@@ -39,7 +39,8 @@ program.parse(process.argv);
 const options = program.opts();
 
 const currentFolder = fs.realpathSync(program.args[0]);
-const newVersionNumber = program.args[1];
+const newEmberVersionNumber = program.args[1];
+const newEmberDataVersionNumber = program.args[2];
 
 let dryRun = options.dryRun;
 let verbose = options.verbose;
@@ -57,7 +58,11 @@ const recursion = (path) => {
       recursion(filePath);
     } else if (fileName.endsWith('.md')) {
       const currentOutput = fs.readFileSync(filePath).toString();
-      const newOutput = replaceURLsVersions(currentOutput, newVersionNumber);
+      const newOutput = replaceURLVersions(
+        currentOutput,
+        newEmberVersionNumber,
+        newEmberDataVersionNumber
+      );
 
       if (currentOutput !== newOutput) {
         if (!dryRun) {


### PR DESCRIPTION
- prompt user to enter EmberData current version and pass it to update links script
- also handle different ember data version when updating links