### PR TITLE
Update more-about-components.md - Rental::Image component test

### DIFF
--- a/guides/release/tutorial/part-1/more-about-components.md
+++ b/guides/release/tutorial/part-1/more-about-components.md
@@ -201,10 +201,7 @@ module('Integration | Component | rental/image', function (hooks) {
     // Template block usage:
   test('it renders the given image', async function (assert) {
     await render(hbs`
-      <Rental::Image>
-        template block text
-      </Rental::Image>
-      <Rental::Image
+       <Rental::Image
         src="/assets/images/teaching-tomster.png"
         alt="Teaching Tomster"
       />


### PR DESCRIPTION
The test for `<Rental::Image />` component failed as a result of two different invocations of the image component. The first one was not passed the attributes, so the test failed with this result. 

`Result: "Element .image img does not have attribute \"src\"" `

The fix: Removing the first component invocation, leaving the second invocation which has attributes passed in, made the test successful.