### PR TITLE
chore: normalize h1 headers in content to h2

### DIFF
--- a/guides/release/components/index.md
+++ b/guides/release/components/index.md
@@ -186,7 +186,7 @@ know HTML and CSS, you know how to build a basic Ember application!
 You can even use SVG or web components without any changes. As long as your HTML
 is valid, Ember will render it.
 
-# Self-Closing Tags
+## Self-Closing Tags
 
 In addition to normal HTML syntax, Ember allows you to use self-closing syntax
 (`<div />`) as a shorthand for an opening and closing tag (`<div></div>`).
@@ -206,7 +206,7 @@ In addition to normal HTML syntax, Ember allows you to use self-closing syntax
   </div>
 </div>
 
-# Supported Features
+## Supported Features
 
 This means that all of the following HTML features work as-is:
 
@@ -216,7 +216,7 @@ This means that all of the following HTML features work as-is:
 - White space (following the same rules as normal HTML)
 - Special HTML elements like `<table>` and `<select>`
 
-# Restrictions
+## Restrictions
 
 There are a handful of restrictions on the HTML that you can put in an Ember
 template:

--- a/guides/release/contributing/index.md
+++ b/guides/release/contributing/index.md
@@ -1,6 +1,6 @@
 Ember is an open source project that succeeds thanks to the help of volunteers. Community members at any level are invited to help out with anything from bug reports to documentation. This guide will give you some tips on how to get started and where to ask for help if you want to get involved. Thanks in advance for your help!
 
-# Types of contributions
+## Types of contributions
 
 Any change that aims to make an improvement is very welcome!
 
@@ -15,7 +15,7 @@ Creating an issue is a great way to start a discussion and gather opinions of ot
 
 Apart from creating new issues and pull requests, another way to contribute is comment on existing issues and pull requests. The more reviewers we get for something, the lower the chance we'll overlook potential problems.
 
-# Where to get started
+## Where to get started
 
 A great place to start is helping improve something you personally ran into. E.g. if you found some of the documentation unclear yourself, please create an issue to highlight it, and optionally suggest how to simplify it.
 
@@ -23,7 +23,7 @@ Have a look at the [list of main repositories](repositories) to learn about the 
 
 If you need some inspiration, you can check out the [Help Wanted](https://help-wanted.emberjs.com/) dashboard to browse for issues. If you are a beginner, look out for issues with the "Help wanted" and "Good first issue" labels.
 
-# Updating the API Guides
+## Updating the API Guides
 
 In the [API Guides](https://api.emberjs.com/ember/release), suppose you found a typo or wish to provide more details for a package, method, or class. Here is how you can make a change.
 
@@ -38,11 +38,11 @@ Next to the words is, once again, the link to the source code [`ds-model-store.t
 Please follow the contributing guide in the specific repo. (Here is an example of the [contributing guide for Ember.js](https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md).)
 The contributing guide may further describe how you can edit files, commit messages, and run linting and testing.
 
-# Asking for help
+## Asking for help
 
 Please comment directly on issues and PRs if you need help. This way others will see and can chime in to help.
 You can also visit the [Ember.js Community Page](https://emberjs.com/community) to join the Ember.js Discord server. Channels that start with `dev` are for contributors working on the corresponding projects, and they are a great place for questions.
 
-# In conclusion
+## In conclusion
 
 We would like to reiterate once again - anyone at any skill level can help out! If you have any ideas to improve anything whatsoever, we would love to see your contribution!

--- a/guides/release/contributing/repositories.md
+++ b/guides/release/contributing/repositories.md
@@ -1,6 +1,6 @@
 Ember is made up of several libraries. If you wish to add a feature or fix a bug please file a pull request against the appropriate repository. Be sure to check the libraries listed below before making changes in the Ember repository.
 
-# Main Repositories
+## Main Repositories
 **Ember.js** - The main repository for Ember.
 
 * [https://github.com/emberjs/ember.js](https://github.com/emberjs/ember.js)
@@ -30,7 +30,7 @@ Ember is made up of several libraries. If you wish to add a feature or fix a bug
 **Community**
 * [https://emberjs.com/community](https://emberjs.com/community)
 
-# Libraries Used By Ember
+## Libraries Used By Ember
 
 These libraries are part of the Ember asset output, but development of them takes place in a separate repository.
 


### PR DESCRIPTION
As part of https://github.com/ember-learn/guidemaker-ember-template/issues/179 I took a look at our current header levels used. It turns out we have a few H1s inside of the guide contents. In general there should only be one h1 on a page, which here is the page title, so having H1s inside the content is odd.

This PR replaces the usages (found via regex search) with H2s.