### PR TITLE
Correct @cached example

### DIFF
--- a/guides/release/in-depth-topics/autotracking-in-depth.md
+++ b/guides/release/in-depth-topics/autotracking-in-depth.md
@@ -378,7 +378,8 @@ class Photo {
 
   @cached
   get aspectRatio() {
-    return getValue(this.#aspectRatioCache);
+    count++;
+    return this.width / this.height;
   }
 }
 


### PR DESCRIPTION
The example for `@cached` was using code that wasn't in the example. Seems like it was missed when the conversion from caching primitives to `@cached` happened in https://github.com/ember-learn/guides-source/pull/1887/files