### PR TITLE
docs: Update urban-living image

### DIFF
--- a/guides/v2.10.0/tutorial/autocomplete-component.md
+++ b/guides/v2.10.0/tutorial/autocomplete-component.md
@@ -230,7 +230,7 @@ export default function() {
         city: 'Seattle',
         type: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v2.10.0/tutorial/installing-addons.md
+++ b/guides/v2.10.0/tutorial/installing-addons.md
@@ -66,7 +66,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.10.0/tutorial/model-hook.md
+++ b/guides/v2.10.0/tutorial/model-hook.md
@@ -29,7 +29,7 @@ let rentals = [{
   city: 'Seattle',
   type: 'Condo',
   bedrooms: 1,
-  image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+  image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
 }, {
   id: 'downtown-charm',
   title: 'Downtown Charm',

--- a/guides/v2.10.0/tutorial/subroutes.md
+++ b/guides/v2.10.0/tutorial/subroutes.md
@@ -182,7 +182,7 @@ export default function() {
         city: "Seattle",
         type: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v2.11.0/tutorial/autocomplete-component.md
+++ b/guides/v2.11.0/tutorial/autocomplete-component.md
@@ -230,7 +230,7 @@ export default function() {
         city: 'Seattle',
         type: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v2.11.0/tutorial/ember-data.md
+++ b/guides/v2.11.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Ember.Route.extend({
       city: 'Seattle',
       type: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v2.11.0/tutorial/installing-addons.md
+++ b/guides/v2.11.0/tutorial/installing-addons.md
@@ -66,7 +66,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.11.0/tutorial/model-hook.md
+++ b/guides/v2.11.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Ember.Route.extend({
       city: 'Seattle',
       type: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
 
     }, {

--- a/guides/v2.11.0/tutorial/subroutes.md
+++ b/guides/v2.11.0/tutorial/subroutes.md
@@ -183,7 +183,7 @@ export default function() {
         city: "Seattle",
         type: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v2.12.0/tutorial/autocomplete-component.md
+++ b/guides/v2.12.0/tutorial/autocomplete-component.md
@@ -163,7 +163,7 @@ export default function() {
         city: 'Seattle',
         type: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v2.12.0/tutorial/ember-data.md
+++ b/guides/v2.12.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Ember.Route.extend({
       city: 'Seattle',
       type: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v2.12.0/tutorial/installing-addons.md
+++ b/guides/v2.12.0/tutorial/installing-addons.md
@@ -70,7 +70,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.12.0/tutorial/model-hook.md
+++ b/guides/v2.12.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Ember.Route.extend({
       city: 'Seattle',
       type: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
 
     }, {

--- a/guides/v2.12.0/tutorial/subroutes.md
+++ b/guides/v2.12.0/tutorial/subroutes.md
@@ -183,7 +183,7 @@ export default function() {
         city: "Seattle",
         type: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v2.13.0/tutorial/autocomplete-component.md
+++ b/guides/v2.13.0/tutorial/autocomplete-component.md
@@ -166,7 +166,7 @@ export default function() {
         city: 'Seattle',
         "property-type": 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v2.13.0/tutorial/ember-data.md
+++ b/guides/v2.13.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Ember.Route.extend({
       city: 'Seattle',
       propertyType: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v2.13.0/tutorial/installing-addons.md
+++ b/guides/v2.13.0/tutorial/installing-addons.md
@@ -70,7 +70,7 @@ export default function() {
           city: 'Seattle',
           "property-type": 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.13.0/tutorial/model-hook.md
+++ b/guides/v2.13.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Ember.Route.extend({
       city: 'Seattle',
       propertyType: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
 
     }, {

--- a/guides/v2.13.0/tutorial/subroutes.md
+++ b/guides/v2.13.0/tutorial/subroutes.md
@@ -183,7 +183,7 @@ export default function() {
         city: "Seattle",
         propertyType: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v2.14.0/tutorial/autocomplete-component.md
+++ b/guides/v2.14.0/tutorial/autocomplete-component.md
@@ -166,7 +166,7 @@ export default function() {
         city: 'Seattle',
         "property-type": 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v2.14.0/tutorial/ember-data.md
+++ b/guides/v2.14.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Ember.Route.extend({
       city: 'Seattle',
       propertyType: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v2.14.0/tutorial/installing-addons.md
+++ b/guides/v2.14.0/tutorial/installing-addons.md
@@ -73,7 +73,7 @@ export default function() {
           city: 'Seattle',
           "property-type": 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.14.0/tutorial/model-hook.md
+++ b/guides/v2.14.0/tutorial/model-hook.md
@@ -40,7 +40,7 @@ export default Ember.Route.extend({
       city: 'Seattle',
       propertyType: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
 
     }, {

--- a/guides/v2.14.0/tutorial/subroutes.md
+++ b/guides/v2.14.0/tutorial/subroutes.md
@@ -183,7 +183,7 @@ export default function() {
         city: "Seattle",
         propertyType: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v2.15.0/tutorial/autocomplete-component.md
+++ b/guides/v2.15.0/tutorial/autocomplete-component.md
@@ -173,7 +173,7 @@ export default function() {
         city: 'Seattle',
         "property-type": 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v2.15.0/tutorial/ember-data.md
+++ b/guides/v2.15.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Ember.Route.extend({
       city: 'Seattle',
       propertyType: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v2.15.0/tutorial/installing-addons.md
+++ b/guides/v2.15.0/tutorial/installing-addons.md
@@ -73,7 +73,7 @@ export default function() {
           city: 'Seattle',
           "property-type": 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.15.0/tutorial/model-hook.md
+++ b/guides/v2.15.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Ember.Route.extend({
       city: 'Seattle',
       propertyType: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
 
     }, {

--- a/guides/v2.15.0/tutorial/subroutes.md
+++ b/guides/v2.15.0/tutorial/subroutes.md
@@ -183,7 +183,7 @@ export default function() {
         city: "Seattle",
         "property-type": "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v2.16.0/tutorial/autocomplete-component.md
+++ b/guides/v2.16.0/tutorial/autocomplete-component.md
@@ -173,7 +173,7 @@ export default function() {
         city: 'Seattle',
         "property-type": 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v2.16.0/tutorial/ember-data.md
+++ b/guides/v2.16.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Route.extend({
       city: 'Seattle',
       propertyType: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v2.16.0/tutorial/installing-addons.md
+++ b/guides/v2.16.0/tutorial/installing-addons.md
@@ -83,7 +83,7 @@ export default function() {
           city: 'Seattle',
           "property-type": 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.16.0/tutorial/model-hook.md
+++ b/guides/v2.16.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       propertyType: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v2.16.0/tutorial/subroutes.md
+++ b/guides/v2.16.0/tutorial/subroutes.md
@@ -194,7 +194,7 @@ export default function() {
         city: "Seattle",
         "property-type": "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v2.17.0/tutorial/autocomplete-component.md
+++ b/guides/v2.17.0/tutorial/autocomplete-component.md
@@ -173,7 +173,7 @@ export default function() {
         city: 'Seattle',
         "property-type": 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v2.17.0/tutorial/ember-data.md
+++ b/guides/v2.17.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Route.extend({
       city: 'Seattle',
       propertyType: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v2.17.0/tutorial/installing-addons.md
+++ b/guides/v2.17.0/tutorial/installing-addons.md
@@ -83,7 +83,7 @@ export default function() {
           city: 'Seattle',
           "property-type": 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.17.0/tutorial/model-hook.md
+++ b/guides/v2.17.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       propertyType: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v2.17.0/tutorial/subroutes.md
+++ b/guides/v2.17.0/tutorial/subroutes.md
@@ -194,7 +194,7 @@ export default function() {
         city: "Seattle",
         "property-type": "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v2.18.0/tutorial/autocomplete-component.md
+++ b/guides/v2.18.0/tutorial/autocomplete-component.md
@@ -176,7 +176,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v2.18.0/tutorial/ember-data.md
+++ b/guides/v2.18.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v2.18.0/tutorial/installing-addons.md
+++ b/guides/v2.18.0/tutorial/installing-addons.md
@@ -82,7 +82,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.18.0/tutorial/model-hook.md
+++ b/guides/v2.18.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v2.18.0/tutorial/subroutes.md
+++ b/guides/v2.18.0/tutorial/subroutes.md
@@ -194,7 +194,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v2.2.0/tutorial/ember-data.md
+++ b/guides/v2.2.0/tutorial/ember-data.md
@@ -84,7 +84,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.2.0/tutorial/model-hook.md
+++ b/guides/v2.2.0/tutorial/model-hook.md
@@ -29,7 +29,7 @@ var rentals = [{
   city: 'Seattle',
   type: 'Condo',
   bedrooms: 1,
-  image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+  image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
 }, {
   id: 3,
   title: 'Downtown Charm',

--- a/guides/v2.3.0/tutorial/autocomplete-component.md
+++ b/guides/v2.3.0/tutorial/autocomplete-component.md
@@ -226,7 +226,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.3.0/tutorial/installing-addons.md
+++ b/guides/v2.3.0/tutorial/installing-addons.md
@@ -62,7 +62,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.3.0/tutorial/model-hook.md
+++ b/guides/v2.3.0/tutorial/model-hook.md
@@ -29,7 +29,7 @@ let rentals = [{
   city: 'Seattle',
   type: 'Condo',
   bedrooms: 1,
-  image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+  image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
 }, {
   id: 3,
   title: 'Downtown Charm',

--- a/guides/v2.4.0/tutorial/autocomplete-component.md
+++ b/guides/v2.4.0/tutorial/autocomplete-component.md
@@ -226,7 +226,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.4.0/tutorial/installing-addons.md
+++ b/guides/v2.4.0/tutorial/installing-addons.md
@@ -62,7 +62,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.4.0/tutorial/model-hook.md
+++ b/guides/v2.4.0/tutorial/model-hook.md
@@ -29,7 +29,7 @@ let rentals = [{
   city: 'Seattle',
   type: 'Condo',
   bedrooms: 1,
-  image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+  image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
 }, {
   id: 3,
   title: 'Downtown Charm',

--- a/guides/v2.5.0/tutorial/autocomplete-component.md
+++ b/guides/v2.5.0/tutorial/autocomplete-component.md
@@ -226,7 +226,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.5.0/tutorial/installing-addons.md
+++ b/guides/v2.5.0/tutorial/installing-addons.md
@@ -62,7 +62,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.5.0/tutorial/model-hook.md
+++ b/guides/v2.5.0/tutorial/model-hook.md
@@ -29,7 +29,7 @@ let rentals = [{
   city: 'Seattle',
   type: 'Condo',
   bedrooms: 1,
-  image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+  image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
 }, {
   id: 3,
   title: 'Downtown Charm',

--- a/guides/v2.6.0/tutorial/autocomplete-component.md
+++ b/guides/v2.6.0/tutorial/autocomplete-component.md
@@ -226,7 +226,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.6.0/tutorial/installing-addons.md
+++ b/guides/v2.6.0/tutorial/installing-addons.md
@@ -64,7 +64,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.6.0/tutorial/model-hook.md
+++ b/guides/v2.6.0/tutorial/model-hook.md
@@ -29,7 +29,7 @@ let rentals = [{
   city: 'Seattle',
   type: 'Condo',
   bedrooms: 1,
-  image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+  image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
 }, {
   id: 3,
   title: 'Downtown Charm',

--- a/guides/v2.7.0/tutorial/autocomplete-component.md
+++ b/guides/v2.7.0/tutorial/autocomplete-component.md
@@ -226,7 +226,7 @@ export default function() {
         city: 'Seattle',
         type: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
       }
     }, {
       type: 'rentals',

--- a/guides/v2.7.0/tutorial/installing-addons.md
+++ b/guides/v2.7.0/tutorial/installing-addons.md
@@ -66,7 +66,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.7.0/tutorial/model-hook.md
+++ b/guides/v2.7.0/tutorial/model-hook.md
@@ -29,7 +29,7 @@ let rentals = [{
   city: 'Seattle',
   type: 'Condo',
   bedrooms: 1,
-  image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+  image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
 }, {
   id: 'downtown-charm',
   title: 'Downtown Charm',

--- a/guides/v2.7.0/tutorial/subroutes.md
+++ b/guides/v2.7.0/tutorial/subroutes.md
@@ -182,7 +182,7 @@ export default function() {
         city: "Seattle",
         type: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v2.8.0/tutorial/autocomplete-component.md
+++ b/guides/v2.8.0/tutorial/autocomplete-component.md
@@ -230,7 +230,7 @@ export default function() {
         city: 'Seattle',
         type: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v2.8.0/tutorial/installing-addons.md
+++ b/guides/v2.8.0/tutorial/installing-addons.md
@@ -66,7 +66,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.8.0/tutorial/model-hook.md
+++ b/guides/v2.8.0/tutorial/model-hook.md
@@ -29,7 +29,7 @@ let rentals = [{
   city: 'Seattle',
   type: 'Condo',
   bedrooms: 1,
-  image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+  image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
 }, {
   id: 'downtown-charm',
   title: 'Downtown Charm',

--- a/guides/v2.8.0/tutorial/subroutes.md
+++ b/guides/v2.8.0/tutorial/subroutes.md
@@ -182,7 +182,7 @@ export default function() {
         city: "Seattle",
         type: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v2.9.0/tutorial/autocomplete-component.md
+++ b/guides/v2.9.0/tutorial/autocomplete-component.md
@@ -230,7 +230,7 @@ export default function() {
         city: 'Seattle',
         type: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v2.9.0/tutorial/installing-addons.md
+++ b/guides/v2.9.0/tutorial/installing-addons.md
@@ -66,7 +66,7 @@ export default function() {
           city: 'Seattle',
           type: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v2.9.0/tutorial/model-hook.md
+++ b/guides/v2.9.0/tutorial/model-hook.md
@@ -29,7 +29,7 @@ let rentals = [{
   city: 'Seattle',
   type: 'Condo',
   bedrooms: 1,
-  image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+  image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
 }, {
   id: 'downtown-charm',
   title: 'Downtown Charm',

--- a/guides/v2.9.0/tutorial/subroutes.md
+++ b/guides/v2.9.0/tutorial/subroutes.md
@@ -182,7 +182,7 @@ export default function() {
         city: "Seattle",
         type: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.0.0/tutorial/autocomplete-component.md
+++ b/guides/v3.0.0/tutorial/autocomplete-component.md
@@ -176,7 +176,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.0.0/tutorial/ember-data.md
+++ b/guides/v3.0.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.0.0/tutorial/installing-addons.md
+++ b/guides/v3.0.0/tutorial/installing-addons.md
@@ -82,7 +82,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v3.0.0/tutorial/model-hook.md
+++ b/guides/v3.0.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.0.0/tutorial/subroutes.md
+++ b/guides/v3.0.0/tutorial/subroutes.md
@@ -194,7 +194,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.1.0/tutorial/autocomplete-component.md
+++ b/guides/v3.1.0/tutorial/autocomplete-component.md
@@ -176,7 +176,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.1.0/tutorial/ember-data.md
+++ b/guides/v3.1.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.1.0/tutorial/installing-addons.md
+++ b/guides/v3.1.0/tutorial/installing-addons.md
@@ -82,7 +82,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v3.1.0/tutorial/model-hook.md
+++ b/guides/v3.1.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.1.0/tutorial/subroutes.md
+++ b/guides/v3.1.0/tutorial/subroutes.md
@@ -194,7 +194,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.10.0/tutorial/autocomplete-component.md
+++ b/guides/v3.10.0/tutorial/autocomplete-component.md
@@ -180,7 +180,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.10.0/tutorial/ember-data.md
+++ b/guides/v3.10.0/tutorial/ember-data.md
@@ -84,7 +84,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.10.0/tutorial/installing-addons.md
+++ b/guides/v3.10.0/tutorial/installing-addons.md
@@ -90,7 +90,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
           description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
         }
       }, {

--- a/guides/v3.10.0/tutorial/model-hook.md
+++ b/guides/v3.10.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.10.0/tutorial/subroutes.md
+++ b/guides/v3.10.0/tutorial/subroutes.md
@@ -196,7 +196,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.11.0/tutorial/autocomplete-component.md
+++ b/guides/v3.11.0/tutorial/autocomplete-component.md
@@ -180,7 +180,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.11.0/tutorial/ember-data.md
+++ b/guides/v3.11.0/tutorial/ember-data.md
@@ -84,7 +84,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.11.0/tutorial/installing-addons.md
+++ b/guides/v3.11.0/tutorial/installing-addons.md
@@ -90,7 +90,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
           description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
         }
       }, {

--- a/guides/v3.11.0/tutorial/model-hook.md
+++ b/guides/v3.11.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.11.0/tutorial/subroutes.md
+++ b/guides/v3.11.0/tutorial/subroutes.md
@@ -196,7 +196,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.12.0/tutorial/autocomplete-component.md
+++ b/guides/v3.12.0/tutorial/autocomplete-component.md
@@ -180,7 +180,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.12.0/tutorial/ember-data.md
+++ b/guides/v3.12.0/tutorial/ember-data.md
@@ -84,7 +84,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.12.0/tutorial/installing-addons.md
+++ b/guides/v3.12.0/tutorial/installing-addons.md
@@ -90,7 +90,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
           description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
         }
       }, {

--- a/guides/v3.12.0/tutorial/model-hook.md
+++ b/guides/v3.12.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.12.0/tutorial/subroutes.md
+++ b/guides/v3.12.0/tutorial/subroutes.md
@@ -196,7 +196,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.13.0/tutorial/autocomplete-component.md
+++ b/guides/v3.13.0/tutorial/autocomplete-component.md
@@ -180,7 +180,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.13.0/tutorial/ember-data.md
+++ b/guides/v3.13.0/tutorial/ember-data.md
@@ -84,7 +84,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.13.0/tutorial/installing-addons.md
+++ b/guides/v3.13.0/tutorial/installing-addons.md
@@ -90,7 +90,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
           description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
         }
       }, {

--- a/guides/v3.13.0/tutorial/model-hook.md
+++ b/guides/v3.13.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.13.0/tutorial/subroutes.md
+++ b/guides/v3.13.0/tutorial/subroutes.md
@@ -196,7 +196,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.14.0/tutorial/autocomplete-component.md
+++ b/guides/v3.14.0/tutorial/autocomplete-component.md
@@ -180,7 +180,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.14.0/tutorial/ember-data.md
+++ b/guides/v3.14.0/tutorial/ember-data.md
@@ -84,7 +84,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.14.0/tutorial/installing-addons.md
+++ b/guides/v3.14.0/tutorial/installing-addons.md
@@ -90,7 +90,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
           description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
         }
       }, {

--- a/guides/v3.14.0/tutorial/model-hook.md
+++ b/guides/v3.14.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.14.0/tutorial/subroutes.md
+++ b/guides/v3.14.0/tutorial/subroutes.md
@@ -196,7 +196,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.15.0/tutorial/part-1/working-with-data.md
+++ b/guides/v3.15.0/tutorial/part-1/working-with-data.md
@@ -325,7 +325,7 @@ Before we go any further, let's pause for a second to look at the server's data 
         },
         "category": "Condo",
         "bedrooms": 1,
-        "image": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         "description": "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.15.0/tutorial/part-2/provider-components.md
+++ b/guides/v3.15.0/tutorial/part-2/provider-components.md
@@ -143,7 +143,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {
@@ -358,7 +358,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {

--- a/guides/v3.16.0/tutorial/part-1/working-with-data.md
+++ b/guides/v3.16.0/tutorial/part-1/working-with-data.md
@@ -325,7 +325,7 @@ Before we go any further, let's pause for a second to look at the server's data 
         },
         "category": "Condo",
         "bedrooms": 1,
-        "image": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         "description": "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.16.0/tutorial/part-2/provider-components.md
+++ b/guides/v3.16.0/tutorial/part-2/provider-components.md
@@ -143,7 +143,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {
@@ -358,7 +358,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {

--- a/guides/v3.17.0/tutorial/part-1/working-with-data.md
+++ b/guides/v3.17.0/tutorial/part-1/working-with-data.md
@@ -325,7 +325,7 @@ Before we go any further, let's pause for a second to look at the server's data 
         },
         "category": "Condo",
         "bedrooms": 1,
-        "image": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         "description": "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.17.0/tutorial/part-2/provider-components.md
+++ b/guides/v3.17.0/tutorial/part-2/provider-components.md
@@ -143,7 +143,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {
@@ -358,7 +358,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {

--- a/guides/v3.18.0/tutorial/part-1/working-with-data.md
+++ b/guides/v3.18.0/tutorial/part-1/working-with-data.md
@@ -325,7 +325,7 @@ Before we go any further, let's pause for a second to look at the server's data 
         },
         "category": "Condo",
         "bedrooms": 1,
-        "image": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         "description": "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.18.0/tutorial/part-2/provider-components.md
+++ b/guides/v3.18.0/tutorial/part-2/provider-components.md
@@ -143,7 +143,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {
@@ -358,7 +358,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {

--- a/guides/v3.19.0/tutorial/part-1/working-with-data.md
+++ b/guides/v3.19.0/tutorial/part-1/working-with-data.md
@@ -325,7 +325,7 @@ Before we go any further, let's pause for a second to look at the server's data 
         },
         "category": "Condo",
         "bedrooms": 1,
-        "image": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         "description": "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.19.0/tutorial/part-2/provider-components.md
+++ b/guides/v3.19.0/tutorial/part-2/provider-components.md
@@ -143,7 +143,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {
@@ -358,7 +358,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {

--- a/guides/v3.2.0/tutorial/autocomplete-component.md
+++ b/guides/v3.2.0/tutorial/autocomplete-component.md
@@ -176,7 +176,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.2.0/tutorial/ember-data.md
+++ b/guides/v3.2.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.2.0/tutorial/installing-addons.md
+++ b/guides/v3.2.0/tutorial/installing-addons.md
@@ -82,7 +82,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v3.2.0/tutorial/model-hook.md
+++ b/guides/v3.2.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.2.0/tutorial/subroutes.md
+++ b/guides/v3.2.0/tutorial/subroutes.md
@@ -194,7 +194,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.20.0/tutorial/part-1/working-with-data.md
+++ b/guides/v3.20.0/tutorial/part-1/working-with-data.md
@@ -325,7 +325,7 @@ Before we go any further, let's pause for a second to look at the server's data 
         },
         "category": "Condo",
         "bedrooms": 1,
-        "image": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         "description": "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.20.0/tutorial/part-2/provider-components.md
+++ b/guides/v3.20.0/tutorial/part-2/provider-components.md
@@ -143,7 +143,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {
@@ -358,7 +358,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {

--- a/guides/v3.21.0/tutorial/part-1/working-with-data.md
+++ b/guides/v3.21.0/tutorial/part-1/working-with-data.md
@@ -325,7 +325,7 @@ Before we go any further, let's pause for a second to look at the server's data 
         },
         "category": "Condo",
         "bedrooms": 1,
-        "image": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         "description": "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.21.0/tutorial/part-2/provider-components.md
+++ b/guides/v3.21.0/tutorial/part-2/provider-components.md
@@ -143,7 +143,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {
@@ -358,7 +358,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {

--- a/guides/v3.22.0/tutorial/part-1/working-with-data.md
+++ b/guides/v3.22.0/tutorial/part-1/working-with-data.md
@@ -325,7 +325,7 @@ Before we go any further, let's pause for a second to look at the server's data 
         },
         "category": "Condo",
         "bedrooms": 1,
-        "image": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         "description": "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.22.0/tutorial/part-2/provider-components.md
+++ b/guides/v3.22.0/tutorial/part-2/provider-components.md
@@ -143,7 +143,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {
@@ -358,7 +358,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {

--- a/guides/v3.23.0/tutorial/part-1/working-with-data.md
+++ b/guides/v3.23.0/tutorial/part-1/working-with-data.md
@@ -325,7 +325,7 @@ Before we go any further, let's pause for a second to look at the server's data 
         },
         "category": "Condo",
         "bedrooms": 1,
-        "image": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         "description": "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.23.0/tutorial/part-2/provider-components.md
+++ b/guides/v3.23.0/tutorial/part-2/provider-components.md
@@ -143,7 +143,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {
@@ -358,7 +358,7 @@ module('Integration | Component | rentals', function(hooks) {
         category: 'Condo',
         type: 'Community',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
       },
       {

--- a/guides/v3.24.0/tutorial/part-1/working-with-data.md
+++ b/guides/v3.24.0/tutorial/part-1/working-with-data.md
@@ -327,7 +327,7 @@ Before we go any further, let's pause for a second to look at the server's data 
         },
         "category": "Condo",
         "bedrooms": 1,
-        "image": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         "description": "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.24.0/tutorial/part-2/provider-components.md
+++ b/guides/v3.24.0/tutorial/part-2/provider-components.md
@@ -149,7 +149,7 @@ module('Integration | Component | rentals', function (hooks) {
           type: 'Community',
           bedrooms: 1,
           image:
-            'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+            'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
           description:
             'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.',
         },
@@ -380,7 +380,7 @@ module('Integration | Component | rentals', function (hooks) {
           type: 'Community',
           bedrooms: 1,
           image:
-            'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+            'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
           description:
             'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.',
         },

--- a/guides/v3.3.0/tutorial/autocomplete-component.md
+++ b/guides/v3.3.0/tutorial/autocomplete-component.md
@@ -176,7 +176,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.3.0/tutorial/ember-data.md
+++ b/guides/v3.3.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.3.0/tutorial/installing-addons.md
+++ b/guides/v3.3.0/tutorial/installing-addons.md
@@ -82,7 +82,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'
         }
       }, {
         type: 'rentals',

--- a/guides/v3.3.0/tutorial/model-hook.md
+++ b/guides/v3.3.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.3.0/tutorial/subroutes.md
+++ b/guides/v3.3.0/tutorial/subroutes.md
@@ -194,7 +194,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.4.0/tutorial/autocomplete-component.md
+++ b/guides/v3.4.0/tutorial/autocomplete-component.md
@@ -177,7 +177,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.4.0/tutorial/ember-data.md
+++ b/guides/v3.4.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.4.0/tutorial/installing-addons.md
+++ b/guides/v3.4.0/tutorial/installing-addons.md
@@ -83,7 +83,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
           description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
         }
       }, {

--- a/guides/v3.4.0/tutorial/model-hook.md
+++ b/guides/v3.4.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.4.0/tutorial/subroutes.md
+++ b/guides/v3.4.0/tutorial/subroutes.md
@@ -194,7 +194,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.5.0/tutorial/autocomplete-component.md
+++ b/guides/v3.5.0/tutorial/autocomplete-component.md
@@ -180,7 +180,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.5.0/tutorial/ember-data.md
+++ b/guides/v3.5.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.5.0/tutorial/installing-addons.md
+++ b/guides/v3.5.0/tutorial/installing-addons.md
@@ -90,7 +90,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
           description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
         }
       }, {

--- a/guides/v3.5.0/tutorial/model-hook.md
+++ b/guides/v3.5.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.5.0/tutorial/subroutes.md
+++ b/guides/v3.5.0/tutorial/subroutes.md
@@ -194,7 +194,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.6.0/tutorial/autocomplete-component.md
+++ b/guides/v3.6.0/tutorial/autocomplete-component.md
@@ -180,7 +180,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.6.0/tutorial/ember-data.md
+++ b/guides/v3.6.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.6.0/tutorial/installing-addons.md
+++ b/guides/v3.6.0/tutorial/installing-addons.md
@@ -90,7 +90,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
           description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
         }
       }, {

--- a/guides/v3.6.0/tutorial/model-hook.md
+++ b/guides/v3.6.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.6.0/tutorial/subroutes.md
+++ b/guides/v3.6.0/tutorial/subroutes.md
@@ -194,7 +194,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.7.0/tutorial/autocomplete-component.md
+++ b/guides/v3.7.0/tutorial/autocomplete-component.md
@@ -180,7 +180,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.7.0/tutorial/ember-data.md
+++ b/guides/v3.7.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.7.0/tutorial/installing-addons.md
+++ b/guides/v3.7.0/tutorial/installing-addons.md
@@ -90,7 +90,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
           description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
         }
       }, {

--- a/guides/v3.7.0/tutorial/model-hook.md
+++ b/guides/v3.7.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.7.0/tutorial/subroutes.md
+++ b/guides/v3.7.0/tutorial/subroutes.md
@@ -194,7 +194,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.8.0/tutorial/autocomplete-component.md
+++ b/guides/v3.8.0/tutorial/autocomplete-component.md
@@ -180,7 +180,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.8.0/tutorial/ember-data.md
+++ b/guides/v3.8.0/tutorial/ember-data.md
@@ -82,7 +82,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.8.0/tutorial/installing-addons.md
+++ b/guides/v3.8.0/tutorial/installing-addons.md
@@ -90,7 +90,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
           description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
         }
       }, {

--- a/guides/v3.8.0/tutorial/model-hook.md
+++ b/guides/v3.8.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.8.0/tutorial/subroutes.md
+++ b/guides/v3.8.0/tutorial/subroutes.md
@@ -195,7 +195,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/guides/v3.9.0/tutorial/autocomplete-component.md
+++ b/guides/v3.9.0/tutorial/autocomplete-component.md
@@ -180,7 +180,7 @@ export default function() {
         city: 'Seattle',
         category: 'Condo',
         bedrooms: 1,
-        image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     }, {

--- a/guides/v3.9.0/tutorial/ember-data.md
+++ b/guides/v3.9.0/tutorial/ember-data.md
@@ -81,7 +81,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
     }, {
       id: 'downtown-charm',

--- a/guides/v3.9.0/tutorial/installing-addons.md
+++ b/guides/v3.9.0/tutorial/installing-addons.md
@@ -90,7 +90,7 @@ export default function() {
           city: 'Seattle',
           category: 'Condo',
           bedrooms: 1,
-          image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+          image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
           description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
         }
       }, {

--- a/guides/v3.9.0/tutorial/model-hook.md
+++ b/guides/v3.9.0/tutorial/model-hook.md
@@ -38,7 +38,7 @@ export default Route.extend({
       city: 'Seattle',
       category: 'Condo',
       bedrooms: 1,
-      image: 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg',
+      image: 'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg',
       description: 'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'
     }, {
       id: 'downtown-charm',

--- a/guides/v3.9.0/tutorial/subroutes.md
+++ b/guides/v3.9.0/tutorial/subroutes.md
@@ -196,7 +196,7 @@ export default function() {
         city: "Seattle",
         category: "Condo",
         bedrooms: 1,
-        image: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg",
+        image: "https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg",
         description: "A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."
       }
     },

--- a/public/v2.10.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.10.0/tutorial/autocomplete-component/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -26,7 +26,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta property="og:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -40,7 +40,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta name="twitter:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -53,7 +53,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember114789" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember114790" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To begin, let's generate our new component. We'll call this component list-filte
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember114791" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.10 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember114791" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember114795" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               </a>
               <div id="ember114798" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember114799" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.10.0/tutorial/index">
@@ -257,11 +257,11 @@ To begin, let's generate our new component. We'll call this component list-filte
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember114813" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember114816" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember114819" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember114822" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember114825" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember114828" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember114831" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember114834" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember114837" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember114840" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember114843" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember114846" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember114849" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -663,7 +663,7 @@ The result of the query is returned to the caller.</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -760,8 +760,8 @@ The result of the query is returned to the caller.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -805,6 +805,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.10.0/tutorial/installing-addons/index.html
+++ b/public/v2.10.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember115203" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember115204" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember115205" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.10 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember115205" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember115209" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember115212" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember115213" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.10.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember115227" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember115230" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember115233" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember115236" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember115239" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember115242" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember115245" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember115248" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember115251" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember115254" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember115257" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember115260" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember115263" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -525,7 +525,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -592,7 +592,7 @@ Without this change, navigation to <code>/rentals</code> in our application woul
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -636,8 +636,8 @@ Without this change, navigation to <code>/rentals</code> in our application woul
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -681,6 +681,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.10.0/tutorial/model-hook/index.html
+++ b/public/v2.10.0/tutorial/model-hook/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember115272" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember115273" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember115274" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.10 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember115274" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember115278" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember115281" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember115282" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.10.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember115296" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember115299" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember115302" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember115305" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember115308" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember115311" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember115314" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember115317" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember115320" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember115323" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember115326" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember115329" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember115332" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -488,7 +488,7 @@ Let's open <code>app/routes/rentals.js</code> and add our hard-coded data as the
   <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
 <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
   <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">title</span><span class="token operator">:</span> <span class="token string">'Downtown Charm'</span><span class="token punctuation">,</span>
@@ -612,8 +612,8 @@ For each rental, we then create a listing with information about the property.</
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -657,6 +657,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.10.0/tutorial/subroutes/index.html
+++ b/public/v2.10.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember115548" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember115549" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember115550" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.10 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember115550" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember115554" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember115557" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember115558" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.10.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember115572" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember115575" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember115578" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember115581" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember115584" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember115587" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember115590" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember115593" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember115596" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember115599" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember115602" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember115605" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember115608" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -633,7 +633,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -848,7 +848,7 @@ Regardless, we hope this has helped you get started with creating your own ambit
           <a href="#toc_final-check">Final Check</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -892,8 +892,8 @@ Regardless, we hope this has helped you get started with creating your own ambit
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -937,6 +937,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.11.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.11.0/tutorial/autocomplete-component/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -26,7 +26,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta property="og:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -40,7 +40,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta name="twitter:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -53,7 +53,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember121729" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember121730" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To begin, let's generate our new component. We'll call this component list-filte
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember121731" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.11 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember121731" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember121735" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               </a>
               <div id="ember121738" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember121739" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.11.0/tutorial/index">
@@ -257,11 +257,11 @@ To begin, let's generate our new component. We'll call this component list-filte
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember121753" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember121756" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember121759" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember121762" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember121765" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember121768" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember121771" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember121774" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember121777" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember121780" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember121783" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember121786" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember121789" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -663,7 +663,7 @@ The result of the query is returned to the caller.</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -760,8 +760,8 @@ The result of the query is returned to the caller.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -805,6 +805,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.11.0/tutorial/ember-data/index.html
+++ b/public/v2.11.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember121936" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember121937" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember121938" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.11 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember121938" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember121942" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember121945" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember121946" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.11.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember121960" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember121963" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember121966" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember121969" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember121972" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember121975" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember121978" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember121981" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember121984" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember121987" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember121990" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember121993" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember121996" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/data/classes/DS.Store.ht
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -581,7 +581,7 @@ When we deploy our app to a production server, we will need to provide a backend
           <a href="#toc_updating-the-model-hook">Updating the Model Hook</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -625,8 +625,8 @@ When we deploy our app to a production server, we will need to provide a backend
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -670,6 +670,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.11.0/tutorial/installing-addons/index.html
+++ b/public/v2.11.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember122143" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember122144" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember122145" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.11 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember122145" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember122149" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember122152" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember122153" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.11.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember122167" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember122170" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember122173" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember122176" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember122179" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember122182" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember122185" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember122188" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember122191" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember122194" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember122197" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember122200" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember122203" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -525,7 +525,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -592,7 +592,7 @@ Without this change, navigation to <code>/rentals</code> in our application woul
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -636,8 +636,8 @@ Without this change, navigation to <code>/rentals</code> in our application woul
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -681,6 +681,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.11.0/tutorial/model-hook/index.html
+++ b/public/v2.11.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember122212" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember122213" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember122214" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.11 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember122214" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember122218" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember122221" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember122222" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.11.0/tutorial/index">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember122236" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember122239" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember122242" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember122245" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember122248" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember122251" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember122254" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember122257" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember122260" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember122263" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember122266" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember122269" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember122272" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -501,7 +501,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
 
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -519,7 +519,7 @@ The model function we've added to our <code>rentals</code> route handler will be
 <span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 <span aria-hidden="true" class="line-numbers-rows"><a href="#C1_L1" id=C1_L1></a><a href="#C1_L2" id=C1_L2></a><a href="#C1_L3" id=C1_L3></a><a href="#C1_L4" id=C1_L4></a><a href="#C1_L5" id=C1_L5></a><a href="#C1_L6" id=C1_L6></a><a href="#C1_L7" id=C1_L7></a><a href="#C1_L8" id=C1_L8></a><a href="#C1_L9" id=C1_L9></a><a href="#C1_L10" id=C1_L10></a><a href="#C1_L11" id=C1_L11></a><a href="#C1_L12" id=C1_L12></a><a href="#C1_L13" id=C1_L13></a><a href="#C1_L14" id=C1_L14></a><a href="#C1_L15" id=C1_L15></a><a href="#C1_L16" id=C1_L16></a><a href="#C1_L17" id=C1_L17></a><a href="#C1_L18" id=C1_L18></a><a href="#C1_L19" id=C1_L19></a><a href="#C1_L20" id=C1_L20></a><a href="#C1_L21" id=C1_L21></a><a href="#C1_L22" id=C1_L22></a><a href="#C1_L23" id=C1_L23></a><a href="#C1_L24" id=C1_L24></a><a href="#C1_L25" id=C1_L25></a><a href="#C1_L26" id=C1_L26></a><a href="#C1_L27" id=C1_L27></a><a href="#C1_L28" id=C1_L28></a><a href="#C1_L29" id=C1_L29></a><a href="#C1_L30" id=C1_L30></a><a href="#C1_L31" id=C1_L31></a><a href="#C1_L32" id=C1_L32></a><a href="#C1_L33" id=C1_L33></a><a href="#C1_L34" id=C1_L34></a><a href="#C1_L35" id=C1_L35></a><a href="#C1_L36" id=C1_L36></a></span></code></pre></div>
 <p>Note that here, we are using the ES6 shorthand method definition syntax: <code>model()</code> is the same as writing <code>model: function()</code>.</p>
-<p>Ember will use the model object returned above and save it as an attribute called <code>model</code>, 
+<p>Ember will use the model object returned above and save it as an attribute called <code>model</code>,
 available to the rentals template we generated with our route in <a href="../routes-and-templates/#toc_a-rentals-route">Routes and Templates</a>.</p>
 <p>Now, let's switch over to our rentals page template.
 We can use the model attribute to display our list of rentals.
@@ -625,8 +625,8 @@ From the rental variable in each step, we create a listing with information abou
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -670,6 +670,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.11.0/tutorial/subroutes/index.html
+++ b/public/v2.11.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember122488" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember122489" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember122490" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.11 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember122490" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember122494" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember122497" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember122498" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.11.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember122512" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember122515" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember122518" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember122521" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember122524" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember122527" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember122530" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember122533" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember122536" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember122539" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember122542" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember122545" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember122548" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -634,7 +634,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -849,7 +849,7 @@ Regardless, we hope this has helped you get started with creating your own ambit
           <a href="#toc_final-check">Final Check</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -893,8 +893,8 @@ Regardless, we hope this has helped you get started with creating your own ambit
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -938,6 +938,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.12.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.12.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember128669" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember128670" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember128671" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.12 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember128671" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember128675" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember128678" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember128679" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.12.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember128693" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember128696" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember128699" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember128702" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember128705" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember128708" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember128711" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember128714" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember128717" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember128720" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember128723" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember128726" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember128729" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -594,7 +594,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -876,7 +876,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -920,8 +920,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -965,6 +965,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.12.0/tutorial/ember-data/index.html
+++ b/public/v2.12.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember128876" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember128877" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember128878" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.12 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember128878" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember128882" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember128885" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember128886" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.12.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember128900" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember128903" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember128906" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember128909" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember128912" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember128915" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember128918" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember128921" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember128924" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember128927" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember128930" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember128933" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember128936" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/data/classes/DS.Store.ht
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -584,7 +584,7 @@ A remote server will allow for data to be shared and updated across users.</p>
           <a href="#toc_updating-the-model-hook">Updating the Model Hook</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -628,8 +628,8 @@ A remote server will allow for data to be shared and updated across users.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -673,6 +673,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.12.0/tutorial/installing-addons/index.html
+++ b/public/v2.12.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember129083" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember129084" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember129085" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.12 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember129085" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember129089" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember129092" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember129093" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.12.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember129107" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember129110" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember129113" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember129116" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember129119" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember129122" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember129125" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember129128" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember129131" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember129134" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember129137" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember129140" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember129143" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -527,7 +527,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -595,7 +595,7 @@ Without this change, navigation to <code>/rentals</code> in our application woul
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -639,8 +639,8 @@ Without this change, navigation to <code>/rentals</code> in our application woul
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -684,6 +684,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.12.0/tutorial/model-hook/index.html
+++ b/public/v2.12.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember129152" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember129153" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember129154" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.12 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember129154" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember129158" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember129161" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember129162" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.12.0/tutorial/index">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember129176" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember129179" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember129182" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember129185" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember129188" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember129191" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember129194" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember129197" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember129200" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember129203" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember129206" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember129209" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember129212" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -501,7 +501,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
 
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -611,7 +611,7 @@ This leaves us with 2 remaining acceptance test failures (and 1 jshint failure):
           <a href="#toc_acceptance-testing-the-rental-list">Acceptance Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -655,8 +655,8 @@ This leaves us with 2 remaining acceptance test failures (and 1 jshint failure):
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -700,6 +700,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.12.0/tutorial/subroutes/index.html
+++ b/public/v2.12.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember129428" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember129429" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember129430" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.12 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember129430" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember129434" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember129437" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember129438" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.12.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember129452" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember129455" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember129458" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember129461" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember129464" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember129467" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember129470" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember129473" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember129476" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember129479" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember129482" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember129485" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember129488" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -634,7 +634,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -861,7 +861,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -905,8 +905,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -950,6 +950,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.13.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.13.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember135681" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember135682" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember135683" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.13 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember135683" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember135687" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember135690" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember135691" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.13.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember135705" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember135708" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember135711" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember135714" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember135717" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember135720" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember135723" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember135726" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember135729" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember135732" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember135735" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember135738" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember135741" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -597,7 +597,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token string-property property">"property-type"</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -879,7 +879,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -923,8 +923,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -968,6 +968,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.13.0/tutorial/ember-data/index.html
+++ b/public/v2.13.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember135888" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember135889" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember135890" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.13 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember135890" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember135894" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember135897" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember135898" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.13.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember135912" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember135915" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember135918" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember135921" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember135924" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember135927" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember135930" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember135933" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember135936" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember135939" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember135942" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember135945" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember135948" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/data/classes/DS.Store.ht
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">propertyType</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -584,7 +584,7 @@ A remote server will allow for data to be shared and updated across users.</p>
           <a href="#toc_updating-the-model-hook">Updating the Model Hook</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -628,8 +628,8 @@ A remote server will allow for data to be shared and updated across users.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -673,6 +673,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.13.0/tutorial/installing-addons/index.html
+++ b/public/v2.13.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember136095" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember136096" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember136097" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.13 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember136097" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember136101" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember136104" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember136105" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.13.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember136119" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember136122" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember136125" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember136128" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember136131" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember136134" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember136137" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember136140" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember136143" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember136146" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember136149" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember136152" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember136155" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -527,7 +527,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token string-property property">"property-type"</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -595,7 +595,7 @@ Without this change, navigation to <code>/rentals</code> in our application woul
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -639,8 +639,8 @@ Without this change, navigation to <code>/rentals</code> in our application woul
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -684,6 +684,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.13.0/tutorial/model-hook/index.html
+++ b/public/v2.13.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember136164" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember136165" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember136166" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.13 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember136166" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember136170" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember136173" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember136174" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.13.0/tutorial/index">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember136188" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember136191" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember136194" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember136197" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember136200" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember136203" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember136206" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember136209" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember136212" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember136215" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember136218" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember136221" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember136224" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -501,7 +501,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">propertyType</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
 
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -611,7 +611,7 @@ This leaves us with 2 remaining acceptance test failures (and 1 jshint failure):
           <a href="#toc_acceptance-testing-the-rental-list">Acceptance Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -655,8 +655,8 @@ This leaves us with 2 remaining acceptance test failures (and 1 jshint failure):
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -700,6 +700,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.13.0/tutorial/subroutes/index.html
+++ b/public/v2.13.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember136440" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember136441" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember136442" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.13 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember136442" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember136446" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember136449" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember136450" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.13.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember136464" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember136467" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember136470" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember136473" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember136476" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember136479" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember136482" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember136485" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember136488" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember136491" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember136494" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember136497" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember136500" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -634,7 +634,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">propertyType</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -862,7 +862,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -906,8 +906,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -951,6 +951,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.14.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.14.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember142768" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember142769" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember142770" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.14 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember142770" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember142774" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember142777" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember142778" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.14.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember142792" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember142795" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember142798" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember142801" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember142804" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember142807" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember142810" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember142813" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember142816" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember142819" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember142822" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember142825" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember142828" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -597,7 +597,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token string-property property">"property-type"</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -879,7 +879,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -923,8 +923,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -968,6 +968,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.14.0/tutorial/ember-data/index.html
+++ b/public/v2.14.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember142975" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember142976" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember142977" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.14 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember142977" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember142981" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember142984" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember142985" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.14.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember142999" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember143002" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember143005" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember143008" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember143011" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember143014" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember143017" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember143020" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember143023" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember143026" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember143029" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember143032" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember143035" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/data/classes/DS.Store.ht
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">propertyType</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -584,7 +584,7 @@ A remote server will allow for data to be shared and updated across users.</p>
           <a href="#toc_updating-the-model-hook">Updating the Model Hook</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -628,8 +628,8 @@ A remote server will allow for data to be shared and updated across users.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -673,6 +673,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.14.0/tutorial/installing-addons/index.html
+++ b/public/v2.14.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember143182" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember143183" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember143184" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.14 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember143184" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember143188" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember143191" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember143192" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.14.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember143206" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember143209" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember143212" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember143215" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember143218" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember143221" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember143224" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember143227" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember143230" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember143233" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember143236" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember143239" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember143242" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ Let's configure Mirage to send back our rentals that we had defined above by upd
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token string-property property">"property-type"</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -629,7 +629,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -673,8 +673,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -718,6 +718,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.14.0/tutorial/model-hook/index.html
+++ b/public/v2.14.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember143251" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember143252" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember143253" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.14 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember143253" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember143257" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember143260" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember143261" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.14.0/tutorial/index">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember143275" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember143278" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember143281" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember143284" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember143287" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember143290" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember143293" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember143296" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember143299" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember143302" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember143305" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember143308" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember143311" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -503,7 +503,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">propertyType</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
 
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -613,7 +613,7 @@ This leaves us with 2 remaining acceptance test failures (and 1 jshint failure):
           <a href="#toc_acceptance-testing-the-rental-list">Acceptance Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -657,8 +657,8 @@ This leaves us with 2 remaining acceptance test failures (and 1 jshint failure):
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -702,6 +702,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.14.0/tutorial/subroutes/index.html
+++ b/public/v2.14.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember143527" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember143528" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember143529" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.14 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember143529" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember143533" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember143536" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember143537" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.14.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember143551" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember143554" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember143557" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember143560" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember143563" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember143566" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember143569" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember143572" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember143575" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember143578" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember143581" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember143584" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember143587" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -634,7 +634,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">propertyType</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -863,7 +863,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -907,8 +907,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -952,6 +952,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.15.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.15.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember149855" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember149856" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember149857" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.15 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember149857" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember149861" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember149864" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember149865" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.15.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember149879" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember149882" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember149885" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember149888" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember149891" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember149894" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember149897" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember149900" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember149903" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember149906" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember149909" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember149912" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember149915" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -616,7 +616,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token string-property property">"property-type"</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -973,7 +973,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1017,8 +1017,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1062,6 +1062,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.15.0/tutorial/ember-data/index.html
+++ b/public/v2.15.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember150062" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember150063" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember150064" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.15 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember150064" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember150068" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember150071" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember150072" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.15.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember150086" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember150089" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember150092" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember150095" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember150098" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember150101" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember150104" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember150107" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember150110" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember150113" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember150116" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember150119" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember150122" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/data/classes/DS.Store.ht
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">propertyType</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -584,7 +584,7 @@ A remote server will allow for data to be shared and updated across users.</p>
           <a href="#toc_updating-the-model-hook">Updating the Model Hook</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -628,8 +628,8 @@ A remote server will allow for data to be shared and updated across users.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -673,6 +673,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.15.0/tutorial/installing-addons/index.html
+++ b/public/v2.15.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember150269" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember150270" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember150271" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.15 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember150271" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember150275" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember150278" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember150279" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.15.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember150293" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember150296" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember150299" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember150302" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember150305" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember150308" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember150311" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember150314" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember150317" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember150320" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember150323" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember150326" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember150329" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ Let's configure Mirage to send back our rentals that we had defined above by upd
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token string-property property">"property-type"</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -629,7 +629,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -673,8 +673,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -718,6 +718,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.15.0/tutorial/model-hook/index.html
+++ b/public/v2.15.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember150338" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember150339" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember150340" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.15 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember150340" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember150344" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember150347" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember150348" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.15.0/tutorial/index">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember150362" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember150365" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember150368" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember150371" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember150374" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember150377" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember150380" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember150383" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember150386" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember150389" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember150392" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember150395" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember150398" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -501,7 +501,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">propertyType</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
 
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -611,7 +611,7 @@ This leaves us with 2 remaining acceptance test failures (and 1 ESLint failure):
           <a href="#toc_acceptance-testing-the-rental-list">Acceptance Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -655,8 +655,8 @@ This leaves us with 2 remaining acceptance test failures (and 1 ESLint failure):
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -700,6 +700,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.15.0/tutorial/subroutes/index.html
+++ b/public/v2.15.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember150614" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember150615" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember150616" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.15 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember150616" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember150620" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember150623" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember150624" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.15.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember150638" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember150641" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember150644" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember150647" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember150650" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember150653" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember150656" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember150659" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember150662" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember150665" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember150668" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember150671" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember150674" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -634,7 +634,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token string-property property">"property-type"</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -863,7 +863,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -907,8 +907,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -952,6 +952,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.16.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.16.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember157006" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember157007" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember157008" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.16 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember157008" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember157012" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember157015" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember157016" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.16.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember157030" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember157033" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember157036" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember157039" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember157042" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember157045" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember157048" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember157051" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember157054" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember157057" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember157060" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember157063" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember157066" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -616,7 +616,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token string-property property">"property-type"</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -973,7 +973,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1017,8 +1017,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1062,6 +1062,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.16.0/tutorial/ember-data/index.html
+++ b/public/v2.16.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember157213" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember157214" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember157215" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.16 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember157215" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember157219" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember157222" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember157223" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.16.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember157237" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember157240" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember157243" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember157246" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember157249" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember157252" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember157255" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember157258" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember157261" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember157264" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember157267" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember157270" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember157273" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/2.16/classes/
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">propertyType</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -584,7 +584,7 @@ A remote server will allow for data to be shared and updated across users.</p>
           <a href="#toc_updating-the-model-hook">Updating the Model Hook</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -628,8 +628,8 @@ A remote server will allow for data to be shared and updated across users.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -673,6 +673,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.16.0/tutorial/installing-addons/index.html
+++ b/public/v2.16.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember157420" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember157421" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember157422" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.16 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember157422" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember157426" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember157429" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember157430" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.16.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember157444" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember157447" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember157450" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember157453" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember157456" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember157459" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember157462" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember157465" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember157468" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember157471" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember157474" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember157477" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember157480" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -537,7 +537,7 @@ Let's configure Mirage to send back our rentals that we had defined above by upd
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token string-property property">"property-type"</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -636,7 +636,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -680,8 +680,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -725,6 +725,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.16.0/tutorial/model-hook/index.html
+++ b/public/v2.16.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember157489" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember157490" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember157491" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.16 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember157491" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember157495" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember157498" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember157499" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.16.0/tutorial/index">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember157513" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember157516" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember157519" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember157522" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember157525" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember157528" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember157531" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember157534" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember157537" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember157540" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember157543" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember157546" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember157549" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -501,7 +501,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">propertyType</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -609,7 +609,7 @@ This leaves us with 2 remaining acceptance test failures (and 1 ESLint failure):
           <a href="#toc_acceptance-testing-the-rental-list">Acceptance Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -653,8 +653,8 @@ This leaves us with 2 remaining acceptance test failures (and 1 ESLint failure):
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -698,6 +698,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.16.0/tutorial/subroutes/index.html
+++ b/public/v2.16.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember157765" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember157766" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember157767" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.16 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember157767" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember157771" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember157774" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember157775" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.16.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember157789" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember157792" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember157795" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember157798" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember157801" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember157804" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember157807" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember157810" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember157813" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember157816" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember157819" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember157822" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember157825" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -643,7 +643,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token string-property property">"property-type"</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -876,7 +876,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -920,8 +920,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -965,6 +965,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.17.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.17.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember164157" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember164158" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember164159" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.17 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember164159" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember164163" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember164166" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember164167" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.17.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember164181" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember164184" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember164187" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember164190" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember164193" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember164196" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember164199" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember164202" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember164205" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember164208" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember164211" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember164214" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember164217" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -616,7 +616,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token string-property property">"property-type"</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -973,7 +973,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1017,8 +1017,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1062,6 +1062,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.17.0/tutorial/ember-data/index.html
+++ b/public/v2.17.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember164364" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember164365" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember164366" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.17 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember164366" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember164370" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember164373" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember164374" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.17.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember164388" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember164391" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember164394" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember164397" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember164400" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember164403" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember164406" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember164409" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember164412" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember164415" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember164418" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember164421" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember164424" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/2.17/classes/
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">propertyType</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -584,7 +584,7 @@ A remote server will allow for data to be shared and updated across users.</p>
           <a href="#toc_updating-the-model-hook">Updating the Model Hook</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -628,8 +628,8 @@ A remote server will allow for data to be shared and updated across users.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -673,6 +673,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.17.0/tutorial/installing-addons/index.html
+++ b/public/v2.17.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember164571" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember164572" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember164573" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.17 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember164573" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember164577" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember164580" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember164581" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.17.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember164595" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember164598" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember164601" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember164604" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember164607" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember164610" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember164613" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember164616" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember164619" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember164622" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember164625" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember164628" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember164631" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -537,7 +537,7 @@ Let's configure Mirage to send back our rentals that we had defined above by upd
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token string-property property">"property-type"</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -636,7 +636,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -680,8 +680,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -725,6 +725,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.17.0/tutorial/model-hook/index.html
+++ b/public/v2.17.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember164640" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember164641" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember164642" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.17 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember164642" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember164646" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember164649" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember164650" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.17.0/tutorial/index">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember164664" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember164667" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember164670" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember164673" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember164676" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember164679" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember164682" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember164685" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember164688" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember164691" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember164694" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember164697" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember164700" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -501,7 +501,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">propertyType</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -609,7 +609,7 @@ This leaves us with 2 remaining acceptance test failures (and 1 ESLint failure):
           <a href="#toc_acceptance-testing-the-rental-list">Acceptance Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -653,8 +653,8 @@ This leaves us with 2 remaining acceptance test failures (and 1 ESLint failure):
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -698,6 +698,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.17.0/tutorial/subroutes/index.html
+++ b/public/v2.17.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember164916" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember164917" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember164918" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.17 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember164918" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember164922" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember164925" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember164926" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.17.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember164940" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember164943" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember164946" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember164949" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember164952" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember164955" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember164958" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember164961" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember164964" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember164967" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember164970" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember164973" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember164976" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -643,7 +643,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token string-property property">"property-type"</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -876,7 +876,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -920,8 +920,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -965,6 +965,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.18.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.18.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember171308" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember171309" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember171310" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.18 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember171310" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember171314" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember171317" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember171318" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.18.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember171332" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember171335" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember171338" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember171341" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember171344" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember171347" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember171350" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember171353" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember171356" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember171359" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember171362" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember171365" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember171368" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -619,7 +619,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -997,7 +997,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1041,8 +1041,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1086,6 +1086,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.18.0/tutorial/ember-data/index.html
+++ b/public/v2.18.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember171515" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember171516" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember171517" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.18 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember171517" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember171521" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember171524" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember171525" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.18.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember171539" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember171542" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember171545" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember171548" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember171551" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember171554" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember171557" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember171560" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember171563" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember171566" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember171569" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember171572" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember171575" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/2.18/classes/
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -584,7 +584,7 @@ A remote server will allow for data to be shared and updated across users.</p>
           <a href="#toc_updating-the-model-hook">Updating the Model Hook</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -628,8 +628,8 @@ A remote server will allow for data to be shared and updated across users.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -673,6 +673,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.18.0/tutorial/installing-addons/index.html
+++ b/public/v2.18.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember171722" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember171723" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember171724" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.18 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember171724" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember171728" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember171731" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember171732" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.18.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember171746" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember171749" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember171752" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember171755" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember171758" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember171761" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember171764" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember171767" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember171770" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember171773" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember171776" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember171779" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember171782" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -536,7 +536,7 @@ Let's configure Mirage to send back our rentals that we had defined above by upd
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -635,7 +635,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -679,8 +679,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -724,6 +724,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.18.0/tutorial/model-hook/index.html
+++ b/public/v2.18.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember171791" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember171792" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember171793" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.18 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember171793" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember171797" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember171800" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember171801" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.18.0/tutorial/index">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember171815" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember171818" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember171821" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember171824" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember171827" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember171830" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember171833" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember171836" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember171839" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember171842" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember171845" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember171848" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember171851" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -501,7 +501,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -609,7 +609,7 @@ This leaves us with 2 remaining acceptance test failures (and 1 ESLint failure):
           <a href="#toc_acceptance-testing-the-rental-list">Acceptance Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -653,8 +653,8 @@ This leaves us with 2 remaining acceptance test failures (and 1 ESLint failure):
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -698,6 +698,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.18.0/tutorial/subroutes/index.html
+++ b/public/v2.18.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember172067" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember172068" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember172069" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.18 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember172069" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember172073" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember172076" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember172077" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.18.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember172091" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember172094" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember172097" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember172100" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember172103" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember172106" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember172109" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember172112" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember172115" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember172118" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember172121" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember172124" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember172127" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -643,7 +643,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -876,7 +876,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -920,8 +920,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -965,6 +965,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.2.0/tutorial/ember-data/index.html
+++ b/public/v2.2.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember60191" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember60192" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember60193" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.2 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember60193" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember60197" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember60200" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember60201" class="ember-view" data-test-toc-link="Routes and Templates" href="/v2.2.0/tutorial/index">
@@ -195,11 +195,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -212,7 +212,7 @@
               <div id="ember60207" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -225,7 +225,7 @@
               <div id="ember60210" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -238,7 +238,7 @@
               <div id="ember60213" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -251,7 +251,7 @@
               <div id="ember60216" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -264,7 +264,7 @@
               <div id="ember60219" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -277,7 +277,7 @@
               <div id="ember60222" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -290,7 +290,7 @@
               <div id="ember60225" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -303,7 +303,7 @@
               <div id="ember60228" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -316,7 +316,7 @@
               <div id="ember60231" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -329,7 +329,7 @@
               <div id="ember60234" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -342,7 +342,7 @@
               <div id="ember60237" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -355,17 +355,17 @@
               <div id="ember60240" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -461,7 +461,7 @@ This will allow us to create fake data to work with while developing our app and
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -533,7 +533,7 @@ When we deploy our app to a production server, we will need to provide a backend
           <a href="#toc_updating-the-model-hook">Updating the Model Hook</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -577,8 +577,8 @@ When we deploy our app to a production server, we will need to provide a backend
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -622,6 +622,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.2.0/tutorial/model-hook/index.html
+++ b/public/v2.2.0/tutorial/model-hook/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember60307" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember60308" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember60309" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.2 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember60309" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember60313" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember60316" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember60317" class="ember-view" data-test-toc-link="Routes and Templates" href="/v2.2.0/tutorial/index">
@@ -195,11 +195,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -212,7 +212,7 @@
               <div id="ember60323" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -225,7 +225,7 @@
               <div id="ember60326" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -238,7 +238,7 @@
               <div id="ember60329" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -251,7 +251,7 @@
               <div id="ember60332" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -264,7 +264,7 @@
               <div id="ember60335" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -277,7 +277,7 @@
               <div id="ember60338" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -290,7 +290,7 @@
               <div id="ember60341" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -303,7 +303,7 @@
               <div id="ember60344" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -316,7 +316,7 @@
               <div id="ember60347" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -329,7 +329,7 @@
               <div id="ember60350" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -342,7 +342,7 @@
               <div id="ember60353" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -355,17 +355,17 @@
               <div id="ember60356" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -419,7 +419,7 @@ Let's open <code>app/routes/index.js</code> and add our hard-coded data as the r
   <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
 <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
   <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token number">3</span><span class="token punctuation">,</span>
   <span class="token literal-property property">title</span><span class="token operator">:</span> <span class="token string">'Downtown Charm'</span><span class="token punctuation">,</span>
@@ -523,8 +523,8 @@ For each rental, we then create a listing with information about the property.</
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -568,6 +568,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.3.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.3.0/tutorial/autocomplete-component/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -26,7 +26,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta property="og:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -40,7 +40,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta name="twitter:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -53,7 +53,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember66580" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember66581" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To begin, let's generate our new component. We'll call this component list-filte
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember66582" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.3 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember66582" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember66586" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               </a>
               <div id="ember66589" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember66590" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.3.0/tutorial/index">
@@ -250,11 +250,11 @@ To begin, let's generate our new component. We'll call this component list-filte
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -267,7 +267,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember66603" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember66606" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember66609" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember66612" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember66615" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember66618" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember66621" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember66624" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember66627" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember66630" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember66633" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember66636" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,17 +423,17 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember66639" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -461,14 +461,14 @@ To begin, let's generate our new component. We'll call this component list-filte
     </div>
     <hr>
 
-    <div id="ember66642" class="ember-view"><p>As they search for a rental, users might also want to narrow their search to a specific city. 
+    <div id="ember66642" class="ember-view"><p>As they search for a rental, users might also want to narrow their search to a specific city.
 Let's build a component that will let them filter rentals by city.</p>
-<p>To begin, let's generate our new component. 
+<p>To begin, let's generate our new component.
 We'll call this component <code>list-filter</code>, since all we want our component to do is filter the list of rentals based on input.</p>
 <pre class="language-bash line-numbers"><code class="bash language-bash">ember g component list-filter
 <span aria-hidden="true" class="line-numbers-rows"><a href="#C1_L1" id=C1_L1></a></span></code></pre>
-<p>As before, this creates a Handlebars template (<code>app/templates/components/list-filter.hbs</code>), 
-a JavaScript file (<code>app/components/list-filter.js</code>), 
+<p>As before, this creates a Handlebars template (<code>app/templates/components/list-filter.hbs</code>),
+a JavaScript file (<code>app/components/list-filter.js</code>),
 and a component integration test (<code>tests/integration/components/list-filter-test.js</code>).</p>
 <p>Let's start with writing some tests to help us think through what we are doing.
 The filter component should yield a list of filtered items to whatever is rendered inside of it, known as its inner template block.
@@ -580,7 +580,7 @@ We want the component to simply provide an input field and yield the results lis
 <div class="filename handlebars"><div class="ribbon"></div><span>app/templates/components/list-filter.hbs</span><pre class="language-handlebars line-numbers"><code class="handlebars language-handlebars"><span class="token handlebars language-handlebars"><span class="token delimiter punctuation">{{</span><span class="token variable">input</span> <span class="token variable">value</span><span class="token punctuation">=</span><span class="token variable">value</span> <span class="token variable">key-up</span><span class="token punctuation">=</span><span class="token punctuation">(</span><span class="token variable">action</span> <span class="token string">'handleFilterEntry'</span><span class="token punctuation">)</span> <span class="token variable">class</span><span class="token punctuation">=</span><span class="token string">"light"</span> <span class="token variable">placeholder</span><span class="token punctuation">=</span><span class="token string">"Filter By City"</span><span class="token delimiter punctuation">}}</span></span>
 <span class="token handlebars language-handlebars"><span class="token delimiter punctuation">{{</span><span class="token variable">yield</span> <span class="token variable">results</span><span class="token delimiter punctuation">}}</span></span>
 <span aria-hidden="true" class="line-numbers-rows"><a href="#C5_L1" id=C5_L1></a><a href="#C5_L2" id=C5_L2></a></span></code></pre></div>
-<p>The template contains an <a href="../../templates/input-helpers/"><code>{{input}}</code></a> helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search. 
+<p>The template contains an <a href="../../templates/input-helpers/"><code>{{input}}</code></a> helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The <code>value</code> property of the <code>input</code> will be bound to the <code>value</code> property in our component.
 The <code>key-up</code> property will be bound to the <code>handleFilterEntry</code> action.</p>
 <p>Here is what the component's JavaScript looks like:</p>
@@ -627,8 +627,8 @@ Our <code>handleFilterEntry</code> action calls our filter action based on the <
   <span class="token punctuation">}</span>
 <span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 <span aria-hidden="true" class="line-numbers-rows"><a href="#C8_L1" id=C8_L1></a><a href="#C8_L2" id=C8_L2></a><a href="#C8_L3" id=C8_L3></a><a href="#C8_L4" id=C8_L4></a><a href="#C8_L5" id=C8_L5></a><a href="#C8_L6" id=C8_L6></a><a href="#C8_L7" id=C8_L7></a><a href="#C8_L8" id=C8_L8></a><a href="#C8_L9" id=C8_L9></a><a href="#C8_L10" id=C8_L10></a><a href="#C8_L11" id=C8_L11></a><a href="#C8_L12" id=C8_L12></a><a href="#C8_L13" id=C8_L13></a></span></code></pre></div>
-<p>When the user types in the text field in our component, the <code>filterByCity</code> action in the controller is called. 
-This action takes in the <code>value</code> property, and filters the <code>rental</code> data for records in data store that match what the user has typed thus far. 
+<p>When the user types in the text field in our component, the <code>filterByCity</code> action in the controller is called.
+This action takes in the <code>value</code> property, and filters the <code>rental</code> data for records in data store that match what the user has typed thus far.
 The result of the query is returned to the caller.</p>
 <p>For this action to work, we need to replace our Mirage <code>config.js</code> file with the following, so that it can respond to our queries.</p>
 <div class="filename javascript"><div class="ribbon"></div><span>mirage/config.js</span><pre class="language-javascript line-numbers"><code class="javascript language-javascript"><span class="token keyword">export</span> <span class="token keyword">default</span> <span class="token keyword">function</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
@@ -653,7 +653,7 @@ The result of the query is returned to the caller.</p>
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -747,8 +747,8 @@ The result of the query is returned to the caller.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -792,6 +792,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.3.0/tutorial/installing-addons/index.html
+++ b/public/v2.3.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember66988" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember66989" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember66990" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.3 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember66990" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember66994" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember66997" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember66998" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.3.0/tutorial/index">
@@ -250,11 +250,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -267,7 +267,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember67011" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember67014" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember67017" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember67020" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember67023" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember67026" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember67029" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember67032" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember67035" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember67038" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember67041" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember67044" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,17 +423,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember67047" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -514,7 +514,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -568,7 +568,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -612,8 +612,8 @@ Mirage will allow us to create fake data to work with while developing our app a
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -657,6 +657,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.3.0/tutorial/model-hook/index.html
+++ b/public/v2.3.0/tutorial/model-hook/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember67056" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember67057" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember67058" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.3 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember67058" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember67062" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember67065" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember67066" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.3.0/tutorial/index">
@@ -244,11 +244,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -261,7 +261,7 @@
               <div id="ember67079" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@
               <div id="ember67082" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@
               <div id="ember67085" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@
               <div id="ember67088" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@
               <div id="ember67091" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@
               <div id="ember67094" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@
               <div id="ember67097" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@
               <div id="ember67100" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@
               <div id="ember67103" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@
               <div id="ember67106" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@
               <div id="ember67109" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@
               <div id="ember67112" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,17 +417,17 @@
               <div id="ember67115" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -481,7 +481,7 @@ Let's open <code>app/routes/index.js</code> and add our hard-coded data as the r
   <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
 <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
   <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token number">3</span><span class="token punctuation">,</span>
   <span class="token literal-property property">title</span><span class="token operator">:</span> <span class="token string">'Downtown Charm'</span><span class="token punctuation">,</span>
@@ -605,8 +605,8 @@ For each rental, we then create a listing with information about the property.</
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -650,6 +650,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.4.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.4.0/tutorial/autocomplete-component/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -26,7 +26,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta property="og:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -40,7 +40,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta name="twitter:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -53,7 +53,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember73427" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember73428" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To begin, let's generate our new component. We'll call this component list-filte
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember73429" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.4 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember73429" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember73433" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               </a>
               <div id="ember73436" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember73437" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.4.0/tutorial/index">
@@ -250,11 +250,11 @@ To begin, let's generate our new component. We'll call this component list-filte
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -267,7 +267,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember73450" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember73453" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember73456" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember73459" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember73462" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember73465" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember73468" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember73471" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember73474" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember73477" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember73480" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember73483" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,17 +423,17 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember73486" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -461,14 +461,14 @@ To begin, let's generate our new component. We'll call this component list-filte
     </div>
     <hr>
 
-    <div id="ember73489" class="ember-view"><p>As they search for a rental, users might also want to narrow their search to a specific city. 
+    <div id="ember73489" class="ember-view"><p>As they search for a rental, users might also want to narrow their search to a specific city.
 Let's build a component that will let them filter rentals by city.</p>
-<p>To begin, let's generate our new component. 
+<p>To begin, let's generate our new component.
 We'll call this component <code>list-filter</code>, since all we want our component to do is filter the list of rentals based on input.</p>
 <pre class="language-bash line-numbers"><code class="bash language-bash">ember g component list-filter
 <span aria-hidden="true" class="line-numbers-rows"><a href="#C1_L1" id=C1_L1></a></span></code></pre>
-<p>As before, this creates a Handlebars template (<code>app/templates/components/list-filter.hbs</code>), 
-a JavaScript file (<code>app/components/list-filter.js</code>), 
+<p>As before, this creates a Handlebars template (<code>app/templates/components/list-filter.hbs</code>),
+a JavaScript file (<code>app/components/list-filter.js</code>),
 and a component integration test (<code>tests/integration/components/list-filter-test.js</code>).</p>
 <p>Let's start with writing some tests to help us think through what we are doing.
 The filter component should yield a list of filtered items to whatever is rendered inside of it, known as its inner template block.
@@ -580,7 +580,7 @@ We want the component to simply provide an input field and yield the results lis
 <div class="filename handlebars"><div class="ribbon"></div><span>app/templates/components/list-filter.hbs</span><pre class="language-handlebars line-numbers"><code class="handlebars language-handlebars"><span class="token handlebars language-handlebars"><span class="token delimiter punctuation">{{</span><span class="token variable">input</span> <span class="token variable">value</span><span class="token punctuation">=</span><span class="token variable">value</span> <span class="token variable">key-up</span><span class="token punctuation">=</span><span class="token punctuation">(</span><span class="token variable">action</span> <span class="token string">'handleFilterEntry'</span><span class="token punctuation">)</span> <span class="token variable">class</span><span class="token punctuation">=</span><span class="token string">"light"</span> <span class="token variable">placeholder</span><span class="token punctuation">=</span><span class="token string">"Filter By City"</span><span class="token delimiter punctuation">}}</span></span>
 <span class="token handlebars language-handlebars"><span class="token delimiter punctuation">{{</span><span class="token variable">yield</span> <span class="token variable">results</span><span class="token delimiter punctuation">}}</span></span>
 <span aria-hidden="true" class="line-numbers-rows"><a href="#C5_L1" id=C5_L1></a><a href="#C5_L2" id=C5_L2></a></span></code></pre></div>
-<p>The template contains an <a href="../../templates/input-helpers/"><code>{{input}}</code></a> helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search. 
+<p>The template contains an <a href="../../templates/input-helpers/"><code>{{input}}</code></a> helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The <code>value</code> property of the <code>input</code> will be bound to the <code>value</code> property in our component.
 The <code>key-up</code> property will be bound to the <code>handleFilterEntry</code> action.</p>
 <p>Here is what the component's JavaScript looks like:</p>
@@ -627,8 +627,8 @@ Our <code>handleFilterEntry</code> action calls our filter action based on the <
   <span class="token punctuation">}</span>
 <span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 <span aria-hidden="true" class="line-numbers-rows"><a href="#C8_L1" id=C8_L1></a><a href="#C8_L2" id=C8_L2></a><a href="#C8_L3" id=C8_L3></a><a href="#C8_L4" id=C8_L4></a><a href="#C8_L5" id=C8_L5></a><a href="#C8_L6" id=C8_L6></a><a href="#C8_L7" id=C8_L7></a><a href="#C8_L8" id=C8_L8></a><a href="#C8_L9" id=C8_L9></a><a href="#C8_L10" id=C8_L10></a><a href="#C8_L11" id=C8_L11></a><a href="#C8_L12" id=C8_L12></a><a href="#C8_L13" id=C8_L13></a></span></code></pre></div>
-<p>When the user types in the text field in our component, the <code>filterByCity</code> action in the controller is called. 
-This action takes in the <code>value</code> property, and filters the <code>rental</code> data for records in data store that match what the user has typed thus far. 
+<p>When the user types in the text field in our component, the <code>filterByCity</code> action in the controller is called.
+This action takes in the <code>value</code> property, and filters the <code>rental</code> data for records in data store that match what the user has typed thus far.
 The result of the query is returned to the caller.</p>
 <p>For this action to work, we need to replace our Mirage <code>config.js</code> file with the following, so that it can respond to our queries.</p>
 <div class="filename javascript"><div class="ribbon"></div><span>mirage/config.js</span><pre class="language-javascript line-numbers"><code class="javascript language-javascript"><span class="token keyword">export</span> <span class="token keyword">default</span> <span class="token keyword">function</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
@@ -653,7 +653,7 @@ The result of the query is returned to the caller.</p>
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -747,8 +747,8 @@ The result of the query is returned to the caller.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -792,6 +792,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.4.0/tutorial/installing-addons/index.html
+++ b/public/v2.4.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember73835" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember73836" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember73837" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.4 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember73837" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember73841" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember73844" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember73845" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.4.0/tutorial/index">
@@ -250,11 +250,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -267,7 +267,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember73858" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember73861" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember73864" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember73867" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember73870" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember73873" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember73876" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember73879" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember73882" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember73885" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember73888" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember73891" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,17 +423,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember73894" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -514,7 +514,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -568,7 +568,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -612,8 +612,8 @@ Mirage will allow us to create fake data to work with while developing our app a
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -657,6 +657,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.4.0/tutorial/model-hook/index.html
+++ b/public/v2.4.0/tutorial/model-hook/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember73903" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember73904" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember73905" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.4 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember73905" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember73909" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember73912" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember73913" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.4.0/tutorial/index">
@@ -244,11 +244,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -261,7 +261,7 @@
               <div id="ember73926" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@
               <div id="ember73929" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@
               <div id="ember73932" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@
               <div id="ember73935" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@
               <div id="ember73938" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@
               <div id="ember73941" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@
               <div id="ember73944" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@
               <div id="ember73947" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@
               <div id="ember73950" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@
               <div id="ember73953" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@
               <div id="ember73956" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@
               <div id="ember73959" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,17 +417,17 @@
               <div id="ember73962" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -481,7 +481,7 @@ Let's open <code>app/routes/index.js</code> and add our hard-coded data as the r
   <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
 <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
   <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token number">3</span><span class="token punctuation">,</span>
   <span class="token literal-property property">title</span><span class="token operator">:</span> <span class="token string">'Downtown Charm'</span><span class="token punctuation">,</span>
@@ -605,8 +605,8 @@ For each rental, we then create a listing with information about the property.</
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -650,6 +650,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.5.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.5.0/tutorial/autocomplete-component/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -26,7 +26,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta property="og:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -40,7 +40,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta name="twitter:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -53,7 +53,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember80274" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember80275" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To begin, let's generate our new component. We'll call this component list-filte
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember80276" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.5 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember80276" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember80280" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               </a>
               <div id="ember80283" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember80284" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.5.0/tutorial/index">
@@ -250,11 +250,11 @@ To begin, let's generate our new component. We'll call this component list-filte
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -267,7 +267,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember80297" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember80300" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember80303" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember80306" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember80309" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember80312" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember80315" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember80318" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember80321" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember80324" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember80327" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember80330" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,17 +423,17 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember80333" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -461,14 +461,14 @@ To begin, let's generate our new component. We'll call this component list-filte
     </div>
     <hr>
 
-    <div id="ember80336" class="ember-view"><p>As they search for a rental, users might also want to narrow their search to a specific city. 
+    <div id="ember80336" class="ember-view"><p>As they search for a rental, users might also want to narrow their search to a specific city.
 Let's build a component that will let them filter rentals by city.</p>
-<p>To begin, let's generate our new component. 
+<p>To begin, let's generate our new component.
 We'll call this component <code>list-filter</code>, since all we want our component to do is filter the list of rentals based on input.</p>
 <pre class="language-bash line-numbers"><code class="bash language-bash">ember g component list-filter
 <span aria-hidden="true" class="line-numbers-rows"><a href="#C1_L1" id=C1_L1></a></span></code></pre>
-<p>As before, this creates a Handlebars template (<code>app/templates/components/list-filter.hbs</code>), 
-a JavaScript file (<code>app/components/list-filter.js</code>), 
+<p>As before, this creates a Handlebars template (<code>app/templates/components/list-filter.hbs</code>),
+a JavaScript file (<code>app/components/list-filter.js</code>),
 and a component integration test (<code>tests/integration/components/list-filter-test.js</code>).</p>
 <p>Let's start with writing some tests to help us think through what we are doing.
 The filter component should yield a list of filtered items to whatever is rendered inside of it, known as its inner template block.
@@ -580,7 +580,7 @@ We want the component to simply provide an input field and yield the results lis
 <div class="filename handlebars"><div class="ribbon"></div><span>app/templates/components/list-filter.hbs</span><pre class="language-handlebars line-numbers"><code class="handlebars language-handlebars"><span class="token handlebars language-handlebars"><span class="token delimiter punctuation">{{</span><span class="token variable">input</span> <span class="token variable">value</span><span class="token punctuation">=</span><span class="token variable">value</span> <span class="token variable">key-up</span><span class="token punctuation">=</span><span class="token punctuation">(</span><span class="token variable">action</span> <span class="token string">'handleFilterEntry'</span><span class="token punctuation">)</span> <span class="token variable">class</span><span class="token punctuation">=</span><span class="token string">"light"</span> <span class="token variable">placeholder</span><span class="token punctuation">=</span><span class="token string">"Filter By City"</span><span class="token delimiter punctuation">}}</span></span>
 <span class="token handlebars language-handlebars"><span class="token delimiter punctuation">{{</span><span class="token variable">yield</span> <span class="token variable">results</span><span class="token delimiter punctuation">}}</span></span>
 <span aria-hidden="true" class="line-numbers-rows"><a href="#C5_L1" id=C5_L1></a><a href="#C5_L2" id=C5_L2></a></span></code></pre></div>
-<p>The template contains an <a href="../../templates/input-helpers/"><code>{{input}}</code></a> helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search. 
+<p>The template contains an <a href="../../templates/input-helpers/"><code>{{input}}</code></a> helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The <code>value</code> property of the <code>input</code> will be bound to the <code>value</code> property in our component.
 The <code>key-up</code> property will be bound to the <code>handleFilterEntry</code> action.</p>
 <p>Here is what the component's JavaScript looks like:</p>
@@ -627,8 +627,8 @@ Our <code>handleFilterEntry</code> action calls our filter action based on the <
   <span class="token punctuation">}</span>
 <span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 <span aria-hidden="true" class="line-numbers-rows"><a href="#C8_L1" id=C8_L1></a><a href="#C8_L2" id=C8_L2></a><a href="#C8_L3" id=C8_L3></a><a href="#C8_L4" id=C8_L4></a><a href="#C8_L5" id=C8_L5></a><a href="#C8_L6" id=C8_L6></a><a href="#C8_L7" id=C8_L7></a><a href="#C8_L8" id=C8_L8></a><a href="#C8_L9" id=C8_L9></a><a href="#C8_L10" id=C8_L10></a><a href="#C8_L11" id=C8_L11></a><a href="#C8_L12" id=C8_L12></a><a href="#C8_L13" id=C8_L13></a></span></code></pre></div>
-<p>When the user types in the text field in our component, the <code>filterByCity</code> action in the controller is called. 
-This action takes in the <code>value</code> property, and filters the <code>rental</code> data for records in data store that match what the user has typed thus far. 
+<p>When the user types in the text field in our component, the <code>filterByCity</code> action in the controller is called.
+This action takes in the <code>value</code> property, and filters the <code>rental</code> data for records in data store that match what the user has typed thus far.
 The result of the query is returned to the caller.</p>
 <p>For this action to work, we need to replace our Mirage <code>config.js</code> file with the following, so that it can respond to our queries.</p>
 <div class="filename javascript"><div class="ribbon"></div><span>mirage/config.js</span><pre class="language-javascript line-numbers"><code class="javascript language-javascript"><span class="token keyword">export</span> <span class="token keyword">default</span> <span class="token keyword">function</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
@@ -653,7 +653,7 @@ The result of the query is returned to the caller.</p>
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -747,8 +747,8 @@ The result of the query is returned to the caller.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -792,6 +792,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.5.0/tutorial/installing-addons/index.html
+++ b/public/v2.5.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember80682" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember80683" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember80684" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.5 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember80684" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember80688" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember80691" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember80692" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.5.0/tutorial/index">
@@ -250,11 +250,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -267,7 +267,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember80705" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember80708" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember80711" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember80714" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember80717" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember80720" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember80723" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember80726" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember80729" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember80732" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember80735" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember80738" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,17 +423,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember80741" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -514,7 +514,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -568,7 +568,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -612,8 +612,8 @@ Mirage will allow us to create fake data to work with while developing our app a
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -657,6 +657,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.5.0/tutorial/model-hook/index.html
+++ b/public/v2.5.0/tutorial/model-hook/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember80750" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember80751" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember80752" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.5 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember80752" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember80756" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember80759" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember80760" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.5.0/tutorial/index">
@@ -244,11 +244,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -261,7 +261,7 @@
               <div id="ember80773" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@
               <div id="ember80776" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@
               <div id="ember80779" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@
               <div id="ember80782" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@
               <div id="ember80785" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@
               <div id="ember80788" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@
               <div id="ember80791" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@
               <div id="ember80794" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@
               <div id="ember80797" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@
               <div id="ember80800" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@
               <div id="ember80803" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@
               <div id="ember80806" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,17 +417,17 @@
               <div id="ember80809" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -481,7 +481,7 @@ Let's open <code>app/routes/index.js</code> and add our hard-coded data as the r
   <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
 <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
   <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token number">3</span><span class="token punctuation">,</span>
   <span class="token literal-property property">title</span><span class="token operator">:</span> <span class="token string">'Downtown Charm'</span><span class="token punctuation">,</span>
@@ -605,8 +605,8 @@ For each rental, we then create a listing with information about the property.</
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -650,6 +650,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.6.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.6.0/tutorial/autocomplete-component/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -26,7 +26,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta property="og:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -40,7 +40,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta name="twitter:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -53,7 +53,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember87121" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember87122" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To begin, let's generate our new component. We'll call this component list-filte
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember87123" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.6 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember87123" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember87127" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               </a>
               <div id="ember87130" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember87131" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.6.0/tutorial/index">
@@ -250,11 +250,11 @@ To begin, let's generate our new component. We'll call this component list-filte
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -267,7 +267,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember87144" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember87147" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember87150" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember87153" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember87156" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember87159" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember87162" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember87165" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember87168" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember87171" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember87174" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember87177" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,17 +423,17 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember87180" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -461,14 +461,14 @@ To begin, let's generate our new component. We'll call this component list-filte
     </div>
     <hr>
 
-    <div id="ember87183" class="ember-view"><p>As they search for a rental, users might also want to narrow their search to a specific city. 
+    <div id="ember87183" class="ember-view"><p>As they search for a rental, users might also want to narrow their search to a specific city.
 Let's build a component that will let them filter rentals by city.</p>
-<p>To begin, let's generate our new component. 
+<p>To begin, let's generate our new component.
 We'll call this component <code>list-filter</code>, since all we want our component to do is filter the list of rentals based on input.</p>
 <pre class="language-bash line-numbers"><code class="bash language-bash">ember g component list-filter
 <span aria-hidden="true" class="line-numbers-rows"><a href="#C1_L1" id=C1_L1></a></span></code></pre>
-<p>As before, this creates a Handlebars template (<code>app/templates/components/list-filter.hbs</code>), 
-a JavaScript file (<code>app/components/list-filter.js</code>), 
+<p>As before, this creates a Handlebars template (<code>app/templates/components/list-filter.hbs</code>),
+a JavaScript file (<code>app/components/list-filter.js</code>),
 and a component integration test (<code>tests/integration/components/list-filter-test.js</code>).</p>
 <p>Let's start with writing some tests to help us think through what we are doing.
 The filter component should yield a list of filtered items to whatever is rendered inside of it, known as its inner template block.
@@ -580,7 +580,7 @@ We want the component to simply provide an input field and yield the results lis
 <div class="filename handlebars"><div class="ribbon"></div><span>app/templates/components/list-filter.hbs</span><pre class="language-handlebars line-numbers"><code class="handlebars language-handlebars"><span class="token handlebars language-handlebars"><span class="token delimiter punctuation">{{</span><span class="token variable">input</span> <span class="token variable">value</span><span class="token punctuation">=</span><span class="token variable">value</span> <span class="token variable">key-up</span><span class="token punctuation">=</span><span class="token punctuation">(</span><span class="token variable">action</span> <span class="token string">'handleFilterEntry'</span><span class="token punctuation">)</span> <span class="token variable">class</span><span class="token punctuation">=</span><span class="token string">"light"</span> <span class="token variable">placeholder</span><span class="token punctuation">=</span><span class="token string">"Filter By City"</span><span class="token delimiter punctuation">}}</span></span>
 <span class="token handlebars language-handlebars"><span class="token delimiter punctuation">{{</span><span class="token variable">yield</span> <span class="token variable">results</span><span class="token delimiter punctuation">}}</span></span>
 <span aria-hidden="true" class="line-numbers-rows"><a href="#C5_L1" id=C5_L1></a><a href="#C5_L2" id=C5_L2></a></span></code></pre></div>
-<p>The template contains an <a href="../../templates/input-helpers/"><code>{{input}}</code></a> helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search. 
+<p>The template contains an <a href="../../templates/input-helpers/"><code>{{input}}</code></a> helper that renders as a text field, in which the user can type a pattern to filter the list of cities used in a search.
 The <code>value</code> property of the <code>input</code> will be bound to the <code>value</code> property in our component.
 The <code>key-up</code> property will be bound to the <code>handleFilterEntry</code> action.</p>
 <p>Here is what the component's JavaScript looks like:</p>
@@ -627,8 +627,8 @@ Our <code>handleFilterEntry</code> action calls our filter action based on the <
   <span class="token punctuation">}</span>
 <span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 <span aria-hidden="true" class="line-numbers-rows"><a href="#C8_L1" id=C8_L1></a><a href="#C8_L2" id=C8_L2></a><a href="#C8_L3" id=C8_L3></a><a href="#C8_L4" id=C8_L4></a><a href="#C8_L5" id=C8_L5></a><a href="#C8_L6" id=C8_L6></a><a href="#C8_L7" id=C8_L7></a><a href="#C8_L8" id=C8_L8></a><a href="#C8_L9" id=C8_L9></a><a href="#C8_L10" id=C8_L10></a><a href="#C8_L11" id=C8_L11></a><a href="#C8_L12" id=C8_L12></a><a href="#C8_L13" id=C8_L13></a></span></code></pre></div>
-<p>When the user types in the text field in our component, the <code>filterByCity</code> action in the controller is called. 
-This action takes in the <code>value</code> property, and filters the <code>rental</code> data for records in data store that match what the user has typed thus far. 
+<p>When the user types in the text field in our component, the <code>filterByCity</code> action in the controller is called.
+This action takes in the <code>value</code> property, and filters the <code>rental</code> data for records in data store that match what the user has typed thus far.
 The result of the query is returned to the caller.</p>
 <p>For this action to work, we need to replace our Mirage <code>config.js</code> file with the following, so that it can respond to our queries.</p>
 <div class="filename javascript"><div class="ribbon"></div><span>mirage/config.js</span><pre class="language-javascript line-numbers"><code class="javascript language-javascript"><span class="token keyword">export</span> <span class="token keyword">default</span> <span class="token keyword">function</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
@@ -653,7 +653,7 @@ The result of the query is returned to the caller.</p>
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -747,8 +747,8 @@ The result of the query is returned to the caller.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -792,6 +792,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.6.0/tutorial/installing-addons/index.html
+++ b/public/v2.6.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember87529" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember87530" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember87531" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.6 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember87531" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember87535" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember87538" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember87539" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.6.0/tutorial/index">
@@ -250,11 +250,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -267,7 +267,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember87552" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember87555" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember87558" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember87561" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember87564" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember87567" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember87570" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember87573" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember87576" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember87579" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember87582" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember87585" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,17 +423,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember87588" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -516,7 +516,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -570,7 +570,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -614,8 +614,8 @@ Mirage will allow us to create fake data to work with while developing our app a
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -659,6 +659,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.6.0/tutorial/model-hook/index.html
+++ b/public/v2.6.0/tutorial/model-hook/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember87597" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember87598" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember87599" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.6 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember87599" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember87603" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember87606" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember87607" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.6.0/tutorial/index">
@@ -244,11 +244,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -261,7 +261,7 @@
               <div id="ember87620" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@
               <div id="ember87623" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@
               <div id="ember87626" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@
               <div id="ember87629" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@
               <div id="ember87632" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@
               <div id="ember87635" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@
               <div id="ember87638" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@
               <div id="ember87641" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@
               <div id="ember87644" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@
               <div id="ember87647" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@
               <div id="ember87650" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@
               <div id="ember87653" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,17 +417,17 @@
               <div id="ember87656" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -481,7 +481,7 @@ Let's open <code>app/routes/index.js</code> and add our hard-coded data as the r
   <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
 <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
   <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token number">3</span><span class="token punctuation">,</span>
   <span class="token literal-property property">title</span><span class="token operator">:</span> <span class="token string">'Downtown Charm'</span><span class="token punctuation">,</span>
@@ -605,8 +605,8 @@ For each rental, we then create a listing with information about the property.</
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -650,6 +650,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.7.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.7.0/tutorial/autocomplete-component/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -26,7 +26,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta property="og:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -40,7 +40,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta name="twitter:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -53,7 +53,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember93969" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember93970" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To begin, let's generate our new component. We'll call this component list-filte
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember93971" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.7 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember93971" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember93975" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               </a>
               <div id="ember93978" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember93979" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.7.0/tutorial/index">
@@ -257,11 +257,11 @@ To begin, let's generate our new component. We'll call this component list-filte
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember93993" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember93996" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember93999" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember94002" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember94005" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember94008" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember94011" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember94014" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember94017" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember94020" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember94023" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember94026" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember94029" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -660,7 +660,7 @@ The result of the query is returned to the caller.</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -755,8 +755,8 @@ The result of the query is returned to the caller.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -800,6 +800,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.7.0/tutorial/installing-addons/index.html
+++ b/public/v2.7.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember94383" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember94384" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember94385" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.7 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember94385" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember94389" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember94392" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember94393" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.7.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember94407" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember94410" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember94413" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember94416" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember94419" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember94422" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember94425" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember94428" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember94431" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember94434" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember94437" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember94440" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember94443" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -525,7 +525,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -592,7 +592,7 @@ Without this change, navigation to <code>/rentals</code> in our application woul
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -636,8 +636,8 @@ Without this change, navigation to <code>/rentals</code> in our application woul
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -681,6 +681,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.7.0/tutorial/model-hook/index.html
+++ b/public/v2.7.0/tutorial/model-hook/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember94452" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember94453" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember94454" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.7 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember94454" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember94458" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember94461" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember94462" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.7.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember94476" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember94479" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember94482" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember94485" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember94488" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember94491" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember94494" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember94497" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember94500" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember94503" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember94506" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember94509" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember94512" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -488,7 +488,7 @@ Let's open <code>app/routes/rentals.js</code> and add our hard-coded data as the
   <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
 <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
   <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">title</span><span class="token operator">:</span> <span class="token string">'Downtown Charm'</span><span class="token punctuation">,</span>
@@ -612,8 +612,8 @@ For each rental, we then create a listing with information about the property.</
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -657,6 +657,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.7.0/tutorial/subroutes/index.html
+++ b/public/v2.7.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember94728" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember94729" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember94730" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.7 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember94730" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember94734" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember94737" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember94738" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.7.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember94752" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember94755" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember94758" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember94761" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember94764" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember94767" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember94770" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember94773" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember94776" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember94779" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember94782" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember94785" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember94788" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -633,7 +633,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -848,7 +848,7 @@ Regardless, we hope this has helped you get started with creating your own ambit
           <a href="#toc_final-check">Final Check</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -892,8 +892,8 @@ Regardless, we hope this has helped you get started with creating your own ambit
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -937,6 +937,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.8.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.8.0/tutorial/autocomplete-component/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -26,7 +26,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta property="og:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -40,7 +40,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta name="twitter:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -53,7 +53,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember100909" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember100910" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To begin, let's generate our new component. We'll call this component list-filte
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember100911" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.8 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember100911" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember100915" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               </a>
               <div id="ember100918" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember100919" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.8.0/tutorial/index">
@@ -257,11 +257,11 @@ To begin, let's generate our new component. We'll call this component list-filte
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember100933" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember100936" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember100939" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember100942" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember100945" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember100948" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember100951" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember100954" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember100957" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember100960" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember100963" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember100966" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember100969" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -663,7 +663,7 @@ The result of the query is returned to the caller.</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -760,8 +760,8 @@ The result of the query is returned to the caller.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -805,6 +805,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.8.0/tutorial/installing-addons/index.html
+++ b/public/v2.8.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember101323" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember101324" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember101325" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.8 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember101325" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember101329" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember101332" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember101333" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.8.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember101347" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember101350" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember101353" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember101356" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember101359" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember101362" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember101365" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember101368" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember101371" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember101374" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember101377" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember101380" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember101383" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -525,7 +525,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -592,7 +592,7 @@ Without this change, navigation to <code>/rentals</code> in our application woul
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -636,8 +636,8 @@ Without this change, navigation to <code>/rentals</code> in our application woul
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -681,6 +681,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.8.0/tutorial/model-hook/index.html
+++ b/public/v2.8.0/tutorial/model-hook/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember101392" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember101393" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember101394" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.8 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember101394" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember101398" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember101401" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember101402" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.8.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember101416" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember101419" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember101422" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember101425" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember101428" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember101431" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember101434" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember101437" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember101440" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember101443" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember101446" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember101449" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember101452" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -488,7 +488,7 @@ Let's open <code>app/routes/rentals.js</code> and add our hard-coded data as the
   <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
 <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
   <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">title</span><span class="token operator">:</span> <span class="token string">'Downtown Charm'</span><span class="token punctuation">,</span>
@@ -612,8 +612,8 @@ For each rental, we then create a listing with information about the property.</
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -657,6 +657,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.8.0/tutorial/subroutes/index.html
+++ b/public/v2.8.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember101668" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember101669" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember101670" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.8 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember101670" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember101674" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember101677" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember101678" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.8.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember101692" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember101695" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember101698" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember101701" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember101704" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember101707" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember101710" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember101713" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember101716" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember101719" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember101722" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember101725" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember101728" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -633,7 +633,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -848,7 +848,7 @@ Regardless, we hope this has helped you get started with creating your own ambit
           <a href="#toc_final-check">Final Check</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -892,8 +892,8 @@ Regardless, we hope this has helped you get started with creating your own ambit
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -937,6 +937,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.9.0/tutorial/autocomplete-component/index.html
+++ b/public/v2.9.0/tutorial/autocomplete-component/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -26,7 +26,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta property="og:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta property="og:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -40,7 +40,7 @@ To begin, let's generate our new component. We'll call this component list-filte
   <meta name="twitter:title" content="Building a Complex Component - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city. 
+  <meta name="twitter:description" content="As they search for a rental, users might also want to narrow their search to a specific city. Let's build a component that will let them filter rentals by city.
 
 To begin, let's generate our new component. We'll call this component list-filter, since all...">
 
@@ -53,7 +53,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To begin, let's generate our new component. We'll call this component list-filte
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember107849" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember107850" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To begin, let's generate our new component. We'll call this component list-filte
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember107851" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.9 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember107851" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember107855" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               </a>
               <div id="ember107858" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember107859" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.9.0/tutorial/index">
@@ -257,11 +257,11 @@ To begin, let's generate our new component. We'll call this component list-filte
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember107873" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember107876" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember107879" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember107882" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember107885" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember107888" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember107891" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember107894" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember107897" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember107900" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember107903" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember107906" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To begin, let's generate our new component. We'll call this component list-filte
               <div id="ember107909" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -663,7 +663,7 @@ The result of the query is returned to the caller.</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -760,8 +760,8 @@ The result of the query is returned to the caller.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -805,6 +805,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.9.0/tutorial/installing-addons/index.html
+++ b/public/v2.9.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember108263" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember108264" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember108265" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.9 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember108265" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember108269" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember108272" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember108273" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.9.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember108287" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember108290" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember108293" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember108296" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember108299" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember108302" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember108305" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember108308" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember108311" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember108314" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember108317" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember108320" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember108323" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -525,7 +525,7 @@ Mirage will allow us to create fake data to work with while developing our app a
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -592,7 +592,7 @@ Without this change, navigation to <code>/rentals</code> in our application woul
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -636,8 +636,8 @@ Without this change, navigation to <code>/rentals</code> in our application woul
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -681,6 +681,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.9.0/tutorial/model-hook/index.html
+++ b/public/v2.9.0/tutorial/model-hook/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember108332" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember108333" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember108334" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.9 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember108334" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember108338" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember108341" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember108342" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.9.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember108356" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember108359" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember108362" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember108365" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember108368" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember108371" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember108374" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember108377" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember108380" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember108383" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember108386" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember108389" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember108392" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -488,7 +488,7 @@ Let's open <code>app/routes/rentals.js</code> and add our hard-coded data as the
   <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+  <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
 <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
   <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
   <span class="token literal-property property">title</span><span class="token operator">:</span> <span class="token string">'Downtown Charm'</span><span class="token punctuation">,</span>
@@ -612,8 +612,8 @@ For each rental, we then create a listing with information about the property.</
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -657,6 +657,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v2.9.0/tutorial/subroutes/index.html
+++ b/public/v2.9.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember108608" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember108609" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember108610" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         2.9 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember108610" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember108614" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember108617" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember108618" class="ember-view" data-test-toc-link="Creating Your App" href="/v2.9.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember108632" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember108635" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember108638" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember108641" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember108644" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember108647" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember108650" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember108653" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember108656" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember108659" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember108662" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember108665" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember108668" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -633,7 +633,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -848,7 +848,7 @@ Regardless, we hope this has helped you get started with creating your own ambit
           <a href="#toc_final-check">Final Check</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -892,8 +892,8 @@ Regardless, we hope this has helped you get started with creating your own ambit
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -937,6 +937,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.0.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.0.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember178024" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember178025" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember178026" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.0 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember178026" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember178030" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember178033" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember178034" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.0.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember178048" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember178051" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember178054" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember178057" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember178060" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember178063" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember178066" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember178069" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember178072" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember178075" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember178078" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember178081" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember178084" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -619,7 +619,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1009,7 +1009,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1053,8 +1053,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1098,6 +1098,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.0.0/tutorial/ember-data/index.html
+++ b/public/v3.0.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember178231" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember178232" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember178233" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.0 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember178233" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember178237" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember178240" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember178241" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.0.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember178255" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember178258" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember178261" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember178264" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember178267" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember178270" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember178273" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember178276" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember178279" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember178282" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember178285" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember178288" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember178291" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.0/classes/D
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -584,7 +584,7 @@ A remote server will allow for data to be shared and updated across users.</p>
           <a href="#toc_updating-the-model-hook">Updating the Model Hook</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -628,8 +628,8 @@ A remote server will allow for data to be shared and updated across users.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -673,6 +673,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.0.0/tutorial/installing-addons/index.html
+++ b/public/v3.0.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember178369" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember178370" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember178371" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.0 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember178371" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember178375" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember178378" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember178379" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.0.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember178393" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember178396" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember178399" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember178402" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember178405" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember178408" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember178411" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember178414" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember178417" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember178420" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember178423" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember178426" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember178429" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -536,7 +536,7 @@ Let's configure Mirage to send back our rentals that we had defined above by upd
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -635,7 +635,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -679,8 +679,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -724,6 +724,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.0.0/tutorial/model-hook/index.html
+++ b/public/v3.0.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember178438" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember178439" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember178440" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.0 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember178440" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember178444" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember178447" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember178448" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.0.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember178462" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember178465" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember178468" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember178471" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember178474" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember178477" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember178480" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember178483" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember178486" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember178489" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember178492" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember178495" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember178498" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -501,7 +501,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -609,7 +609,7 @@ This leaves us with 2 remaining acceptance test failures (and 1 ESLint failure):
           <a href="#toc_acceptance-testing-the-rental-list">Acceptance Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -653,8 +653,8 @@ This leaves us with 2 remaining acceptance test failures (and 1 ESLint failure):
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -698,6 +698,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.0.0/tutorial/subroutes/index.html
+++ b/public/v3.0.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember178714" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember178715" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember178716" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.0 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember178716" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember178720" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember178723" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember178724" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.0.0/tutorial/ember-cli">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember178738" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember178741" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember178744" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember178747" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember178750" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember178753" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember178756" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember178759" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember178762" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember178765" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember178768" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember178771" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember178774" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -643,7 +643,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -876,7 +876,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_acceptance-tests">Acceptance Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -920,8 +920,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -965,6 +965,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.1.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.1.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember184753" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember184754" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember184755" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.1 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember184755" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember184759" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember184762" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember184763" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.1.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember184777" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember184780" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember184783" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember184786" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember184789" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember184792" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember184795" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember184798" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember184801" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember184804" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember184807" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember184810" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember184813" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -619,7 +619,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1003,7 +1003,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_an-integration-test">An Integration Test</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1047,8 +1047,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1092,6 +1092,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.1.0/tutorial/ember-data/index.html
+++ b/public/v3.1.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember184960" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember184961" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember184962" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.1 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember184962" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember184966" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember184969" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember184970" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.1.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember184984" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember184987" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember184990" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember184993" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember184996" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember184999" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember185002" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember185005" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember185008" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember185011" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember185014" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember185017" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember185020" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.1/classes/D
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -613,7 +613,7 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
           <a href="#toc_setting-up-application-tests-to-use-mirage">Setting up Application Tests to use Mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -657,8 +657,8 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -702,6 +702,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.1.0/tutorial/installing-addons/index.html
+++ b/public/v3.1.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember185098" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember185099" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember185100" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.1 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember185100" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember185104" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember185107" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember185108" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.1.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember185122" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember185125" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember185128" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember185131" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember185134" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember185137" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember185140" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember185143" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember185146" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember185149" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember185152" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember185155" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember185158" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -536,7 +536,7 @@ Let's configure Mirage to send back our rentals that we had defined above by upd
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -635,7 +635,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -679,8 +679,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -724,6 +724,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.1.0/tutorial/model-hook/index.html
+++ b/public/v3.1.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember185167" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember185168" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember185169" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.1 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember185169" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember185173" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember185176" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember185177" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.1.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember185191" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember185194" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember185197" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember185200" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember185203" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember185206" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember185209" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember185212" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember185215" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember185218" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember185221" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember185224" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember185227" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -501,7 +501,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -613,7 +613,7 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
           <a href="#toc_application-testing-the-rental-list">Application Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -657,8 +657,8 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -702,6 +702,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.1.0/tutorial/subroutes/index.html
+++ b/public/v3.1.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember185443" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember185444" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember185445" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.1 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember185445" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember185449" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember185452" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember185453" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.1.0/tutorial/ember-cli">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember185467" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember185470" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember185473" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember185476" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember185479" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember185482" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember185485" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember185488" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember185491" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember185494" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember185497" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember185500" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember185503" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -643,7 +643,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -875,7 +875,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -919,8 +919,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -964,6 +964,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.10.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.10.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember247834" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember247835" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember247836" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.10 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember247836" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember247840" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember247843" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember247844" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.10.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember247858" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember247861" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember247864" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember247867" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember247870" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember247873" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember247876" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember247879" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember247882" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember247885" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember247888" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember247891" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember247894" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,17 +437,17 @@
               <div id="ember247897" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -636,7 +636,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1026,7 +1026,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1070,8 +1070,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1115,6 +1115,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.10.0/tutorial/ember-data/index.html
+++ b/public/v3.10.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember248050" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember248051" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember248052" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.10 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember248052" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember248056" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember248059" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember248060" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.10.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember248074" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember248077" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember248080" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember248083" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember248086" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember248089" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember248092" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember248095" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember248098" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember248101" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember248104" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember248107" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember248110" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,17 +437,17 @@
               <div id="ember248113" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -545,7 +545,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.10/classes/
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -628,7 +628,7 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
           <a href="#toc_setting-up-application-tests-to-use-mirage">Setting up Application Tests to use Mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -672,8 +672,8 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -717,6 +717,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.10.0/tutorial/installing-addons/index.html
+++ b/public/v3.10.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember248194" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember248195" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember248196" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.10 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember248196" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248200" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember248203" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember248204" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.10.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248218" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248221" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248224" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248227" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248230" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248233" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248236" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248239" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248242" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248245" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248248" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248251" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248254" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,17 +443,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember248257" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -556,7 +556,7 @@ For example, the data we are providing below will be substituted when a request 
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -657,7 +657,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -701,8 +701,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -746,6 +746,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.10.0/tutorial/model-hook/index.html
+++ b/public/v3.10.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember248266" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember248267" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember248268" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.10 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember248268" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248272" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember248275" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember248276" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.10.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248290" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248293" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248296" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248299" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248302" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248305" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248308" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248311" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248314" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248317" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248320" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248323" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248326" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,17 +443,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember248329" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -514,7 +514,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -622,7 +622,7 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
           <a href="#toc_application-testing-the-rental-list">Application Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -666,8 +666,8 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -711,6 +711,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.10.0/tutorial/subroutes/index.html
+++ b/public/v3.10.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember248554" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember248555" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember248556" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.10 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember248556" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember248560" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember248563" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember248564" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.10.0/tutorial/ember-cli">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember248578" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember248581" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember248584" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember248587" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember248590" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember248593" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember248596" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember248599" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember248602" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember248605" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember248608" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember248611" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,7 +436,7 @@
               <div id="ember248614" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -449,17 +449,17 @@
               <div id="ember248617" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -658,7 +658,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -901,7 +901,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -945,8 +945,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -990,6 +990,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.11.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.11.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember255733" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember255734" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember255735" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.11 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember255735" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember255739" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember255742" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember255743" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.11.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember255757" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember255760" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember255763" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember255766" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember255769" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember255772" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember255775" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember255778" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember255781" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember255784" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember255787" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember255790" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember255793" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,17 +437,17 @@
               <div id="ember255796" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -636,7 +636,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1026,7 +1026,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1070,8 +1070,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1115,6 +1115,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.11.0/tutorial/ember-data/index.html
+++ b/public/v3.11.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember255949" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember255950" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember255951" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.11 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember255951" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember255955" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember255958" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember255959" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.11.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember255973" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember255976" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember255979" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember255982" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember255985" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember255988" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember255991" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember255994" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember255997" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember256000" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember256003" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember256006" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember256009" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,17 +437,17 @@
               <div id="ember256012" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -545,7 +545,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.11/classes/
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -628,7 +628,7 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
           <a href="#toc_setting-up-application-tests-to-use-mirage">Setting up Application Tests to use Mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -672,8 +672,8 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -717,6 +717,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.11.0/tutorial/installing-addons/index.html
+++ b/public/v3.11.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember256165" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember256166" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember256167" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.11 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember256167" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256171" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember256174" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember256175" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.11.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256189" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256192" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256195" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256198" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256201" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256204" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256207" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256210" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256213" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256216" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256219" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256222" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256225" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,17 +443,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember256228" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -556,7 +556,7 @@ For example, the data we are providing below will be substituted when a request 
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -657,7 +657,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -701,8 +701,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -746,6 +746,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.11.0/tutorial/model-hook/index.html
+++ b/public/v3.11.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember256237" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember256238" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember256239" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.11 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember256239" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256243" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember256246" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember256247" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.11.0/tutorial/index">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256261" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256264" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256267" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256270" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256273" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256276" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256279" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256282" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256285" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256288" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256291" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256294" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256297" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,17 +443,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember256300" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -514,7 +514,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -622,7 +622,7 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
           <a href="#toc_application-testing-the-rental-list">Application Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -666,8 +666,8 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -711,6 +711,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.11.0/tutorial/subroutes/index.html
+++ b/public/v3.11.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember256525" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember256526" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember256527" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.11 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember256527" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember256531" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember256534" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember256535" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.11.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember256549" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember256552" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember256555" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember256558" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember256561" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember256564" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember256567" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember256570" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember256573" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember256576" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember256579" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember256582" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,7 +436,7 @@
               <div id="ember256585" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -449,17 +449,17 @@
               <div id="ember256588" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -658,7 +658,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -901,7 +901,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -945,8 +945,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -990,6 +990,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.12.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.12.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember264431" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember264432" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember264433" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.12 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember264433" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember264437" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember264440" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember264441" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.12.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember264455" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember264458" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember264461" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember264464" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember264467" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember264470" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember264473" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember264476" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember264479" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember264482" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember264485" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember264488" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember264491" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,7 +437,7 @@
               <div id="ember264494" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -450,17 +450,17 @@
               <div id="ember264497" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -649,7 +649,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1040,7 +1040,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1084,8 +1084,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1129,6 +1129,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.12.0/tutorial/ember-data/index.html
+++ b/public/v3.12.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember264656" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember264657" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember264658" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.12 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember264658" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember264662" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember264665" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember264666" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.12.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember264680" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember264683" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember264686" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember264689" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember264692" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember264695" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember264698" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember264701" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember264704" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember264707" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember264710" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember264713" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember264716" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,7 +437,7 @@
               <div id="ember264719" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -450,17 +450,17 @@
               <div id="ember264722" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -558,7 +558,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.12/classes/
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -641,7 +641,7 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
           <a href="#toc_setting-up-application-tests-to-use-mirage">Setting up Application Tests to use Mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -685,8 +685,8 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -730,6 +730,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.12.0/tutorial/installing-addons/index.html
+++ b/public/v3.12.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember264881" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember264882" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember264883" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.12 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember264883" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264887" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember264890" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember264891" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.12.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264905" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264908" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264911" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264914" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264917" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264920" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264923" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264926" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264929" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264932" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264935" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264938" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264941" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,7 +443,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264944" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -456,17 +456,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember264947" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -569,7 +569,7 @@ For example, the data we are providing below will be substituted when a request 
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -670,7 +670,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -714,8 +714,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -759,6 +759,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.12.0/tutorial/model-hook/index.html
+++ b/public/v3.12.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember264956" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember264957" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember264958" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.12 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember264958" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember264962" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember264965" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember264966" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.12.0/tutorial/index">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember264980" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember264983" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember264986" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember264989" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember264992" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember264995" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember264998" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember265001" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember265004" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember265007" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember265010" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember265013" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember265016" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,7 +443,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember265019" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -456,17 +456,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember265022" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -527,7 +527,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -635,7 +635,7 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
           <a href="#toc_application-testing-the-rental-list">Application Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -679,8 +679,8 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -724,6 +724,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.12.0/tutorial/subroutes/index.html
+++ b/public/v3.12.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember265256" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember265257" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember265258" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.12 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember265258" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember265262" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember265265" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember265266" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.12.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember265280" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember265283" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember265286" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember265289" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember265292" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember265295" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember265298" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember265301" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember265304" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember265307" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember265310" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember265313" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,7 +436,7 @@
               <div id="ember265316" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -449,7 +449,7 @@
               <div id="ember265319" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -462,17 +462,17 @@
               <div id="ember265322" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -671,7 +671,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -914,7 +914,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -958,8 +958,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1003,6 +1003,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.13.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.13.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember273165" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember273166" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember273167" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.13 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember273167" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember273171" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember273174" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember273175" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.13.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember273189" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember273192" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember273195" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember273198" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember273201" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember273204" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember273207" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember273210" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember273213" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember273216" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember273219" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember273222" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember273225" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,7 +437,7 @@
               <div id="ember273228" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -450,17 +450,17 @@
               <div id="ember273231" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -649,7 +649,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1040,7 +1040,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1084,8 +1084,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1129,6 +1129,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.13.0/tutorial/ember-data/index.html
+++ b/public/v3.13.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember273390" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember273391" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember273392" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.13 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember273392" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember273396" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember273399" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember273400" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.13.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember273414" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember273417" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember273420" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember273423" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember273426" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember273429" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember273432" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember273435" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember273438" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember273441" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember273444" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember273447" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember273450" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,7 +437,7 @@
               <div id="ember273453" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -450,17 +450,17 @@
               <div id="ember273456" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -558,7 +558,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.13/classes/
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -641,7 +641,7 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
           <a href="#toc_setting-up-application-tests-to-use-mirage">Setting up Application Tests to use Mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -685,8 +685,8 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -730,6 +730,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.13.0/tutorial/installing-addons/index.html
+++ b/public/v3.13.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember273615" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember273616" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember273617" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.13 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember273617" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273621" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember273624" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember273625" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.13.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273639" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273642" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273645" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273648" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273651" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273654" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273657" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273660" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273663" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273666" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273669" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273672" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273675" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,7 +443,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273678" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -456,17 +456,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember273681" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -569,7 +569,7 @@ For example, the data we are providing below will be substituted when a request 
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -670,7 +670,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -714,8 +714,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -759,6 +759,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.13.0/tutorial/model-hook/index.html
+++ b/public/v3.13.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember273690" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember273691" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember273692" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.13 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember273692" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273696" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember273699" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember273700" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.13.0/tutorial/index">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273714" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273717" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273720" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273723" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273726" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273729" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273732" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273735" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273738" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273741" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273744" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273747" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273750" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,7 +443,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273753" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -456,17 +456,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember273756" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -527,7 +527,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -635,7 +635,7 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
           <a href="#toc_application-testing-the-rental-list">Application Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -679,8 +679,8 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -724,6 +724,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.13.0/tutorial/subroutes/index.html
+++ b/public/v3.13.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember273990" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember273991" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember273992" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.13 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember273992" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember273996" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember273999" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember274000" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.13.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember274014" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember274017" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember274020" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember274023" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember274026" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember274029" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember274032" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember274035" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember274038" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember274041" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember274044" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember274047" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,7 +436,7 @@
               <div id="ember274050" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -449,7 +449,7 @@
               <div id="ember274053" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -462,17 +462,17 @@
               <div id="ember274056" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -671,7 +671,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -914,7 +914,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -958,8 +958,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1003,6 +1003,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.14.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.14.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember281973" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember281974" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember281975" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.14 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember281975" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember281979" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember281982" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember281983" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.14.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember281997" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember282000" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember282003" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember282006" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember282009" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember282012" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember282015" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember282018" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember282021" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember282024" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember282027" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember282030" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember282033" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,7 +437,7 @@
               <div id="ember282036" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -450,17 +450,17 @@
               <div id="ember282039" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -649,7 +649,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1040,7 +1040,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1084,8 +1084,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1129,6 +1129,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.14.0/tutorial/ember-data/index.html
+++ b/public/v3.14.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember282198" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember282199" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember282200" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.14 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember282200" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember282204" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember282207" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember282208" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.14.0/tutorial/index">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember282222" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember282225" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember282228" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember282231" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember282234" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember282237" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember282240" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember282243" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember282246" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember282249" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember282252" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember282255" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember282258" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,7 +437,7 @@
               <div id="ember282261" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -450,17 +450,17 @@
               <div id="ember282264" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -558,7 +558,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.14/classes/
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -641,7 +641,7 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
           <a href="#toc_setting-up-application-tests-to-use-mirage">Setting up Application Tests to use Mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -685,8 +685,8 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -730,6 +730,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.14.0/tutorial/installing-addons/index.html
+++ b/public/v3.14.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember282423" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember282424" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember282425" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.14 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember282425" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282429" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember282432" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember282433" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.14.0/tutorial/index">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282447" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282450" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282453" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282456" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282459" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282462" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282465" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282468" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282471" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282474" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282477" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282480" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282483" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,7 +443,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282486" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -456,17 +456,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember282489" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -569,7 +569,7 @@ For example, the data we are providing below will be substituted when a request 
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -670,7 +670,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -714,8 +714,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -759,6 +759,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.14.0/tutorial/model-hook/index.html
+++ b/public/v3.14.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember282498" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember282499" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember282500" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.14 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember282500" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282504" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember282507" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember282508" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.14.0/tutorial/index">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282522" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282525" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282528" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282531" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282534" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282537" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282540" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282543" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282546" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282549" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282552" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282555" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282558" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,7 +443,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282561" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -456,17 +456,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember282564" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -527,7 +527,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -635,7 +635,7 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
           <a href="#toc_application-testing-the-rental-list">Application Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -679,8 +679,8 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -724,6 +724,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.14.0/tutorial/subroutes/index.html
+++ b/public/v3.14.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember282798" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember282799" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember282800" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.14 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember282800" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember282804" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember282807" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember282808" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.14.0/tutorial/index">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember282822" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember282825" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember282828" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember282831" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember282834" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember282837" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember282840" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember282843" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember282846" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember282849" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember282852" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember282855" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,7 +436,7 @@
               <div id="ember282858" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -449,7 +449,7 @@
               <div id="ember282861" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -462,17 +462,17 @@
               <div id="ember282864" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -671,7 +671,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -914,7 +914,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -958,8 +958,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1003,6 +1003,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.15.0/tutorial/part-1/working-with-data/index.html
+++ b/public/v3.15.0/tutorial/part-1/working-with-data/index.html
@@ -9,15 +9,15 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Working With Data - Part 1 - Ember Guides</title>
 
-  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -31,11 +31,11 @@ In this chapter, you will learn about:
   <meta property="og:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -50,11 +50,11 @@ In this chapter, you will learn about:
   <meta name="twitter:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -68,7 +68,7 @@ In this chapter, you will learn about:
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -112,7 +112,7 @@ In this chapter, you will learn about:
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember293112" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember293113" class="ds-dropdown-results ember-tether ember-view">
@@ -132,28 +132,28 @@ In this chapter, you will learn about:
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember293114" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.15 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember293114" class="ember-basic-dropdown-content-placeholder"></div>
@@ -174,7 +174,7 @@ In this chapter, you will learn about:
               <div id="ember293118" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -186,7 +186,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember293121" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="true">
             <div id="ember293122" class="cp-Panel cp-is-open ember-view">
@@ -197,7 +197,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember293124" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember293125" class="ember-view" data-test-toc-link="Introduction" href="/v3.15.0/tutorial/part-1/index">
@@ -270,11 +270,11 @@ In this chapter, you will learn about:
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,15 +287,15 @@ In this chapter, you will learn about:
               <div id="ember293137" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -309,7 +309,7 @@ In this chapter, you will learn about:
               <div id="ember293140" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -322,7 +322,7 @@ In this chapter, you will learn about:
               <div id="ember293143" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -335,7 +335,7 @@ In this chapter, you will learn about:
               <div id="ember293146" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -348,7 +348,7 @@ In this chapter, you will learn about:
               <div id="ember293149" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -361,7 +361,7 @@ In this chapter, you will learn about:
               <div id="ember293152" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -375,7 +375,7 @@ In this chapter, you will learn about:
               <div id="ember293155" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -388,7 +388,7 @@ In this chapter, you will learn about:
               <div id="ember293158" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -401,7 +401,7 @@ In this chapter, you will learn about:
               <div id="ember293161" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -414,7 +414,7 @@ In this chapter, you will learn about:
               <div id="ember293164" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -427,7 +427,7 @@ In this chapter, you will learn about:
               <div id="ember293167" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -440,7 +440,7 @@ In this chapter, you will learn about:
               <div id="ember293170" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -454,7 +454,7 @@ In this chapter, you will learn about:
               <div id="ember293173" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -467,7 +467,7 @@ In this chapter, you will learn about:
               <div id="ember293176" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -480,17 +480,17 @@ In this chapter, you will learn about:
               <div id="ember293179" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -805,7 +805,7 @@ In this chapter, you will learn about:
         <span class="token punctuation">}</span><span class="token punctuation">,</span>
         <span class="token property">"category"</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token property">"bedrooms"</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -948,7 +948,7 @@ In this chapter, you will learn about:
           <a href="#toc_loops-and-local-variables-in-templates-with-each">Loops and Local Variables in Templates with {{#each}}</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -992,8 +992,8 @@ In this chapter, you will learn about:
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1037,6 +1037,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.15.0/tutorial/part-2/provider-components/index.html
+++ b/public/v3.15.0/tutorial/part-2/provider-components/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Provider Components - Part 2 - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember293332" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember293333" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember293334" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.15 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember293334" class="ember-basic-dropdown-content-placeholder"></div>
@@ -153,7 +153,7 @@
               <div id="ember293338" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -165,7 +165,7 @@
               </a>
               <div id="ember293341" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="false">
             <div id="ember293342" class="cp-Panel cp-is-closed ember-view">
@@ -177,7 +177,7 @@
               <div id="ember293344" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -189,7 +189,7 @@
               </a>
               <div id="ember293347" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember293348" class="ember-view" data-test-toc-link="Introduction" href="/v3.15.0/tutorial/part-2/index">
@@ -234,19 +234,19 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -260,7 +260,7 @@
               <div id="ember293356" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -273,7 +273,7 @@
               <div id="ember293359" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -286,7 +286,7 @@
               <div id="ember293362" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -299,7 +299,7 @@
               <div id="ember293365" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -312,7 +312,7 @@
               <div id="ember293368" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -326,7 +326,7 @@
               <div id="ember293371" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@
               <div id="ember293374" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@
               <div id="ember293377" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@
               <div id="ember293380" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@
               <div id="ember293383" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@
               <div id="ember293386" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -405,7 +405,7 @@
               <div id="ember293389" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -418,7 +418,7 @@
               <div id="ember293392" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -431,17 +431,17 @@
               <div id="ember293395" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -593,7 +593,7 @@
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -777,7 +777,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -886,7 +886,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
           <a href="#toc_adding-the-rentalsfilter-provider-component">Adding the &lt;Rentals::Filter&gt; Provider Component</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -930,8 +930,8 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -975,6 +975,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.16.0/tutorial/part-1/working-with-data/index.html
+++ b/public/v3.16.0/tutorial/part-1/working-with-data/index.html
@@ -9,15 +9,15 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Working With Data - Part 1 - Ember Guides</title>
 
-  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -31,11 +31,11 @@ In this chapter, you will learn about:
   <meta property="og:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -50,11 +50,11 @@ In this chapter, you will learn about:
   <meta name="twitter:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -68,7 +68,7 @@ In this chapter, you will learn about:
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -112,7 +112,7 @@ In this chapter, you will learn about:
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember304812" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember304813" class="ds-dropdown-results ember-tether ember-view">
@@ -132,28 +132,28 @@ In this chapter, you will learn about:
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember304814" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.16 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember304814" class="ember-basic-dropdown-content-placeholder"></div>
@@ -174,7 +174,7 @@ In this chapter, you will learn about:
               <div id="ember304818" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -186,7 +186,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember304821" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="true">
             <div id="ember304822" class="cp-Panel cp-is-open ember-view">
@@ -197,7 +197,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember304824" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember304825" class="ember-view" data-test-toc-link="Introduction" href="/v3.16.0/tutorial/part-1/index">
@@ -270,11 +270,11 @@ In this chapter, you will learn about:
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,15 +287,15 @@ In this chapter, you will learn about:
               <div id="ember304837" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -309,7 +309,7 @@ In this chapter, you will learn about:
               <div id="ember304840" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -322,7 +322,7 @@ In this chapter, you will learn about:
               <div id="ember304843" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -335,7 +335,7 @@ In this chapter, you will learn about:
               <div id="ember304846" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -348,7 +348,7 @@ In this chapter, you will learn about:
               <div id="ember304849" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -361,7 +361,7 @@ In this chapter, you will learn about:
               <div id="ember304852" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -375,7 +375,7 @@ In this chapter, you will learn about:
               <div id="ember304855" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -388,7 +388,7 @@ In this chapter, you will learn about:
               <div id="ember304858" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -401,7 +401,7 @@ In this chapter, you will learn about:
               <div id="ember304861" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -414,7 +414,7 @@ In this chapter, you will learn about:
               <div id="ember304864" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -427,7 +427,7 @@ In this chapter, you will learn about:
               <div id="ember304867" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -440,7 +440,7 @@ In this chapter, you will learn about:
               <div id="ember304870" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -454,7 +454,7 @@ In this chapter, you will learn about:
               <div id="ember304873" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -467,7 +467,7 @@ In this chapter, you will learn about:
               <div id="ember304876" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -480,17 +480,17 @@ In this chapter, you will learn about:
               <div id="ember304879" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -805,7 +805,7 @@ In this chapter, you will learn about:
         <span class="token punctuation">}</span><span class="token punctuation">,</span>
         <span class="token property">"category"</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token property">"bedrooms"</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -948,7 +948,7 @@ In this chapter, you will learn about:
           <a href="#toc_loops-and-local-variables-in-templates-with-each">Loops and Local Variables in Templates with {{#each}}</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -992,8 +992,8 @@ In this chapter, you will learn about:
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1037,6 +1037,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.16.0/tutorial/part-2/provider-components/index.html
+++ b/public/v3.16.0/tutorial/part-2/provider-components/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Provider Components - Part 2 - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember305032" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember305033" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember305034" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.16 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember305034" class="ember-basic-dropdown-content-placeholder"></div>
@@ -153,7 +153,7 @@
               <div id="ember305038" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -165,7 +165,7 @@
               </a>
               <div id="ember305041" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="false">
             <div id="ember305042" class="cp-Panel cp-is-closed ember-view">
@@ -177,7 +177,7 @@
               <div id="ember305044" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -189,7 +189,7 @@
               </a>
               <div id="ember305047" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember305048" class="ember-view" data-test-toc-link="Introduction" href="/v3.16.0/tutorial/part-2/index">
@@ -234,19 +234,19 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -260,7 +260,7 @@
               <div id="ember305056" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -273,7 +273,7 @@
               <div id="ember305059" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -286,7 +286,7 @@
               <div id="ember305062" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -299,7 +299,7 @@
               <div id="ember305065" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -312,7 +312,7 @@
               <div id="ember305068" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -326,7 +326,7 @@
               <div id="ember305071" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@
               <div id="ember305074" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@
               <div id="ember305077" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@
               <div id="ember305080" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@
               <div id="ember305083" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@
               <div id="ember305086" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -405,7 +405,7 @@
               <div id="ember305089" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -418,7 +418,7 @@
               <div id="ember305092" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -431,17 +431,17 @@
               <div id="ember305095" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -593,7 +593,7 @@
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -777,7 +777,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -886,7 +886,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
           <a href="#toc_adding-the-rentalsfilter-provider-component">Adding the &lt;Rentals::Filter&gt; Provider Component</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -930,8 +930,8 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -975,6 +975,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.17.0/tutorial/part-1/working-with-data/index.html
+++ b/public/v3.17.0/tutorial/part-1/working-with-data/index.html
@@ -9,15 +9,15 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Working With Data - Part 1 - Ember Guides</title>
 
-  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -31,11 +31,11 @@ In this chapter, you will learn about:
   <meta property="og:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -50,11 +50,11 @@ In this chapter, you will learn about:
   <meta name="twitter:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -68,7 +68,7 @@ In this chapter, you will learn about:
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -112,7 +112,7 @@ In this chapter, you will learn about:
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember316512" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember316513" class="ds-dropdown-results ember-tether ember-view">
@@ -132,28 +132,28 @@ In this chapter, you will learn about:
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember316514" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.17 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember316514" class="ember-basic-dropdown-content-placeholder"></div>
@@ -174,7 +174,7 @@ In this chapter, you will learn about:
               <div id="ember316518" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -186,7 +186,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember316521" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="true">
             <div id="ember316522" class="cp-Panel cp-is-open ember-view">
@@ -197,7 +197,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember316524" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember316525" class="ember-view" data-test-toc-link="Introduction" href="/v3.17.0/tutorial/part-1/index">
@@ -270,11 +270,11 @@ In this chapter, you will learn about:
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,15 +287,15 @@ In this chapter, you will learn about:
               <div id="ember316537" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -309,7 +309,7 @@ In this chapter, you will learn about:
               <div id="ember316540" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -322,7 +322,7 @@ In this chapter, you will learn about:
               <div id="ember316543" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -335,7 +335,7 @@ In this chapter, you will learn about:
               <div id="ember316546" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -348,7 +348,7 @@ In this chapter, you will learn about:
               <div id="ember316549" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -361,7 +361,7 @@ In this chapter, you will learn about:
               <div id="ember316552" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -375,7 +375,7 @@ In this chapter, you will learn about:
               <div id="ember316555" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -388,7 +388,7 @@ In this chapter, you will learn about:
               <div id="ember316558" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -401,7 +401,7 @@ In this chapter, you will learn about:
               <div id="ember316561" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -414,7 +414,7 @@ In this chapter, you will learn about:
               <div id="ember316564" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -427,7 +427,7 @@ In this chapter, you will learn about:
               <div id="ember316567" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -441,7 +441,7 @@ In this chapter, you will learn about:
               <div id="ember316570" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -455,7 +455,7 @@ In this chapter, you will learn about:
               <div id="ember316573" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -468,7 +468,7 @@ In this chapter, you will learn about:
               <div id="ember316576" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -481,17 +481,17 @@ In this chapter, you will learn about:
               <div id="ember316579" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -806,7 +806,7 @@ In this chapter, you will learn about:
         <span class="token punctuation">}</span><span class="token punctuation">,</span>
         <span class="token property">"category"</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token property">"bedrooms"</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -949,7 +949,7 @@ In this chapter, you will learn about:
           <a href="#toc_loops-and-local-variables-in-templates-with-each">Loops and Local Variables in Templates with {{#each}}</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -993,8 +993,8 @@ In this chapter, you will learn about:
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1038,6 +1038,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.17.0/tutorial/part-2/provider-components/index.html
+++ b/public/v3.17.0/tutorial/part-2/provider-components/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Provider Components - Part 2 - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember316732" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember316733" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember316734" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.17 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember316734" class="ember-basic-dropdown-content-placeholder"></div>
@@ -153,7 +153,7 @@
               <div id="ember316738" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -165,7 +165,7 @@
               </a>
               <div id="ember316741" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="false">
             <div id="ember316742" class="cp-Panel cp-is-closed ember-view">
@@ -177,7 +177,7 @@
               <div id="ember316744" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -189,7 +189,7 @@
               </a>
               <div id="ember316747" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember316748" class="ember-view" data-test-toc-link="Introduction" href="/v3.17.0/tutorial/part-2/index">
@@ -234,19 +234,19 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -260,7 +260,7 @@
               <div id="ember316756" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -273,7 +273,7 @@
               <div id="ember316759" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -286,7 +286,7 @@
               <div id="ember316762" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -299,7 +299,7 @@
               <div id="ember316765" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -312,7 +312,7 @@
               <div id="ember316768" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -326,7 +326,7 @@
               <div id="ember316771" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@
               <div id="ember316774" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@
               <div id="ember316777" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@
               <div id="ember316780" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@
               <div id="ember316783" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -392,7 +392,7 @@
               <div id="ember316786" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -406,7 +406,7 @@
               <div id="ember316789" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -419,7 +419,7 @@
               <div id="ember316792" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -432,17 +432,17 @@
               <div id="ember316795" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -594,7 +594,7 @@
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -778,7 +778,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -887,7 +887,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
           <a href="#toc_adding-the-rentalsfilter-provider-component">Adding the &lt;Rentals::Filter&gt; Provider Component</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -931,8 +931,8 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -976,6 +976,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.18.0/tutorial/part-1/working-with-data/index.html
+++ b/public/v3.18.0/tutorial/part-1/working-with-data/index.html
@@ -9,15 +9,15 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Working With Data - Part 1 - Ember Guides</title>
 
-  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -31,11 +31,11 @@ In this chapter, you will learn about:
   <meta property="og:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -50,11 +50,11 @@ In this chapter, you will learn about:
   <meta name="twitter:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -68,7 +68,7 @@ In this chapter, you will learn about:
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -112,7 +112,7 @@ In this chapter, you will learn about:
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember328212" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember328213" class="ds-dropdown-results ember-tether ember-view">
@@ -132,28 +132,28 @@ In this chapter, you will learn about:
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember328214" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.18 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember328214" class="ember-basic-dropdown-content-placeholder"></div>
@@ -174,7 +174,7 @@ In this chapter, you will learn about:
               <div id="ember328218" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -186,7 +186,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember328221" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="true">
             <div id="ember328222" class="cp-Panel cp-is-open ember-view">
@@ -197,7 +197,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember328224" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember328225" class="ember-view" data-test-toc-link="Introduction" href="/v3.18.0/tutorial/part-1/index">
@@ -270,11 +270,11 @@ In this chapter, you will learn about:
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,15 +287,15 @@ In this chapter, you will learn about:
               <div id="ember328237" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -309,7 +309,7 @@ In this chapter, you will learn about:
               <div id="ember328240" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -322,7 +322,7 @@ In this chapter, you will learn about:
               <div id="ember328243" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -335,7 +335,7 @@ In this chapter, you will learn about:
               <div id="ember328246" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -348,7 +348,7 @@ In this chapter, you will learn about:
               <div id="ember328249" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -361,7 +361,7 @@ In this chapter, you will learn about:
               <div id="ember328252" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -375,7 +375,7 @@ In this chapter, you will learn about:
               <div id="ember328255" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -388,7 +388,7 @@ In this chapter, you will learn about:
               <div id="ember328258" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -401,7 +401,7 @@ In this chapter, you will learn about:
               <div id="ember328261" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -414,7 +414,7 @@ In this chapter, you will learn about:
               <div id="ember328264" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -427,7 +427,7 @@ In this chapter, you will learn about:
               <div id="ember328267" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -441,7 +441,7 @@ In this chapter, you will learn about:
               <div id="ember328270" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -455,7 +455,7 @@ In this chapter, you will learn about:
               <div id="ember328273" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -468,7 +468,7 @@ In this chapter, you will learn about:
               <div id="ember328276" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -481,17 +481,17 @@ In this chapter, you will learn about:
               <div id="ember328279" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -806,7 +806,7 @@ In this chapter, you will learn about:
         <span class="token punctuation">}</span><span class="token punctuation">,</span>
         <span class="token property">"category"</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token property">"bedrooms"</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -949,7 +949,7 @@ In this chapter, you will learn about:
           <a href="#toc_loops-and-local-variables-in-templates-with-each">Loops and Local Variables in Templates with {{#each}}</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -993,8 +993,8 @@ In this chapter, you will learn about:
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1038,6 +1038,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.18.0/tutorial/part-2/provider-components/index.html
+++ b/public/v3.18.0/tutorial/part-2/provider-components/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Provider Components - Part 2 - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember328432" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember328433" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember328434" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.18 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember328434" class="ember-basic-dropdown-content-placeholder"></div>
@@ -153,7 +153,7 @@
               <div id="ember328438" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -165,7 +165,7 @@
               </a>
               <div id="ember328441" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="false">
             <div id="ember328442" class="cp-Panel cp-is-closed ember-view">
@@ -177,7 +177,7 @@
               <div id="ember328444" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -189,7 +189,7 @@
               </a>
               <div id="ember328447" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember328448" class="ember-view" data-test-toc-link="Introduction" href="/v3.18.0/tutorial/part-2/index">
@@ -234,19 +234,19 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -260,7 +260,7 @@
               <div id="ember328456" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -273,7 +273,7 @@
               <div id="ember328459" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -286,7 +286,7 @@
               <div id="ember328462" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -299,7 +299,7 @@
               <div id="ember328465" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -312,7 +312,7 @@
               <div id="ember328468" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -326,7 +326,7 @@
               <div id="ember328471" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@
               <div id="ember328474" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@
               <div id="ember328477" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@
               <div id="ember328480" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@
               <div id="ember328483" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -392,7 +392,7 @@
               <div id="ember328486" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -406,7 +406,7 @@
               <div id="ember328489" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -419,7 +419,7 @@
               <div id="ember328492" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -432,17 +432,17 @@
               <div id="ember328495" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -594,7 +594,7 @@
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -778,7 +778,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -887,7 +887,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
           <a href="#toc_adding-the-rentalsfilter-provider-component">Adding the &lt;Rentals::Filter&gt; Provider Component</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -931,8 +931,8 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -976,6 +976,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.19.0/tutorial/part-1/working-with-data/index.html
+++ b/public/v3.19.0/tutorial/part-1/working-with-data/index.html
@@ -9,15 +9,15 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Working With Data - Part 1 - Ember Guides</title>
 
-  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -31,11 +31,11 @@ In this chapter, you will learn about:
   <meta property="og:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -50,11 +50,11 @@ In this chapter, you will learn about:
   <meta name="twitter:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -68,7 +68,7 @@ In this chapter, you will learn about:
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -112,7 +112,7 @@ In this chapter, you will learn about:
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember339912" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember339913" class="ds-dropdown-results ember-tether ember-view">
@@ -132,28 +132,28 @@ In this chapter, you will learn about:
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember339914" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.19 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember339914" class="ember-basic-dropdown-content-placeholder"></div>
@@ -174,7 +174,7 @@ In this chapter, you will learn about:
               <div id="ember339918" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -186,7 +186,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember339921" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="true">
             <div id="ember339922" class="cp-Panel cp-is-open ember-view">
@@ -197,7 +197,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember339924" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember339925" class="ember-view" data-test-toc-link="Introduction" href="/v3.19.0/tutorial/part-1/index">
@@ -270,11 +270,11 @@ In this chapter, you will learn about:
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,15 +287,15 @@ In this chapter, you will learn about:
               <div id="ember339937" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -309,7 +309,7 @@ In this chapter, you will learn about:
               <div id="ember339940" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -322,7 +322,7 @@ In this chapter, you will learn about:
               <div id="ember339943" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -335,7 +335,7 @@ In this chapter, you will learn about:
               <div id="ember339946" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -348,7 +348,7 @@ In this chapter, you will learn about:
               <div id="ember339949" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -361,7 +361,7 @@ In this chapter, you will learn about:
               <div id="ember339952" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -375,7 +375,7 @@ In this chapter, you will learn about:
               <div id="ember339955" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -388,7 +388,7 @@ In this chapter, you will learn about:
               <div id="ember339958" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -401,7 +401,7 @@ In this chapter, you will learn about:
               <div id="ember339961" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -414,7 +414,7 @@ In this chapter, you will learn about:
               <div id="ember339964" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -427,7 +427,7 @@ In this chapter, you will learn about:
               <div id="ember339967" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -441,7 +441,7 @@ In this chapter, you will learn about:
               <div id="ember339970" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -455,7 +455,7 @@ In this chapter, you will learn about:
               <div id="ember339973" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -468,7 +468,7 @@ In this chapter, you will learn about:
               <div id="ember339976" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -481,17 +481,17 @@ In this chapter, you will learn about:
               <div id="ember339979" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -806,7 +806,7 @@ In this chapter, you will learn about:
         <span class="token punctuation">}</span><span class="token punctuation">,</span>
         <span class="token property">"category"</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token property">"bedrooms"</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -949,7 +949,7 @@ In this chapter, you will learn about:
           <a href="#toc_loops-and-local-variables-in-templates-with-each">Loops and Local Variables in Templates with {{#each}}</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -993,8 +993,8 @@ In this chapter, you will learn about:
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1038,6 +1038,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.19.0/tutorial/part-2/provider-components/index.html
+++ b/public/v3.19.0/tutorial/part-2/provider-components/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Provider Components - Part 2 - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember340132" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember340133" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember340134" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.19 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember340134" class="ember-basic-dropdown-content-placeholder"></div>
@@ -153,7 +153,7 @@
               <div id="ember340138" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -165,7 +165,7 @@
               </a>
               <div id="ember340141" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="false">
             <div id="ember340142" class="cp-Panel cp-is-closed ember-view">
@@ -177,7 +177,7 @@
               <div id="ember340144" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -189,7 +189,7 @@
               </a>
               <div id="ember340147" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember340148" class="ember-view" data-test-toc-link="Introduction" href="/v3.19.0/tutorial/part-2/index">
@@ -234,19 +234,19 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -260,7 +260,7 @@
               <div id="ember340156" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -273,7 +273,7 @@
               <div id="ember340159" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -286,7 +286,7 @@
               <div id="ember340162" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -299,7 +299,7 @@
               <div id="ember340165" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -312,7 +312,7 @@
               <div id="ember340168" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -326,7 +326,7 @@
               <div id="ember340171" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@
               <div id="ember340174" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@
               <div id="ember340177" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@
               <div id="ember340180" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@
               <div id="ember340183" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -392,7 +392,7 @@
               <div id="ember340186" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -406,7 +406,7 @@
               <div id="ember340189" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -419,7 +419,7 @@
               <div id="ember340192" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -432,17 +432,17 @@
               <div id="ember340195" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -594,7 +594,7 @@
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -778,7 +778,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -887,7 +887,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
           <a href="#toc_adding-the-rentalsfilter-provider-component">Adding the &lt;Rentals::Filter&gt; Provider Component</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -931,8 +931,8 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -976,6 +976,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.2.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.2.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember191482" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember191483" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember191484" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.2 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember191484" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember191488" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember191491" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember191492" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.2.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember191506" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember191509" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember191512" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember191515" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember191518" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember191521" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember191524" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember191527" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember191530" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember191533" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember191536" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember191539" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember191542" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -619,7 +619,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1009,7 +1009,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1053,8 +1053,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1098,6 +1098,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.2.0/tutorial/ember-data/index.html
+++ b/public/v3.2.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember191689" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember191690" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember191691" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.2 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember191691" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember191695" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember191698" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember191699" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.2.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember191713" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember191716" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember191719" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember191722" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember191725" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember191728" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember191731" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember191734" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember191737" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember191740" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember191743" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember191746" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember191749" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.2/classes/D
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -613,7 +613,7 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
           <a href="#toc_setting-up-application-tests-to-use-mirage">Setting up Application Tests to use Mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -657,8 +657,8 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -702,6 +702,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.2.0/tutorial/installing-addons/index.html
+++ b/public/v3.2.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember191827" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember191828" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember191829" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.2 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember191829" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember191833" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember191836" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember191837" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.2.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember191851" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember191854" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember191857" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember191860" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember191863" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember191866" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember191869" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember191872" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember191875" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember191878" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember191881" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember191884" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember191887" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -536,7 +536,7 @@ Let's configure Mirage to send back our rentals that we had defined above by upd
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -635,7 +635,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -679,8 +679,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -724,6 +724,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.2.0/tutorial/model-hook/index.html
+++ b/public/v3.2.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember191896" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember191897" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember191898" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.2 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember191898" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember191902" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember191905" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember191906" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.2.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember191920" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember191923" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember191926" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember191929" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember191932" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember191935" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember191938" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember191941" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember191944" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember191947" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember191950" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember191953" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember191956" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -501,7 +501,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -613,7 +613,7 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
           <a href="#toc_application-testing-the-rental-list">Application Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -657,8 +657,8 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -702,6 +702,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.2.0/tutorial/subroutes/index.html
+++ b/public/v3.2.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember192172" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember192173" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember192174" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.2 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember192174" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember192178" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember192181" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember192182" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.2.0/tutorial/ember-cli">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember192196" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember192199" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember192202" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember192205" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember192208" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember192211" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember192214" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember192217" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember192220" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember192223" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember192226" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember192229" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember192232" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -643,7 +643,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -875,7 +875,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -919,8 +919,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -964,6 +964,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.20.0/tutorial/part-1/working-with-data/index.html
+++ b/public/v3.20.0/tutorial/part-1/working-with-data/index.html
@@ -9,15 +9,15 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Working With Data - Part 1 - Ember Guides</title>
 
-  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -31,11 +31,11 @@ In this chapter, you will learn about:
   <meta property="og:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -50,11 +50,11 @@ In this chapter, you will learn about:
   <meta name="twitter:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -68,7 +68,7 @@ In this chapter, you will learn about:
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -112,7 +112,7 @@ In this chapter, you will learn about:
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember351612" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember351613" class="ds-dropdown-results ember-tether ember-view">
@@ -132,28 +132,28 @@ In this chapter, you will learn about:
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember351614" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.20 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember351614" class="ember-basic-dropdown-content-placeholder"></div>
@@ -174,7 +174,7 @@ In this chapter, you will learn about:
               <div id="ember351618" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -186,7 +186,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember351621" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="true">
             <div id="ember351622" class="cp-Panel cp-is-open ember-view">
@@ -197,7 +197,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember351624" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember351625" class="ember-view" data-test-toc-link="Introduction" href="/v3.20.0/tutorial/part-1/index">
@@ -270,11 +270,11 @@ In this chapter, you will learn about:
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,15 +287,15 @@ In this chapter, you will learn about:
               <div id="ember351637" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -309,7 +309,7 @@ In this chapter, you will learn about:
               <div id="ember351640" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -322,7 +322,7 @@ In this chapter, you will learn about:
               <div id="ember351643" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -335,7 +335,7 @@ In this chapter, you will learn about:
               <div id="ember351646" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -348,7 +348,7 @@ In this chapter, you will learn about:
               <div id="ember351649" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -361,7 +361,7 @@ In this chapter, you will learn about:
               <div id="ember351652" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -375,7 +375,7 @@ In this chapter, you will learn about:
               <div id="ember351655" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -388,7 +388,7 @@ In this chapter, you will learn about:
               <div id="ember351658" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -401,7 +401,7 @@ In this chapter, you will learn about:
               <div id="ember351661" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -414,7 +414,7 @@ In this chapter, you will learn about:
               <div id="ember351664" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -427,7 +427,7 @@ In this chapter, you will learn about:
               <div id="ember351667" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -441,7 +441,7 @@ In this chapter, you will learn about:
               <div id="ember351670" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -455,7 +455,7 @@ In this chapter, you will learn about:
               <div id="ember351673" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -468,7 +468,7 @@ In this chapter, you will learn about:
               <div id="ember351676" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -481,17 +481,17 @@ In this chapter, you will learn about:
               <div id="ember351679" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -806,7 +806,7 @@ In this chapter, you will learn about:
         <span class="token punctuation">}</span><span class="token punctuation">,</span>
         <span class="token property">"category"</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token property">"bedrooms"</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -949,7 +949,7 @@ In this chapter, you will learn about:
           <a href="#toc_loops-and-local-variables-in-templates-with-each">Loops and Local Variables in Templates with {{#each}}</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -993,8 +993,8 @@ In this chapter, you will learn about:
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1038,6 +1038,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.20.0/tutorial/part-2/provider-components/index.html
+++ b/public/v3.20.0/tutorial/part-2/provider-components/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Provider Components - Part 2 - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember351832" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember351833" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember351834" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.20 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember351834" class="ember-basic-dropdown-content-placeholder"></div>
@@ -153,7 +153,7 @@
               <div id="ember351838" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -165,7 +165,7 @@
               </a>
               <div id="ember351841" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="false">
             <div id="ember351842" class="cp-Panel cp-is-closed ember-view">
@@ -177,7 +177,7 @@
               <div id="ember351844" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -189,7 +189,7 @@
               </a>
               <div id="ember351847" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember351848" class="ember-view" data-test-toc-link="Introduction" href="/v3.20.0/tutorial/part-2/index">
@@ -234,19 +234,19 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -260,7 +260,7 @@
               <div id="ember351856" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -273,7 +273,7 @@
               <div id="ember351859" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -286,7 +286,7 @@
               <div id="ember351862" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -299,7 +299,7 @@
               <div id="ember351865" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -312,7 +312,7 @@
               <div id="ember351868" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -326,7 +326,7 @@
               <div id="ember351871" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@
               <div id="ember351874" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@
               <div id="ember351877" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@
               <div id="ember351880" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@
               <div id="ember351883" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -392,7 +392,7 @@
               <div id="ember351886" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -406,7 +406,7 @@
               <div id="ember351889" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -419,7 +419,7 @@
               <div id="ember351892" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -432,17 +432,17 @@
               <div id="ember351895" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -594,7 +594,7 @@
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -778,7 +778,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -887,7 +887,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
           <a href="#toc_adding-the-rentalsfilter-provider-component">Adding the &lt;Rentals::Filter&gt; Provider Component</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -931,8 +931,8 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -976,6 +976,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.21.0/tutorial/part-1/working-with-data/index.html
+++ b/public/v3.21.0/tutorial/part-1/working-with-data/index.html
@@ -9,15 +9,15 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Working With Data - Part 1 - Ember Guides</title>
 
-  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -31,11 +31,11 @@ In this chapter, you will learn about:
   <meta property="og:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -50,11 +50,11 @@ In this chapter, you will learn about:
   <meta name="twitter:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -68,7 +68,7 @@ In this chapter, you will learn about:
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -112,7 +112,7 @@ In this chapter, you will learn about:
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember363312" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember363313" class="ds-dropdown-results ember-tether ember-view">
@@ -132,28 +132,28 @@ In this chapter, you will learn about:
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember363314" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.21 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember363314" class="ember-basic-dropdown-content-placeholder"></div>
@@ -174,7 +174,7 @@ In this chapter, you will learn about:
               <div id="ember363318" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -186,7 +186,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember363321" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="true">
             <div id="ember363322" class="cp-Panel cp-is-open ember-view">
@@ -197,7 +197,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember363324" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember363325" class="ember-view" data-test-toc-link="Introduction" href="/v3.21.0/tutorial/part-1/index">
@@ -270,11 +270,11 @@ In this chapter, you will learn about:
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,15 +287,15 @@ In this chapter, you will learn about:
               <div id="ember363337" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -309,7 +309,7 @@ In this chapter, you will learn about:
               <div id="ember363340" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -322,7 +322,7 @@ In this chapter, you will learn about:
               <div id="ember363343" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -335,7 +335,7 @@ In this chapter, you will learn about:
               <div id="ember363346" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -348,7 +348,7 @@ In this chapter, you will learn about:
               <div id="ember363349" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -361,7 +361,7 @@ In this chapter, you will learn about:
               <div id="ember363352" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -375,7 +375,7 @@ In this chapter, you will learn about:
               <div id="ember363355" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -388,7 +388,7 @@ In this chapter, you will learn about:
               <div id="ember363358" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -401,7 +401,7 @@ In this chapter, you will learn about:
               <div id="ember363361" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -414,7 +414,7 @@ In this chapter, you will learn about:
               <div id="ember363364" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -427,7 +427,7 @@ In this chapter, you will learn about:
               <div id="ember363367" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -441,7 +441,7 @@ In this chapter, you will learn about:
               <div id="ember363370" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -455,7 +455,7 @@ In this chapter, you will learn about:
               <div id="ember363373" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -468,7 +468,7 @@ In this chapter, you will learn about:
               <div id="ember363376" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -481,17 +481,17 @@ In this chapter, you will learn about:
               <div id="ember363379" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -806,7 +806,7 @@ In this chapter, you will learn about:
         <span class="token punctuation">}</span><span class="token punctuation">,</span>
         <span class="token property">"category"</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token property">"bedrooms"</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -949,7 +949,7 @@ In this chapter, you will learn about:
           <a href="#toc_loops-and-local-variables-in-templates-with-each">Loops and Local Variables in Templates with {{#each}}</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -993,8 +993,8 @@ In this chapter, you will learn about:
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1038,6 +1038,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.21.0/tutorial/part-2/provider-components/index.html
+++ b/public/v3.21.0/tutorial/part-2/provider-components/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Provider Components - Part 2 - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember363532" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember363533" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember363534" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.21 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember363534" class="ember-basic-dropdown-content-placeholder"></div>
@@ -153,7 +153,7 @@
               <div id="ember363538" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -165,7 +165,7 @@
               </a>
               <div id="ember363541" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="false">
             <div id="ember363542" class="cp-Panel cp-is-closed ember-view">
@@ -177,7 +177,7 @@
               <div id="ember363544" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -189,7 +189,7 @@
               </a>
               <div id="ember363547" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember363548" class="ember-view" data-test-toc-link="Introduction" href="/v3.21.0/tutorial/part-2/index">
@@ -234,19 +234,19 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -260,7 +260,7 @@
               <div id="ember363556" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -273,7 +273,7 @@
               <div id="ember363559" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -286,7 +286,7 @@
               <div id="ember363562" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -299,7 +299,7 @@
               <div id="ember363565" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -312,7 +312,7 @@
               <div id="ember363568" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -326,7 +326,7 @@
               <div id="ember363571" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@
               <div id="ember363574" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@
               <div id="ember363577" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@
               <div id="ember363580" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@
               <div id="ember363583" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -392,7 +392,7 @@
               <div id="ember363586" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -406,7 +406,7 @@
               <div id="ember363589" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -419,7 +419,7 @@
               <div id="ember363592" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -432,17 +432,17 @@
               <div id="ember363595" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -594,7 +594,7 @@
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -778,7 +778,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -887,7 +887,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
           <a href="#toc_adding-the-rentalsfilter-provider-component">Adding the &lt;Rentals::Filter&gt; Provider Component</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -931,8 +931,8 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -976,6 +976,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.22.0/tutorial/part-1/working-with-data/index.html
+++ b/public/v3.22.0/tutorial/part-1/working-with-data/index.html
@@ -9,15 +9,15 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Working With Data - Part 1 - Ember Guides</title>
 
-  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -31,11 +31,11 @@ In this chapter, you will learn about:
   <meta property="og:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -50,11 +50,11 @@ In this chapter, you will learn about:
   <meta name="twitter:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -68,7 +68,7 @@ In this chapter, you will learn about:
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -112,7 +112,7 @@ In this chapter, you will learn about:
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember375434" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember375435" class="ds-dropdown-results ember-tether ember-view">
@@ -132,28 +132,28 @@ In this chapter, you will learn about:
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember375436" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.22 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember375436" class="ember-basic-dropdown-content-placeholder"></div>
@@ -174,7 +174,7 @@ In this chapter, you will learn about:
               <div id="ember375440" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -186,7 +186,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember375443" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="true">
             <div id="ember375444" class="cp-Panel cp-is-open ember-view">
@@ -197,7 +197,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember375446" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember375447" class="ember-view" data-test-toc-link="Introduction" href="/v3.22.0/tutorial/part-1/index">
@@ -270,11 +270,11 @@ In this chapter, you will learn about:
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,15 +287,15 @@ In this chapter, you will learn about:
               <div id="ember375459" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -309,7 +309,7 @@ In this chapter, you will learn about:
               <div id="ember375462" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -322,7 +322,7 @@ In this chapter, you will learn about:
               <div id="ember375465" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -335,7 +335,7 @@ In this chapter, you will learn about:
               <div id="ember375468" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -348,7 +348,7 @@ In this chapter, you will learn about:
               <div id="ember375471" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -361,7 +361,7 @@ In this chapter, you will learn about:
               <div id="ember375474" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -375,7 +375,7 @@ In this chapter, you will learn about:
               <div id="ember375477" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -388,7 +388,7 @@ In this chapter, you will learn about:
               <div id="ember375480" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -401,7 +401,7 @@ In this chapter, you will learn about:
               <div id="ember375483" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -414,7 +414,7 @@ In this chapter, you will learn about:
               <div id="ember375486" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -427,7 +427,7 @@ In this chapter, you will learn about:
               <div id="ember375489" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -441,7 +441,7 @@ In this chapter, you will learn about:
               <div id="ember375492" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -454,7 +454,7 @@ In this chapter, you will learn about:
               <div id="ember375495" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -468,7 +468,7 @@ In this chapter, you will learn about:
               <div id="ember375498" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -481,7 +481,7 @@ In this chapter, you will learn about:
               <div id="ember375501" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -494,17 +494,17 @@ In this chapter, you will learn about:
               <div id="ember375504" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -819,7 +819,7 @@ In this chapter, you will learn about:
         <span class="token punctuation">}</span><span class="token punctuation">,</span>
         <span class="token property">"category"</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token property">"bedrooms"</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -962,7 +962,7 @@ In this chapter, you will learn about:
           <a href="#toc_loops-and-local-variables-in-templates-with-each">Loops and Local Variables in Templates with {{#each}}</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1006,8 +1006,8 @@ In this chapter, you will learn about:
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1051,6 +1051,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.22.0/tutorial/part-2/provider-components/index.html
+++ b/public/v3.22.0/tutorial/part-2/provider-components/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Provider Components - Part 2 - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember375663" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember375664" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember375665" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.22 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember375665" class="ember-basic-dropdown-content-placeholder"></div>
@@ -153,7 +153,7 @@
               <div id="ember375669" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -165,7 +165,7 @@
               </a>
               <div id="ember375672" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="false">
             <div id="ember375673" class="cp-Panel cp-is-closed ember-view">
@@ -177,7 +177,7 @@
               <div id="ember375675" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -189,7 +189,7 @@
               </a>
               <div id="ember375678" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember375679" class="ember-view" data-test-toc-link="Introduction" href="/v3.22.0/tutorial/part-2/index">
@@ -234,19 +234,19 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -260,7 +260,7 @@
               <div id="ember375687" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -273,7 +273,7 @@
               <div id="ember375690" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -286,7 +286,7 @@
               <div id="ember375693" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -299,7 +299,7 @@
               <div id="ember375696" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -312,7 +312,7 @@
               <div id="ember375699" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -326,7 +326,7 @@
               <div id="ember375702" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@
               <div id="ember375705" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@
               <div id="ember375708" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@
               <div id="ember375711" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@
               <div id="ember375714" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -392,7 +392,7 @@
               <div id="ember375717" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -405,7 +405,7 @@
               <div id="ember375720" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -419,7 +419,7 @@
               <div id="ember375723" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -432,7 +432,7 @@
               <div id="ember375726" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -445,17 +445,17 @@
               <div id="ember375729" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -607,7 +607,7 @@
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -791,7 +791,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -900,7 +900,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
           <a href="#toc_adding-the-rentalsfilter-provider-component">Adding the &lt;Rentals::Filter&gt; Provider Component</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -944,8 +944,8 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -989,6 +989,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.23.0/tutorial/part-1/working-with-data/index.html
+++ b/public/v3.23.0/tutorial/part-1/working-with-data/index.html
@@ -9,15 +9,15 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Working With Data - Part 1 - Ember Guides</title>
 
-  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -31,11 +31,11 @@ In this chapter, you will learn about:
   <meta property="og:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -50,11 +50,11 @@ In this chapter, you will learn about:
   <meta name="twitter:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -68,7 +68,7 @@ In this chapter, you will learn about:
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -112,7 +112,7 @@ In this chapter, you will learn about:
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember387613" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember387614" class="ds-dropdown-results ember-tether ember-view">
@@ -132,28 +132,28 @@ In this chapter, you will learn about:
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember387615" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.23 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember387615" class="ember-basic-dropdown-content-placeholder"></div>
@@ -174,7 +174,7 @@ In this chapter, you will learn about:
               <div id="ember387619" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -186,7 +186,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember387622" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="true">
             <div id="ember387623" class="cp-Panel cp-is-open ember-view">
@@ -197,7 +197,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember387625" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember387626" class="ember-view" data-test-toc-link="Introduction" href="/v3.23.0/tutorial/part-1/index">
@@ -270,11 +270,11 @@ In this chapter, you will learn about:
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,15 +287,15 @@ In this chapter, you will learn about:
               <div id="ember387638" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -309,7 +309,7 @@ In this chapter, you will learn about:
               <div id="ember387641" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -322,7 +322,7 @@ In this chapter, you will learn about:
               <div id="ember387644" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -335,7 +335,7 @@ In this chapter, you will learn about:
               <div id="ember387647" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -348,7 +348,7 @@ In this chapter, you will learn about:
               <div id="ember387650" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -361,7 +361,7 @@ In this chapter, you will learn about:
               <div id="ember387653" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -375,7 +375,7 @@ In this chapter, you will learn about:
               <div id="ember387656" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -388,7 +388,7 @@ In this chapter, you will learn about:
               <div id="ember387659" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -401,7 +401,7 @@ In this chapter, you will learn about:
               <div id="ember387662" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -414,7 +414,7 @@ In this chapter, you will learn about:
               <div id="ember387665" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -427,7 +427,7 @@ In this chapter, you will learn about:
               <div id="ember387668" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -441,7 +441,7 @@ In this chapter, you will learn about:
               <div id="ember387671" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -454,7 +454,7 @@ In this chapter, you will learn about:
               <div id="ember387674" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -468,7 +468,7 @@ In this chapter, you will learn about:
               <div id="ember387677" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -481,7 +481,7 @@ In this chapter, you will learn about:
               <div id="ember387680" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -494,17 +494,17 @@ In this chapter, you will learn about:
               <div id="ember387683" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -819,7 +819,7 @@ In this chapter, you will learn about:
         <span class="token punctuation">}</span><span class="token punctuation">,</span>
         <span class="token property">"category"</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token property">"bedrooms"</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -962,7 +962,7 @@ In this chapter, you will learn about:
           <a href="#toc_loops-and-local-variables-in-templates-with-each">Loops and Local Variables in Templates with {{#each}}</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1006,8 +1006,8 @@ In this chapter, you will learn about:
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1051,6 +1051,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.23.0/tutorial/part-2/provider-components/index.html
+++ b/public/v3.23.0/tutorial/part-2/provider-components/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Provider Components - Part 2 - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember387842" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember387843" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember387844" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.23 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember387844" class="ember-basic-dropdown-content-placeholder"></div>
@@ -153,7 +153,7 @@
               <div id="ember387848" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -165,7 +165,7 @@
               </a>
               <div id="ember387851" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="false">
             <div id="ember387852" class="cp-Panel cp-is-closed ember-view">
@@ -177,7 +177,7 @@
               <div id="ember387854" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -189,7 +189,7 @@
               </a>
               <div id="ember387857" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember387858" class="ember-view" data-test-toc-link="Introduction" href="/v3.23.0/tutorial/part-2/index">
@@ -234,19 +234,19 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -260,7 +260,7 @@
               <div id="ember387866" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -273,7 +273,7 @@
               <div id="ember387869" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -286,7 +286,7 @@
               <div id="ember387872" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -299,7 +299,7 @@
               <div id="ember387875" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -312,7 +312,7 @@
               <div id="ember387878" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -326,7 +326,7 @@
               <div id="ember387881" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@
               <div id="ember387884" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@
               <div id="ember387887" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@
               <div id="ember387890" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@
               <div id="ember387893" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -392,7 +392,7 @@
               <div id="ember387896" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -405,7 +405,7 @@
               <div id="ember387899" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -419,7 +419,7 @@
               <div id="ember387902" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -432,7 +432,7 @@
               <div id="ember387905" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -445,17 +445,17 @@
               <div id="ember387908" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -607,7 +607,7 @@
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -791,7 +791,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span>
       <span class="token punctuation">{</span>
@@ -900,7 +900,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
           <a href="#toc_adding-the-rentalsfilter-provider-component">Adding the &lt;Rentals::Filter&gt; Provider Component</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -944,8 +944,8 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -989,6 +989,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.24.0/tutorial/part-1/working-with-data/index.html
+++ b/public/v3.24.0/tutorial/part-1/working-with-data/index.html
@@ -9,15 +9,15 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Working With Data - Part 1 - Ember Guides</title>
 
-  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -31,11 +31,11 @@ In this chapter, you will learn about:
   <meta property="og:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta property="og:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -50,11 +50,11 @@ In this chapter, you will learn about:
   <meta name="twitter:title" content="Working With Data - Part 1 - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server: 
+  <meta name="twitter:description" content="In this chapter, we will remove the hard-coded data from our <Rental> component. By the end, your app would finally be displaying real data that came from the server:
 
- 
 
-In this chapter, you will learn about: 
+
+In this chapter, you will learn about:
 
 - Working with route files
 - Returning local...">
@@ -68,7 +68,7 @@ In this chapter, you will learn about:
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -112,7 +112,7 @@ In this chapter, you will learn about:
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember399792" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember399793" class="ds-dropdown-results ember-tether ember-view">
@@ -132,28 +132,28 @@ In this chapter, you will learn about:
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember399794" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.24 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember399794" class="ember-basic-dropdown-content-placeholder"></div>
@@ -174,7 +174,7 @@ In this chapter, you will learn about:
               <div id="ember399798" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -186,7 +186,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember399801" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="true">
             <div id="ember399802" class="cp-Panel cp-is-open ember-view">
@@ -197,7 +197,7 @@ In this chapter, you will learn about:
               </a>
               <div id="ember399804" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember399805" class="ember-view" data-test-toc-link="Introduction" href="/v3.24.0/tutorial/part-1/index">
@@ -270,11 +270,11 @@ In this chapter, you will learn about:
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,15 +287,15 @@ In this chapter, you will learn about:
               <div id="ember399817" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -309,7 +309,7 @@ In this chapter, you will learn about:
               <div id="ember399820" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -322,7 +322,7 @@ In this chapter, you will learn about:
               <div id="ember399823" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -335,7 +335,7 @@ In this chapter, you will learn about:
               <div id="ember399826" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -348,7 +348,7 @@ In this chapter, you will learn about:
               <div id="ember399829" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -361,7 +361,7 @@ In this chapter, you will learn about:
               <div id="ember399832" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -375,7 +375,7 @@ In this chapter, you will learn about:
               <div id="ember399835" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -388,7 +388,7 @@ In this chapter, you will learn about:
               <div id="ember399838" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -401,7 +401,7 @@ In this chapter, you will learn about:
               <div id="ember399841" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -414,7 +414,7 @@ In this chapter, you will learn about:
               <div id="ember399844" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -427,7 +427,7 @@ In this chapter, you will learn about:
               <div id="ember399847" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -441,7 +441,7 @@ In this chapter, you will learn about:
               <div id="ember399850" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -454,7 +454,7 @@ In this chapter, you will learn about:
               <div id="ember399853" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -468,7 +468,7 @@ In this chapter, you will learn about:
               <div id="ember399856" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -481,7 +481,7 @@ In this chapter, you will learn about:
               <div id="ember399859" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -494,17 +494,17 @@ In this chapter, you will learn about:
               <div id="ember399862" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -821,7 +821,7 @@ In this chapter, you will learn about:
         <span class="token punctuation">}</span><span class="token punctuation">,</span>
         <span class="token property">"category"</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token property">"bedrooms"</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token property">"image"</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -961,7 +961,7 @@ In this chapter, you will learn about:
           <a href="#toc_loops-and-local-variables-in-templates-with-each">Loops and Local Variables in Templates with {{#each}}</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1005,8 +1005,8 @@ In this chapter, you will learn about:
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1050,6 +1050,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.24.0/tutorial/part-2/provider-components/index.html
+++ b/public/v3.24.0/tutorial/part-2/provider-components/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Provider Components - Part 2 - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember400021" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember400022" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember400023" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.24 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember400023" class="ember-basic-dropdown-content-placeholder"></div>
@@ -153,7 +153,7 @@
               <div id="ember400027" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -165,7 +165,7 @@
               </a>
               <div id="ember400030" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
           <li class="toc-item toc-group" aria-expanded="false">
             <div id="ember400031" class="cp-Panel cp-is-closed ember-view">
@@ -177,7 +177,7 @@
               <div id="ember400033" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -189,7 +189,7 @@
               </a>
               <div id="ember400036" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember400037" class="ember-view" data-test-toc-link="Introduction" href="/v3.24.0/tutorial/part-2/index">
@@ -234,19 +234,19 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
 </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Core Concepts</li>
@@ -260,7 +260,7 @@
               <div id="ember400045" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -273,7 +273,7 @@
               <div id="ember400048" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -286,7 +286,7 @@
               <div id="ember400051" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -299,7 +299,7 @@
               <div id="ember400054" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -312,7 +312,7 @@
               <div id="ember400057" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Application Development</li>
@@ -326,7 +326,7 @@
               <div id="ember400060" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@
               <div id="ember400063" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@
               <div id="ember400066" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@
               <div id="ember400069" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@
               <div id="ember400072" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Developer Tools</li>
@@ -392,7 +392,7 @@
               <div id="ember400075" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -405,7 +405,7 @@
               <div id="ember400078" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
         <li class="toc-heading">Additional Resources</li>
@@ -419,7 +419,7 @@
               <div id="ember400081" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -432,7 +432,7 @@
               <div id="ember400084" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -445,17 +445,17 @@
               <div id="ember400087" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -612,7 +612,7 @@
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
           <span class="token literal-property property">image</span><span class="token operator">:</span>
-            <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+            <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">description</span><span class="token operator">:</span>
             <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span><span class="token punctuation">,</span>
         <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -812,7 +812,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
           <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'Community'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
           <span class="token literal-property property">image</span><span class="token operator">:</span>
-            <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+            <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">description</span><span class="token operator">:</span>
             <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span><span class="token punctuation">,</span>
         <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -933,7 +933,7 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
           <a href="#toc_adding-the-rentalsfilter-provider-component">Adding the &lt;Rentals::Filter&gt; Provider Component</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -977,8 +977,8 @@ Just as we can create a variable like <code>let banana = ...</code>, and then ha
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1022,6 +1022,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.3.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.3.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember198220" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember198221" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember198222" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.3 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember198222" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember198226" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember198229" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember198230" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.3.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember198244" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember198247" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember198250" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember198253" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember198256" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember198259" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember198262" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember198265" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember198268" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember198271" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember198274" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember198277" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember198280" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -619,7 +619,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1009,7 +1009,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1053,8 +1053,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1098,6 +1098,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.3.0/tutorial/ember-data/index.html
+++ b/public/v3.3.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember198427" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember198428" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember198429" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.3 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember198429" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember198433" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember198436" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember198437" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.3.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember198451" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember198454" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember198457" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember198460" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember198463" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember198466" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember198469" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember198472" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember198475" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember198478" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember198481" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember198484" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember198487" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.3/classes/D
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -613,7 +613,7 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
           <a href="#toc_setting-up-application-tests-to-use-mirage">Setting up Application Tests to use Mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -657,8 +657,8 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -702,6 +702,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.3.0/tutorial/installing-addons/index.html
+++ b/public/v3.3.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember198565" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember198566" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember198567" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.3 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember198567" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember198571" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember198574" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember198575" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.3.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember198589" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember198592" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember198595" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember198598" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember198601" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember198604" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember198607" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember198610" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember198613" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember198616" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember198619" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember198622" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember198625" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -536,7 +536,7 @@ Let's configure Mirage to send back our rentals that we had defined above by upd
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
         <span class="token literal-property property">type</span><span class="token operator">:</span> <span class="token string">'rentals'</span><span class="token punctuation">,</span>
@@ -635,7 +635,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -679,8 +679,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -724,6 +724,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.3.0/tutorial/model-hook/index.html
+++ b/public/v3.3.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember198634" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember198635" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember198636" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.3 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember198636" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember198640" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember198643" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember198644" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.3.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember198658" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember198661" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember198664" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember198667" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember198670" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember198673" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember198676" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember198679" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember198682" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember198685" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember198688" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember198691" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember198694" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -501,7 +501,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -613,7 +613,7 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
           <a href="#toc_application-testing-the-rental-list">Application Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -657,8 +657,8 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -702,6 +702,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.3.0/tutorial/subroutes/index.html
+++ b/public/v3.3.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember198910" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember198911" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember198912" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.3 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember198912" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember198916" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember198919" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember198920" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.3.0/tutorial/ember-cli">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember198934" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember198937" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember198940" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember198943" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember198946" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember198949" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember198952" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember198955" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember198958" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember198961" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember198964" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember198967" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember198970" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -643,7 +643,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -875,7 +875,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -919,8 +919,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -964,6 +964,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.4.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.4.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember205025" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember205026" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember205027" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.4 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember205027" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember205031" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember205034" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember205035" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.4.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember205049" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember205052" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember205055" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember205058" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember205061" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember205064" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember205067" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember205070" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember205073" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember205076" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember205079" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember205082" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember205085" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -620,7 +620,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1010,7 +1010,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1054,8 +1054,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1099,6 +1099,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.4.0/tutorial/ember-data/index.html
+++ b/public/v3.4.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember205232" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember205233" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember205234" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.4 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember205234" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember205238" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember205241" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember205242" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.4.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember205256" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember205259" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember205262" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember205265" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember205268" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember205271" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember205274" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember205277" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember205280" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember205283" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember205286" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember205289" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember205292" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.4/classes/D
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -613,7 +613,7 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
           <a href="#toc_setting-up-application-tests-to-use-mirage">Setting up Application Tests to use Mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -657,8 +657,8 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -702,6 +702,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.4.0/tutorial/installing-addons/index.html
+++ b/public/v3.4.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember205370" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember205371" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember205372" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.4 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember205372" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember205376" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember205379" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember205380" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.4.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember205394" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember205397" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember205400" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember205403" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember205406" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember205409" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember205412" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember205415" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember205418" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember205421" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember205424" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember205427" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember205430" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -537,7 +537,7 @@ Let's configure Mirage to send back our rentals that we had defined above by upd
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -638,7 +638,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -682,8 +682,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -727,6 +727,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.4.0/tutorial/model-hook/index.html
+++ b/public/v3.4.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember205439" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember205440" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember205441" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.4 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember205441" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember205445" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember205448" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember205449" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.4.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember205463" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember205466" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember205469" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember205472" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember205475" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember205478" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember205481" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember205484" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember205487" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember205490" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember205493" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember205496" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember205499" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -501,7 +501,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -607,7 +607,7 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
           <a href="#toc_application-testing-the-rental-list">Application Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -651,8 +651,8 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -696,6 +696,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.4.0/tutorial/subroutes/index.html
+++ b/public/v3.4.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember205715" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember205716" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember205717" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.4 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember205717" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember205721" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember205724" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember205725" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.4.0/tutorial/ember-cli">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember205739" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember205742" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember205745" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember205748" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember205751" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember205754" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember205757" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember205760" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember205763" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember205766" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember205769" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember205772" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember205775" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -643,7 +643,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -875,7 +875,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -919,8 +919,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -964,6 +964,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.5.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.5.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember211830" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember211831" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember211832" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.5 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember211832" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember211836" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember211839" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember211840" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.5.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember211854" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember211857" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember211860" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember211863" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember211866" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember211869" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember211872" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember211875" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember211878" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember211881" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember211884" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember211887" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember211890" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -623,7 +623,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1013,7 +1013,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1057,8 +1057,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1102,6 +1102,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.5.0/tutorial/ember-data/index.html
+++ b/public/v3.5.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember212037" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember212038" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember212039" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.5 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember212039" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember212043" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember212046" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember212047" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.5.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember212061" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember212064" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember212067" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember212070" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember212073" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember212076" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember212079" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember212082" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember212085" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember212088" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember212091" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember212094" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember212097" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.5/classes/D
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -613,7 +613,7 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
           <a href="#toc_setting-up-application-tests-to-use-mirage">Setting up Application Tests to use Mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -657,8 +657,8 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -702,6 +702,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.5.0/tutorial/installing-addons/index.html
+++ b/public/v3.5.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember212175" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember212176" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember212177" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.5 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember212177" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember212181" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember212184" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember212185" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.5.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember212199" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember212202" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember212205" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember212208" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember212211" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember212214" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember212217" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember212220" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember212223" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember212226" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember212229" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember212232" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember212235" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -543,7 +543,7 @@ For example, the data we are providing below will be substituted when a request 
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -644,7 +644,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -688,8 +688,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -733,6 +733,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.5.0/tutorial/model-hook/index.html
+++ b/public/v3.5.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember212244" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember212245" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember212246" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.5 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember212246" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember212250" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember212253" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember212254" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.5.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember212268" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember212271" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember212274" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember212277" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember212280" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember212283" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember212286" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember212289" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember212292" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember212295" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember212298" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember212301" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember212304" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -501,7 +501,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -609,7 +609,7 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
           <a href="#toc_application-testing-the-rental-list">Application Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -653,8 +653,8 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -698,6 +698,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.5.0/tutorial/subroutes/index.html
+++ b/public/v3.5.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember212520" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember212521" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember212522" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.5 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember212522" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember212526" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember212529" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember212530" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.5.0/tutorial/ember-cli">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember212544" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember212547" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember212550" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember212553" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember212556" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember212559" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember212562" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember212565" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember212568" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember212571" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember212574" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember212577" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember212580" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -643,7 +643,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -886,7 +886,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -930,8 +930,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -975,6 +975,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.6.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.6.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember218635" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember218636" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember218637" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.6 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember218637" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember218641" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember218644" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember218645" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.6.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember218659" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember218662" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember218665" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember218668" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember218671" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember218674" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember218677" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember218680" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember218683" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember218686" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember218689" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember218692" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember218695" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -623,7 +623,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1013,7 +1013,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1057,8 +1057,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1102,6 +1102,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.6.0/tutorial/ember-data/index.html
+++ b/public/v3.6.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember218842" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember218843" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember218844" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.6 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember218844" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember218848" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember218851" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember218852" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.6.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember218866" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember218869" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember218872" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember218875" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember218878" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember218881" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember218884" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember218887" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember218890" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember218893" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember218896" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember218899" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,17 +424,17 @@
               <div id="ember218902" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -530,7 +530,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.6/classes/D
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -613,7 +613,7 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
           <a href="#toc_setting-up-application-tests-to-use-mirage">Setting up Application Tests to use Mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -657,8 +657,8 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -702,6 +702,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.6.0/tutorial/installing-addons/index.html
+++ b/public/v3.6.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember218980" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember218981" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember218982" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.6 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember218982" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember218986" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember218989" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember218990" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.6.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember219004" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember219007" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember219010" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember219013" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember219016" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember219019" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember219022" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember219025" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember219028" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember219031" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember219034" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember219037" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember219040" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -543,7 +543,7 @@ For example, the data we are providing below will be substituted when a request 
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -644,7 +644,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -688,8 +688,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -733,6 +733,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.6.0/tutorial/model-hook/index.html
+++ b/public/v3.6.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember219049" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember219050" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember219051" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.6 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember219051" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember219055" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember219058" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember219059" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.6.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember219073" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember219076" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember219079" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember219082" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember219085" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember219088" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember219091" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember219094" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember219097" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember219100" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember219103" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember219106" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,17 +430,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember219109" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -501,7 +501,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -609,7 +609,7 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
           <a href="#toc_application-testing-the-rental-list">Application Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -653,8 +653,8 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -698,6 +698,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.6.0/tutorial/subroutes/index.html
+++ b/public/v3.6.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember219325" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember219326" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember219327" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.6 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember219327" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember219331" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember219334" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember219335" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.6.0/tutorial/ember-cli">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember219349" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember219352" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember219355" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember219358" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember219361" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember219364" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember219367" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember219370" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember219373" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember219376" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember219379" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember219382" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,17 +436,17 @@
               <div id="ember219385" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -643,7 +643,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -886,7 +886,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -930,8 +930,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -975,6 +975,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.7.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.7.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember225840" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember225841" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember225842" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.7 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember225842" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember225846" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember225849" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember225850" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.7.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember225864" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember225867" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember225870" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember225873" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember225876" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember225879" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember225882" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember225885" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember225888" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember225891" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember225894" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember225897" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember225900" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,17 +437,17 @@
               <div id="ember225903" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -636,7 +636,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1026,7 +1026,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1070,8 +1070,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1115,6 +1115,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.7.0/tutorial/ember-data/index.html
+++ b/public/v3.7.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember226056" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember226057" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember226058" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.7 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember226058" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember226062" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember226065" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember226066" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.7.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember226080" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember226083" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember226086" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember226089" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember226092" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember226095" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember226098" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember226101" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember226104" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember226107" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember226110" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember226113" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember226116" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,17 +437,17 @@
               <div id="ember226119" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -543,7 +543,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.7/classes/D
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -626,7 +626,7 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
           <a href="#toc_setting-up-application-tests-to-use-mirage">Setting up Application Tests to use Mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -670,8 +670,8 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -715,6 +715,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.7.0/tutorial/installing-addons/index.html
+++ b/public/v3.7.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember226200" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember226201" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember226202" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.7 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember226202" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226206" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember226209" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember226210" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.7.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226224" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226227" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226230" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226233" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226236" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226239" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226242" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226245" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226248" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226251" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226254" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226257" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226260" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,17 +443,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember226263" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -556,7 +556,7 @@ For example, the data we are providing below will be substituted when a request 
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -657,7 +657,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -701,8 +701,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -746,6 +746,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.7.0/tutorial/model-hook/index.html
+++ b/public/v3.7.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember226272" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember226273" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember226274" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.7 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember226274" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226278" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember226281" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember226282" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.7.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226296" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226299" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226302" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226305" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226308" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226311" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226314" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226317" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226320" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226323" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226326" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226329" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226332" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,17 +443,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember226335" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -514,7 +514,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -622,7 +622,7 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
           <a href="#toc_application-testing-the-rental-list">Application Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -666,8 +666,8 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -711,6 +711,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.7.0/tutorial/subroutes/index.html
+++ b/public/v3.7.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember226560" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember226561" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember226562" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.7 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember226562" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember226566" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember226569" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember226570" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.7.0/tutorial/ember-cli">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember226584" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember226587" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember226590" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember226593" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember226596" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember226599" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember226602" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember226605" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember226608" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember226611" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember226614" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember226617" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,7 +436,7 @@
               <div id="ember226620" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -449,17 +449,17 @@
               <div id="ember226623" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -656,7 +656,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -899,7 +899,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -943,8 +943,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -988,6 +988,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.8.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.8.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember233078" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember233079" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember233080" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.8 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember233080" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember233084" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember233087" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember233088" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.8.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember233102" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember233105" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember233108" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember233111" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember233114" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember233117" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember233120" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember233123" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember233126" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember233129" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember233132" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember233135" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember233138" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,17 +437,17 @@
               <div id="ember233141" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -636,7 +636,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1032,7 +1032,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1076,8 +1076,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1121,6 +1121,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.8.0/tutorial/ember-data/index.html
+++ b/public/v3.8.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember233294" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember233295" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember233296" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.8 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember233296" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember233300" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember233303" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember233304" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.8.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember233318" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember233321" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember233324" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember233327" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember233330" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember233333" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember233336" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember233339" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember233342" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember233345" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember233348" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember233351" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember233354" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,17 +437,17 @@
               <div id="ember233357" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -543,7 +543,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.8/classes/D
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -626,7 +626,7 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
           <a href="#toc_setting-up-application-tests-to-use-mirage">Setting up Application Tests to use Mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -670,8 +670,8 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -715,6 +715,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.8.0/tutorial/installing-addons/index.html
+++ b/public/v3.8.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember233438" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember233439" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember233440" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.8 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember233440" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233444" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember233447" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember233448" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.8.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233462" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233465" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233468" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233471" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233474" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233477" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233480" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233483" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233486" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233489" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233492" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233495" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233498" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,17 +443,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember233501" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -556,7 +556,7 @@ For example, the data we are providing below will be substituted when a request 
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -657,7 +657,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -701,8 +701,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -746,6 +746,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.8.0/tutorial/model-hook/index.html
+++ b/public/v3.8.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember233510" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember233511" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember233512" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.8 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember233512" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233516" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember233519" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember233520" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.8.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233534" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233537" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233540" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233543" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233546" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233549" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233552" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233555" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233558" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233561" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233564" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233567" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233570" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,17 +443,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember233573" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -514,7 +514,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -622,7 +622,7 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
           <a href="#toc_application-testing-the-rental-list">Application Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -666,8 +666,8 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -711,6 +711,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.8.0/tutorial/subroutes/index.html
+++ b/public/v3.8.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember233798" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember233799" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember233800" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.8 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember233800" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember233804" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember233807" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember233808" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.8.0/tutorial/ember-cli">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember233822" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember233825" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember233828" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember233831" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember233834" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember233837" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember233840" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember233843" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember233846" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember233849" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember233852" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember233855" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,7 +436,7 @@
               <div id="ember233858" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -449,17 +449,17 @@
               <div id="ember233861" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -657,7 +657,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -900,7 +900,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -944,8 +944,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -989,6 +989,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.9.0/tutorial/autocomplete-component/index.html
+++ b/public/v3.9.0/tutorial/autocomplete-component/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Building a Complex Component - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember240456" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember240457" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember240458" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.9 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember240458" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember240462" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember240465" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember240466" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.9.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember240480" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember240483" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember240486" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember240489" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember240492" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember240495" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember240498" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember240501" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember240504" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember240507" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember240510" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember240513" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember240516" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,17 +437,17 @@
               <div id="ember240519" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -636,7 +636,7 @@ Instead of simply returning the list of rentals, our Mirage HTTP GET handler for
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -1023,7 +1023,7 @@ and the item displayed shows "Seattle" as the location.</p>
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -1067,8 +1067,8 @@ and the item displayed shows "Seattle" as the location.</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -1112,6 +1112,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.9.0/tutorial/ember-data/index.html
+++ b/public/v3.9.0/tutorial/ember-data/index.html
@@ -9,7 +9,7 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Using Ember Data - Tutorial - Ember Guides</title>
 
@@ -47,7 +47,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -91,7 +91,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember240672" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember240673" class="ds-dropdown-results ember-tether ember-view">
@@ -111,28 +111,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember240674" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.9 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember240674" class="ember-basic-dropdown-content-placeholder"></div>
@@ -152,7 +152,7 @@
               <div id="ember240678" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -164,7 +164,7 @@
               </a>
               <div id="ember240681" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember240682" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.9.0/tutorial/ember-cli">
@@ -251,11 +251,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -268,7 +268,7 @@
               <div id="ember240696" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -281,7 +281,7 @@
               <div id="ember240699" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -294,7 +294,7 @@
               <div id="ember240702" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -307,7 +307,7 @@
               <div id="ember240705" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -320,7 +320,7 @@
               <div id="ember240708" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -333,7 +333,7 @@
               <div id="ember240711" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -346,7 +346,7 @@
               <div id="ember240714" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -359,7 +359,7 @@
               <div id="ember240717" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -372,7 +372,7 @@
               <div id="ember240720" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -385,7 +385,7 @@
               <div id="ember240723" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -398,7 +398,7 @@
               <div id="ember240726" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -411,7 +411,7 @@
               <div id="ember240729" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -424,7 +424,7 @@
               <div id="ember240732" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -437,17 +437,17 @@
               <div id="ember240735" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -542,7 +542,7 @@ In this case, call the <a href="https://api.emberjs.com/ember-data/3.9/classes/D
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -625,7 +625,7 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
           <a href="#toc_setting-up-application-tests-to-use-mirage">Setting up Application Tests to use Mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -669,8 +669,8 @@ Now that we've hooked in Ember Data, which by default attempts to fetch data via
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -714,6 +714,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.9.0/tutorial/installing-addons/index.html
+++ b/public/v3.9.0/tutorial/installing-addons/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Installing Addons - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -26,7 +26,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta property="og:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta property="og:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -40,7 +40,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <meta name="twitter:title" content="Installing Addons - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project. 
+  <meta name="twitter:description" content="Ember has a rich ecosystem of addons that can be easily added to projects. Addons provide a wide range of functionality to projects, often saving time and letting you focus on your project.
 
 To browse addons, visit the Ember Observer website. It catalogs...">
 
@@ -53,7 +53,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember240816" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember240817" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ To browse addons, visit the Ember Observer website. It catalogs...">
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember240818" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.9 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember240818" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240822" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               </a>
               <div id="ember240825" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember240826" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.9.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ To browse addons, visit the Ember Observer website. It catalogs...">
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240840" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240843" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240846" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240849" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240852" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240855" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240858" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240861" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240864" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240867" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240870" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240873" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240876" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,17 +443,17 @@ To browse addons, visit the Ember Observer website. It catalogs...">
               <div id="ember240879" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -556,7 +556,7 @@ For example, the data we are providing below will be substituted when a request 
           <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+          <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
           <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
         <span class="token punctuation">}</span>
       <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
@@ -657,7 +657,7 @@ For now, let's generate an adapter for our application:</p>
           <a href="#toc_ember-cli-mirage">ember-cli-mirage</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -701,8 +701,8 @@ For now, let's generate an adapter for our application:</p>
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -746,6 +746,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.9.0/tutorial/model-hook/index.html
+++ b/public/v3.9.0/tutorial/model-hook/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>The Model Hook - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -26,7 +26,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta property="og:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta property="og:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -40,7 +40,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <meta name="twitter:title" content="The Model Hook - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created. 
+  <meta name="twitter:description" content="Now, let's add a list of available rentals to the rentals page we've just created.
 
 Ember keeps data for a page in an object called a model. To keep things simple at first, we'll populate the model for our rental listing page to use a hard-coded array of...">
 
@@ -53,7 +53,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -97,7 +97,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember240888" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember240889" class="ds-dropdown-results ember-tether ember-view">
@@ -117,28 +117,28 @@ Ember keeps data for a page in an object called a model. To keep things simple a
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember240890" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.9 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember240890" class="ember-basic-dropdown-content-placeholder"></div>
@@ -158,7 +158,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240894" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -170,7 +170,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               </a>
               <div id="ember240897" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember240898" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.9.0/tutorial/ember-cli">
@@ -257,11 +257,11 @@ Ember keeps data for a page in an object called a model. To keep things simple a
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -274,7 +274,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240912" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -287,7 +287,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240915" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -300,7 +300,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240918" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -313,7 +313,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240921" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -326,7 +326,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240924" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -339,7 +339,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240927" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -352,7 +352,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240930" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -365,7 +365,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240933" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -378,7 +378,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240936" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -391,7 +391,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240939" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -404,7 +404,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240942" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -417,7 +417,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240945" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -430,7 +430,7 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240948" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -443,17 +443,17 @@ Ember keeps data for a page in an object called a model. To keep things simple a
               <div id="ember240951" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -514,7 +514,7 @@ The model function we've added to our <code>rentals</code> route handler will be
       <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">'Seattle'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">'Condo'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg'</span><span class="token punctuation">,</span>
+      <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">'https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg'</span><span class="token punctuation">,</span>
       <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">'A commuters dream. This rental is within walking distance of 2 bus stops and the Metro.'</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
       <span class="token literal-property property">id</span><span class="token operator">:</span> <span class="token string">'downtown-charm'</span><span class="token punctuation">,</span>
@@ -622,7 +622,7 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
           <a href="#toc_application-testing-the-rental-list">Application Testing the Rental List</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -666,8 +666,8 @@ This leaves us with 2 remaining application test failures (and 1 ESLint failure)
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -711,6 +711,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>

--- a/public/v3.9.0/tutorial/subroutes/index.html
+++ b/public/v3.9.0/tutorial/subroutes/index.html
@@ -9,11 +9,11 @@
     <meta name="twitter:site" content="@emberjs" />
     <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
-    
+
 <meta name="ember-guides/config/environment" content="%7B%22modulePrefix%22%3A%22ember-guides%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22locationType%22%3A%22trailing-history%22%2C%22historySupportMiddleware%22%3Atrue%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22APP%22%3A%7B%7D%2C%22ember-meta%22%3A%7B%22description%22%3A%22Ember.js%20helps%20developers%20be%20more%20productive%20out%20of%20the%20box.%20Designed%20with%20developer%20ergonomics%20in%20mind%2C%20its%20friendly%20APIs%20help%20you%20get%20your%20job%20done%E2%80%94fast.%22%2C%22title%22%3A%22Ember%20Guides%22%7D%2C%22guidemaker%22%3A%7B%22title%22%3A%22Ember%20Guides%22%2C%22sourceRepo%22%3A%22https%3A%2F%2Fgithub.com%2Fember-learn%2Fguides-source%22%7D%2C%22algolia%22%3A%7B%22algoliaId%22%3A%22Y1OMR4C7MF%22%2C%22algoliaKey%22%3A%225d01c83734dc36754d9e94cbf6f8964d%22%2C%22indexName%22%3A%22ember-guides%22%7D%2C%22showdown%22%3A%7B%22ghCompatibleHeaderId%22%3Atrue%2C%22prefixHeaderId%22%3A%22toc_%22%7D%2C%22deprecationsGuideURL%22%3A%22https%3A%2F%2Fwww.emberjs.com%2Fdeprecations%2F%22%2C%22metricsAdapters%22%3A%5B%7B%22name%22%3A%22GoogleAnalytics%22%2C%22environments%22%3A%5B%22production%22%5D%2C%22config%22%3A%7B%22id%22%3A%22UA-27675533-1%22%2C%22require%22%3A%5B%22linkid%22%5D%7D%7D%5D%2C%22exportApplicationGlobal%22%3Afalse%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22ember-collapsible-panel%22%3A%7B%7D%7D" />
 <!-- EMBER_CLI_FASTBOOT_TITLE -->  <meta name="ember-cli-head-start" content>  <title>Adding Nested Routes - Tutorial - Ember Guides</title>
 
-  <meta name="description" content="Up to this point, we've generated four top level routes. 
+  <meta name="description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta property="og:description" content="Up to this point, we've generated four top level routes. 
+  <meta property="og:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -44,7 +44,7 @@
   <meta name="twitter:title" content="Adding Nested Routes - Tutorial - Ember Guides">
 
 <!---->
-  <meta name="twitter:description" content="Up to this point, we've generated four top level routes. 
+  <meta name="twitter:description" content="Up to this point, we've generated four top level routes.
 
 - An about route, that gives information on our application.
 - A contact route, with information on how to contact the company.
@@ -59,7 +59,7 @@
     <link integrity="" rel="stylesheet" href="/assets/ember-guides-92dca9f7555a994d11fd3e94376c4753.css">
     <link rel="shortcut icon" href="/images/favicon.png" />
 
-    
+
   </head>
   <body  class="application version show version-show">
     <script type="x/boundary" id="fastboot-body-start"></script><!---->
@@ -103,7 +103,7 @@
     </ul>
 
       <div class="navbar-end">
-        
+
   <div id="ember241176" class="search-input ember-view">  <input id="search-input" placeholder="Search the guides" autocomplete="off" data-test-search-input type="search">
 
   <div id="ember241177" class="ds-dropdown-results ember-tether ember-view">
@@ -123,28 +123,28 @@
   <div class="sidebar-container">
   <nav class="es-sidebar" aria-label="Secondary content navigation" aria-expanded="false">
   <button class="es-button-secondary es-sidebar-close" aria-label="Close Sidebar" type="button">
-    
+
     <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><path d="M12.343 10.929L18 16.585l5.657-5.656a1 1 0 011.414 1.414L19.415 18l5.656 5.657a1 1 0 01-1.414 1.414L18 19.415l-5.657 5.656a1 1 0 01-1.414-1.414L16.585 18l-5.656-5.657a1 1 0 011.414-1.414z" fill="#FFF" fill-rule="evenodd"/></svg>
-  
+
 </button>
   <div class="es-sidebar-content">
-    
+
     <label for="version-select" class="visually-hidden">Guides version</label>
           <div class="ember-basic-dropdown">
       <div class="ember-view ember-basic-dropdown-trigger
        ember-basic-dropdown-trigger--in-place
-      
-      
+
+
        ember-power-select-trigger " tabindex="0" aria-controls="ember-power-select-options-ember241178" aria-haspopup="listbox" aria-owns role="button">
-    
+
             <span class="ember-power-select-selected-item">
-          
+
         3.9 <!---->
-      
+
         </span>
 <!----><span class="ember-power-select-status-icon"></span>
 
-    
+
   </div>
 
       <div id="ember-basic-dropdown-content-ember241178" class="ember-basic-dropdown-content-placeholder"></div>
@@ -164,7 +164,7 @@
               <div id="ember241182" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="true">
@@ -176,7 +176,7 @@
               </a>
               <div id="ember241185" class="cp-Panel-body cp-is-open ember-view">
     <div class="cp-Panel-body-inner">
-      
+
                 <ul class="table-of-contents sub-table-of-contents">
         <li class="toc-item toc-link ">
           <a id="ember241186" class="ember-view" data-test-toc-link="Creating Your App" href="/v3.9.0/tutorial/ember-cli">
@@ -263,11 +263,11 @@
           </a>
         </li>
       </ul>
-              
+
     </div>
 
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -280,7 +280,7 @@
               <div id="ember241200" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -293,7 +293,7 @@
               <div id="ember241203" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -306,7 +306,7 @@
               <div id="ember241206" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -319,7 +319,7 @@
               <div id="ember241209" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -332,7 +332,7 @@
               <div id="ember241212" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -345,7 +345,7 @@
               <div id="ember241215" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -358,7 +358,7 @@
               <div id="ember241218" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -371,7 +371,7 @@
               <div id="ember241221" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -384,7 +384,7 @@
               <div id="ember241224" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -397,7 +397,7 @@
               <div id="ember241227" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -410,7 +410,7 @@
               <div id="ember241230" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -423,7 +423,7 @@
               <div id="ember241233" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -436,7 +436,7 @@
               <div id="ember241236" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
           <li class="toc-item toc-group" aria-expanded="false">
@@ -449,17 +449,17 @@
               <div id="ember241239" class="cp-Panel-body ember-view">
 <!---->
 </div>
-            
+
 </div>
           </li>
 </ul>
     </nav>
-  
+
   </div>
 </nav>
 
 <button class="es-button es-sidebar-toggle" aria-label="Toggle Sidebar" type="button">
-    
+
   <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M28 24.5a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zm0-7a1 1 0 010 2H13a1 1 0 010-2h15zM9 24a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-7a1.5 1.5 0 110 3 1.5 1.5 0 010-3z" fill="#FFF" fill-rule="evenodd"/></svg>
 
 </button>
@@ -658,7 +658,7 @@ handler to return a specific rental:</p>
         <span class="token literal-property property">city</span><span class="token operator">:</span> <span class="token string">"Seattle"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">category</span><span class="token operator">:</span> <span class="token string">"Condo"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">bedrooms</span><span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span>
-        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/0/0e/Alfonso_13_Highrise_Tegucigalpa.jpg"</span><span class="token punctuation">,</span>
+        <span class="token literal-property property">image</span><span class="token operator">:</span> <span class="token string">"https://upload.wikimedia.org/wikipedia/commons/2/20/Seattle_-_Barnes_and_Bell_Buildings.jpg"</span><span class="token punctuation">,</span>
         <span class="token literal-property property">description</span><span class="token operator">:</span> <span class="token string">"A commuters dream. This rental is within walking distance of 2 bus stops and the Metro."</span>
       <span class="token punctuation">}</span>
     <span class="token punctuation">}</span><span class="token punctuation">,</span>
@@ -901,7 +901,7 @@ We'll click on the title and validate that an expanded description of the rental
           <a href="#toc_application-tests">Application Tests</a>
         </li>
     </ul>
-    
+
   </div>
 
   </div>
@@ -945,8 +945,8 @@ We'll click on the title and validate that an expanded description of the rental
   <div class="footer-help">
   <p class="container py-1">
 
-If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>, 
-open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>, 
+If you want help you can contact us by <a href="mailto:help@emberjs.com?subject=Help">email</a>,
+open an <a href="https://github.com/ember-learn/ember-website/issues/new"> issue</a>,
 or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember Discord</a>.
 
   </p>
@@ -990,6 +990,6 @@ or  get realtime help by joining the <a href="https://discord.gg/emberjs">Ember 
 <script src="/assets/chunk.143.291d124bd6dfab5cbec8.js"></script>
     <script src="/assets/ember-guides-b67bb3465e86e70c9677b41d5e7f4769.js"></script>
 
-    
+
   </body>
 </html>


### PR DESCRIPTION
The image url for the urban-living entry is invalid. I replaced it with the image used in the 3.28 version.