### PR TITLE
Add missing `)` in EmberData Models  docs

### DIFF
--- a/guides/release/tutorial/part-2/ember-data.md
+++ b/guides/release/tutorial/part-2/ember-data.md
@@ -107,7 +107,7 @@ export default class RentalModel extends Model {
 }
 ```
 
-Here, we created a `RentalModel` class that extends EmberData's `Model` superclass. When fetching the listing data from the server, each individual rental property will be represented by an instance (also known as a _[record](../../../models/finding-records/)_ of our `RentalModel` class.
+Here, we created a `RentalModel` class that extends EmberData's `Model` superclass. When fetching the listing data from the server, each individual rental property will be represented by an instance (also known as a _[record](../../../models/finding-records/)_) of our `RentalModel` class.
 
 We used the `@attr` decorator to declare the attributes of a rental property. These attributes correspond directly to the `attributes` data we expect the server to provide in its responses:
 


### PR DESCRIPTION
[Here](https://guides.emberjs.com/release/tutorial/part-2/ember-data/#toc_emberdata-models), close parenthesis is missing.

<img width="1095" alt="Screenshot 2024-04-09 at 6 54 16 PM" src="https://github.com/ember-learn/guides-source/assets/24503078/6403d236-0f43-4e9d-b2f9-cd1845613d43">
