### PR TITLE
style: lighten up backtick code

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -209,3 +209,9 @@ li.toc-heading.toc-level-0:first-of-type {
 li.toc-group.toc-level-0 {
   padding-left: 1em;
 }
+
+/* Override dark background from styleguide */
+code:not([class*="language-"]) {
+  background-color: var(--color-gray-200);
+  border: 1px solid var(--color-gray-300);
+}


### PR DESCRIPTION
Small tweak to make the inline code backticks more readable and easier to scan on the page.

| Before | After |
|--------|--------|
| ![before](https://github.com/ember-learn/guides-source/assets/10243652/929f3c4d-130f-4ac6-bf54-8a8c69b716c8) | ![after](https://github.com/ember-learn/guides-source/assets/10243652/118795c1-d659-4f80-a665-a29b3fea8485) | 

PR to include in styleguide: https://github.com/ember-learn/ember-styleguide/pull/511