### PR TITLE
Add references to EmberData alpha types

### DIFF
--- a/guides/release/typescript/core-concepts/ember-data.md
+++ b/guides/release/typescript/core-concepts/ember-data.md
@@ -2,6 +2,23 @@ In this section, we cover how to use TypeScript effectively with specific EmberD
 
 We do _not_ cover general usage of EmberData; instead, we assume that as background knowledge. Please see the [EmberData Guides][ED-guides] and [API docs][ED-api-docs]!
 
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          These guides currently assume you are using the EmberData <code>@types</code> packages in conjunction with the Ember <code>@types</code> packages.
+        </p>
+        <p>
+          For improved (albeit less stable) types, you can switch to <a href="https://github.com/emberjs/data/blob/main/guides/typescript/index.md">EmberData's alpha native types, documented at this link</a>. Using the EmberData alpha native types will also require <a href="https://blog.emberjs.com/stable-typescript-types-in-ember-5-1/">switching to the Ember native types</a>, which are guaranteed to always be 100% correct and 100% up to date!
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
+
 ## Models
 
 EmberData models are normal TypeScript classes, but with properties decorated to define how the model represents an API resource and relationships to other resources. The decorators the library supplies "just work" with TypeScript at runtime, but require type annotations to be useful with TypeScript. Additionally, you must register each model with the [`ModelRegistry`][ED-registry] as shown in the examples below.

--- a/guides/release/typescript/getting-started.md
+++ b/guides/release/typescript/getting-started.md
@@ -33,7 +33,12 @@ The `typescript` package provides tooling to support TypeScript type checking an
     <div class="cta-note-body">
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
-        Ember also publishes its own native types compiled directly from its source code, as described <a href="https://blog.emberjs.com/stable-typescript-types-in-ember-5-1/">in this blog post</a>. For now, we continue to use the <code>@types</code> packages by default for the sake of compatibility with EmberData, because EmberData is not yet compatible with Ember's native official types. However, if you do not use EmberData, we <i>highly</i> recommend following the instructions in that blog post to switch to the native types, which are guaranteed to always be 100% correct and 100% up to date!
+        <p>
+          Ember also publishes its own native types compiled directly from its source code. For now, we continue to use the <code>@types</code> packages in these guides for the sake of compatibility with EmberData, because the EmberData <code>@types</code> packages are not compatible with Ember's native official types.
+        </p>
+        <p>
+          If you do not use EmberData, or if you use <a href="https://github.com/emberjs/data/blob/main/guides/typescript/index.md">EmberData's alpha native types</a>, we <i>highly</i> recommend following the instructions <a href="https://blog.emberjs.com/stable-typescript-types-in-ember-5-1/">in this blog post</a> to switch to the native types, which are guaranteed to always be 100% correct and 100% up to date!
+        </p>
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">


### PR DESCRIPTION
Adds references to EmberData's alpha native types, which unlock the ability to use Ember native types. Also includes links to the WIP documentation for the EmberData native types.

This helps us move toward recommending emberjs/rfcs#0724 ("Official TypeScript Support") re: https://github.com/emberjs/rfcs/pull/952#issuecomment-2168532426.

<img width="839" alt="image" src="https://github.com/ember-learn/guides-source/assets/14152574/386ff0d7-8e51-4140-ba22-34aa88a502d0">


<img width="839" alt="image" src="https://github.com/ember-learn/guides-source/assets/14152574/0bfb9d98-dddb-4315-af19-5d6081cda56b">
