### PR TITLE
Replace not existing `removeObject` method

### DIFF
--- a/guides/release/models/relationships.md
+++ b/guides/release/models/relationships.md
@@ -466,9 +466,9 @@ It is also possible to remove a record from a `hasMany` relationship:
 
 ```javascript
 let blogPost = this.store.peekRecord('blog-post', 1);
-let comment = this.store.peekRecord('comment', 1);
+let commentToRemove = this.store.peekRecord('comment', 1);
 let comments = await blogPost.comments;
-comments.removeObject(comment);
+blockPost.comments = comments.filter((comment) => comment !== commentToRemove);
 blogPost.save();
 ```
 


### PR DESCRIPTION
New Ember provides `EXTEND_PROTOTYPES: false`, then method like `removeObject` doesn't exist which can be confusing for new developers. Feel free to suggest how write it more pretty 🙏 