### PR TITLE
deps: upgrade ember-styleguide to latest patch

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -209,9 +209,3 @@ li.toc-heading.toc-level-0:first-of-type {
 li.toc-group.toc-level-0 {
   padding-left: 1em;
 }
-
-/* Override dark background from styleguide */
-code:not([class*="language-"]) {
-  background-color: var(--color-gray-200);
-  border: 1px solid var(--color-gray-300);
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19975,9 +19975,9 @@
       }
     },
     "node_modules/ember-styleguide": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/ember-styleguide/-/ember-styleguide-11.0.0.tgz",
-      "integrity": "sha512-p/cAoXu/Qo5pRYLVL5/mV4cdCOG6wm94crBaDLD8vKfUjTLpYMrLhcqbxvdpNoqMf6GDWWz2P1pFJZlPQb18Fg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/ember-styleguide/-/ember-styleguide-11.0.1.tgz",
+      "integrity": "sha512-XDLhFUJ18GNaLQrZwlc8EyIgGpkRSDTyKykelYK/YlvbNt/3Evjuu2zjP31Pz1+/pWG+1bk+IEQD2PbmOLLMXQ==",
       "dev": true,
       "dependencies": {
         "@ember/render-modifiers": "^2.0.2",


### PR DESCRIPTION
Upgrades to the latest `ember-styleguide` patch, and removes the temporarily CSS override which now comes from the package.