### PR TITLE
Remove outdated link

### DIFF
--- a/guides/release/getting-started/index.md
+++ b/guides/release/getting-started/index.md
@@ -12,7 +12,7 @@ Some of these features that you'll learn about in the guides are:
 * [Routing](../routing/) - A central part of an Ember application. Enables developers to drive the application state from the URL.
 * [Services](../services/) - The way to store long-term state in your application and pass it around.
 * [EmberData](../models/) - EmberData provides a consistent way to communicate with external APIs and manage application state
-* [Ember Inspector](../ember-inspector/) - A browser extension, or bookmarklet, to inspect your application live. It's also useful for spotting Ember applications in the wild, try to install it and open up the [NASA website](https://www.nasa.gov/)!
+* [Ember Inspector](../ember-inspector/) - A browser extension, or bookmarklet, to inspect your application live. It's also useful for spotting Ember applications in the wild.
 
 ## Organization
 


### PR DESCRIPTION
This link was bragging about nasa.gov being an ember app, but that is no longer true.

If someone wants to maintain some other link or links that's fine but I think it's better to drop this now than worry about that.