### PR TITLE
deps: upgrade `ember-showdown-shiki`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4949,18 +4949,18 @@
       }
     },
     "node_modules/@shikijs/core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.4.0.tgz",
-      "integrity": "sha512-CxpKLntAi64h3j+TwWqVIQObPTED0FyXLHTTh3MKXtqiQNn2JGcMQQ362LftDbc9kYbDtrksNMNoVmVXzKFYUQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-EmUful2MQtY8KgCF1OkBtOuMcvaZEvmdubhW0UHCGXi21O9dRLeADVCj+k6ZS+de7Mz9d2qixOXJ+GLhcK3pXg==",
       "dev": true
     },
     "node_modules/@shikijs/transformers": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.4.0.tgz",
-      "integrity": "sha512-kzvlWmWYYSeaLKRce/kgmFFORUtBtFahfXRKndor0b60ocYiXufBQM6d6w1PlMuUkdk55aor9xLvy9wy7hTEJg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.9.1.tgz",
+      "integrity": "sha512-wPrGTpBURQ95IKPIhPQE3bGsANpPPtea1+aVHZp0aYtgxfL5UM3QbJ5rNdCuhcyjz/JNp5ZvSItOr+ayJxebJQ==",
       "dev": true,
       "dependencies": {
-        "shiki": "1.4.0"
+        "shiki": "1.9.1"
       }
     },
     "node_modules/@simple-dom/document": {
@@ -19719,15 +19719,15 @@
       "license": "ISC"
     },
     "node_modules/ember-showdown-shiki": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ember-showdown-shiki/-/ember-showdown-shiki-1.1.0.tgz",
-      "integrity": "sha512-sL3ExL3w+buHNfDmZywhqzxwsP53MZA0BH7eo0aHOmgVIhJkzxZL3jJtut1biIey/XzRfoVp7b66aEQSGcYlhg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-showdown-shiki/-/ember-showdown-shiki-1.2.0.tgz",
+      "integrity": "sha512-jl4JM9uzFNBOj0rHIyg/PzfCI7NhJQJiX/SmO/Z2h2HOIzP9Hb1l4d8NAtXZiT/c8YmvzybGUxzOamfbGss7pw==",
       "dev": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",
-        "@shikijs/transformers": "^1.2.0",
+        "@shikijs/transformers": "^1.9.1",
         "decorator-transforms": "^1.0.1",
-        "shiki": "^1.2.0"
+        "shiki": "^1.9.1"
       },
       "peerDependencies": {
         "showdown": ">1.0.0"
@@ -33298,12 +33298,12 @@
       "license": "MIT"
     },
     "node_modules/shiki": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.4.0.tgz",
-      "integrity": "sha512-5WIn0OL8PWm7JhnTwRWXniy6eEDY234mRrERVlFa646V2ErQqwIFd2UML7e0Pq9eqSKLoMa3Ke+xbsF+DAuy+Q==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.9.1.tgz",
+      "integrity": "sha512-8PDkgb5ja3nfujTjvC4VytL6wGOGCtFAClUb2r3QROevYXxcq+/shVJK5s6gy0HZnjaJgFxd6BpPqpRfqne5rA==",
       "dev": true,
       "dependencies": {
-        "@shikijs/core": "1.4.0"
+        "@shikijs/core": "1.9.1"
       }
     },
     "node_modules/showdown": {


### PR DESCRIPTION
Upgrades `ember-showdown-shiki` to include AA compliant color changes.

https://github.com/IgnaceMaes/ember-showdown-shiki/releases/tag/ember-showdown-shiki%401.2.0