### PR TITLE
deps: bump ember-showdown-shiki

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19719,9 +19719,9 @@
       "license": "ISC"
     },
     "node_modules/ember-showdown-shiki": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ember-showdown-shiki/-/ember-showdown-shiki-1.2.0.tgz",
-      "integrity": "sha512-jl4JM9uzFNBOj0rHIyg/PzfCI7NhJQJiX/SmO/Z2h2HOIzP9Hb1l4d8NAtXZiT/c8YmvzybGUxzOamfbGss7pw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ember-showdown-shiki/-/ember-showdown-shiki-1.2.1.tgz",
+      "integrity": "sha512-h3WYvEVjK7R86SosU6Y9lA7kvlVff4Y/7KS/D79lJ828NReLW1CnQAcxRSoGVvu+S6A8uONzImzJhyDXwuZDZA==",
       "dev": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",


### PR DESCRIPTION
Fixes highlighting empty line diffs.