### PR TITLE
add heading about configuring netlify URL handlers

### DIFF
--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -425,6 +425,8 @@ First you need to [sign up for a Netlify account](https://app.netlify.com/signup
 
 ![deploying to Netlify](/images/quick-guide/netlify/create-netlify-account.png)
 
+**Configuring Netlify URL handling**
+
 The next step is to let the web app server know how to handle URLs. There are 2 ways to do so.
 
 One, you can create a file in your `ember-quickstart/public` folder called


### PR DESCRIPTION
make it easier to see that configuration is required.

I missed this paragraph even when I was directly looking for it.