### PR TITLE
Fix typo "blockPost" => "blogPost" in code example, section EmberData > Relationships > removing-relationships

### DIFF
--- a/guides/release/models/relationships.md
+++ b/guides/release/models/relationships.md
@@ -468,7 +468,7 @@ It is also possible to remove a record from a `hasMany` relationship:
 let blogPost = this.store.peekRecord('blog-post', 1);
 let commentToRemove = this.store.peekRecord('comment', 1);
 let comments = await blogPost.comments;
-blockPost.comments = comments.filter((comment) => comment !== commentToRemove);
+blogPost.comments = comments.filter((comment) => comment !== commentToRemove);
 blogPost.save();
 ```
 


### PR DESCRIPTION
We detected a typo in [this section](https://guides.emberjs.com/release/models/relationships/#toc_removing-relationships).