### PR TITLE
Remove discussion of old debug handler polyfill, it's been a minute

### DIFF
--- a/guides/release/configuring-ember/handling-deprecations.md
+++ b/guides/release/configuring-ember/handling-deprecations.md
@@ -29,9 +29,6 @@ export function initialize() {
 export default { initialize };
 ```
 
-The deprecation handler API was released in Ember 2.1.
-If you would like to leverage this API in a prior release of Ember you can install the [ember-debug-handlers-polyfill](http://emberobserver.com/addons/ember-debug-handlers-polyfill) addon into your project.
-
 ## Deprecation Workflow
 
 Once you've removed deprecations that you may not need to immediately address, you may still be left with many deprecations.


### PR DESCRIPTION
As part of discussing https://github.com/emberjs/rfcs/pull/1009, I took another look at the deprecation workflows page. I don't think we need to recommend installing the pre 2.1 deprecation workflow polyfill any more ... 😉 

Not least because it's archived and likely won't even working in the last few versions of Ember: https://github.com/ember-polyfills/ember-debug-handlers-polyfill