### PR TITLE
Remove broken image link

### DIFF
--- a/guides/release/ember-inspector/deprecations.md
+++ b/guides/release/ember-inspector/deprecations.md
@@ -15,8 +15,6 @@ list of sources for each deprecation. If you are using Chrome or Firefox,
 clicking on the source opens the sources panel and takes you to
 the code that caused the deprecation message to be displayed.
 
-<img src="/images/guides/ember-inspector/v4.3.4/deprecations-source.png" />
-
 <img src="/images/guides/ember-inspector/v4.3.4/deprecations-sources-panel.png" width="680"/>
 
 You can send the deprecation message's stack trace to the


### PR DESCRIPTION
As far as I can tell, even the original commit that introduced this `<img>` never contained the corresponding file.