### PR TITLE
Fix syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "retext-spell": "^4.0.0",
     "retext-syntax-urls": "^2.0.0",
     "shelljs": "^0.8.5",
+    "showdown": "^2.1.0",
     "unified": "^9.2.1",
     "walk-sync": "^2.0.2",
     "webpack": "^5.72.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ devDependencies:
   shelljs:
     specifier: ^0.8.5
     version: 0.8.5
+  showdown:
+    specifier: ^2.1.0
+    version: 2.1.0
   unified:
     specifier: ^9.2.1
     version: 9.2.2


### PR DESCRIPTION
https://github.com/ember-learn/guides-source/pull/2071 broke syntax highlighting because guides-sources fails to satisfy ember-shiki's peerDependency on showdown.

By not providing it, we left pnpm free to pick whatever copy it wanted, and thus there was no way to guarantee that ember-shiki and the rest of guides-source were using *the same* copy.