### PR TITLE
Change LSP to match Ember.js Extension Pack

### DIFF
--- a/guides/release/code-editors/index.md
+++ b/guides/release/code-editors/index.md
@@ -20,8 +20,8 @@ Syntax formatting for glimmer templates.
 
 ### Language Server
 
-[Stable Ember Language Server](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable) -
-Stable Ember Language Server is a stable, full-featured language server. Its name comes from its history as a fork of Ember Language Server and the efforts to keep up with changes in Ember.
+[Ember Language Server](https://marketplace.visualstudio.com/items?itemName=EmberTooling.vscode-ember) -
+Adds enhanced editor features like auto completion and go to definition.
 
 ### Workflow
 


### PR DESCRIPTION
[Ember.js Extension Pack](https://marketplace.visualstudio.com/items?itemName=EmberTooling.emberjs) now lists [Ember Language Server](https://marketplace.visualstudio.com/items?itemName=EmberTooling.vscode-ember) as their used LSP.

Stable Ember Language Server is no longer supported and their [Github page](https://github.com/lifeart/ember-language-server?tab=readme-ov-file) says it was merged into [ember-tooling/ember-language-server](https://github.com/ember-tooling/ember-language-server).