### PR TITLE
Deprecate Non Strict Relationships

### DIFF
--- a/guides/v5.0.0/models/customizing-serializers.md
+++ b/guides/v5.0.0/models/customizing-serializers.md
@@ -401,7 +401,7 @@ a model:
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class CommentModel extends Model {
-  @belongsTo('post', { async: false, inverse: 'comments' }) originalPost
+  @belongsTo('post', { async: true, inverse: 'comments' }) originalPost
 }
 ```
 
@@ -713,8 +713,8 @@ import Model, { attr, hasMany } from '@ember-data/model';
 export default class Post extends Model {
   @attr('string') title;
   @attr('string') tag;
-  @hasMany('comment', { async: false, inverse: 'post' }) comments;
-  @hasMany('post', { async: false, inverse: 'relatedPosts' }) relatedPosts;
+  @hasMany('comment', { async: true, inverse: 'post' }) comments;
+  @hasMany('post', { async: true, inverse: 'relatedPosts' }) relatedPosts;
 }
 ```
 

--- a/guides/v5.0.0/models/customizing-serializers.md
+++ b/guides/v5.0.0/models/customizing-serializers.md
@@ -365,7 +365,7 @@ have a model with a `hasMany` relationship:
 import Model, { hasMany } from '@ember-data/model';
 
 export default class PostModel extends Model {
-  @hasMany('comment', { async: true }) comments;
+  @hasMany('comment', { async: true, inverse: 'originalPost' }) comments;
 }
 ```
 
@@ -401,7 +401,7 @@ a model:
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class CommentModel extends Model {
-  @belongsTo('post') originalPost
+  @belongsTo('post', { async: false, inverse: 'comments' }) originalPost
 }
 ```
 
@@ -713,8 +713,8 @@ import Model, { attr, hasMany } from '@ember-data/model';
 export default class Post extends Model {
   @attr('string') title;
   @attr('string') tag;
-  @hasMany('comment', { async: false }) comments;
-  @hasMany('post') relatedPosts;
+  @hasMany('comment', { async: false, inverse: 'post' }) comments;
+  @hasMany('post', { async: false, inverse: 'relatedPosts' }) relatedPosts;
 }
 ```
 

--- a/guides/v5.0.0/models/index.md
+++ b/guides/v5.0.0/models/index.md
@@ -238,7 +238,7 @@ example, an `order` may have many `line-items`, and a
 import Model, { hasMany } from "@ember-data/model";
 
 export default class OrderModel extends Model {
-  @hasMany("line-item") lineItems;
+  @hasMany("line-item", { async: false, inverse: 'order' }) lineItems;
 }
 ```
 
@@ -246,7 +246,7 @@ export default class OrderModel extends Model {
 import Model, { belongsTo } from "@ember-data/model";
 
 export default class LineItemModel extends Model {
-  @belongsTo("order") order;
+  @belongsTo("order", { async: false, inverse: 'lineItems' }) order;
 }
 ```
 

--- a/guides/v5.0.0/models/relationships.md
+++ b/guides/v5.0.0/models/relationships.md
@@ -10,7 +10,7 @@ To declare a one-to-one relationship between two models, use
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class UserModel extends Model {
-  @belongsTo('profile') profile;
+  @belongsTo('profile', { async: true, inverse: 'user' }) profile;
 }
 ```
 
@@ -18,7 +18,7 @@ export default class UserModel extends Model {
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class ProfileModel extends Model {
-  @belongsTo('user') user;
+  @belongsTo('user', { async: true, inverse: 'profile' }) user;
 }
 ```
 
@@ -31,7 +31,7 @@ To declare a one-to-many relationship between two models, use
 import Model, { hasMany } from '@ember-data/model';
 
 export default class BlogPostModel extends Model {
-  @hasMany('comment') comments;
+  @hasMany('comment', { async: true, inverse: 'blogPost' }) comments;
 }
 ```
 
@@ -39,7 +39,7 @@ export default class BlogPostModel extends Model {
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class CommentModel extends Model {
-  @belongsTo('blog-post') blogPost;
+  @belongsTo('blog-post', { async: true, inverse: 'comments' }) blogPost;
 }
 ```
 
@@ -52,7 +52,7 @@ To declare a many-to-many relationship between two models, use
 import Model, { hasMany } from '@ember-data/model';
 
 export default class BlogPostModel extends Model {
-  @hasMany('tag') tags;
+  @hasMany('tag', { async: true, inverse: 'blogPosts' }) tags;
 }
 ```
 
@@ -60,32 +60,22 @@ export default class BlogPostModel extends Model {
 import Model, { hasMany } from '@ember-data/model';
 
 export default class TagModel extends Model {
-  @hasMany('blog-post') blogPosts;
+  @hasMany('blog-post', { async: true, inverse: 'tags' }) blogPosts;
 }
 ```
 
-### Explicit Inverses
+### No Inverse Relations
 
-EmberData will do its best to discover which relationships map to one
-another. In the one-to-many code above, for example, EmberData can figure out that
-changing the `comments` relationship should update the `blogPost`
-relationship on the inverse because `blogPost` is the only relationship to
-that model.
-
-However, sometimes you may have multiple `belongsTo`/`hasMany`s for
-the same type. You can specify which property on the related model is
-the inverse using `belongsTo` or `hasMany`'s `inverse`
-option. Relationships without an inverse can be indicated as such by
-including `{ inverse: null }`.
+If an inverse relationship exists and you wish changes on one side
+to reflect onto the other side, use the inverse key. 
+If you wish to not have changes reflected or 
+no inverse relationship exists, specify `{inverse: null }`.
 
 ```javascript {data-filename=app/models/comment.js}
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class CommentModel extends Model {
-  @belongsTo('blog-post', { inverse: null }) onePost;
-  @belongsTo('blog-post') twoPost;
-  @belongsTo('blog-post') redPost;
-  @belongsTo('blog-post') bluePost;
+  @belongsTo('blog-post', { async: true, inverse: null }) blogPost;
 }
 ```
 
@@ -93,18 +83,13 @@ export default class CommentModel extends Model {
 import Model, { hasMany } from '@ember-data/model';
 
 export default class BlogPostModel extends Model {
-  @hasMany('comment', {
-    inverse: 'redPost'
-  })
-  comments;
 }
 ```
 
 ### Reflexive Relations
 
-When you want to define a reflexive relation (a model that has a relationship to
-itself), you must explicitly define the inverse relationship. If there
-is no inverse relationship then you can set the inverse to `null`.
+If you want to define a reflexive relation (a model that has a relationship to
+itself), you can do it via specifying `inverse`.
 
 Here's an example of a one-to-many reflexive relationship:
 
@@ -112,8 +97,8 @@ Here's an example of a one-to-many reflexive relationship:
 import Model, { belongsTo, hasMany } from '@ember-data/model';
 
 export default class FolderModel extends Model {
-  @hasMany('folder', { inverse: 'parent' }) children;
-  @belongsTo('folder', { inverse: 'children' }) parent;
+  @hasMany('folder', { async: true, inverse: 'parent' }) children;
+  @belongsTo('folder', { async: true, inverse: 'children' }) parent;
 }
 ```
 
@@ -124,7 +109,7 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class UserModel extends Model {
   @attr('string') name;
-  @belongsTo('user', { inverse: 'bestFriend' }) bestFriend;
+  @belongsTo('user', { async: true, inverse: 'bestFriend' }) bestFriend;
 }
 ```
 
@@ -134,7 +119,7 @@ You can also define a reflexive relationship that doesn't have an inverse:
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class FolderModel extends Model {
-  @belongsTo('folder', { inverse: null }) parent;
+  @belongsTo('folder', { async: true, inverse: null }) parent;
 }
 ```
 
@@ -156,7 +141,7 @@ First, let's look at the model definitions:
 import Model, { hasMany } from '@ember-data/model';
 
 export default class UserModel extends Model {
-  @hasMany('payment-method', { polymorphic: true }) paymentMethods;
+  @hasMany('payment-method', { async: true, inverse: 'user', polymorphic: true }) paymentMethods;
 }
 ```
 
@@ -164,7 +149,7 @@ export default class UserModel extends Model {
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class PaymentMethodModel extends Model {
-  @belongsTo('user', { inverse: 'paymentMethods' }) user;
+  @belongsTo('user', { async: true, inverse: 'paymentMethods' }) user;
 }
 ```
 
@@ -277,7 +262,7 @@ Let's assume that we have a `blog-post` and a `comment` model. A single blog pos
 import Model, { hasMany } from '@ember-data/model';
 
 export default class BlogPostModel extends Model {
-  @hasMany('comment') comments;
+  @hasMany('comment', { async: true, inverse: 'blogPost' }) comments;
 }
 ```
 
@@ -285,7 +270,7 @@ export default class BlogPostModel extends Model {
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class CommentModel extends Model {
-  @belongsTo('blog-post') blogPost;
+  @belongsTo('blog-post', { async: true, inverse: 'comments' }) blogPost;
 }
 ```
 

--- a/guides/v5.0.0/models/relationships.md
+++ b/guides/v5.0.0/models/relationships.md
@@ -10,7 +10,7 @@ To declare a one-to-one relationship between two models, use
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class UserModel extends Model {
-  @belongsTo('profile', { async: true, inverse: 'user' }) profile;
+  @belongsTo('profile', { async: false, inverse: 'user' }) profile;
 }
 ```
 
@@ -18,7 +18,7 @@ export default class UserModel extends Model {
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class ProfileModel extends Model {
-  @belongsTo('user', { async: true, inverse: 'profile' }) user;
+  @belongsTo('user', { async: false, inverse: 'profile' }) user;
 }
 ```
 
@@ -31,7 +31,7 @@ To declare a one-to-many relationship between two models, use
 import Model, { hasMany } from '@ember-data/model';
 
 export default class BlogPostModel extends Model {
-  @hasMany('comment', { async: true, inverse: 'blogPost' }) comments;
+  @hasMany('comment', { async: false, inverse: 'blogPost' }) comments;
 }
 ```
 
@@ -39,7 +39,7 @@ export default class BlogPostModel extends Model {
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class CommentModel extends Model {
-  @belongsTo('blog-post', { async: true, inverse: 'comments' }) blogPost;
+  @belongsTo('blog-post', { async: false, inverse: 'comments' }) blogPost;
 }
 ```
 
@@ -52,7 +52,7 @@ To declare a many-to-many relationship between two models, use
 import Model, { hasMany } from '@ember-data/model';
 
 export default class BlogPostModel extends Model {
-  @hasMany('tag', { async: true, inverse: 'blogPosts' }) tags;
+  @hasMany('tag', { async: false, inverse: 'blogPosts' }) tags;
 }
 ```
 
@@ -60,7 +60,7 @@ export default class BlogPostModel extends Model {
 import Model, { hasMany } from '@ember-data/model';
 
 export default class TagModel extends Model {
-  @hasMany('blog-post', { async: true, inverse: 'tags' }) blogPosts;
+  @hasMany('blog-post', { async: false, inverse: 'tags' }) blogPosts;
 }
 ```
 
@@ -75,7 +75,7 @@ no inverse relationship exists, specify `{inverse: null }`.
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class CommentModel extends Model {
-  @belongsTo('blog-post', { async: true, inverse: null }) blogPost;
+  @belongsTo('blog-post', { async: false, inverse: null }) blogPost;
 }
 ```
 
@@ -97,8 +97,8 @@ Here's an example of a one-to-many reflexive relationship:
 import Model, { belongsTo, hasMany } from '@ember-data/model';
 
 export default class FolderModel extends Model {
-  @hasMany('folder', { async: true, inverse: 'parent' }) children;
-  @belongsTo('folder', { async: true, inverse: 'children' }) parent;
+  @hasMany('folder', { async: false, inverse: 'parent' }) children;
+  @belongsTo('folder', { async: false, inverse: 'children' }) parent;
 }
 ```
 
@@ -109,7 +109,7 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class UserModel extends Model {
   @attr('string') name;
-  @belongsTo('user', { async: true, inverse: 'bestFriend' }) bestFriend;
+  @belongsTo('user', { async: false, inverse: 'bestFriend' }) bestFriend;
 }
 ```
 
@@ -119,7 +119,7 @@ You can also define a reflexive relationship that doesn't have an inverse:
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class FolderModel extends Model {
-  @belongsTo('folder', { async: true, inverse: null }) parent;
+  @belongsTo('folder', { async: false, inverse: null }) parent;
 }
 ```
 
@@ -141,7 +141,7 @@ First, let's look at the model definitions:
 import Model, { hasMany } from '@ember-data/model';
 
 export default class UserModel extends Model {
-  @hasMany('payment-method', { async: true, inverse: 'user', polymorphic: true }) paymentMethods;
+  @hasMany('payment-method', { async: false, inverse: 'user', polymorphic: true }) paymentMethods;
 }
 ```
 
@@ -149,7 +149,7 @@ export default class UserModel extends Model {
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class PaymentMethodModel extends Model {
-  @belongsTo('user', { async: true, inverse: 'paymentMethods' }) user;
+  @belongsTo('user', { async: false, inverse: 'paymentMethods' }) user;
 }
 ```
 
@@ -262,7 +262,7 @@ Let's assume that we have a `blog-post` and a `comment` model. A single blog pos
 import Model, { hasMany } from '@ember-data/model';
 
 export default class BlogPostModel extends Model {
-  @hasMany('comment', { async: true, inverse: 'blogPost' }) comments;
+  @hasMany('comment', { async: false, inverse: 'blogPost' }) comments;
 }
 ```
 
@@ -270,7 +270,7 @@ export default class BlogPostModel extends Model {
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class CommentModel extends Model {
-  @belongsTo('blog-post', { async: true, inverse: 'comments' }) blogPost;
+  @belongsTo('blog-post', { async: false, inverse: 'comments' }) blogPost;
 }
 ```
 

--- a/guides/v5.0.0/testing/testing-models.md
+++ b/guides/v5.0.0/testing/testing-models.md
@@ -77,7 +77,7 @@ export default class ProfileModel extends Model {}
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class UserModel extends Model {
-  @belongsTo('profile') profile;
+  @belongsTo('profile', { async: false, inverse: null }) profile;
 }
 ```
 


### PR DESCRIPTION
- As per [ember-data:deprecate-non-strict-relationships](https://deprecations.emberjs.com/ember-data/v4.x/#toc_ember-data-deprecate-non-strict-relationships) we should update the guides to list all relationships explicitly
- Seems like we want most of the examples to be `{ async: false }`

## TODO
- [ ] Can someone check that I set `inverse` correctly (author blindness, can't guarantee)?
- [ ] 

- Fixes: #1988 