### PR TITLE
fix: fix link to test-types.md

### DIFF
--- a/guides/release/testing/testing-tools.md
+++ b/guides/release/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/release/testing/testing-tools.md
+++ b/guides/release/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.10.0/testing/testing-tools.md
+++ b/guides/v4.10.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.10.0/testing/testing-tools.md
+++ b/guides/v4.10.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.11.0/testing/testing-tools.md
+++ b/guides/v4.11.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.11.0/testing/testing-tools.md
+++ b/guides/v4.11.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.12.0/testing/testing-tools.md
+++ b/guides/v4.12.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.12.0/testing/testing-tools.md
+++ b/guides/v4.12.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.4.0/testing/testing-tools.md
+++ b/guides/v4.4.0/testing/testing-tools.md
@@ -68,7 +68,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.4.0/testing/testing-tools.md
+++ b/guides/v4.4.0/testing/testing-tools.md
@@ -68,7 +68,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.5.0/testing/testing-tools.md
+++ b/guides/v4.5.0/testing/testing-tools.md
@@ -68,7 +68,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.5.0/testing/testing-tools.md
+++ b/guides/v4.5.0/testing/testing-tools.md
@@ -68,7 +68,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.6.0/testing/testing-tools.md
+++ b/guides/v4.6.0/testing/testing-tools.md
@@ -68,7 +68,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.6.0/testing/testing-tools.md
+++ b/guides/v4.6.0/testing/testing-tools.md
@@ -68,7 +68,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.7.0/testing/testing-tools.md
+++ b/guides/v4.7.0/testing/testing-tools.md
@@ -68,7 +68,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.7.0/testing/testing-tools.md
+++ b/guides/v4.7.0/testing/testing-tools.md
@@ -68,7 +68,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.8.0/testing/testing-tools.md
+++ b/guides/v4.8.0/testing/testing-tools.md
@@ -68,7 +68,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.8.0/testing/testing-tools.md
+++ b/guides/v4.8.0/testing/testing-tools.md
@@ -68,7 +68,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.9.0/testing/testing-tools.md
+++ b/guides/v4.9.0/testing/testing-tools.md
@@ -68,7 +68,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v4.9.0/testing/testing-tools.md
+++ b/guides/v4.9.0/testing/testing-tools.md
@@ -68,7 +68,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.0.0/testing/testing-tools.md
+++ b/guides/v5.0.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.0.0/testing/testing-tools.md
+++ b/guides/v5.0.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.1.0/testing/testing-tools.md
+++ b/guides/v5.1.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.1.0/testing/testing-tools.md
+++ b/guides/v5.1.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.10.0/testing/testing-tools.md
+++ b/guides/v5.10.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.10.0/testing/testing-tools.md
+++ b/guides/v5.10.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.11.0/testing/testing-tools.md
+++ b/guides/v5.11.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.11.0/testing/testing-tools.md
+++ b/guides/v5.11.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.12.0/testing/testing-tools.md
+++ b/guides/v5.12.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.12.0/testing/testing-tools.md
+++ b/guides/v5.12.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.2.0/testing/testing-tools.md
+++ b/guides/v5.2.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.2.0/testing/testing-tools.md
+++ b/guides/v5.2.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.3.0/testing/testing-tools.md
+++ b/guides/v5.3.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.3.0/testing/testing-tools.md
+++ b/guides/v5.3.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.4.0/testing/testing-tools.md
+++ b/guides/v5.4.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.4.0/testing/testing-tools.md
+++ b/guides/v5.4.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.5.0/testing/testing-tools.md
+++ b/guides/v5.5.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.5.0/testing/testing-tools.md
+++ b/guides/v5.5.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.6.0/testing/testing-tools.md
+++ b/guides/v5.6.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.6.0/testing/testing-tools.md
+++ b/guides/v5.6.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.7.0/testing/testing-tools.md
+++ b/guides/v5.7.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.7.0/testing/testing-tools.md
+++ b/guides/v5.7.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.8.0/testing/testing-tools.md
+++ b/guides/v5.8.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.8.0/testing/testing-tools.md
+++ b/guides/v5.8.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.9.0/testing/testing-tools.md
+++ b/guides/v5.9.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v5.9.0/testing/testing-tools.md
+++ b/guides/v5.9.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v6.0.0/testing/testing-tools.md
+++ b/guides/v6.0.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v6.0.0/testing/testing-tools.md
+++ b/guides/v6.0.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v6.1.0/testing/testing-tools.md
+++ b/guides/v6.1.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types/).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 

--- a/guides/v6.1.0/testing/testing-tools.md
+++ b/guides/v6.1.0/testing/testing-tools.md
@@ -52,7 +52,7 @@ test("should allow disabling the button", async function (assert) {
 
 ### Ember CLI
 
-When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](./test-types).
+When you use [Ember CLI](https://ember-cli.com/generators-and-blueprints) to generate an Ember "object" (e.g. component, model, service), it will create a test file with a setup that correctly addresses your testing framework and the [type of test that you should write](../test-types).
 
 You can also use Ember CLI to create the test file separately from the object. For example, if you enter the following lines in the terminal:
 


### PR DESCRIPTION
In https://guides.emberjs.com/release/testing/testing-tools/, there's a link "type of test that you should write" which is broken. This PR fixes the link path.

It seems to have been broken since this link was moved from `index.md` to its own `testing-tools.md` page (e.g. see [4.3](https://guides.emberjs.com/v4.3.0/testing/) the link was in the introduction page, and see [4.4](https://guides.emberjs.com/v4.4.0/testing/testing-tools/) where the link was first moved to a separate page).

See [Deploy Preview](https://deploy-preview-2101--ember-guides.netlify.app/release/testing/testing-tools/) to check that the link is no longer broken.