### PR TITLE
Remove old code line from component-state-and-actions.md

### DIFF
--- a/guides/release/components/component-state-and-actions.md
+++ b/guides/release/components/component-state-and-actions.md
@@ -337,7 +337,6 @@ export default class CounterComponent extends Component {
   @tracked multiple = 1;
 
   get total() {
-    return this.count * this.multiple;
     return this.count * this.args.multiple;
   }
 


### PR DESCRIPTION
Looks like this line was leftover from the previous example; leaving it in prevents the new line from ever being called.