### PR TITLE
Fix self-closing tag syntax in Profile component test

### DIFF
--- a/guides/v5.7.0/typescript/application-development/testing.md
+++ b/guides/v5.7.0/typescript/application-development/testing.md
@@ -73,7 +73,7 @@ module('Integration | Component | Profile', function (hooks) {
     };
     this.user = user;
 
-    await render(hbs`<Profile @user={{this.user}}`);
+    await render(hbs`<Profile @user={{this.user}} />`);
 
     assert.dom('[data-test-name]').hasText(this.user.displayName);
     assert
@@ -142,7 +142,7 @@ module('Integration | Component | Profile', function (hooks) {
       avatarUrl: 'https://example.com/star-wars/rey',
     };
 
-    await render(hbs`<Profile @user={{this.user}}`);
+    await render(hbs`<Profile @user={{this.user}} />`);
 
     assert.dom('[data-test-name]').hasText(this.user.displayName);
     assert


### PR DESCRIPTION
The only change made was adding a closing `/>` to properly terminate the self-closing <Profile> component tag.