### PR TITLE
Update looping-through-lists.md last subheading mistypo

### DIFF
--- a/guides/release/components/looping-through-lists.md
+++ b/guides/release/components/looping-through-lists.md
@@ -369,7 +369,7 @@ export default class SomeComponent extends Component {
 </ul>
 ```
 
-### Empty Lists
+### Empty Objects
 
 The [`{{#each}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper can also have a corresponding `{{else}}`. The contents of this block will


### PR DESCRIPTION
Incorrect Subheading:
❌ Empty Lists

Corrected Subheading:
✅ Empty Object