### PR TITLE
Convert core concepts / components to use gjs

### DIFF
--- a/guides/release/components/block-content.md
+++ b/guides/release/components/block-content.md
@@ -2,24 +2,32 @@ Component templates can leave one or more placeholders that users can fill with 
 These are called blocks.
 Here's an example that provides a component with the implicit default block.
 
-```handlebars
-<ExampleComponent>
-  This is the default <b>block content</b> that will
-  replace `{{yield}}` (or `{{yield to="default"}}`)
-  in the `ExampleComponent` template.
-</ExampleComponent>
+```gjs
+import ExampleComponent from './example-component.gjs';
+
+<template>
+  <ExampleComponent>
+    This is the default <b>block content</b> that will
+    replace `{{yield}}` (or `{{yield to="default"}}`)
+    in the `ExampleComponent` template.
+  </ExampleComponent>
+</template>
 ```
 
 This is equivalent to explicitly naming the default block using the named block syntax.
 
-```handlebars
-<ExampleComponent>
-  <:default>
-    This is the default <b>block content</b> that will
-    replace `{{yield}}` (or `{{yield to="default"}}`)
-    in the `ExampleComponent` template.
-  </:default>
-</ExampleComponent>
+```gjs
+import ExampleComponent from './example-component.gjs';
+
+<template>
+  <ExampleComponent>
+    <:default>
+      This is the default <b>block content</b> that will
+      replace `{{yield}}` (or `{{yield to="default"}}`)
+      in the `ExampleComponent` template.
+    </:default>
+  </ExampleComponent>
+</template>
 ```
 
 Through Block Content, users of the component can add additional styling and
@@ -28,57 +36,61 @@ behavior by using HTML, modifiers, and other components within the block.
 To make that more concrete, let's take a look at two similar components
 representing different user's messages.
 
-```handlebars {data-filename="app/components/received-message.hbs"}
-<aside>
-  <div class="avatar is-active" title="Tomster's avatar">T</div>
-</aside>
-<section>
-  <h4 class="username">
-    Tomster
-    <span class="local-time">their local time is 4:56pm</span>
-  </h4>
+```gjs {data-filename="app/components/received-message.gjs"}
+<template>
+  <aside>
+    <div class="avatar is-active" title="Tomster's avatar">T</div>
+  </aside>
+  <section>
+    <h4 class="username">
+      Tomster
+      <span class="local-time">their local time is 4:56pm</span>
+    </h4>
 
-  <p>
-    Hey Zoey, have you had a chance to look at the EmberConf
-    brainstorming doc I sent you?
-  </p>
-</section>
+    <p>
+      Hey Zoey, have you had a chance to look at the EmberConf
+      brainstorming doc I sent you?
+    </p>
+  </section>
+</template>
 ```
 
-```handlebars {data-filename="app/components/sent-message.hbs"}
-<aside class="current-user">
-  <div class="avatar" title="Zoey's avatar">Z</div>
-</aside>
-<section>
-  <h4 class="username">Zoey</h4>
+```gjs {data-filename="app/components/sent-message.gjs"}
+<template>
+  <aside class="current-user">
+    <div class="avatar" title="Zoey's avatar">Z</div>
+  </aside>
+  <section>
+    <h4 class="username">Zoey</h4>
 
-  <p>Hey!</p>
+    <p>Hey!</p>
 
-  <p>
-    I love the ideas! I'm really excited about where this year's
-    EmberConf is going, I'm sure it's going to be the best one yet.
-    Some quick notes:
-  </p>
+    <p>
+      I love the ideas! I'm really excited about where this year's
+      EmberConf is going, I'm sure it's going to be the best one yet.
+      Some quick notes:
+    </p>
 
-  <ul>
-    <li>
-      Definitely agree that we should double the coffee budget this
-      year (it really is impressive how much we go through!)
-    </li>
-    <li>
-      A blimp would definitely make the venue very easy to find, but
-      I think it might be a bit out of our budget. Maybe we could
-      rent some spotlights instead?
-    </li>
-    <li>
-      We absolutely will need more hamster wheels, last year's line
-      was <em>way</em> too long. Will get on that now before rental
-      season hits its peak.
-    </li>
-  </ul>
+    <ul>
+      <li>
+        Definitely agree that we should double the coffee budget this
+        year (it really is impressive how much we go through!)
+      </li>
+      <li>
+        A blimp would definitely make the venue very easy to find, but
+        I think it might be a bit out of our budget. Maybe we could
+        rent some spotlights instead?
+      </li>
+      <li>
+        We absolutely will need more hamster wheels, last year's line
+        was <em>way</em> too long. Will get on that now before rental
+        season hits its peak.
+      </li>
+    </ul>
 
-  <p>Let me know when you've nailed down the dates!</p>
-</section>
+    <p>Let me know when you've nailed down the dates!</p>
+  </section>
+</template>
 ```
 
 Instead of having two different components, one for sent messages and one for
@@ -90,21 +102,26 @@ Their structure is pretty straightforward and similar, so we can use arguments
 and conditionals to handle the differences in content between them (see the
 previous chapters for details on how to do this).
 
-```handlebars {data-filename="app/components/message.hbs"}
-<Message::Avatar
-  @title={{@avatarTitle}}
-  @initial={{@avatarInitial}}
-  @isActive={{@userIsActive}}
-  class="{{if @isCurrentUser "current-user"}}"
-/>
-<section>
-  <Message::Username
-    @name={{@username}}
-    @localTime={{@userLocalTime}}
-  />
+```gjs {data-filename="app/components/message.gjs"}
+import MessageAvatar from './message/avatar.gjs';
+import MessageUsername from './message/username.gjs';
 
-  ...
-</section>
+<template>
+  <MessageAvatar
+    @title={{@avatarTitle}}
+    @initial={{@avatarInitial}}
+    @isActive={{@userIsActive}}
+    class="{{if @isCurrentUser "current-user"}}"
+  />
+  <section>
+    <MessageUsername
+      @name={{@username}}
+      @localTime={{@userLocalTime}}
+    />
+
+    ...
+  </section>
+</template>
 ```
 
 This works pretty well, but the message content is very different. It's also
@@ -114,21 +131,26 @@ supplied by the `<Message>` tag.
 
 The way to do this in Ember is by using the `{{yield}}` syntax.
 
-```handlebars {data-filename="app/components/message.hbs"}
-<Message::Avatar
-  @title={{@avatarTitle}}
-  @initial={{@avatarInitial}}
-  @isActive={{@userIsActive}}
-  class="{{if @isCurrentUser "current-user"}}"
-/>
-<section>
-  <Message::Username
-    @name={{@username}}
-    @localTime={{@userLocalTime}}
-  />
+```gjs {data-filename="app/components/message.gjs"}
+import MessageAvatar from './message/avatar.gjs';
+import MessageUsername from './message/username.gjs';
 
-  {{yield}}
-</section>
+<template>
+  <MessageAvatar
+    @title={{@avatarTitle}}
+    @initial={{@avatarInitial}}
+    @isActive={{@userIsActive}}
+    class="{{if @isCurrentUser "current-user"}}"
+  />
+  <section>
+    <MessageUsername
+      @name={{@username}}
+      @localTime={{@userLocalTime}}
+    />
+
+    {{yield}}
+  </section>
+</template>
 ```
 
 <div class="cta">
@@ -151,57 +173,65 @@ The way to do this in Ember is by using the `{{yield}}` syntax.
 You can think of using `{{yield}}` as leaving a placeholder for the content of the
 `<Message>` tag.
 
-```handlebars {data-filename="app/components/received-message.hbs"}
-<Message
-  @username="Tomster"
-  @userIsActive={{true}}
-  @userLocalTime="4:56pm"
+```gjs {data-filename="app/components/received-message.gjs"}
+import Message from './message.gjs';
 
-  @avatarTitle="Tomster's avatar"
-  @avatarInitial="T"
->
-  <p>
-    Hey Zoey, have you had a chance to look at the EmberConf
-    brainstorming doc I sent you?
-  </p>
-</Message>
+<template>
+  <Message
+    @username="Tomster"
+    @userIsActive={{true}}
+    @userLocalTime="4:56pm"
+
+    @avatarTitle="Tomster's avatar"
+    @avatarInitial="T"
+  >
+    <p>
+      Hey Zoey, have you had a chance to look at the EmberConf
+      brainstorming doc I sent you?
+    </p>
+  </Message>
+</template>
 ```
 
-```handlebars {data-filename="app/components/sent-message.hbs"}
-<Message
-  @username="Zoey"
-  @isCurrentUser={{true}}
+```gjs {data-filename="app/components/sent-message.gjs"}
+import Message from './message.gjs';
 
-  @avatarTitle="Zoey's avatar"
-  @avatarInitial="Z"
->
-  <p>Hey!</p>
+<template>
+  <Message
+    @username="Zoey"
+    @isCurrentUser={{true}}
 
-  <p>
-    I love the ideas! I'm really excited about where this year's
-    EmberConf is going, I'm sure it's going to be the best one yet.
-    Some quick notes:
-  </p>
+    @avatarTitle="Zoey's avatar"
+    @avatarInitial="Z"
+  >
+    <p>Hey!</p>
 
-  <ul>
-    <li>
-      Definitely agree that we should double the coffee budget this
-      year (it really is impressive how much we go through!)
-    </li>
-    <li>
-      A blimp would definitely make the venue very easy to find, but
-      I think it might be a bit out of our budget. Maybe we could
-      rent some spotlights instead?
-    </li>
-    <li>
-      We absolutely will need more hamster wheels, last year's line
-      was <em>way</em> too long. Will get on that now before rental
-      season hits its peak.
-    </li>
-  </ul>
+    <p>
+      I love the ideas! I'm really excited about where this year's
+      EmberConf is going, I'm sure it's going to be the best one yet.
+      Some quick notes:
+    </p>
 
-  <p>Let me know when you've nailed down the dates!</p>
-</Message>
+    <ul>
+      <li>
+        Definitely agree that we should double the coffee budget this
+        year (it really is impressive how much we go through!)
+      </li>
+      <li>
+        A blimp would definitely make the venue very easy to find, but
+        I think it might be a bit out of our budget. Maybe we could
+        rent some spotlights instead?
+      </li>
+      <li>
+        We absolutely will need more hamster wheels, last year's line
+        was <em>way</em> too long. Will get on that now before rental
+        season hits its peak.
+      </li>
+    </ul>
+
+    <p>Let me know when you've nailed down the dates!</p>
+  </Message>
+</template>
 ```
 
 As shown here, we can pass different content into the tag. The content
@@ -230,21 +260,27 @@ hasn't provided a block. For instance, consider an error message dialog that has
 a default message in cases where we don't know what error occurred. We could show
 the default message using the `(has-block)` syntax in an `ErrorDialog` component.
 
-```handlebars {data-filename=app/components/error-dialog.hbs}
-<dialog>
-  {{#if (has-block)}}
-    {{yield}}
-  {{else}}
-    An unknown error occurred!
-  {{/if}}
-</dialog>
+```gjs {data-filename="app/components/error-dialog.gjs"}
+<template>
+  <dialog>
+    {{#if (has-block)}}
+      {{yield}}
+    {{else}}
+      An unknown error occurred!
+    {{/if}}
+  </dialog>
+</template>
 ```
 
 Now, if we use our `ErrorDialog` component without a block, we'll get the
 default message.
 
-```handlebars
-<ErrorDialog/>
+```gjs
+import ErrorDialog from './error-dialog.gjs';
+
+<template>
+  <ErrorDialog/>
+</template>
 ```
 ```html
 <!-- rendered -->
@@ -256,11 +292,16 @@ default message.
 If we had a more detailed message, though, we could use the block to pass it to
 the dialog.
 
-```handlebars
-<ErrorDialog>
-  <Icon type="no-internet" />
-  <p>You are not connected to the internet!</p>
-</ErrorDialog>
+```gjs
+import ErrorDialog from './error-dialog.gjs';
+import Icon from './icon.gjs';
+
+<template>
+  <ErrorDialog>
+    <Icon type="no-internet" />
+    <p>You are not connected to the internet!</p>
+  </ErrorDialog>
+</template>
 ```
 
 ## Block Parameters
@@ -268,16 +309,22 @@ the dialog.
 Blocks can also pass values back into the template, similar to a callback
 function in JavaScript. Consider for instance a simple `BlogPost` component.
 
-```handlebars {data-filename=app/components/blog-post.hbs}
-<h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h2>
+```gjs {data-filename="app/components/blog-post.gjs"}
+<template>
+  <h1>{{@post.title}}</h1>
+  <h2>{{@post.author}}</h2>
 
-{{@post.body}}
+  {{@post.body}}
+</template>
 ```
 
-```handlebars
-<!-- usage -->
-<BlogPost @post={{@blogPost}} />
+```gjs
+import BlogPost from './blog-post.gjs';
+
+<template>
+  <!-- usage -->
+  <BlogPost @post={{@blogPost}} />
+</template>
 ```
 
 We may want to give the user the ability to put extra content before or after
@@ -285,79 +332,101 @@ the post, such as an image or a profile. Since we don't know what the
 user wants to do with the body of the post, we can instead pass the body back
 to them.
 
-```handlebars {data-filename=app/components/blog-post.hbs}
-<h1>{{@post.title}}</h1>
-<h2>{{@post.author}}</h2>
+```gjs {data-filename="app/components/blog-post.gjs"}
+<template>
+  <h1>{{@post.title}}</h1>
+  <h2>{{@post.author}}</h2>
 
-{{yield @post.body}}
+  {{yield @post.body}}
+</template>
 ```
 
-```handlebars
-<!-- usage -->
-<BlogPost @post={{@blogPost}} as |postBody|>
-  <img alt="" role="presentation" src="./blog-logo.png">
+```gjs
+import BlogPost from './blog-post.gjs';
+import AuthorBio from './author-bio.gjs';
 
-  {{postBody}}
+<template>
+  <!-- usage -->
+  <BlogPost @post={{@blogPost}} as |postBody|>
+    <img alt="" role="presentation" src="./blog-logo.png">
 
-  <AuthorBio @author={{@blogPost.author}} />
-</BlogPost>
+    {{postBody}}
+
+    <AuthorBio @author={{@blogPost.author}} />
+  </BlogPost>
+</template>
 ```
 
 We can yield back multiple values as well, separated by spaces.
 
-```handlebars {data-filename=app/components/blog-post.hbs}
-{{yield @post.title @post.author @post.body }}
+```gjs {data-filename="app/components/blog-post.gjs"}
+<template>
+  {{yield @post.title @post.author @post.body }}
+</template>
 ```
 
-```handlebars
-<!-- usage -->
-<BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
-  <img alt="" role="presentation" src="./blog-logo.png">
+```gjs
+import BlogPost from './blog-post.gjs';
+import AuthorBio from './author-bio.gjs';
 
-  {{postTitle}}
+<template>
+  <!-- usage -->
+  <BlogPost @post={{@blogPost}} as |postTitle postAuthor postBody|>
+    <img alt="" role="presentation" src="./blog-logo.png">
 
-  {{postBody}}
+    {{postTitle}}
 
-  <AuthorBio @author={{postAuthor}} />
-</BlogPost>
+    {{postBody}}
+
+    <AuthorBio @author={{postAuthor}} />
+  </BlogPost>
+</template>
 ```
 
 ## Named Blocks
 
 If you want to yield content to different spots in the same component, you can use named blocks. You just need to specify a name for the yielded block, like this:
 
-```handlebars
-{{yield to="somePlace"}}
+```gjs
+<template>
+  {{yield to="somePlace"}}
+</template>
 ```
 
 You could also want to pass some values. This is the same process as the default `yield`, but you just have to pass `to` as the last argument. An example would be the popover:
 
-```handlebars {data-filename=app/components/popover.hbs}
-<div class="popover">
-  <div class="popover__trigger">
-    {{yield this.isOpen to="trigger"}}
-  </div>
-  {{#if this.isOpen}}
-    <div class="popover__content">
-      {{yield to="content"}}
+```gjs {data-filename="app/components/popover.gjs"}
+<template>
+  <div class="popover">
+    <div class="popover__trigger">
+      {{yield this.isOpen to="trigger"}}
     </div>
-  {{/if}}
-</div>
+    {{#if this.isOpen}}
+      <div class="popover__content">
+        {{yield to="content"}}
+      </div>
+    {{/if}}
+  </div>
+</template>
 ```
 
 Without named blocks, we would certainly have to pass components as `args` to the popover. But this is much more practical!
 
 Here’s how we would call our named blocks as a consumer:
 
-```handlebars
-<Popover>
-  <:trigger as |open|>
-    <button type="button">Click to {{if open "close" "open"}}  the popover!</button>
-  </:trigger>
-  <:content>
-     This is what is shown when I'm opened!
-  </:content>
-</Popover>
+```gjs
+import Popover from './popover.gjs';
+
+<template>
+  <Popover>
+    <:trigger as |open|>
+      <button type="button">Click to {{if open "close" "open"}}  the popover!</button>
+    </:trigger>
+    <:content>
+       This is what is shown when I'm opened!
+    </:content>
+  </Popover>
+</template>
 ```
 
 We know the state of the popover because we passed it as an argument to the `yield`. To access its value, use the block parameters at the named block scope. It will not be accessible at the `Popover` level, so if you want the value to be available for all the blocks, you will have to pass it for each of them.
@@ -378,38 +447,48 @@ Rendering the previous code example would give this as result:
 
 Don't worry, you can also still use `yield` by itself, and mix it with named blocks. Let’s take a card example:
 
-```handlebars {data-filename=app/components/card.hbs}
-<div class="card">
-  {{#if (has-block "title")}}
-    <div class="card__title">
-      {{yield to="title"}}
+```gjs {data-filename="app/components/card.gjs"}
+<template>
+  <div class="card">
+    {{#if (has-block "title")}}
+      <div class="card__title">
+        {{yield to="title"}}
+      </div>
+    {{/if}}
+    <div class="card__content">
+      {{yield}}
     </div>
-  {{/if}}
-  <div class="card__content">
-    {{yield}}
   </div>
-</div>
+</template>
 ```
 
 A yielded block without a name is called `default`. So to access it, it’s like any other named blocks.
 
-```handlebars
-<Card>
-  <:title>
-    <h3>It's nice to have me. Sometimes</h3>
-  </:title>
-  <:default>
-    The card content will appear here!
-  </:default>
-</Card>
+```gjs
+import Card from './card.gjs';
+
+<template>
+  <Card>
+    <:title>
+      <h3>It's nice to have me. Sometimes</h3>
+    </:title>
+    <:default>
+      The card content will appear here!
+    </:default>
+  </Card>
+</template>
 ```
 
 The title being optional when you create a card, you can use the `(has-block)` helper with the named block by adding its name as a first parameter. That means you could also create this card:
 
-```handlebars
-<Card>
-  I don't want any title, and I only have a default content!
-</Card>
+```gjs
+import Card from './card.gjs';
+
+<template>
+  <Card>
+    I don't want any title, and I only have a default content!
+  </Card>
+</template>
 ```
 
 As you are not using named blocks, you can simply yield the content you would like to add, which becomes the default yield block.

--- a/guides/release/components/built-in-components.md
+++ b/guides/release/components/built-in-components.md
@@ -12,13 +12,17 @@ We mentioned that the built-in components are similar in HTML markup to their na
 
 Consider the following example in a template file.
 
-```handlebars
-<label for="user-question">Ask a question about Ember:</label>
-<Input
-  id="user-question"
-  @type="text"
-  @value="How do text fields work?"
-/>
+```gjs
+import { Input } from '@ember/component';
+
+<template>
+  <label for="user-question">Ask a question about Ember:</label>
+  <Input
+    id="user-question"
+    @type="text"
+    @value="How do text fields work?"
+  />
+</template>
 ```
 
 When Ember renders this template, you will see the following HTML code:
@@ -35,40 +39,71 @@ Every input should be associated with a label. In HTML, there are a few ways to 
 
 1. You can nest the input inside the label.
 
-   ```handlebars
-   <label>
-     Ask a question about Ember:
+  ```gjs
+  import Component from "@glimmer/component";
+  import { Input } from '@ember/component';
+  import { tracked } from '@glimmer/tracking';
 
-     <Input
-       @type="text"
-       @value={{this.userQuestion}}
-     />
-   </label>
-   ```
+  export default class Example extends Component {
+    @tracked userQuestion = '';
+
+    <template>
+      <label>
+        Ask a question about Ember:
+
+        <Input
+          @type="text"
+          @value={{this.userQuestion}}
+        />
+      </label>
+    </template>
+  }
+  ```
 
 2. You can create an ID (globally unique within the webpage), then associate the label to the input with `for` attribute and `id` attribute.
 
-   ```handlebars
-   <label for={{this.myUniqueId}}>
-     Ask a question about Ember:
-   </label>
+  ```gjs
+  import Component from "@glimmer/component";
+  import { Input } from '@ember/component';
+  import { tracked } from '@glimmer/tracking';
 
-   <Input
-     id={{this.myUniqueId}}
-     @type="text"
-     @value={{this.userQuestion}}
-   />
-   ```
+  export default class Example extends Component {
+    @tracked userQuestion = '';
+    myUniqueId = "this-is-a-unique-id";
+
+    <template>
+      <label for={{this.myUniqueId}}>
+        Ask a question about Ember:
+      </label>
+
+      <Input
+        id={{this.myUniqueId}}
+        @type="text"
+        @value={{this.userQuestion}}
+      />
+    </template>
+  }
+  ```
 
 3. You can use the `aria-label` attribute to label the input with a string that is visually hidden but still available to assistive technology. 
 
-   ```handlebars
-   <Input
-     aria-label="Ask a question about Ember"
-     @type="text"
-     @value={{this.userQuestion}}
-   />
-   ```
+   ```gjs
+  import Component from "@glimmer/component";
+  import { Input } from '@ember/component';
+  import { tracked } from '@glimmer/tracking';
+
+  export default class Example extends Component {
+    @tracked userQuestion = '';
+
+    <template>
+      <Input
+        aria-label="Ask a question about Ember"
+        @type="text"
+        @value={{this.userQuestion}}
+      />
+    </template>
+  }
+  ```
 
 While it is more appropriate to use the `<label>` element, the `aria-label` attribute can be used in instances where visible text content is not possible.
 
@@ -79,9 +114,13 @@ With a few exceptions, you can pass [input attributes](https://developer.mozilla
 
 For example, the `aria-labelledby` attribute may be useful if you have a search input. The search button can serve as the label for the input element:
 
-```handlebars
-<Input aria-labelledby="button-search" />
-<button id="button-search" type="button">Search</button>
+```gjs
+import { Input } from '@ember/component';
+
+<template>
+  <Input aria-labelledby="button-search" />
+  <button id="button-search" type="button">Search</button>
+</template>
 ```
 
 If an attribute is set to a quoted string (`"button-search"` in the prior example), its value will be set directly on the element.
@@ -89,14 +128,25 @@ If an attribute is set to a quoted string (`"button-search"` in the prior exampl
 You can also bind the attribute value to a property that you own.
 In the next example, the `disabled` attribute is bound to the value of `isReadOnly` in the current context.
 
-```handlebars
-<label for="input-name">Name:</label>
-<Input
-  id="input-name"
-  @value={{this.name}}
-  disabled={{this.isReadOnly}}
-  maxlength="50"
-/>
+```gjs
+import Component from "@glimmer/component";
+import { Input } from '@ember/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class Example extends Component {
+  @tracked isReadOnly = true;
+  @tracked name = 'Tomster';
+
+  <template>
+    <label for="input-name">Name:</label>
+    <Input
+      id="input-name"
+      @value={{this.name}}
+      disabled={{this.isReadOnly}}
+      maxlength="50"
+    />
+  </template>
+}
 ```
 
 Recall that there were a few exceptions. The following input attributes must be passed as arguments (i.e. do prepend `@`) to the `<Input>` component:
@@ -110,13 +160,27 @@ Recall that there were a few exceptions. The following input attributes must be 
 
 Starting with Ember Octane, we recommend using the `{{on}}` modifier to call an action on specific events such as the [input event](https://developer.mozilla.org/docs/Web/API/HTMLElement/input_event).
 
-```handlebars
-<label for="input-name">Name:</label>
-<Input
-  id="input-name"
-  @value={{this.name}}
-  {{on "input" this.validateName}}
-/>
+```gjs
+import Component from "@glimmer/component";
+import { Input } from '@ember/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class Example extends Component {
+  @tracked name = '';
+
+  validateName = (inputValue) => {
+    // Name validation here
+  };
+
+  <template>
+    <label for="input-name">Name:</label>
+    <Input
+      id="input-name"
+      @value={{this.name}}
+      {{on "input" this.validateName}}
+    />
+  </template>
+}
 ```
 
 [Learn more about the `{{on}}` modifier.](../../upgrading/current-edition/action-on-and-fn/#toc_the-on-modifier)
@@ -127,18 +191,36 @@ The modern, Octane-style way to handle keyboard events is to [write a modifier](
 
 There are [community-made addons](https://emberobserver.com/?query=keyboard) to help manage keyboard events. For example, with [ember-keyboard](https://github.com/adopted-ember-addons/ember-keyboard), you can write,
 
-```handlebars
-{{!-- Before --}}
-<Input
-  @enter={{this.doSomething}}
-  @escape-press={{this.doSomethingElse}}
-/>
+```gjs
+import Component from "@glimmer/component";
+import { Input } from '@ember/component';
+import onKey from 'ember-keyboard/modifiers/on-key.js';
 
-{{!-- After --}}
-<Input
-  {{on-key "Enter" this.doSomething}}
-  {{on-key "Escape" this.doSomethingElse event="keydown"}}
-/>
+export default class Example extends Component {
+
+  doSomething = () => {
+    alert('something');
+  };
+
+  doSomethingElse = () => {
+    alert('something else');
+  };
+  
+
+  <template>
+    {{!-- Before --}}
+    <Input
+      @enter={{this.doSomething}}
+      @escape-press={{this.doSomethingElse}}
+    />
+
+    {{!-- After --}}
+    <Input
+      {{onKey "Enter" this.doSomething}}
+      {{onKey "Escape" this.doSomethingElse event="keydown"}}
+    />
+  </template>
+}
 ```
 
 Note, the `keydown` event was used for `Escape` because `keypress` is deprecated.
@@ -150,25 +232,50 @@ You can use the
 [`<Input>`](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input)
 component to create a checkbox. Set `@type` to the string `"checkbox"`, and use `@checked` instead of `@value`.
 
-```handlebars
-<label for="admin-checkbox">Is Admin?</label>
-<Input
-  id="admin-checkbox"
-  @type="checkbox"
-  @checked={{this.isAdmin}}
-/>
+```gjs
+import Component from "@glimmer/component";
+import { Input } from '@ember/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class Example extends Component {
+  @tracked isAdmin = false;
+
+  <template>
+    <label for="admin-checkbox">Is Admin?</label>
+    <Input
+      id="admin-checkbox"
+      @type="checkbox"
+      @checked={{this.isAdmin}}
+    />
+  </template>
+}
 ```
 
 To call an action on specific events, use the `{{on}}` modifier:
 
-```handlebars
-<label for="admin-checkbox">Is Admin?</label>
-<Input
-  id="admin-checkbox"
-  @type="checkbox"
-  @checked={{this.isAdmin}}
-  {{on "input" this.validateRole}}
-/>
+```gjs
+import Component from "@glimmer/component";
+import { Input } from '@ember/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+
+export default class Example extends Component {
+  @tracked isAdmin = false;
+
+  validateRole = () => {
+    // validate logic
+  };
+
+  <template>
+    <label for="admin-checkbox">Is Admin?</label>
+    <Input
+      id="admin-checkbox"
+      @type="checkbox"
+      @checked={{this.isAdmin}}
+      {{on "input" this.validateRole}}
+    />
+  </template>
+  }
 ```
 
 
@@ -176,45 +283,26 @@ To call an action on specific events, use the `{{on}}` modifier:
 
 The following example shows how to bind `this.userComment` to a text area's value.
 
-```handlebars
-<label for="user-comment">Comment:</label>
-<Textarea
-  id="user-comment"
-  @value={{this.userComment}}
-  rows="6"
-  cols="80"
-/>
-```
+```gjs
+import Component from "@glimmer/component";
+import { Textarea } from '@ember/component';
+import { tracked } from '@glimmer/tracking';
 
+export default class Example extends Component {
+  @tracked userComment = '';
+
+  <template>
+    <label for="user-comment">Comment:</label>
+    <Textarea
+      id="user-comment"
+      @value={{this.userComment}}
+      rows="6"
+      cols="80"
+    />
+  </template>
+}
+```
 
 ### Setting attributes on `<Textarea>`
 
 With the exception of `@value` argument, you can use any [attribute](https://developer.mozilla.org/docs/Web/HTML/Element/textarea#Attributes) that `<textarea>` natively supports.
-
-
-<!--
-  TODO:
-  Move this section to a dedicated page for how to build forms.
-  Please present a solution that does not use `{{mut}}`.
--->
-## Binding dynamic attribute
-
-You might need to bind a property dynamically to an input if you're building a
-flexible form, for example. To achieve this you need to use the
-[`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
-and [`{{mut}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/mut?anchor=mut)
-in conjunction like shown in the following example:
-
-```handlebars
-<label for="input-name">Name:</label>
-<Input
-  id="input-name"
-  @value={{mut (get this.person this.field)}}
-/>
-```
-
-The `{{get}}` helper allows you to dynamically specify which property to bind,
-while the `{{mut}}` helper allows the binding to be updated from the input. See
-the respective helper documentation for more detail:
-[`{{get}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/get?anchor=get)
-and [`{{mut}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/mut?anchor=mut).

--- a/guides/release/components/component-arguments-and-html-attributes.md
+++ b/guides/release/components/component-arguments-and-html-attributes.md
@@ -3,16 +3,20 @@ Components become useful building blocks of our app if we make them _reusable_. 
 Let's start with two similar but not identical avatar components, that represent
 different users:
 
-```handlebars {data-filename="app/components/received-message/avatar.hbs"}
-<aside>
-  <div class="avatar" title="Tomster's avatar">T</div>
-</aside>
+```gjs {data-filename="app/components/received-message/avatar.gjs"}
+<template>
+  <aside>
+    <div class="avatar" title="Tomster's avatar">T</div>
+  </aside>
+</template>
 ```
 
-```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
-<aside class="current-user">
-  <div class="avatar" title="Zoey's avatar">Z</div>
-</aside>
+```gjs {data-filename="app/components/sent-message/avatar.gjs"}
+<template>
+  <aside class="current-user">
+    <div class="avatar" title="Zoey's avatar">Z</div>
+  </aside>
+</template>
 ```
 
 The _structure_ of these components is identical, but they have somewhat
@@ -37,10 +41,12 @@ attributes).
 We can create a component that can be used in both situations by _templating_
 the parts of the HTML that are different.
 
-```handlebars {data-filename="app/components/avatar.hbs"}
-<aside>
-  <div class="avatar" title={{@title}}>{{@initial}}</div>
-</aside>
+```gjs {data-filename="app/components/avatar.gjs"}
+<template>
+  <aside>
+    <div class="avatar" title={{@title}}>{{@initial}}</div>
+  </aside>
+</template>
 ```
 
 The syntax `{{@initial}}` means that the contents inside the `<div>` tag are
@@ -49,8 +55,12 @@ _dynamic_ and will be specified by the `<Avatar>` tag. Likewise, the
 and will be specified in the same way. We can now replace the received message
 avatar by using the `<Avatar>` tag and providing it with some arguments.
 
-```handlebars {data-filename="app/components/received-message/avatar.hbs"}
-<Avatar @title="Tomster's avatar" @initial="T" />
+```gjs {data-filename="app/components/received-message/avatar.gjs"}
+import Avatar from "../..app/components/avatar.gjs";
+
+<template>
+  <Avatar @title="Tomster's avatar" @initial="T" />
+</template>
 ```
 
 This code includes the `<Avatar>` component, which expects two _arguments_:
@@ -80,13 +90,17 @@ the _browser_ what to do, it's telling your custom tag what to do.
 
 Let's try to use our `<Avatar>` component for the sent message avatar.
 
-```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
-<Avatar @title="Zoey's avatar" @initial="Z" />
+```gjs {data-filename="app/components/sent-message/avatar.gjs"}
+import Avatar from "../..app/components/avatar.gjs";
+
+<template>
+  <Avatar @title="Zoey's avatar" @initial="Z" />
+</template>
 ```
 
 We're really, really close.
 
-```handlebars {data-filename="output" data-diff="-1,+2"}
+```html {data-filename="output" data-diff="-1,+2"}
 <aside class="current-user">
 <aside>
   <div class="avatar" title="Zoey's avatar">Z</div>
@@ -96,21 +110,27 @@ We're really, really close.
 We're just missing the `current-user` class on the HTML `<aside>` element. To
 make that work, we'll specify the HTML attribute `class` on the `<Avatar>` tag.
 
-```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
-<Avatar
-  @title="Zoey's avatar"
-  @initial="Z"
-  class="current-user"
-/>
+```gjs {data-filename="app/components/sent-message/avatar.gjs"}
+import Avatar from "../..app/components/avatar.gjs";
+
+<template>
+  <Avatar
+    @title="Zoey's avatar"
+    @initial="Z"
+    class="current-user"
+  />
+</template>
 ```
 
 The avatar component also needs to specify where to put attributes that were
 specified on the tag.
 
-```handlebars {data-filename="app/components/avatar.hbs"}
-<aside ...attributes>
-  <div class="avatar" title={{@title}}>{{@initial}}</div>
-</aside>
+```gjs {data-filename="app/components/avatar.gjs"}
+<template>
+  <aside ...attributes>
+    <div class="avatar" title={{@title}}>{{@initial}}</div>
+  </aside>
+</template>
 ```
 
 The `...attributes` syntax determines where the attributes from a tag should

--- a/guides/release/components/conditional-content.md
+++ b/guides/release/components/conditional-content.md
@@ -1,23 +1,46 @@
 In a template, you can use `if` to conditionally render content.
 There are 2 styles of `if`: **block** and **inline**.
 
-```handlebars
-{{#if this.thingIsTrue}}
-  Content for the block form of "if"
-{{/if}}
+```gjs
+<template>
+  {{#if this.thingIsTrue}}
+    Content for the block form of "if"
+  {{/if}}
 
-<div class={{if this.thingIsTrue "value-if-true" "value-if-false"}}>
-  This div used the inline "if" to calculate the class to use.
-</div>
+  <div class={{if this.thingIsTrue "value-if-true" "value-if-false"}}>
+    This div used the inline "if" to calculate the class to use.
+  </div>
+</template>
 ```
 
 Additionally, you can use template helpers like `concat` within a conditional. For the example below, if `@color` has a truthy value, such as `'navy'`, the div classes will include `badge-navy`:
 
-```handlebars
-<div class="badge {{if @color (concat 'badge-' @color)}}">
-  Badge Text
-</div>
+```gjs
+import { concat } from '@ember/helper';
+
+<template>
+  <div class="badge {{if @color (concat 'badge-' @color)}}">
+    Badge Text
+  </div>
+</template>
 ```
+
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        <p>
+          Helpers like `concat` in Ember are regular JavaScript functions that 
+          return a value, in this case a string.
+          The section on Helper Functions goes into more detail about how to use them and create your own.
+        </p>
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
+
 
 ## Block `if`
 
@@ -25,17 +48,21 @@ Additionally, you can use template helpers like `concat` within a conditional. F
 
 Let's take a look at two components that display a person's username.
 
-```handlebars {data-filename="app/components/received-message/username.hbs"}
-<h4 class="username">
-  Tomster
-  <span class="local-time">their local time is 4:56pm</span>
-</h4>
+```gjs {data-filename="app/components/received-message/username.gjs"}
+<template>
+  <h4 class="username">
+    Tomster
+    <span class="local-time">their local time is 4:56pm</span>
+  </h4>
+<template>
 ```
 
-```handlebars {data-filename="app/components/sent-message/username.hbs"}
-<h4 class="username">
-  Zoey
-</h4>
+```gjs {data-filename="app/components/sent-message/username.gjs"}
+<template>
+  <h4 class="username">
+    Zoey
+  </h4>
+</template>
 ```
 
 The components look similar, don't they?
@@ -43,11 +70,13 @@ The first component shows extra information about the user's local time.
 
 Let's say we tried to create a single `username` component.
 
-```handlebars {data-filename="app/components/username.hbs"}
-<h4 class="username">
-  {{@name}}
-  <span class="local-time">their local time is {{@localTime}}</span>
-</h4>
+```gjs {data-filename="app/components/username.gjs"}
+<template>
+  <h4 class="username">
+    {{@name}}
+    <span class="local-time">their local time is {{@localTime}}</span>
+  </h4>
+<template>
 ```
 
 If the `<Username>` tag doesn't specify a `@localTime` argument,
@@ -56,13 +85,28 @@ we will see an extra, incomplete text, `their local time is `, on the screen.
 What we need is a way to display the local time if `@localTime` exists.
 We can do this with an `if`.
 
-```handlebars {data-filename="app/components/username.hbs"}
-<h4 class="username">
-  {{@name}}
-  {{#if @localTime}}
-    <span class="local-time">their local time is {{@localTime}}</span>
-  {{/if}}
-</h4>
+```gjs {data-filename="app/components/username.gjs"}
+<template>
+  <h4 class="username">
+    {{@name}}
+    {{#if @localTime}}
+      <span class="local-time">their local time is {{@localTime}}</span>
+    {{/if}}
+  </h4>
+</template>
+```
+
+Now we can use this component like so:
+
+```gjs
+import Username from './components/username.gjs';
+
+<template>
+  {{!-- call it with @localTime  --}}
+  <Username @name="Tomster" @localTime="10:32am" >
+  {{!-- or without  --}}
+  <Username @name="Tomster" />
+</template>
 ```
 
 <div class="cta">
@@ -84,10 +128,12 @@ We can do this with an `if`.
 
 ### Usage
 
-```handlebars {data-filename="app/components/my-component.hbs"}
-{{#if condition}}
-  {{!-- some content --}}
-{{/if}}
+```gjs {data-filename="app/components/my-component.gjs"}
+<template>
+  {{#if condition}}
+    {{!-- some content --}}
+  {{/if}}
+</template>
 ```
 
 This is the syntax for an `if` statement in block form.
@@ -96,22 +142,24 @@ If the `condition` is true, Ember will render the content that is inside the blo
 Like many programming languages, Ember also allows you to write `if else` and
 `if else if` statements in a template.
 
-```handlebars {data-filename="app/components/my-component.hbs"}
-{{#if condition}}
-  {{!-- some content --}}
-{{else}}
-  {{!-- some other content --}}
-{{/if}}
+```gjs {data-filename="app/components/my-component.gjs"}
+<template>
+  {{#if condition}}
+    {{!-- some content --}}
+  {{else}}
+    {{!-- some other content --}}
+  {{/if}}
 
-{{#if condition1}}
-  ...
-{{else if condition2}}
-  ...
-{{else if condition3}}
-  ...
-{{else}}
-  ...
-{{/if}}
+  {{#if condition1}}
+    ...
+  {{else if condition2}}
+    ...
+  {{else if condition3}}
+    ...
+  {{else}}
+    ...
+  {{/if}}
+</template>
 ```
 
 
@@ -124,26 +172,30 @@ Sometimes, you will want to conditionally set an argument or attribute.
 For instance, consider two components that display a user's avatar.
 One is for a recipient and the other for a sender.
 
-```handlebars {data-filename="app/components/received-message/avatar.hbs"}
-<aside>
-  <div
-    class="avatar is-active"
-    title="Tomster's avatar"
-  >
-    T
-  </div>
-</aside>
+```gjs {data-filename="app/components/received-message/avatar.gjs"}
+<template>
+  <aside>
+    <div
+      class="avatar is-active"
+      title="Tomster's avatar"
+    >
+      T
+    </div>
+  </aside>
+</template>
 ```
 
-```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
-<aside class="current-user">
-  <div
-    class="avatar"
-    title="Zoey's avatar"
-  >
-    Z
-  </div>
-</aside>
+```gjs {data-filename="app/components/sent-message/avatar.gjs"}
+<template>
+  <aside class="current-user">
+    <div
+      class="avatar"
+      title="Zoey's avatar"
+    >
+      Z
+    </div>
+  </aside>
+</template>
 ```
 
 Again, the two components look similar.
@@ -162,33 +214,43 @@ Let's use `...attributes` to apply the `current-user` class.
 We take these API designs into account and end up with a reusable component.
 The component uses an inline `if` to conditionally apply the `is-active` class.
 
-```handlebars {data-filename="app/components/avatar.hbs"}
-<aside ...attributes>
-  <div
-    class="avatar {{if @isActive "is-active"}}"
-    title={{@title}}
-  >
-    {{@initial}}
-  </div>
-</aside>
+```gjs {data-filename="app/components/avatar.gjs"}
+<template>
+  <aside ...attributes>
+    <div
+      class="avatar {{if @isActive "is-active"}}"
+      title={{@title}}
+    >
+      {{@initial}}
+    </div>
+  </aside>
+</template>
 ```
 
 Afterwards, we can refactor the initial components.
 
-```handlebars {data-filename="app/components/received-message/avatar.hbs"}
-<Avatar
-  @isActive={{true}}
-  @title="Tomster's avatar"
-  @initial="T"
-/>
+```gjs {data-filename="app/components/received-message/avatar.gjs"}
+import Avatar from '../avatar.gjs';
+
+<template>
+  <Avatar
+    @isActive={{true}}
+    @title="Tomster's avatar"
+    @initial="T"
+  />
+</template>
 ```
 
-```handlebars {data-filename="app/components/sent-message/avatar.hbs"}
-<Avatar
-  class="current-user"
-  @title="Zoey's avatar"
-  @initial="Z"
-/>
+```gjs {data-filename="app/components/sent-message/avatar.gjs"}
+import Avatar from '../avatar.gjs';
+
+<template>
+  <Avatar
+    class="current-user"
+    @title="Zoey's avatar"
+    @initial="Z"
+  />
+</template>
 ```
 
 <div class="cta">
@@ -211,8 +273,10 @@ Afterwards, we can refactor the initial components.
 
 ### Usage
 
-```handlebars {data-filename="app/components/my-component.hbs"}
-{{if condition value}}
+```gjs {data-filename="app/components/my-component.gjs"}
+<template>
+  {{if condition value}}
+</template>
 ```
 
 This is the syntax for an `if` statement in inline form.
@@ -221,8 +285,10 @@ If the `condition` is true, Ember will use `value` at the invocation site.
 Ember also allows you to write an `if else` statement in inline form.
 It looks similar to a ternary operator.
 
-```handlebars {data-filename="app/components/my-component.hbs"}
-{{if condition value1 value2}}
+```gjs {data-filename="app/components/my-component.gjs"}
+<template>
+  {{if condition value1 value2}}
+</template>
 ```
 
 

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -1,39 +1,48 @@
 Helper functions are JavaScript functions that you can call from your template.
 
-Ember's template syntax limits what you can express to keep the structure of your application clear at a glance. When you need to compute something using JavaScript, you can use helper functions. It's possible to create your own helpers, locally or just [use the built-in ones](./#toc_built-in-helpers).
+Ember's template syntax limits what you can express to keep the structure of your application clear at a glance. When you need to compute something using JavaScript, you can use helper functions. Helper functions are just plain JavaScript, so it's possible to create your own helpers. You can define functions locally or import them like any other JavaScript code.  Ember also ships with a few [common functions](./#toc_built-in-helpers) you can import as well.
 
 Let's take a look at a generic message component from a messaging app.
 
-```handlebars {data-filename="app/components/message.hbs"}
-<Message::Avatar
-  @title={{@avatarTitle}}
-  @initial={{@avatarInitial}}
-  @isActive={{@userIsActive}}
-  class={{if @isCurrentUser "current-user"}}
-/>
-<section>
-  <Message::Username
-    @name={{@username}}
-    @localTime={{@userLocalTime}}
-  />
+```gjs {data-filename="app/components/message.gjs"}
+import MessageAvatar from './message/avatar.gjs';
+import MessageUsername from './message/username.gjs';
 
-  {{yield}}
-</section>
+<template>
+  <MessageAvatar
+    @title={{@avatarTitle}}
+    @initial={{@avatarInitial}}
+    @isActive={{@userIsActive}}
+    class={{if @isCurrentUser "current-user"}}
+  />
+  <section>
+    <MessageUsername
+      @name={{@username}}
+      @localTime={{@userLocalTime}}
+    />
+
+    {{yield}}
+  </section>
+</template>
 ```
 
-```handlebars
-<Message
-  @username="Tomster"
-  @userIsActive={{true}}
-  @userLocalTime="4:56pm"
-  @avatarTitle="Tomster's avatar"
-  @avatarInitial="T"
->
-  <p>
-    Hey Zoey, have you had a chance to look at the EmberConf
-    brainstorming doc I sent you?
-  </p>
-</Message>
+```gjs
+import Message from './message.gjs';
+
+<template>
+  <Message
+    @username="Tomster"
+    @userIsActive={{true}}
+    @userLocalTime="4:56pm"
+    @avatarTitle="Tomster's avatar"
+    @avatarInitial="T"
+  >
+    <p>
+      Hey Zoey, have you had a chance to look at the EmberConf
+      brainstorming doc I sent you?
+    </p>
+  </Message>
+</template>
 ```
 
 By looking at how we use the `<Message>` component, we can see that some of the arguments are fairly repetitive. Both `@avatarTitle` and `@avatarInitial` are based on the user's `@username`, but the title has more text, and the initial is only the first letter of the name. We'd rather just pass a username to the `<Message>` component and _compute_ the value of the title and initial.
@@ -42,22 +51,27 @@ Let's update the component to do that. It'll take a `@username` argument and cal
 
 Since the title is just the `@username` plus some extra stuff, we can replace `@avatarTitle` by _interpolating_ the `@username` argument in a string literal passed to `<Message::Avatar>`.
 
-```handlebars {data-filename="app/components/message.hbs" data-diff="-2,+3"}
-<Message::Avatar
-  @title={{@avatarTitle}}
-  @title="{{@username}}'s avatar"
-  @initial={{@avatarInitial}}
-  @isActive={{@userIsActive}}
-  class={{if @isCurrentUser "current-user"}}
-/>
-<section>
-  <Message::Username
-    @name={{@username}}
-    @localTime={{@userLocalTime}}
-  />
+```gjs {data-filename="app/components/message.gjs" data-diff="-6,+7"}
+import MessageAvatar from './message/avatar.gjs';
+import MessageUsername from './message/username.gjs';
 
-  {{yield}}
-</section>
+<template>
+  <MessageAvatar
+    @title={{@avatarTitle}}
+    @title="{{@username}}'s avatar"
+    @initial={{@avatarInitial}}
+    @isActive={{@userIsActive}}
+    class={{if @isCurrentUser "current-user"}}
+  />
+  <section>
+    <MessageUsername
+      @name={{@username}}
+      @localTime={{@userLocalTime}}
+    />
+
+    {{yield}}
+  </section>
+</template>
 ```
 
 However, to get the first initial of the string, we'll need to use JavaScript. To do that, we'll write a helper function.
@@ -66,36 +80,36 @@ In this case we want a helper function that takes three arguments: a string, a s
 
 ## Local Helper Functions
 
-It's possible to use plain functions for helpers and modifiers. A plain helper function can be "local" to or defined on components and controllers.
-
-```js {data-filename="app/components/message.js"}
-import Component from '@glimmer/component';
-import { setComponentTemplate } from '@ember/component';
-import { hbs } from 'ember-cli-htmlbars';
-
-export default class Message extends Component {
-  substring = (string, start, end) => string.substring(start, end);
-}
-```
+It's possible to use plain functions for helpers and modifiers. A plain helper function can be "local" to our component file.
 
 We can then use this helper in the component's template to get the first letter of the username.
 
-```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4"}
-<Message::Avatar
-  @title="{{@username}}'s avatar"
-  @initial={{@avatarInitial}}
-  @initial={{this.substring @username 0 1}}
-  @isActive={{@userIsActive}}
-  class={{if @isCurrentUser "current-user"}}
-/>
-<section>
-  <Message::Username
-    @name={{@username}}
-    @localTime={{@userLocalTime}}
-  />
+```gjs {data-filename="app/components/message.gjs" data-diff="+4,+5,+6,+7,-12,+13"}
+import MessageAvatar from './message/avatar.gjs';
+import MessageUsername from './message/username.gjs';
 
-  {{yield}}
-</section>
+// Regular JavaScript function to exctract a substring
+function substring(string, start, end) {
+  return string.substring(start, end);
+}
+
+<template>
+  <MessageAvatar
+    @title="{{@username}}'s avatar"
+    @initial={{@avatarInitial}}
+    @initial={{substring @username 0 1}}
+    @isActive={{@userIsActive}}
+    class={{if @isCurrentUser "current-user"}}
+  />
+  <section>
+    <MessageUsername
+      @name={{@username}}
+      @localTime={{@userLocalTime}}
+    />
+
+    {{yield}}
+  </section>
+</template>
 ```
 
 ### Named Arguments
@@ -104,50 +118,48 @@ Helpers default to using positional arguments, but sometimes it can make the cor
 
 Using named arguments, we could make our template a lot clearer.
 
-```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4,+5"}
-<Message::Avatar
-  @title="{{@username}}'s avatar"
-  @initial={{substring @username 0 1}}
-  {{! This won't work yet! We need to update the substring helper }}
-  @initial={{substring @username start=0 end=1}}
-  @isActive={{@userIsActive}}
-  class={{if @isCurrentUser "current-user"}}
-/>
-<section>
-  <Message::Username
-    @name={{@username}}
-    @localTime={{@userLocalTime}}
-  />
-
-  {{yield}}
-</section>
-```
-
 Helpers take _named arguments_ as a JavaScript object. All named arguments are grouped into an "options object" as the last parameter.
 
-```js {data-filename="app/components/message.js" data-diff="-6,+7"}
-import Component from '@glimmer/component';
-import { setComponentTemplate } from '@ember/component';
-import { hbs } from 'ember-cli-htmlbars';
+```gjs {data-filename="app/components/message.gjs" data-diff="-5,-6,+7,+8,-14,+15"}
+import MessageAvatar from './message/avatar.gjs';
+import MessageUsername from './message/username.gjs';
 
-export default class Message extends Component {
-  substring = (string, start, end) => string.substring(start, end);
-  substring = (string, options) => string.substring(options.start, options.end);
+// Regular JavaScript function to exctract a substring
+function substring(string, start, end) {
+  return string.substring(start, end);
+function substring(string, options) {
+  return string.substring(options.start, options.end);
 }
+
+<template>
+  <MessageAvatar
+    @title="{{@username}}'s avatar"
+    @initial={{substring @username 0 1}}
+    @initial={{substring @username start=0 end=1}}
+    @isActive={{@userIsActive}}
+    class={{if @isCurrentUser "current-user"}}
+  />
+  <section>
+    <MessageUsername
+      @name={{@username}}
+      @localTime={{@userLocalTime}}
+    />
+
+    {{yield}}
+  </section>
+</template>
 ```
 
 You can mix positional and named arguments to make your templates easy to read:
 
-```handlebars {data-filename="app/components/calculator.hbs"}
-{{this.calculate 1 2 op="add"}}
-```
-
-```js {data-filename="app/components/calculator.js"}
-export default class Calculator extends Component {
-  calculate(first, second, options) {
-    // ...
-  }
+```gjs {data-filename="app/components/calculator.gjs"}
+function calculate(first, second, options) {
+  // ...
 }
+
+<template>
+  {{calculate 1 2 op="add"}}
+</template>
 ```
 
 ### Nested Helpers
@@ -156,8 +168,18 @@ Sometimes, you might see helpers invoked by placing them inside parentheses,
 `()`. This means that a Helper is being used inside of another Helper or
 Component. This is referred to as a "nested" Helper Invocation. Parentheses must be used because curly braces `{{}}` cannot be nested.
 
-```handlebars {data-filename=app/templates/application.hbs}
-{{this.sum (this.multiply 2 4) 2}}
+```gjs {data-filename="app/templates/application.gjs"}
+function sum(first, second) {
+  return first + second;
+}
+
+function multiply(first, second) {
+  return first * second;
+}
+
+<template>
+  {{sum (multiply 2 4) 2}}
+</template>
 ```
 
 In this example, we are using a helper to multiply `2` and `4` _before_ passing the value into `{{sum}}`.
@@ -166,18 +188,16 @@ Thus, the output of these combined helpers is `10`.
 
 As you move forward with these template guides, keep in mind that a helper can be used anywhere a normal value can be used.
 
-Many of Ember's built-in helpers (as well as your custom helpers) can be used in nested form.
+## Shared Helper Functions
 
-## Global Helper Functions
-
-Next to local helpers, ember provides a way to use global helpers. We define global helper functions in the `app/helpers` folder. Once defined, they will be available to use directly inside all templates in your app.
+Since helper functions are plain JavaScript functions, we can define them anywhere in our app and import them into our component files. 
 
 <div class="cta">
   <div class="cta-note">
     <div class="cta-note-body">
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
-        Before Ember 4.5, using global helpers was the only way to define helpers.
+        Before `.gjs`, Ember applications defined reusable helper functions in `app/helpers` and made them automatically available to legacy components. You may still put shared functions there, but it is no longer a requirement.
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">
@@ -192,53 +212,30 @@ export default function substring(string, start, end) {
 }
 ```
 
-We can then use this helper in the component's template to get the first letter of the username.
+We can then import this helper and use it in the component's template to get the first letter of the username.
 
-```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4"}
-<Message::Avatar
-  @title="{{@username}}'s avatar"
-  @initial={{@avatarInitial}}
-  @initial={{substring @username 0 1}}
-  @isActive={{@userIsActive}}
-  class={{if @isCurrentUser "current-user"}}
-/>
-<section>
-  <Message::Username
-    @name={{@username}}
-    @localTime={{@userLocalTime}}
+```gjs {data-filename="app/components/message.gjs" data-diff="+3,-8,+9"}
+import MessageAvatar from './message/avatar.gjs';
+import MessageUsername from './message/username.gjs';
+import substring from '../helpers/substring.js';
+
+<template>
+  <MessageAvatar
+    @title="{{@username}}'s avatar"
+    @initial={{@avatarInitial}}
+    @initial={{substring @username 0 1}}
+    @isActive={{@userIsActive}}
+    class={{if @isCurrentUser "current-user"}}
   />
+  <section>
+    <MessageUsername
+      @name={{@username}}
+      @localTime={{@userLocalTime}}
+    />
 
-  {{yield}}
-</section>
-```
-
-### Named arguments
-
-Similar to local helpers, global helpers also can mix positional and named arguments.
-
-```handlebars {data-filename="app/components/message.hbs" data-diff="-3,+4,+5"}
-<Message::Avatar
-  @title="{{@username}}'s avatar"
-  @initial={{substring @username 0 1}}
-  {{! This won't work yet! We need to update the substring helper }}
-  @initial={{substring @username start=0 end=1}}
-  @isActive={{@userIsActive}}
-  class={{if @isCurrentUser "current-user"}}
-/>
-<section>
-  <Message::Username
-    @name={{@username}}
-    @localTime={{@userLocalTime}}
-  />
-
-  {{yield}}
-</section>
-```
-
-```js {data-filename="app/helpers/substring.js"}
-export default function substring(string, { start, end }) {
-  return string.substring(start || 0, end);
-}
+    {{yield}}
+  </section>
+</template>
 ```
 
 ### Classic Helpers
@@ -302,70 +299,116 @@ Class helpers are useful when the helper logic is fairly complicated, requires
 fine-grained control of the helper lifecycle, is _stateful_ (we'll be
 discussing state in the next chapter), or requiring access to a [service](../../services/).
 
-## Built-in Helpers
+## Built-in and Common Helpers
+
+<div class="cta">
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading">Zoey says...</div>
+      <div class="cta-note-message">
+        Unlike nearly everything else in `.gts` files, these helpers do not need to be explicitly imported.
+      </div>
+    </div>
+    <img src="/images/mascots/zoey.png" role="presentation" alt="">
+  </div>
+</div>
 
 Below you will find some useful template helpers documented.
-For the full list of available helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/).
+For the full list of available helpers, you can check the [template helpers API documentation](https://api.emberjs.com/ember/6.5/classes/Ember.Templates.helpers/).
 
 ### The `get` helper
 
-The [`{{get}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/get?anchor=get)
+The [`{{get}}`](https://api.emberjs.com/ember/6.5/classes/Ember.Templates.helpers/methods/get?anchor=get)
 helper makes it easy to dynamically look up a property on an object or an element in an array. The second argument to `{{get}}` can be a string or a number, depending on the object being accessed.
 
 
 To access a property on an object with a string key:
 
-```handlebars
-{{get this.someObject "object_key"}}
+```gjs
+import { get } from '@ember/helper';
+
+const someObject = { object_key: 'Value' };
+
+<template>
+  {{get someObject "object_key"}}
+</template>
 ```
 
 To access the first element in an array:
 
-```handlebars
-{{get this.someArray 0}}
+```gjs
+import { get } from '@ember/helper';
+
+const someArray = [ 'one', 'two' ];
+
+<template>
+  {{get someArray 0}}
+</template>
 ```
 
 To access a property on an object with a dynamic key:
 
-```handlebars
-{{get this.address this.part}}
+```gjs
+import { get } from '@ember/helper';
+
+const address = { city: 'Chicago', state: 'IL', zip: '60610' };
+let part = 'zip';
+
+<template>
+  {{get address part}}
+</template>
 ```
 
-If the `part` getter returns "zip", this will display the result of `this.address.zip`.
-If it returns "city", you get `this.address.city`.
+If the `part` is "zip", this will display the result of `address.zip`.
+If it's "city", you get `address.city`.
 
 
 ### The `concat` helper
 
 We mentioned above that helpers can be nested. This can be
 combined with different dynamic helpers. For example, the
-[`{{concat}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
+[`{{concat}}`](https://api.emberjs.com/ember/6.5/classes/Ember.Templates.helpers/methods/concat?anchor=concat)
 helper makes it easy to dynamically send a number of parameters to a component
 or helper as a single parameter in the format of a concatenated string.
 
-```handlebars
-{{get this.foo (concat "item" this.index)}}
+```gjs
+import { concat, get } from '@ember/helper';
+
+const foo = { item1: 'One', item2: 'Two' };
+let index = 1;
+
+<template>
+  {{get foo (concat "item" index)}}
+</template>
 ```
 
-This will display the result of `this.foo.item1` when index is 1, and
-`this.foo.item2` when index is 2, etc.
+This will display the result of `foo.item1` when index is 1, and
+`foo.item2` when index is 2, etc.
 
 ### The `let` helper
 
 Now let's say your template is starting to get a bit cluttered and you want
 to clean up the logic in your templates. This can be achieved with the `let`
 block helper.
-The [`{{let}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/let?anchor=let)
+The [`{{let}}`](https://api.emberjs.com/ember/6.5/classes/Ember.Templates.helpers/methods/let?anchor=let)
 helper lets you create new bindings (or temporary variables) in your template.
 
 Say your template now looks like this:
 
-```handlebars
-Welcome back {{concat (capitalize this.person.givenName) ' ' (capitalize this.person.familyName)}}
+```gjs
+import { concat } from '@ember/helper';
 
-Account Details:
-Given Name: {{capitalize this.person.givenName}}
-Family Name: {{capitalize this.person.familyName}}
+const capitalize = (s) => s.toUpperCase();
+
+const person = { givenName: 'George', familyName: 'Washington' };
+
+<template>
+  Welcome back {{concat (capitalize person.givenName) ' ' (capitalize person.familyName)}}
+
+  Account Details:
+  Given Name: {{capitalize person.givenName}}
+  Family Name: {{capitalize person.familyName}}
+</template>
 ```
 
 As mentioned in the previous section, we use the `concat` helper to render both
@@ -374,16 +417,24 @@ sure that the names are capitalized. It gets a bit repetitive to keep writing
 `capitalize` and honestly, we might just forget it at some point. Thankfully, we
 can use the `{{let}}` helper to fix this:
 
-```handlebars
-{{#let (capitalize this.person.givenName) (capitalize this.person.familyName)
-  as |givenName familyName|
-}}
-  Welcome back {{concat givenName ' ' familyName}}
+```gjs
+import { concat } from '@ember/helper';
 
-  Account Details:
-  Given Name: {{givenName}}
-  Family Name: {{familyName}}
-{{/let}}
+const capitalize = (s) => s.toUpperCase();
+
+const person = { givenName: 'George', familyName: 'Washington' };
+
+<template>
+  {{#let (capitalize person.givenName) (capitalize person.familyName)
+    as |givenName familyName|
+  }}
+    Welcome back {{concat givenName ' ' familyName}}
+
+    Account Details:
+    Given Name: {{givenName}}
+    Family Name: {{familyName}}
+  {{/let}}
+</template>
 ```
 
 Now, as long as your template is wrapped in the `let` helper, you can access the
@@ -392,109 +443,90 @@ capitalized given name and family name as `givenName` and `familyName` instead o
 
 ### The `array` helper
 
-Using the [`{{array}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
+Using the [`{{array}}`](https://api.emberjs.com/ember/6.5/classes/Ember.Templates.helpers/methods/array?anchor=array) helper,
 you can pass arrays directly from the template as an argument to your components.
 
-```handlebars
-<MyComponent
-  @people={{array
-    'Tom Dale'
-    'Yehuda Katz'
-    this.myOtherPerson
-  }}
-/>
+```gjs
+import { array } from '@ember/helper';
+import MyComponent from './my-component.gjs';
+
+const myOtherPerson = 'George Washington';
+
+<template>
+  <MyComponent
+    @people={{array
+      'Tom Dale'
+      'Yehuda Katz'
+      myOtherPerson
+    }}
+  />
+</template>
 ```
 
 In the component's template, you can then use the `people` argument as an array:
 
-```handlebars {data-filename=app/components/my-component/template.hbs}
-<ul>
-  {{#each @people as |person|}}
-    <li>{{person}}</li>
-  {{/each}}
-</ul>
+```gjs {data-filename="app/components/my-component.gjs"}
+<template>
+  <ul>
+    {{#each @people as |person|}}
+      <li>{{person}}</li>
+    {{/each}}
+  </ul>
+</template>
 ```
 
 ### The `hash` helper
 
-Using the [`{{hash}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
+Using the [`{{hash}}`](https://api.emberjs.com/ember/6.5/classes/Ember.Templates.helpers/methods/hash?anchor=hash)
 helper, you can pass objects directly from the template as an argument to your
 components.
 
-```handlebars
-<Greeting
-  @person={{hash
-    givenName='Jen'
-    familyName='Weber'
-  }}
-/>
+```gjs
+import { hash } from '@ember/helper';
+import Greeting from './greeting.gjs';
+
+<template>
+  <Greeting
+    @person={{hash
+      givenName='Jen'
+      familyName='Weber'
+    }}
+  />
+</template>
 ```
 
 In the component's template, you can then use the `person` object:
-```handlebars {data-filename=app/components/greeting/template.hbs}
-Hello, {{@person.givenName}} {{@person.familyName}}
+```gjs {data-filename="app/components/greeting.gjs"}
+<template>
+  Hello, {{@person.givenName}} {{@person.familyName}}
+</template>
 ```
 
 ### The `in-element` helper
 
-Using the [`{{in-element}}`](https://api.emberjs.com/ember/4.5.0/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. For instance, we might want
-to render a modal, tooltip, or dropdown.
+Using the [`{{in-element}}`](https://api.emberjs.com/ember/6.5/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element) helper, you can render content into a DOM element that is in a _different_ part of the page. 
 
-Suppose we want to show a dropdown menu when the user clicks on a button. The code below shows a `<button>` element, a placeholder `<div>` element, and a dropdown component. The argument `@show`, when set to `true`, will add the dropdown to the placeholder div.
-```handlebars {data-filename=app/components/some-component.hbs}
-  <button
-    type="button"
-    {{on "click" this.onClickShowDropdown}}
-  >
-    More Actions
-  </button>
-  <div id="dropdown-destination" />
+Suppose we want to change the footer text of the page when a component is shown. In this example, the footer has static markup like this:
 
-  <MyDropdownComponent
-    @show={{this.showDropdown}}
-  />
-```
-
-When the user clicks on the button, the flag `showDropdown` will be set to `true`.
-```js {data-filename=app/components/some-component.js}
-  @tracked
-  showDropdown = false;
-
-  @action
-  onClickShowDropdown() {
-    this.showDropdown = true;
-  }
-```
-
-The dropdown component uses the argument `@show` to activate the `in-element` helper. We must **provide the destination DOM element** to the helper. In other words, where should the helper render its block content?
-```handlebars {data-filename=app/components/my-dropdown-component.hbs}
-{{#if @show}}
-  {{#in-element this.destinationElement}}
-    <ul>
-      <li>Archive</li>
-      <li>Mark as Read</li>
-      <li>Report</li>
-    </ul>
-  {{/in-element}}
-{{/if}}
-```
-
-```js {data-filename=app/components/my-dropdown-component.js}
-  get destinationElement() {
-    return document.querySelector('#dropdown-destination');
-  }
-```
-
-After the user clicks on the button, the final HTML result for the div will be like this:
 ```html
-  <div id="dropdown-destination">
-    <ul>
-      <li>Archive</li>
-      <li>Mark as Read</li>
-      <li>Report</li>
-    </ul>
-  </div>
+<footer>
+  Original text
+</footer>
 ```
+
+We can use `in-element` to target the footer even though our component is nowhere near the footer.
+
+```gjs {data-filename="app/components/footer-changer.gjs"}
+const destinationElement = document.querySelector('footer');
+
+<template>
+  {{#in-element destinationElement}}
+    Updated text
+  {{/in-element}}
+</template>
+```
+
+This completely replaces the contents of the `<footer>` with whatever is in the body of the `in-element` block.
 
 Things to note:
 - The destination element needs to exist in the DOM before we use the helper. Otherwise, an error will be thrown if you are in development mode. The error is not thrown in production.

--- a/guides/release/components/index.md
+++ b/guides/release/components/index.md
@@ -1,83 +1,74 @@
-At its core, Ember's UIs are _HTML_ driven - every part of the UI that
-is shown to the user is defined in an HTML template somewhere in your
-application. Because of this, templates are central to Ember, and one of the
-most important parts of the framework.
+At its core, Ember's UIs are _HTML_ driven - every part of the UI that is shown to the user is defined in an HTML template somewhere in your application. Because of this, templates are central to Ember, and one of the most important parts of the framework.
 
-We'll discuss the capabilities and core concepts of templates in the following
-chapters, but before we do that, we should get started with the basics. The
-simplest way to get started on an Ember template is with some HTML!
+We'll discuss the capabilities and core concepts of templates in the following chapters, but before we do that, we should get started with the basics. The simplest way to get started on an Ember template is with some HTML!
 
 ## The Application Template
 
-The central template in an Ember application is the `app/templates/application.hbs`
-file. We can copy HTML into this file, and it will work without any changes. For
-instance, you can copy the following example HTML for a simple messaging app:
+The central template in an Ember application is the `app/templates/application.gjs` file. The `.gjs` extension is short for "Glimmer JavaScript" and it allows us to put both the JavaScript and template in the same file. We can copy HTML inside the `<template>` section of this file, and it will work without any changes. For instance, you can copy the following example HTML for a simple messaging app:
 
-```html {data-filename=app/templates/application.hbs}
-<div class="messages">
-  <aside>
-    <div class="avatar is-active" title="Tomster's avatar">T</div>
-  </aside>
-  <section>
-    <h4 class="username">
-      Tomster
-      <span class="local-time">their local time is 4:56pm</span>
-    </h4>
+```gjs {data-filename=app/templates/application.gjs}
+<template>
+  <div class="messages">
+    <aside>
+      <div class="avatar is-active" title="Tomster's avatar">T</div>
+    </aside>
+    <section>
+      <h4 class="username">
+        Tomster
+        <span class="local-time">their local time is 4:56pm</span>
+      </h4>
 
-    <p>
-      Hey Zoey, have you had a chance to look at the EmberConf brainstorming doc
-      I sent you?
-    </p>
-  </section>
+      <p>
+        Hey Zoey, have you had a chance to look at the EmberConf brainstorming doc
+        I sent you?
+      </p>
+    </section>
 
-  <aside class="current-user">
-    <div class="avatar" title="Zoey's avatar">Z</div>
-  </aside>
-  <section>
-    <h4 class="username">Zoey</h4>
+    <aside class="current-user">
+      <div class="avatar" title="Zoey's avatar">Z</div>
+    </aside>
+    <section>
+      <h4 class="username">Zoey</h4>
 
-    <p>Hey!</p>
+      <p>Hey!</p>
 
-    <p>
-      I love the ideas! I'm really excited about where this year's EmberConf is
-      going, I'm sure it's going to be the best one yet. Some quick notes:
-    </p>
+      <p>
+        I love the ideas! I'm really excited about where this year's EmberConf is
+        going, I'm sure it's going to be the best one yet. Some quick notes:
+      </p>
 
-    <ul>
-      <li>
-        Definitely agree that we should double the coffee budget this year (it
-        really is impressive how much we go through!)
-      </li>
-      <li>
-        A blimp would definitely make the venue very easy to find, but I think
-        it might be a bit out of our budget. Maybe we could rent some spotlights
-        instead?
-      </li>
-      <li>
-        We absolutely will need more hamster wheels, last year's line was
-        <em>way</em> too long. Will get on that now before rental season hits
-        its peak.
-      </li>
-    </ul>
+      <ul>
+        <li>
+          Definitely agree that we should double the coffee budget this year (it
+          really is impressive how much we go through!)
+        </li>
+        <li>
+          A blimp would definitely make the venue very easy to find, but I think
+          it might be a bit out of our budget. Maybe we could rent some spotlights
+          instead?
+        </li>
+        <li>
+          We absolutely will need more hamster wheels, last year's line was
+          <em>way</em> too long. Will get on that now before rental season hits
+          its peak.
+        </li>
+      </ul>
 
-    <p>Let me know when you've nailed down the dates!</p>
-  </section>
+      <p>Let me know when you've nailed down the dates!</p>
+    </section>
 
-  <form>
-    <label for="message">Message</label>
-    <input id="message" />
-    <button type="submit">
-      Send
-    </button>
-  </form>
-</div>
+    <form>
+      <label for="message">Message</label>
+      <input id="message" />
+      <button type="submit">Send</button>
+    </form>
+  </div>
+</template>
 ```
 
-You can _serve_ the app by running `ember s` in your terminal, which will make
-the local copy of your application available to view in your web browser.
+You can _serve_ the app by running `npm start` in your terminal, which will make the local copy of your application available to view in your web browser.
 
-If you serve the app and go to `localhost:4200` in your web browser, you'll see
-the HTML rendered. At this point, it will still be unstyled.
+If you serve the app and go to `localhost:4200` in your web browser, you'll see the HTML rendered. At this point, it will still be unstyled.
 
 To style the application, copy the following CSS into `app/styles/app.css`:
 
@@ -174,22 +165,19 @@ form > button {
   border-bottom-right-radius: 0.5em;
   border: 1px solid #cccccc;
   font-size: 1em;
-  grid-area: 2 / 2 / 3 / 3; 
+  grid-area: 2 / 2 / 3 / 3;
 }
 ```
 
 ![screenshot of styled message app](/images/ember-core-concepts/messaging-app-1.png)
 
-You start building parts of an Ember application using HTML, so if you already
-know HTML and CSS, you know how to build a basic Ember application!
+You start building parts of an Ember application using HTML, so if you already know HTML and CSS, you know how to build a basic Ember application!
 
-You can even use SVG or web components without any changes. As long as your HTML
-is valid, Ember will render it.
+You can even use SVG or web components without any changes. As long as your HTML is valid, Ember will render it.
 
 ## Self-Closing Tags
 
-In addition to normal HTML syntax, Ember allows you to use self-closing syntax
-(`<div />`) as a shorthand for an opening and closing tag (`<div></div>`).
+In addition to normal HTML syntax, Ember allows you to use self-closing syntax (`<div />`) as a shorthand for an opening and closing tag (`<div></div>`).
 
 <div class="cta">
   <div class="cta-note">
@@ -218,8 +206,7 @@ This means that all of the following HTML features work as-is:
 
 ## Restrictions
 
-There are a handful of restrictions on the HTML that you can put in an Ember
-template:
+There are a handful of restrictions on the HTML that you can put in an Ember template:
 
 - Only valid HTML elements in a `<body>` tag can be used
 - No `<script>` tags

--- a/guides/release/components/introducing-components.md
+++ b/guides/release/components/introducing-components.md
@@ -4,64 +4,66 @@ In Ember, those smaller pieces are called _components_.
 
 Let's start with the sample HTML for a messaging app (that we introduced in the previous chapter, if you're reading the guides in order):
 
-```handlebars {data-filename="app/templates/application.hbs"}
-<div class="messages">
-  <aside>
-    <div class="avatar is-active" title="Tomster's avatar">T</div>
-  </aside>
-  <section>
-    <h4 class="username">
-      Tomster
-      <span class="local-time">their local time is 4:56pm</span>
-    </h4>
+```gjs {data-filename="app/templates/application.gjs"}
+<template>
+  <div class="messages">
+    <aside>
+      <div class="avatar is-active" title="Tomster's avatar">T</div>
+    </aside>
+    <section>
+      <h4 class="username">
+        Tomster
+        <span class="local-time">their local time is 4:56pm</span>
+      </h4>
 
-    <p>
-      Hey Zoey, have you had a chance to look at the EmberConf brainstorming doc
-      I sent you?
-    </p>
-  </section>
+      <p>
+        Hey Zoey, have you had a chance to look at the EmberConf brainstorming
+        doc I sent you?
+      </p>
+    </section>
 
-  <aside class="current-user">
-    <div class="avatar" title="Zoey's avatar">Z</div>
-  </aside>
-  <section>
-    <h4 class="username">Zoey</h4>
+    <aside class="current-user">
+      <div class="avatar" title="Zoey's avatar">Z</div>
+    </aside>
+    <section>
+      <h4 class="username">Zoey</h4>
 
-    <p>Hey!</p>
+      <p>Hey!</p>
 
-    <p>
-      I love the ideas! I'm really excited about where this year's EmberConf is
-      going, I'm sure it's going to be the best one yet. Some quick notes:
-    </p>
+      <p>
+        I love the ideas! I'm really excited about where this year's EmberConf
+        is going, I'm sure it's going to be the best one yet. Some quick notes:
+      </p>
 
-    <ul>
-      <li>
-        Definitely agree that we should double the coffee budget this year (it
-        really is impressive how much we go through!)
-      </li>
-      <li>
-        A blimp would definitely make the venue very easy to find, but I think
-        it might be a bit out of our budget. Maybe we could rent some spotlights
-        instead?
-      </li>
-      <li>
-        We absolutely will need more hamster wheels, last year's line was
-        <em>way</em> too long. Will get on that now before rental season hits
-        its peak.
-      </li>
-    </ul>
+      <ul>
+        <li>
+          Definitely agree that we should double the coffee budget this year (it
+          really is impressive how much we go through!)
+        </li>
+        <li>
+          A blimp would definitely make the venue very easy to find, but I think
+          it might be a bit out of our budget. Maybe we could rent some
+          spotlights instead?
+        </li>
+        <li>
+          We absolutely will need more hamster wheels, last year's line was
+          <em>way</em> too long. Will get on that now before rental season hits
+          its peak.
+        </li>
+      </ul>
 
-    <p>Let me know when you've nailed down the dates!</p>
-  </section>
+      <p>Let me know when you've nailed down the dates!</p>
+    </section>
 
-  <form>
-    <label for="message">Message</label>
-    <input id="message" />
-    <button type="submit">
-      Send
-    </button>
-  </form>
-</div>
+    <form>
+      <label for="message">Message</label>
+      <input id="message" />
+      <button type="submit">
+        Send
+      </button>
+    </form>
+  </div>
+</template>
 ```
 
 ## Breaking it into pieces
@@ -76,31 +78,10 @@ We'll break apart the larger HTML file into files containing each of these parts
 
 ### The Received Message
 
-First, let's copy Tomster's message into its own component. Components go in the `app/components` directory.
+First, let's copy Tomster's message into its own component. Components go in the `app/components` directory. Again, we will use a `.gjs` file for this.
 
-```handlebars {data-filename="app/components/received-message.hbs"}
-<aside>
-  <div class="avatar is-active" title="Tomster's avatar">T</div>
-</aside>
-<section>
-  <h4 class="username">
-    Tomster
-    <span class="local-time">their local time is 4:56pm</span>
-  </h4>
-
-  <p>
-    Hey Zoey, have you had a chance to look at the EmberConf
-    brainstorming doc I sent you?
-  </p>
-</section>
-```
-
-We've just created our first component!
-
-We can include our new component into our application by using HTML tag syntax.
-
-```handlebars {data-filename="app/templates/application.hbs" data-diff="-2,-3,-4,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,+16"}
-<div class="messages">
+```gjs {data-filename="app/components/received-message.gjs"}
+<template>
   <aside>
     <div class="avatar is-active" title="Tomster's avatar">T</div>
   </aside>
@@ -115,62 +96,86 @@ We can include our new component into our application by using HTML tag syntax.
       brainstorming doc I sent you?
     </p>
   </section>
-  <ReceivedMessage/>
-
-  <aside class="current-user">
-    <div class="avatar" title="Zoey's avatar">Z</div>
-  </aside>
-  <section>
-    <h4 class="username">Zoey</h4>
-
-    <p>Hey!</p>
-
-    <p>
-      I love the ideas! I'm really excited about where this year's
-      EmberConf is going, I'm sure it's going to be the best one yet.
-      Some quick notes:
-    </p>
-
-    <ul>
-      <li>
-        Definitely agree that we should double the coffee budget this
-        year (it really is impressive how much we go through!)
-      </li>
-      <li>
-        A blimp would definitely make the venue very easy to find, but
-        I think it might be a bit out of our budget. Maybe we could
-        rent some spotlights instead?
-      </li>
-      <li>
-        We absolutely will need more hamster wheels, last year's line
-        was <em>way</em> too long. Will get on that now before rental
-        season hits its peak.
-      </li>
-    </ul>
-
-    <p>Let me know when you've nailed down the dates!</p>
-  </section>
-
-  <form>
-    <label for="message">Message</label>
-    <input id="message" />
-    <button type="submit">
-      Send
-    </button>
-  </form>
-</div>
+</template>
 ```
 
-A _component_ is kind of like your own custom HTML tag. You can tell that a tag refers to an Ember component because it starts with a capital letter. Built-in HTML tags start with lowercase letters (`<div>`, `<p>`, `<table>`). Our component is called `<ReceivedMessage>`, based on its name on the file system.
+We've just created our first component!
+
+We can include our new component into our application by importing the component at the top of our `application.gjs` file and embedding it in the template.
+
+```gjs {data-filename="app/templates/application.gjs" data-diff="+1,+2,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,+19"}
+import ReceivedMessage from '../components/received-message.gjs';
+
+<template>
+  <div class="messages">
+    <aside>
+      <div class="avatar is-active" title="Tomster's avatar">T</div>
+    </aside>
+    <section>
+      <h4 class="username">
+        Tomster
+        <span class="local-time">their local time is 4:56pm</span>
+      </h4>
+
+      <p>
+        Hey Zoey, have you had a chance to look at the EmberConf brainstorming
+        doc I sent you?
+      </p>
+    </section>
+    <ReceivedMessage />
+
+    <aside class="current-user">
+      <div class="avatar" title="Zoey's avatar">Z</div>
+    </aside>
+    <section>
+      <h4 class="username">Zoey</h4>
+
+      <p>Hey!</p>
+
+      <p>
+        I love the ideas! I'm really excited about where this year's EmberConf
+        is going, I'm sure it's going to be the best one yet. Some quick notes:
+      </p>
+
+      <ul>
+        <li>
+          Definitely agree that we should double the coffee budget this year (it
+          really is impressive how much we go through!)
+        </li>
+        <li>
+          A blimp would definitely make the venue very easy to find, but I think
+          it might be a bit out of our budget. Maybe we could rent some
+          spotlights instead?
+        </li>
+        <li>
+          We absolutely will need more hamster wheels, last year's line was
+          <em>way</em> too long. Will get on that now before rental season hits
+          its peak.
+        </li>
+      </ul>
+
+      <p>Let me know when you've nailed down the dates!</p>
+    </section>
+
+    <form>
+      <label for="message">Message</label>
+      <input id="message" />
+      <button type="submit">
+        Send
+      </button>
+    </form>
+  </div>
+</template>
+```
+
+A _component_ is kind of like your own custom HTML tag. When we imported the component we gave it the name `ReceivedMessage`. In general, you should always give your components names that start with a capital letter. Built-in HTML tags start with lowercase letters (`<div>`, `<p>`, `<table>`).
 
 <div class="cta">
   <div class="cta-note">
     <div class="cta-note-body">
       <div class="cta-note-heading">Zoey says...</div>
       <div class="cta-note-message">
-        A component's name is derived from its file name.
-        We capitalize the first letter and every letter after <code>-</code>, then remove the hyphens.
-        This is known as pascal case.
+        Importing a component like this is sometimes called "strict mode" because everything that is not HTML must be imported into a <code>.gjs</code> file before it can be used.
       </div>
     </div>
     <img src="/images/mascots/zoey.png" role="presentation" alt="">
@@ -181,47 +186,9 @@ A _component_ is kind of like your own custom HTML tag. You can tell that a tag 
 
 Let's do it again. We'll copy the sent message content into a new component, and then include it in our application template.
 
-```handlebars {data-filename="app/components/sent-message.hbs"}
-<aside class="current-user">
-  <div class="avatar" title="Zoey's avatar">Z</div>
-</aside>
-<section>
-  <h4 class="username">Zoey</h4>
-
-  <p>Hey!</p>
-
-  <p>
-    I love the ideas! I'm really excited about where this year's
-    EmberConf is going, I'm sure it's going to be the best one yet.
-    Some quick notes:
-  </p>
-
-  <ul>
-    <li>
-      Definitely agree that we should double the coffee budget this
-      year (it really is impressive how much we go through!)
-    </li>
-    <li>
-      A blimp would definitely make the venue very easy to find, but
-      I think it might be a bit out of our budget. Maybe we could
-      rent some spotlights instead?
-    </li>
-    <li>
-      We absolutely will need more hamster wheels, last year's line
-      was <em>way</em> too long. Will get on that now before rental
-      season hits its peak.
-    </li>
-  </ul>
-
-  <p>Let me know when you've nailed down the dates!</p>
-</section>
-```
-
-```handlebars {data-filename="app/templates/application.hbs" data-diff="-4,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31,-32,-33,-34,-35,-36,+37"}
-<div class="messages">
-  <ReceivedMessage />
-
-  <aside>
+```gjs {data-filename="app/components/sent-message.gjs"}
+<template>
+  <aside class="current-user">
     <div class="avatar" title="Zoey's avatar">Z</div>
   </aside>
   <section>
@@ -230,64 +197,91 @@ Let's do it again. We'll copy the sent message content into a new component, and
     <p>Hey!</p>
 
     <p>
-      I love the ideas! I'm really excited about where this year's
-      EmberConf is going, I'm sure it's going to be the best one yet.
-      Some quick notes:
+      I love the ideas! I'm really excited about where this year's EmberConf
+      is going, I'm sure it's going to be the best one yet. Some quick notes:
     </p>
 
     <ul>
       <li>
-        Definitely agree that we should double the coffee budget this
-        year (it really is impressive how much we go through!)
+        Definitely agree that we should double the coffee budget this year (it
+        really is impressive how much we go through!)
       </li>
       <li>
-        A blimp would definitely make the venue very easy to find, but
-        I think it might be a bit out of our budget. Maybe we could
-        rent some spotlights instead?
+        A blimp would definitely make the venue very easy to find, but I think
+        it might be a bit out of our budget. Maybe we could rent some
+        spotlights instead?
       </li>
       <li>
-        We absolutely will need more hamster wheels, last year's line
-        was <em>way</em> too long. Will get on that now before rental
-        season hits its peak.
+        We absolutely will need more hamster wheels, last year's line was
+        <em>way</em> too long. Will get on that now before rental season hits
+        its peak.
       </li>
     </ul>
 
     <p>Let me know when you've nailed down the dates!</p>
   </section>
-  <SentMessage />
+</template>
+```
 
-  <form>
-    <label for="message">Message</label>
-    <input id="message" />
-    <button type="submit">
-      Send
-    </button>
-  </form>
-</div>
+```gjs {data-filename="app/templates/application.gjs" data-diff="+2,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31,-32,-33,-34,-35,-36,-37,-38,-39,+40"}
+import ReceivedMessage from '../components/received-message.gjs';
+import SentMessage from '../components/sent-message.gjs';
+
+<template>
+  <div class="messages">
+    <ReceivedMessage />
+
+    <aside class="current-user">
+      <div class="avatar" title="Zoey's avatar">Z</div>
+    </aside>
+    <section>
+      <h4 class="username">Zoey</h4>
+
+      <p>Hey!</p>
+
+      <p>
+        I love the ideas! I'm really excited about where this year's EmberConf
+        is going, I'm sure it's going to be the best one yet. Some quick notes:
+      </p>
+
+      <ul>
+        <li>
+          Definitely agree that we should double the coffee budget this year (it
+          really is impressive how much we go through!)
+        </li>
+        <li>
+          A blimp would definitely make the venue very easy to find, but I think
+          it might be a bit out of our budget. Maybe we could rent some
+          spotlights instead?
+        </li>
+        <li>
+          We absolutely will need more hamster wheels, last year's line was
+          <em>way</em> too long. Will get on that now before rental season hits
+          its peak.
+        </li>
+      </ul>
+
+      <p>Let me know when you've nailed down the dates!</p>
+    </section>
+    <SentMessage />
+
+    <form>
+      <label for="message">Message</label>
+      <input id="message" />
+      <button type="submit">
+        Send
+      </button>
+    </form>
+  </div>
+</template>
 ```
 
 ### The New Message Input
 
 We have one last component to extract. Let's pull out the new message input.
 
-```handlebars {data-filename="app/components/new-message-input.hbs"}
-<form>
-  <label for="message">Message</label>
-  <input id="message" />
-  <button type="submit">
-    Send
-  </button>
-</form>
-```
-
-And include it in our `application.hbs` file.
-
-```handlebars {data-filename="app/templates/application.hbs" data-diff="-6,-7,-8,-9,-10,-11,-12,+13"}
-<div class="messages">
-  <ReceivedMessage />
-
-  <SentMessage />
-
+```gjs {data-filename="app/components/new-message-input.gjs"}
+<template>
   <form>
     <label for="message">Message</label>
     <input id="message" />
@@ -295,196 +289,239 @@ And include it in our `application.hbs` file.
       Send
     </button>
   </form>
-  <NewMessageInput />
-</div>
+</template>
+```
+
+And include it in our `application.gjs` file.
+
+```gjs {data-filename="app/templates/application.gjs" data-diff="+3,-11,-12,-13,-14,-15,-16,-17,+18"}
+import ReceivedMessage from '../components/received-message.gjs';
+import SentMessage from '../components/sent-message.gjs';
+import NewMessageInput from '../components/new-message-input.gjs';
+
+<template>
+  <div class="messages">
+    <ReceivedMessage />
+
+    <SentMessage />
+
+    <form>
+      <label for="message">Message</label>
+      <input id="message" />
+      <button type="submit">
+        Send
+      </button>
+    </form>
+    <NewMessageInput />
+  </div>
+</template>
 ```
 
 ## Breaking Components Down Further
 
 We can use components _within_ other components, so we can continue to break down our template into smaller pieces if we want. For instance, Tomster's avatar could be made into its own component that is then used within the `<ReceivedMessage>`.
 
-```handlebars {data-filename="app/components/received-message-avatar.hbs"}
-<aside>
-  <div class="avatar is-active" title="Tomster's avatar">T</div>
-</aside>
+```gjs {data-filename="app/components/received-message-avatar.gjs"}
+<template>
+  <aside>
+    <div class="avatar is-active" title="Tomster's avatar">T</div>
+  </aside>
+</template>
 ```
 
-```handlebars {data-filename="app/components/received-message.hbs" data-diff="-1,-2,-3,+4"}
-<aside>
-  <div class="avatar is-active" title="Tomster's avatar">T</div>
-</aside>
-<ReceivedMessageAvatar />
-<section>
-  <h4 class="username">
-    Tomster
-    <span class="local-time">their local time is 4:56pm</span>
-  </h4>
+```gjs {data-filename="app/components/received-message.gjs" data-diff="+1,+2,-4,-5,-6,+7"}
+import ReceivedMessageAvatar from './received-message-avatar.gjs';
 
-  <p>
-    Hey Zoey, have you had a chance to look at the EmberConf
-    brainstorming doc I sent you?
-  </p>
-</section>
+<template>
+  <aside>
+    <div class="avatar is-active" title="Tomster's avatar">T</div>
+  </aside>
+  <ReceivedMessageAvatar />
+  <section>
+    <h4 class="username">
+      Tomster
+      <span class="local-time">their local time is 4:56pm</span>
+    </h4>
+
+    <p>
+      Hey Zoey, have you had a chance to look at the EmberConf
+      brainstorming doc I sent you?
+    </p>
+  </section>
+</template>
 ```
 
 We could also extract the username from the message:
 
-```handlebars {data-filename="app/components/received-message-username.hbs"}
-<h4 class="username">
-  Tomster
-  <span class="local-time">their local time is 4:56pm</span>
-</h4>
-```
-
-```handlebars {data-filename="app/components/received-message.hbs" data-diff="-3,-4,-5,-6,+7"}
-<ReceivedMessageAvatar />
-<section>
+```gjs {data-filename="app/components/received-message-username.gjs"}
+<template>
   <h4 class="username">
     Tomster
     <span class="local-time">their local time is 4:56pm</span>
   </h4>
-  <ReceivedMessageUsername />
+</template>
+```
 
-  <p>
-    Hey Zoey, have you had a chance to look at the EmberConf
-    brainstorming doc I sent you?
-  </p>
-</section>
+```gjs {data-filename="app/components/received-message.gjs" data-diff="+2,-7,-8,-9,-10,+11"}
+import ReceivedMessageAvatar from './received-message-avatar.gjs';
+import ReceivedMessageUsername from './received-message-username.gjs';
+
+<template>
+  <ReceivedMessageAvatar />
+  <section>
+    <h4 class="username">
+      Tomster
+      <span class="local-time">their local time is 4:56pm</span>
+    </h4>
+    <ReceivedMessageUsername />
+
+    <p>
+      Hey Zoey, have you had a chance to look at the EmberConf
+      brainstorming doc I sent you?
+    </p>
+  </section>
+</template>
 ```
 
 We can do the same for the `<SentMessage>` component:
 
-```handlebars {data-filename="app/components/sent-message-avatar.hbs"}
-<aside class="current-user">
-  <div class="avatar" title="Zoey's avatar">Z</div>
-</aside>
+```gjs {data-filename="app/components/sent-message-avatar.gjs"}
+<template>
+  <aside class="current-user">
+    <div class="avatar" title="Zoey's avatar">Z</div>
+  </aside>
+</template>
 ```
 
-```handlebars {data-filename="app/components/sent-message-username.hbs"}
-<h4 class="username">Zoey</h4>
-```
-
-```handlebars {data-filename="app/components/sent-message.hbs" data-diff="-3,+4"}
-<SentMessageAvatar />
-<section>
+```gjs {data-filename="app/components/sent-message-username.gjs"}
+<template>
   <h4 class="username">Zoey</h4>
-  <SentMessageUsername />
+</template>
+```
 
-  <p>Hey!</p>
+```gjs {data-filename="app/components/sent-message.gjs"}
+import SentMessageAvatar from './sent-message-avatar.gjs';
+import SentMessageUsername from './sent-message-username.gjs';
 
-  <p>
-    I love the ideas! I'm really excited about where this year's
-    EmberConf is going, I'm sure it's going to be the best one yet.
-    Some quick notes:
-  </p>
+<template>
+  <SentMessageAvatar />
+  <section>
+    <SentMessageUsername />
 
-  <ul>
-    <li>
-      Definitely agree that we should double the coffee budget this
-      year (it really is impressive how much we go through!)
-    </li>
-    <li>
-      A blimp would definitely make the venue very easy to find, but
-      I think it might be a bit out of our budget. Maybe we could
-      rent some spotlights instead?
-    </li>
-    <li>
-      We absolutely will need more hamster wheels, last year's line
-      was <em>way</em> too long. Will get on that now before rental
-      season hits its peak.
-    </li>
-  </ul>
+    <p>Hey!</p>
 
-  <p>Let me know when you've nailed down the dates!</p>
-</section>
+    <p>
+      I love the ideas! I'm really excited about where this year's EmberConf
+      is going, I'm sure it's going to be the best one yet. Some quick notes:
+    </p>
+
+    <ul>
+      <li>
+        Definitely agree that we should double the coffee budget this year (it
+        really is impressive how much we go through!)
+      </li>
+      <li>
+        A blimp would definitely make the venue very easy to find, but I think
+        it might be a bit out of our budget. Maybe we could rent some
+        spotlights instead?
+      </li>
+      <li>
+        We absolutely will need more hamster wheels, last year's line was
+        <em>way</em> too long. Will get on that now before rental season hits
+        its peak.
+      </li>
+    </ul>
+
+    <p>Let me know when you've nailed down the dates!</p>
+  </section>
+</template>
 ```
 
 Components can be broken down to any level, included in each other and reused.
 
-### Nesting Components in Folders
+## Nesting Components in Folders
 
-The avatar and username components are directly related to the sent and received message components. Right now, they're grouped at the top level. As you get more components, this could make a big mess! Instead, we want to group the related components together in the filesystem. We can do this by moving them into subfolders within `app/components`.
+The avatar and username components are directly related to the sent and received message components. Right now, they're grouped at the top level. As you get more components, this could make a big mess! Instead, we want to group the related components together in the filesystem. We can do this by moving them into subfolders within app/components.
 
-```handlebars {data-filename="" data-diff="-4,-5,+6,+7,+8,-9,-10,-11,+12,+13,+14"}
+```hbs {data-filename="" data-diff="-4,-5,+6,+7,+8,-9,-10,-11,+12,+13,+14"}
 app/
   components/
-    received-message.hbs
-    received-message-avatar.hbs
-    received-message-username.hbs
+    received-message.gjs
+    received-message-avatar.gjs
+    received-message-username.gjs
     received-message/
-      avatar.hbs
-      username.hbs
-    sent-message.hbs
-    sent-message-avatar.hbs
-    sent-message-username.hbs
+      avatar.gjs
+      username.gjs
+    sent-message.gjs
+    sent-message-avatar.gjs
+    sent-message-username.gjs
     sent-message/
-      avatar.hbs
-      username.hbs
+      avatar.gjs
+      username.gjs
+```
+Then, only the import path needs to be changed to the new location.
+
+```gjs {data-filename="app/components/received-message.gjs" data-diff="-1,+2,-3,+4"}
+import ReceivedMessageAvatar from './received-message-avatar.gjs';
+import ReceivedMessageAvatar from './received-message/avatar.gjs';
+import ReceivedMessageUsername from './received-message-username.gjs';
+import ReceivedMessageUsername from './received-message/username.gjs';
+
+<template>
+  <ReceivedMessageAvatar />
+  <section>
+    <h4 class="username">
+      Tomster
+      <span class="local-time">their local time is 4:56pm</span>
+    </h4>
+    <ReceivedMessageUsername />
+
+    <p>
+      Hey Zoey, have you had a chance to look at the EmberConf
+      brainstorming doc I sent you?
+    </p>
+  </section>
+</template>
 ```
 
-We can then use the `::` separator in templates to access components within a
-folder:
+```gjs {data-filename="app/components/sent-message.gjs" data-diff="-1,+2,-3,+4"}
+import SentMessageAvatar from './sent-message-avatar.gjs';
+import SentMessageAvatar from './sent-message/avatar.gjs';
+import SentMessageUsername from './sent-message-username.gjs';
+import SentMessageUsername from './sent-message/username.gjs';
 
-```handlebars {data-filename="app/components/received-message.hbs" data-diff="-1,+2,-4,+5"}
-<ReceivedMessageAvatar />
-<ReceivedMessage::Avatar />
-<section>
-  <ReceivedMessageUsername />
-  <ReceivedMessage::Username />
+<template>
+  <SentMessageAvatar />
+  <section>
+    <SentMessageUsername />
 
-  <p>
-    Hey Zoey, have you had a chance to look at the EmberConf
-    brainstorming doc I sent you?
-  </p>
-</section>
-```
+    <p>Hey!</p>
 
-```handlebars {data-filename="app/components/sent-message.hbs" data-diff="-1,+2,-4,+5"}
-<SentMessageAvatar />
-<SentMessage::Avatar />
-<section>
-  <SentMessageUsername />
-  <SentMessage::Username />
+    <p>
+      I love the ideas! I'm really excited about where this year's EmberConf
+      is going, I'm sure it's going to be the best one yet. Some quick notes:
+    </p>
 
-  <p>Hey!</p>
+    <ul>
+      <li>
+        Definitely agree that we should double the coffee budget this year (it
+        really is impressive how much we go through!)
+      </li>
+      <li>
+        A blimp would definitely make the venue very easy to find, but I think
+        it might be a bit out of our budget. Maybe we could rent some
+        spotlights instead?
+      </li>
+      <li>
+        We absolutely will need more hamster wheels, last year's line was
+        <em>way</em> too long. Will get on that now before rental season hits
+        its peak.
+      </li>
+    </ul>
 
-  <p>
-    I love the ideas! I'm really excited about where this year's
-    EmberConf is going, I'm sure it's going to be the best one yet.
-    Some quick notes:
-  </p>
-
-  <ul>
-    <li>
-      Definitely agree that we should double the coffee budget this
-      year (it really is impressive how much we go through!)
-    </li>
-    <li>
-      A blimp would definitely make the venue very easy to find, but
-      I think it might be a bit out of our budget. Maybe we could
-      rent some spotlights instead?
-    </li>
-    <li>
-      We absolutely will need more hamster wheels, last year's line
-      was <em>way</em> too long. Will get on that now before rental
-      season hits its peak.
-    </li>
-  </ul>
-
-  <p>Let me know when you've nailed down the dates!</p>
-</section>
-```
-
-If you have a component named `index.hbs`, you can refer to it without the `::Index`. So we can refactor `app/components/received-message.hbs` to `app/components/received-message/index.hbs` and continue to use it as `<ReceivedMessage>` without changing all the tags that refer to it:
-
-```handlebars {data-filename="" data-diff="-3,+5"}
-app/
-  components/
-    received-message.hbs
-    received-message/
-      index.hbs
-      avatar.hbs
-      username.hbs
+    <p>Let me know when you've nailed down the dates!</p>
+  </section>
+</template>
 ```
 
 Components can be nested in multiple sub folders this way, allowing you to organize them as you see fit.

--- a/guides/release/components/looping-through-lists.md
+++ b/guides/release/components/looping-through-lists.md
@@ -7,52 +7,57 @@ for each item in the list.
 For instance, in a messaging app, we could have a `<Message>` component that we
 repeat for each message that the users have sent to each other.
 
-```handlebars {data-filename="app/components/messages.hbs"}
-<div class="messages">
-  <Message
-    @username="Tomster"
-    @userIsActive={{true}}
-    @userLocalTime="4:56pm"
-  >
-    <p>
-      Hey Zoey, have you had a chance to look at the EmberConf
-      brainstorming doc I sent you?
-    </p>
-  </Message>
-  <Message
-    @username="Zoey"
-    @userIsActive={{true}}
-  >
-    <p>Hey!</p>
+```gjs {data-filename="app/components/messages.gjs"}
+import Message from './message.gjs';
+import NewMessageInput from './new-message-input.gjs';
 
-    <p>
-      I love the ideas! I'm really excited about where this year's
-      EmberConf is going, I'm sure it's going to be the best one yet.
-      Some quick notes:
-    </p>
+<template>
+  <div class="messages">
+    <Message
+      @username="Tomster"
+      @userIsActive={{true}}
+      @userLocalTime="4:56pm"
+    >
+      <p>
+        Hey Zoey, have you had a chance to look at the EmberConf
+        brainstorming doc I sent you?
+      </p>
+    </Message>
+    <Message
+      @username="Zoey"
+      @userIsActive={{true}}
+    >
+      <p>Hey!</p>
 
-    <ul>
-      <li>
-        Definitely agree that we should double the coffee budget this
-        year (it really is impressive how much we go through!)
-      </li>
-      <li>
-        A blimp would definitely make the venue very easy to find, but
-        I think it might be a bit out of our budget. Maybe we could
-        rent some spotlights instead?
-      </li>
-      <li>
-        We absolutely will need more hamster wheels, last year's line
-        was <em>way</em> too long. Will get on that now before rental
-        season hits its peak.
-      </li>
-    </ul>
+      <p>
+        I love the ideas! I'm really excited about where this year's
+        EmberConf is going, I'm sure it's going to be the best one yet.
+        Some quick notes:
+      </p>
 
-    <p>Let me know when you've nailed down the dates!</p>
-  </Message>
+      <ul>
+        <li>
+          Definitely agree that we should double the coffee budget this
+          year (it really is impressive how much we go through!)
+        </li>
+        <li>
+          A blimp would definitely make the venue very easy to find, but
+          I think it might be a bit out of our budget. Maybe we could
+          rent some spotlights instead?
+        </li>
+        <li>
+          We absolutely will need more hamster wheels, last year's line
+          was <em>way</em> too long. Will get on that now before rental
+          season hits its peak.
+        </li>
+      </ul>
 
-  <NewMessageInput />
-</div>
+      <p>Let me know when you've nailed down the dates!</p>
+    </Message>
+
+    <NewMessageInput />
+  </div>
+</template>
 ```
 
 First, we would add a component class and extract the parts of each `<Message>`
@@ -60,10 +65,16 @@ component that are different into an array on that class. We would extract the
 username, active value, local time, and the yielded content for each message.
 For the yielded content, since it's plain HTML, we can extract it as a string.
 
-```js {data-filename="app/components/messages.js"}
+Then, we can add an `{{each}}` helper to the template by passing
+`this.messages` to it. `{{each}}` will receive each message as its first block
+param, and we can use that item in the template block for the loop.
+
+
+```gjs {data-filename="app/components/messages.gjs"}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
+import Message from './message.gjs';
+import NewMessageInput from './new-message-input.gjs';
 
 export default class MessagesComponent extends Component {
   @tracked messages = [
@@ -111,68 +122,23 @@ export default class MessagesComponent extends Component {
       `
     }
   ];
-}
-```
 
-Then, we can add an `{{each}}` helper to the template by passing
-`this.messages` to it. `{{each}}` will receive each message as its first block
-param, and we can use that item in the template block for the loop.
-
-```handlebars {data-filename="app/components/messages.hbs" data-diff="+2,+3,+4,+5,+6,+7,+8,+9,+10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31,-32,-33,-34,-35,-36,-37,-38,-39,-40,-41,-42,-43,-44,-45,-46,-47,-48,-49,-50,-51"}
-<div class="messages">
-  {{#each this.messages as |message|}}
-    <Message
-      @username={{message.username}}
-      @userIsActive={{message.active}}
-      @userLocaltime={{message.localTime}}
-    >
-      {{{message.content}}}
-    </Message>
-  {{/each}}
-  <Message
-    @username="Tomster"
-    @userIsActive={{true}}
-    @userLocalTime="4:56pm"
-  >
-    <p>
-      Hey Zoey, have you had a chance to look at the EmberConf
-      brainstorming doc I sent you?
-    </p>
-  </Message>
-  <Message
-    @username="Zoey"
-    @userIsActive={{true}}
-  >
-    <p>Hey!</p>
-
-    <p>
-      I love the ideas! I'm really excited about where this year's
-      EmberConf is going, I'm sure it's going to be the best one yet.
-      Some quick notes:
-    </p>
-
-    <ul>
-      <li>
-        Definitely agree that we should double the coffee budget this
-        year (it really is impressive how much we go through!)
-      </li>
-      <li>
-        A blimp would definitely make the venue very easy to find, but
-        I think it might be a bit out of our budget. Maybe we could
-        rent some spotlights instead?
-      </li>
-      <li>
-        We absolutely will need more hamster wheels, last year's line
-        was <em>way</em> too long. Will get on that now before rental
-        season hits its peak.
-      </li>
-    </ul>
-
-    <p>Let me know when you've nailed down the dates!</p>
-  </Message>
+  <template>
+    <div class="messages">
+      {{#each this.messages as |message|}}
+        <Message
+          @username={{message.username}}
+          @userIsActive={{message.active}}
+          @userLocaltime={{message.localTime}}
+        >
+          {{{message.content}}}
+        </Message>
+      {{/each}}
+    </div>
 
   <NewMessageInput />
-</div>
+  </template>
+}
 ```
 
 Notice that we used triple curly brackets around `{{{message.content}}}`. This
@@ -208,33 +174,15 @@ Next, let's add a way for the user to send a new message. First, we need to
 add an action for creating the new message. We'll add this to the
 `<NewMessageInput />` component:
 
-```handlebars {data-filename="app/components/new-message-input.hbs" data-diff="-1,+2,-3,+4"}
-<form>
-<form {{on "submit" this.createMessage}}>
-  <input>
-  <Input @value={{this.message}}>
-  <button type="submit">
-    Send
-  </button>
-</form>
-```
-
-We're using the `submit` event on the form itself here rather than adding a
-`click` event handler to the button since it is about submitting the form as a
-whole. We also updated the `input` tag to instead use the built in `<Input>`
-component, which automatically updates the value we pass to `@value`. Next,
-let's add the component class:
-
-```javascript {data-filename="app/components/new-message-input.js"}
+```gjs {data-filename="app/components/new-message-input.gjs"}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
+import { on } from '@ember/modifier';
 
 export default class NewMessageInputComponent extends Component {
   @tracked message;
 
-  @action
-  createMessage(event) {
+  createMessage = (event) => {
     event.preventDefault();
 
     if (this.message && this.args.onCreate) {
@@ -243,9 +191,23 @@ export default class NewMessageInputComponent extends Component {
       // reset the message input
       this.message = '';
     }
-  }
+  };
+
+  <template>
+    <form {{on "submit" this.createMessage}}>
+      <Input @value={{this.message}}>
+      <button type="submit">
+        Send
+      </button>
+    </form>
+  </template>
 }
 ```
+
+We're using the `submit` event on the form itself here rather than adding a
+`click` event handler to the button since it is about submitting the form as a
+whole. We also use the built in `<Input>`
+component, which automatically updates the value we pass to `@value`. 
 
 This action uses the `onCreate` argument to expose a public API for defining
 what happens when a message is created. This way, the `<NewMessageInput>`
@@ -253,45 +215,17 @@ component doesn't have to worry about the external details - it can focus on
 getting the new message input.
 
 Next, we'll update the parent component to use this new argument.
-
-```handlebars {data-filename="app/components/messages.hbs" data-diff="-12,+13"}
-<div class="messages">
-  {{#each this.messages as |message|}}
-    <Message
-      @username={{message.username}}
-      @userIsActive={{message.active}}
-      @userLocaltime={{message.localTime}}
-    >
-      {{{message.content}}}
-    </Message>
-  {{/each}}
-
-  <NewMessageInput />
-  <NewMessageInput @onCreate={{this.addMessage}} />
-</div>
-```
-
-And in the component class, we'll add the `addMessage` action. This action will
+In the component class, we'll add the `addMessage` action. This action will
 create the new message from the text that the `<NewMessageInput>` component
 gives us, and push it into the messages array.
 
-```js {data-filename="app/components/messages.js"}
+```gjs {data-filename="app/components/messages.gjs" data-diff="+53,+54,+55,+56,+57,+58,+59,-74,+75"}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
+import Message from './message.gjs';
+import NewMessageInput from './new-message-input.gjs';
 
 export default class MessagesComponent extends Component {
-  username = 'Zoey';
-
-  @action
-  addMessage(messageText) {
-    this.messages = [...this.messages, {
-      username: this.username,
-      active: true,
-      content: `<p>${messageText}</p>`
-    }];
-  }
-
   @tracked messages = [
     {
       username: 'Tomster',
@@ -337,6 +271,31 @@ export default class MessagesComponent extends Component {
       `
     }
   ];
+
+  addMessage = (messageText) => {
+    this.messages = [...this.messages, {
+      username: this.username,
+      active: true,
+      content: `<p>${messageText}</p>`
+    }];
+  }
+
+  <template>
+    <div class="messages">
+      {{#each this.messages as |message|}}
+        <Message
+          @username={{message.username}}
+          @userIsActive={{message.active}}
+          @userLocaltime={{message.localTime}}
+        >
+          {{{message.content}}}
+        </Message>
+      {{/each}}
+    </div>
+
+  <NewMessageInput />
+  <NewMessageInput @onCreate={{this.addMessage}} />
+  </template>
 }
 ```
 
@@ -349,7 +308,7 @@ The index of each item in the array is provided as a second block param. This
 can be useful at times if you need the index, for instance if you needed to
 print positions in a queue
 
-```javascript
+```gjs
 import Component from '@glimmer/component';
 
 export default class SomeComponent extends Component {
@@ -358,15 +317,15 @@ export default class SomeComponent extends Component {
     { name: 'Jen' },
     { name: 'Rob' }
   ];
-}
-```
 
-```handlebars
-<ul>
-  {{#each this.queue as |person index|}}
-    <li>Hello, {{person.name}}! You're number {{index}} in line</li>
-  {{/each}}
-</ul>
+  <template>
+    <ul>
+      {{#each this.queue as |person index|}}
+        <li>Hello, {{person.name}}! You're number {{index}} in line</li>
+      {{/each}}
+    </ul>
+  </template>
+}
 ```
 
 ### Empty Lists
@@ -375,12 +334,21 @@ The [`{{#each}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.
 helper can also have a corresponding `{{else}}`. The contents of this block will
 render if the array passed to `{{#each}}` is empty:
 
-```handlebars
-{{#each this.people as |person|}}
-  Hello, {{person.name}}!
-{{else}}
-  Sorry, nobody is here.
-{{/each}}
+```gjs
+const people = [
+  {
+    name: "Shelly Sails",
+    age: 42
+  }
+];
+
+<template>
+  {{#each people as |person|}}
+    Hello, {{person.name}}!
+  {{else}}
+    Sorry, nobody is here.
+  {{/each}}
+</template>
 ```
 
 ## Looping Through Objects
@@ -390,7 +358,7 @@ object rather than an array, similar to JavaScript's `for...in` loop. We can use
 the [`{{#each-in}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper to do this:
 
-```javascript {data-filename=/app/components/store-categories.js}
+```gjs {data-filename=/app/components/store-categories.gjs}
 import Component from '@glimmer/component';
 
 export default class StoreCategoriesComponent extends Component {
@@ -401,21 +369,21 @@ export default class StoreCategoriesComponent extends Component {
     'Bourbons': ['Bulleit', 'Four Roses', 'Woodford Reserve'],
     'Ryes': ['WhistlePig', 'High West']
   };
-}
-```
 
-```handlebars {data-filename=/app/components/store-categories.hbs}
-<ul>
-  {{#each-in this.categories as |category products|}}
-    <li>{{category}}
-      <ol>
-        {{#each products as |product|}}
-          <li>{{product}}</li>
-        {{/each}}
-      </ol>
-    </li>
-  {{/each-in}}
-</ul>
+  <template>
+    <ul>
+      {{#each-in this.categories as |category products|}}
+        <li>{{category}}
+          <ol>
+            {{#each products as |product|}}
+              <li>{{product}}</li>
+            {{/each}}
+          </ol>
+        </li>
+      {{/each-in}}
+    </ul>
+  </template>
+}
 ```
 
 The template inside of the `{{#each-in}}` block is repeated once for each key in the passed object.
@@ -450,18 +418,27 @@ should use `Object.keys` to get an array, sort that array with the built-in Java
 tools, and use the [`{{#each}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=each)
 helper instead.
 
-### Empty Lists
+### Empty Object
 
 The [`{{#each-in}}`](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in)
 helper can have a matching `{{else}}`. The contents of this block will render if
 the object is empty, null, or undefined:
 
-```handlebars
-{{#each-in this.people as |name person|}}
-  Hello, {{name}}! You are {{person.age}} years old.
-{{else}}
-  Sorry, nobody is here.
-{{/each-in}}
+```gjs
+const developer = {
+  name: "Shelly Sails",
+  age: 42
+};
+
+<template>
+  <ul>
+    {{#each-in developer as |key value|}}
+      <li>{{key}}: {{value}}</li>
+    {{else}}
+      <li>Nothing to see here</li>
+    {{/each-in}}
+  </ul>
+</template>
 ```
 
 <!-- eof - needed for pages that end in a code block  -->


### PR DESCRIPTION
This PR migrates all the code blocks in the Core Concepts > Components to use GJS.  In general, this means that where there were `hbs` + `js` blocks, they are now a single `gjs` block.  My goal here was to just do the format conversion without much content editing. There were a few things that required me to make some editorial decisions, so I was hoping somebody could give some feedback on these.  Below are some notes on the conversion.

## General Notes

The old loose mode docs never had to worry about imports, so the location of the components relative to each other was not an issue. In the strict world, we have to import from somewhere.  I did what I think was right and required the least amount of change and/or explanation. If anyone has a better approach, let me know.

I tested a majority of these changes directly in the incredible Limber tool.  With very few exceptions, you can just paste the block directly in Limber and it should work. This is a wonderful resource.

### GJS codefence bug?

Looks like there might be a bug in the gjs code fence, or I'm doing something wrong. Seeing `// [!code --]` at the end of several code blocks on a couple pages.  See: `guides/release/components/helper-functions.md`, for example.  Here's a picture.

<img width="601" height="499" alt="Screenshot 2025-07-14 at 3 54 41 PM" src="https://github.com/user-attachments/assets/9be4eee8-1ec9-4e35-a309-0bf2c6608545" />

## Specific files

These are some notes on specific files I changed.  Not married to anything here, so feel free to override everything.

### guides/release/components/block-content.md

Here, I think we should use an example other than Popover or eliminate it and possibly use the `Card` example that is used later.  Specifically, the problem is that the code has `this.isOpen` but nowhere do we ever mention state or `this`. We haven't even introduced the `Component` class yet.  When this documentation was written, `this.isOpen` was on-the-fly tracked because of `Ember.Object`, but it's a bad example now.

### guides/release/components/helper-functions.md

Renamed "Global Helper Functions" to "Shared Helper Functions" and reframed it to reflect the strict mode nature of gjs.

I renamed the "Built-in Helpers" to "Built-in and Common Helpers" because nearly all of them require importing and I think "built-in" could be misleading here.  We could maybe split this into two sections also.

These require importing:
  - get
  - concat
  - array
  - hash

No importing required:
  - let
  - in-element

I feel like the import vs automatically available should at least be mentioned somewhere.

Also in this section, I updated the hard-coded links from version "4.5.0" to "6.5".  **Do we have a relative link available here?**  After doing so, I realized that many of these helpers are no longer showing up in the API docs, so I am not sure what we should do.  For example, the `get` helper is still there and not deprecated, so I think the API docs are just broken.  Suggestions?

I rewrote the section on the `in-element` helper. I think at this point in the docs, it's way too in-the-weeds since we're just introducing the helper.

### guides/release/components/template-lifecycle-dom-and-modifiers.md

This page has a real Frankenstein's monster quality to it. After a good intro paragraph, it goes into a philosophical reframing of things already covered elsewhere.  And I believe the info to be mostly out of date for the modern Glimmer VM, e.g., "the best way to think about your component's output is to assume that it will be re-executed from the top every time anything changes in your application". This is later addressed in a CTA, stating: "Ember avoids updating parts of the DOM that haven't changed".  

I converted the code snippets to gjs, but I honestly think we'd be better off  removing the first 4 sections from this page:
  - Thinking About Updates
  - Manipulating Attributes
  - Conditional Attributes
  - Summary: The Principle of Substitution

I think these parts are generally well written, but maybe they should be extracted and folded into the other pages (like "Component Arguments and HTML Attributes" or "Conditional Content").

The "Event Handlers" section is a retread of the `<Counter>` example.

The "Manipulating Properties" is easy enough to convert to gjs, but it does encourage the use of the 3rd-party, `ember-prop-modifier`, which I believe is a v1 addon.  I'm not sure what the import path should be and not entirely sure how to test it.  Modifiying element properties is quite easy now with modifiers and single file components, so I wonder if this part shouldn't just be rewritten to use a local modifier. 

### guides/release/components/built-in-components.md

Converted the ember-keyboard parts to gjs, but had trouble getting them to work in Limber.  I think the service is the problem, but I'm not sure.  I think the import path is right.  Also, perhaps the mention of `@enter`, `@insert-newline` and `@escape-press` for the `<Input>` and `<Textarea>` components should be removed.

I removed the example using `{{get}}` and `{{mut}}`, as the relevant dynamic property lookup is done elsewhere.
