### PR TITLE
Document the import path for the built-in `uniqueId` helper

### DIFF
--- a/guides/release/components/template-tag-format.md
+++ b/guides/release/components/template-tag-format.md
@@ -174,6 +174,7 @@ import { concat } from '@ember/helper';
 import { fn } from '@ember/helper';
 import { get } from '@ember/helper';
 import { hash } from '@ember/helper';
+import { uniqueId } from '@ember/helper';
 
 // Built-in modifiers
 import { on } from '@ember/modifier';


### PR DESCRIPTION
This import is missing from the template tag format documentation but has been available since [v5.2](https://blog.emberjs.com/ember-released-5-2).