### PR TITLE
refactor: fix release guides minor double quotes in yml

### DIFF
--- a/scripts/create-new-minor-version
+++ b/scripts/create-new-minor-version
@@ -40,7 +40,7 @@ read -n 1 -s -r -p "Press any key to continue"
 # `-d "."` specifies `.` as the delimiter.
 # `-f N` specifies which of the delimited sections to keep
 # `cut -c 2-` gets rid of the "v" prefix by selecting from the second character onwards.
-CURRENT_VERSION=$(grep "currentVersion" guides/versions.yml | sed "s/currentVersion.*\(v.*\)\"/\1/")
+CURRENT_VERSION=$(grep "currentVersion" guides/versions.yml | sed "s/currentVersion: \(v.*\)/\1/")
 MAJOR_VERSION=$(echo $CURRENT_VERSION | cut -d "." -f 1 | cut -c 2-)
 MINOR_VERSION=$(echo $CURRENT_VERSION | cut -d "." -f 2)
 PATCH_VERSION=$(echo $CURRENT_VERSION | cut -d "." -f 3)
@@ -62,9 +62,9 @@ echo "  DONE"
 # Then we interpolate the new version and replace the closing double quote.
 # We also add the relevant version to the list by using sed's i command.
 echo "🤖 Updating /guides/versions.yml"
-sed -i .bak "s/\(currentVersion:.*v\).*/\1$(echo $NEXT_VERSION)\"/" guides/versions.yml
+sed -i .bak "s/\(currentVersion:.*v\).*/\1$(echo $NEXT_VERSION)/" guides/versions.yml
 sed -i .bak -e "/currentVersion/i \\
-\ \ - \"v$(echo $NEXT_VERSION)\"" guides/versions.yml
+\ \ - v$(echo $NEXT_VERSION)" guides/versions.yml
 rm guides/versions.yml.bak
 echo "  DONE"
 


### PR DESCRIPTION
This fixes an issue where the version of the release guides minor script that exists in this repo looks for double quotes in the version.yml file and the script falls over.

We have a new release tool that probably should be preferred over the script internal to this repo https://github.com/ember-learn/guides-source, but since it appears that using that tool created a versions.yml without double quotes we are adapting to that format with the changes in this PR.

For reference here is the commit that changed the format of versions.yml

https://github.com/ember-learn/guides-source/commit/9632ba6a3cc8eb1c47090167f0e2c36d4bccb4cb#diff-7c320a9d771bef713f21002783458ef1a3221a465e43fd969da532e7e3bfd0f2