### PR TITLE
Clarify credit card requirement for Mapbox free account sign-up.

### DIFF
--- a/guides/release/tutorial/part-1/reusable-components.md
+++ b/guides/release/tutorial/part-1/reusable-components.md
@@ -16,7 +16,7 @@ While adding the map, you will learn about:
 
 ## Managing Application-level Configurations
 
-We will use the [Mapbox](https://www.mapbox.com) API to generate maps for our rental properties. You can [sign up](https://www.mapbox.com/signup/) for free and without a credit card.
+We will use the [Mapbox](https://www.mapbox.com) API to generate maps for our rental properties. Mapbox offers a free tier, but you'll be asked to add billing details when creating your account to obtain an access token. You can sign up [here](https://www.mapbox.com/signup/).
 
 Mapbox provides a [static map images API](https://docs.mapbox.com/api/maps/#static-images), which serves map images in PNG format. This means that we can generate the appropriate URL for the parameters we want and render the map using a standard `<img>` tag. Pretty neat!
 


### PR DESCRIPTION
**Summary**
Updates the Super Rentals tutorial sentence about Mapbox sign-up. Mapbox still offers a free tier, but new accounts are asked to add billing details (credit/debit card) to obtain an access token. This change removes the outdated “without a credit card” language.