### PR TITLE
WIP: Spike out quick reference

### DIFF
--- a/guides/release/quick-reference/index.md
+++ b/guides/release/quick-reference/index.md
@@ -1,0 +1,71 @@
+<!-- aka "cheatsheet": no (or minimal) explanation, no fluff -->
+
+## Counter Component
+
+<!--
+TODO: 
+- Implement <Sample>
+  - Renders code snippet from file
+  - Invokes <REPL> with the code snippet
+-->
+<Sample @code="quick-reference/counter.gjs" />
+
+## if
+
+## if else
+
+## inline if
+
+## inline if else
+
+## unless
+
+## unless else
+
+## inline unless
+
+## inline unless else
+
+## let
+
+## each
+
+## keyed each
+
+## each-in
+
+## keyed each-in
+
+## in-element
+
+<!-- aka portalling -->
+
+## yield 
+
+<!-- aka "block" aka "slot" -->
+
+## yield to="name"
+
+<!-- aka "named block" aka "named slot" -->
+
+## modifier
+
+<!-- aka "partial application of a modifier" aka "currying a modifier" -->
+
+## component
+
+<!-- aka "partial application of a component" aka "currying a component" -->
+
+## component for attributes and modifiers
+
+<!-- aka "partial application of a component" aka "currying a component" -->
+
+## helper
+
+<!-- aka "partial application of a helper" aka "currying a helper" -->
+
+## fn
+
+<!-- aka "partial application of a function" aka "currying a function" -->
+
+

--- a/guides/release/quick-reference/platform.md
+++ b/guides/release/quick-reference/platform.md
@@ -1,0 +1,62 @@
+In [RFC #1070](https://github.com/emberjs/rfcs/pull/1070), we defined a set of criteria to allow many of the platform native utilities to be used directly within the `<template>...</template>` region of components.
+
+<details><summary>That criteria may be viewed here</summary>
+
+  Criteria for inclusion in this list:
+ 
+  Any of:
+    - begins with an uppercase letter
+    - guaranteed to never be added to glimmer as a keyword (e.g.: globalThis)
+
+  And:
+    - must not need new to invoke
+    - must not require lifetime management (e.g.: setTimeout)
+    - must not be a single-word lower-case API, because of potential collision with future new HTML elements
+    - if the API is a function, the return value should not be a promise
+    - must be one one of these lists:
+       - https://tc39.es/ecma262/#sec-global-object
+       - https://tc39.es/ecma262/#sec-function-properties-of-the-global-object
+       - https://html.spec.whatwg.org/multipage/nav-history-apis.html#window
+       - https://html.spec.whatwg.org/multipage/indices.html#all-interfaces
+       - https://html.spec.whatwg.org/multipage/webappapis.html
+
+</details>
+
+## TC39
+
+### `globalThis`
+### `Atomics`
+### `JSON`
+### `Math`
+### `Reflect`
+
+### `isNaN`
+### `isFinite`
+### `parseInt`
+### `parseFloat`
+### `decodeURI`
+### `decodeURIComponent`
+### `encodeURI`
+### `encodeURIComponent`
+
+### `Array`
+### `BigInt`
+### `Boolean`
+### `Date`
+### `Number`
+### `Object`
+### `String`
+
+### `Infinity`
+### `NaN`
+
+## WHATWG
+
+### `localStorage`
+### `sessionStorage`
+### `URL`
+
+### `postMessage`
+### `structuredClone`
+
+### `isSecureContext`

--- a/public/samples/quick-reference/counter.gjs
+++ b/public/samples/quick-reference/counter.gjs
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+
+export default class HelloWorld extends Component {
+  @tracked count = 0;
+
+  increment = () => this.count += 1;
+
+  <template>
+    <p>You have clicked the button {{this.count}} times.</p>
+
+    <button type="button" {{on "click" this.increment}}>Click</button>
+  </template>
+}


### PR DESCRIPTION
This is cheat-sheet format

No code yet, because I need to finish:
- https://github.com/NullVoxPopuli/limber/pull/1962

the tl;dr: is that these quick reference documents show _everything_ we can do (as long as we wouldn't recommend that folks should avoid using a thing -- at least, not without `<details>` explaining why / why not).

I dunno if it'd be possible to render all of this on the same page, but that would make for some very nice ctrl+f