### PR TITLE
stop showing the GJS warning on the vite branch

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -48,7 +48,8 @@ module.exports = function (environment) {
     guidemaker: {
       title: 'Ember Guides',
       sourceRepo: 'https://github.com/ember-learn/guides-source',
-      gjsVersions: ['v6.7.0'],
+      // TODO turn this back on before merging the Vite branch
+      // gjsVersions: ['v6.7.0'],
       gjsLink: '/release/components/template-tag-format/',
     },
 


### PR DESCRIPTION
The vite branch is going to be merged as 6.8 so this change isn't actually needed, it just makes it easier to review since we don't need to tell people to ignore the GJS warning at the top of each page 🙈 