### PR TITLE
Simplified rules for @tracked

### DIFF
--- a/guides/release/in-depth-topics/autotracking-in-depth.md
+++ b/guides/release/in-depth-topics/autotracking-in-depth.md
@@ -55,13 +55,10 @@ like `this.greeting` or `@name` argument, that's less clear. It appears
 should probably change, right? At the least, we should _check_ to see if it
 should change.
 
-In order to tell Ember a value might change, we need to mark it as _trackable_.
-Trackable values are values that:
+If a value can change and the change should cause Ember to re-render, then
+the value should be tracked.
 
-1. Can change over their component’s lifetime and
-2. Should cause Ember to rerender if and when they change
-
-We can do this by marking the field with the `@tracked` decorator:
+To track such values, we mark them with the `@tracked` decorator:
 
 ```gjs {data-filename=app/components/hello.gjs data-diff="+2,-5,+6"}
 import Component from '@glimmer/component';


### PR DESCRIPTION
## Background

A month ago, a developer had asked when to use `@tracked` and, more importantly, when we don't need to.

There was confusion among developers, because https://guides.emberjs.com/release/in-depth-topics/autotracking-in-depth/ currently shows a paragraph that (I think) is hard for non-native English speakers to parse.

- The word "and," which is currently listed at the end of `1. Can change over their component’s lifetime and`, is easy to miss. Once the word is missed, the listing of `1.` and `2.` can be falsely interpreted as an or-statement.
- It's hard to tell whether the italicized word "trackable" is a technical term. The term appears nowhere else in the Guides.