### PR TITLE
typescript: document Glint as a default

### DIFF
--- a/guides/release/typescript/additional-resources/faq.md
+++ b/guides/release/typescript/additional-resources/faq.md
@@ -21,7 +21,7 @@ These are all fallbacks, of course, you should use the types supplied directly w
 
 At the root of your application or addon, we include a `types/<your project>` directory with an `index.d.ts` file in it. Anything which is part of your project but which must be declared globally can go in this file. For example, if you have data attached to the `Window` object when the page is loaded (for bootstrapping or whatever other reason), this is a good place to declare it.
 
-We automatically configure `index.d.ts` to be ready for [Glint][], which will make type checking work with Ember's templates. The default configuration only supports Ember's classic pairing of separate `.ts` and `.hbs` files, but Glint also supports the `<template>` format with `.gts` files. See the [corresponding package README][glint-environment-ember-template-imports] for more details. (Once Ember enables `<template>` by default, so will our Glint configuration!)
+We automatically configure `index.d.ts` to be ready for [Glint][], which makes type checking work with Ember's templates. Glint targets template-tag (`.gts` / `.gjs`) authoring, where templates are tied to a backing module via import resolution.
 
 ### Environment configuration typings
 
@@ -83,7 +83,6 @@ You can enable TypeScript's current strictest configuration by including the `@t
 [assertion-function]: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions
 [debug-assert]: https://api.emberjs.com/ember/release/functions/@ember%2Fdebug/assert
 [DefinitelyTyped]: https://github.com/DefinitelyTyped/DefinitelyTyped
-[glint-environment-ember-template-imports]: https://github.com/typed-ember/glint/tree/main/packages/environment-ember-template-imports#readme
 [glint]: https://typed-ember.gitbook.io/glint
 [tsconfig-paths]: https://www.typescriptlang.org/tsconfig#paths
 [type-narrowing]: https://www.typescriptlang.org/docs/handbook/2/narrowing.html

--- a/guides/release/typescript/getting-started.md
+++ b/guides/release/typescript/getting-started.md
@@ -22,11 +22,7 @@ In addition to the usual packages added with `ember new`, the following packages
 - `@types/qunit` - TypeScript type definitions for QUnit.
 - `@types/rsvp` - TypeScript type definitions for RSVP.
 - `@warp-drive/core-types` - shared core types, type utilities and constants for the WarpDrive and EmberData packages.
-
-<!--
-TODO: Uncomment this line when we add Glint docs
-- `@glint/*` – a set of packages to support type-checking in templates.
-  -->
+- `@glint/ember-tsc`, `@glint/template`, and `@glint/tsserver-plugin` – [Glint][glint], the template-aware type-checker. `ember-tsc --noEmit` is wired to the `lint:types` script; the `@glint/tsserver-plugin` package augments the TypeScript Server in your editor with template-aware diagnostics.
 
 <div class="cta">
   <div class="cta-note">
@@ -52,7 +48,7 @@ In addition to the usual files added with `ember new`, we also add:
 
 Additionally:
 
-- `package.json` will have a `lint:types` script to check types with the command line.
+- `package.json` will have a `lint:types` script (`ember-tsc --noEmit`) to check both TypeScript and templates with the command line.
 - `ember-cli-build.js` will be configured to transform TypeScript at build-time.
 - `.ember-cli` has `isTypeScriptProject` set to true, which will force the blueprint generators to generate TypeScript rather than JavaScript by default.
 - `.eslintrc.js` will be configured for TypeScript.
@@ -68,5 +64,9 @@ To convert an existing app to TypeScript, you'll need to make the changes descri
 [environment-types]: ../additional-resources/faq/#toc_environment-configuration-typings
 [global-types]: ../additional-resources/faq/#toc_global-types-for-your-project
 [tsconfig]: ../application-development/configuration/#toc_tsconfigjson
+
+<!-- External links -->
+
+[glint]: https://typed-ember.gitbook.io/glint/
 
 <!-- External links -->


### PR DESCRIPTION
## Summary

Surface [RFC #976: Enable Glint by Default](https://github.com/emberjs/rfcs/pull/976) in the TypeScript guides:

- `getting-started.md` — replace the long-standing Glint TODO comment with the actual Glint v2 packages (`@glint/ember-tsc`, `@glint/template`, `@glint/tsserver-plugin`) and note that `lint:types` is wired to `ember-tsc --noEmit`.
- `additional-resources/faq.md` — refresh the "types directory" section for Glint v2's template-tag-only model and drop the dead `environment-ember-template-imports` README link.

## Related

- RFC: emberjs/rfcs#976
- App blueprint: ember-cli/ember-app-blueprint#273
- Addon blueprint: ember-cli/ember-addon-blueprint#141
- Upstream ember-cli blueprint swap: ember-cli/ember-cli#11015
- Announcement post (draft): ember-learn/ember-blog#1373

## Test plan

- [ ] Build the guides locally and skim the rendered TypeScript section.
- [ ] Confirm the cross-link to https://typed-ember.gitbook.io/glint/ resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)