### PR TITLE
Redirect templates/input-components to built-in-components (#2228)

### DIFF
--- a/guides/release/templates/input-components.md
+++ b/guides/release/templates/input-components.md
@@ -1,0 +1,3 @@
+---
+redirect: components/built-in-components
+---


### PR DESCRIPTION
Fixes #2228

The v3.14 page still ranks in search, but "Go to v7.1" kept the old path which no longer exists and showed an unknown error. Mirror the existing `input-helpers` redirect stub to `components/built-in-components`.