### PR TITLE
Fix Quick Start diff description and restore +/- markers (#2090)

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -113,40 +113,35 @@ code {
   z-index: 10;
 }
 
-/* Fix diff formatting */
+/*
+  Diff formatting for Shiki (ember-showdown-shiki).
+  Show +/- beside line numbers so diffs are not color-only (#2090).
+  Colors match .shiki .line.add / .line.remove in ember-showdown-shiki.
 
-code[data-diff] .diff-deletion {
-  background-color: rgb(144 84 84 / 70%);
+  Use a fixed-width gutter for every line in a diff block so code stays
+  aligned whether the line is added, removed, or unchanged.
+*/
+pre.has-diff code.line-numbers .line::before {
+  width: 5ch;
+  margin-right: 1rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
-code[data-diff] .diff-insertion {
-  background-color: rgb(93 125 93 / 50%);
+pre.has-diff code.line-numbers .line:not(.add):not(.remove)::before {
+  content: "\00a0\00a0" counter(step);
 }
 
-code[data-diff] .diff-deletion .diff-deletion,
-code[data-diff] .diff-deletion .diff-insertion,
-code[data-diff] .diff-insertion .diff-deletion,
-code[data-diff] .diff-insertion .diff-insertion {
-  background-color: transparent;
+pre.has-diff code.line-numbers .line.add::before {
+  content: "+ " counter(step);
+  color: rgb(16 185 129);
+  font-weight: 600;
 }
 
-code[data-diff] .diff-deletion > .diff-operator,
-code[data-diff] .diff-insertion > .diff-operator {
-  display: none;
-}
-
-code[data-diff] .diff-deletion::before {
-  content: "-";
-  margin-left: -1ch;
-  background-color: rgb(144 84 84 / 70%);
-  color: #f8f8f2;
-}
-
-code[data-diff] .diff-insertion::before {
-  content: "+";
-  margin-left: -1ch;
-  background-color: rgb(93 125 93 / 50%);
-  color: #f8f8f2;
+pre.has-diff code.line-numbers .line.remove::before {
+  content: "- " counter(step);
+  color: rgb(244 63 94);
+  font-weight: 600;
 }
 
 /* Fix <Foo::Bar> */

--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -266,7 +266,11 @@ We're going to tell our component:
 
 We'll need to make some changes to the code we wrote before.
 
-In the rest of the code examples in this tutorial, whenever we add or remove code, we will show a "diff." The lines you need to remove have a minus sign in front of them, and the lines you should add have a plus sign. If you are using a screen reader while you go through the Guides, we recommend using Firefox and NVDA or Safari and VoiceOver for the best experience.
+In the rest of the code examples in this tutorial, whenever we add or remove code, we will show a "diff."
+Lines you need to remove are highlighted in red with a `-` next to the line number,
+and lines you should add are highlighted in green with a `+` next to the line number.
+If you are using a screen reader while you go through the Guides,
+we recommend using Firefox and NVDA or Safari and VoiceOver for the best experience.
 
 Let's replace all our old code with our new componentized version:
 


### PR DESCRIPTION
Fixes #2090

After the Shiki migration, code diffs were highlighted with color only. The Quick Start guide still said added/removed lines would show `+` / `-`, but those markers were gone because the old Prism CSS no longer matched Shiki’s classes.

This PR restores `+` / `-` next to line numbers on all Shiki diff blocks (using the existing Shiki add/remove colors), keeps a fixed-width gutter so indentation stays aligned, and updates the Quick Start wording to match.

**Text change** (Quick Start only):
https://guides.emberjs.com/release/getting-started/quick-start/

**Visual `+`/`-` markers** (every page with diffs, including Quick Start), e.g.:
- https://guides.emberjs.com/release/getting-started/quick-start/
- https://guides.emberjs.com/release/tutorial/part-1/component-basics/
- https://guides.emberjs.com/release/tutorial/part-1/interactive-components/
- https://guides.emberjs.com/release/components/introducing-components/
- https://guides.emberjs.com/release/components/component-state-and-actions/
- https://guides.emberjs.com/release/tutorial/part-1/working-with-data/

The same CSS also applies under other guide versions that use Shiki diffs (e.g. `/v7.0.0/...`), since it ships in shared `/assets/`.