### PR TITLE
remove imports that aren't needed on ember >= 7.1

### DIFF
--- a/guides/release/components/built-in-components.md
+++ b/guides/release/components/built-in-components.md
@@ -164,7 +164,6 @@ We recommend using the `{{on}}` modifier to call an action on specific events su
 import Component from "@glimmer/component";
 import { Input } from '@ember/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 
 export default class Example extends Component {
   @tracked name = '';
@@ -256,7 +255,6 @@ To call an action on specific events, use the `{{on}}` modifier:
 import Component from "@glimmer/component";
 import { Input } from '@ember/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 
 export default class Example extends Component {
   @tracked isAdmin = false;

--- a/guides/release/components/component-state-and-actions.md
+++ b/guides/release/components/component-state-and-actions.md
@@ -78,7 +78,6 @@ To make those event handlers do something, we will need to define those methods 
 ```gjs {data-filename="app/components/counter.gjs" data-diff="+3,+8,+9,+10,+11,+12,+13,+14,-19,+20,-21,+22"}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 
 export default class CounterComponent extends Component {
   @tracked count = 0;
@@ -121,8 +120,6 @@ helper.
 ```gjs {data-filename="app/components/counter.gjs" data-diff="+4,-9,-10,-11,-12,-13,-14,-15,+17,+18,+19,-24,+25,-26,+27"}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
-import { fn } from '@ember/helper';
 
 export default class CounterComponent extends Component {
   @tracked count = 0;
@@ -189,8 +186,6 @@ Then, we'll update the template to call the `double` action. We'll also add
 ```gjs {data-filename="app/components/counter.gjs" data-diff="+8,+14,+15,+16,+20,+25"}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
-import { fn } from '@ember/helper';
 
 export default class CounterComponent extends Component {
   @tracked count = 0;
@@ -228,8 +223,7 @@ We can also update the template to use the `total` property.
 ```gjs {data-filename="app/components/counter.gjs" data-diff="+10,+11,+12,+25"}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
-import { fn } from '@ember/helper';
+
 
 export default class CounterComponent extends Component {
   @tracked count = 0;
@@ -298,7 +292,6 @@ let's allow it to be passed in.  We'll start by creating a new component called 
 ```gjs {data-filename="app/components/double-it.gjs"}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 import Counter from './counter.gjs';
 
 export default class DoubleItComponent extends Component {
@@ -407,7 +400,6 @@ function) with the new value for `multiple`, and the parent component, `DoubleIt
 ```gjs {data-filename="app/components/double-it.gjs"}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 import Counter from './counter.gjs';
 
 export default class DoubleItComponent extends Component {

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -445,7 +445,6 @@ Using the [`{{array}}`](https://api.emberjs.com/ember/release/classes/@ember%2Fh
 you can pass arrays directly from the template as an argument to your components.
 
 ```gjs
-import { array } from '@ember/helper';
 import MyComponent from 'my-app/components/my-component';
 
 const myOtherPerson = 'George Washington';
@@ -461,7 +460,7 @@ const myOtherPerson = 'George Washington';
 </template>
 ```
 
-In the component's template, you can then use the `people` argument as an array:
+In the component's implementation, you can then use the `people` argument as an array:
 
 ```gjs {data-filename="app/components/my-component.gjs"}
 <template>
@@ -480,7 +479,6 @@ helper, you can pass objects directly from the template as an argument to your
 components.
 
 ```gjs
-import { hash } from '@ember/helper';
 import Greeting from 'my-app/components/greeting';
 
 <template>
@@ -493,7 +491,7 @@ import Greeting from 'my-app/components/greeting';
 </template>
 ```
 
-In the component's template, you can then use the `person` object:
+In the component's implementation, you can then use the `person` object:
 
 ```gjs {data-filename="app/components/greeting.gjs"}
 <template>

--- a/guides/release/components/looping-through-lists.md
+++ b/guides/release/components/looping-through-lists.md
@@ -177,7 +177,6 @@ add an action for creating the new message. We'll add this to the
 ```gjs {data-filename="app/components/new-message-input.gjs"}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 import { Input } from '@ember/component';
 
 export default class NewMessageInputComponent extends Component {

--- a/guides/release/components/template-lifecycle-dom-and-modifiers.md
+++ b/guides/release/components/template-lifecycle-dom-and-modifiers.md
@@ -184,7 +184,6 @@ If you want to add an event handler to an HTML element, you can use the `{{on` e
 
 ```gjs {data-filename="app/components/counter.gjs"}
 import Component from "@glimmer/component";
-import { on } from '@ember/modifier';
 import { tracked } from '@glimmer/tracking';
 
 export default class CounterComponent extends Component {
@@ -361,7 +360,6 @@ First, we add actions to handle the `click` events for the `Play` and `Pause` bu
 
 ```gjs {data-filename="app/components/audio-player.gjs" data-diff="+2,+6,+7,+8,+10,+11,+12,-17,+18,-19,+20"}
 import Component from "@glimmer/component";
-import { on } from '@ember/modifier';
 
 export default class AudioPlayerComponent extends Component {
 
@@ -388,7 +386,6 @@ Recall that our modifier will manage the DOM (i.e. calling the audio element's `
 
 ```gjs {data-filename="app/components/audio-player.gjs" data-diff="+3,+6,-9,+10,-14,+15"}
 import Component from "@glimmer/component";
-import { on } from '@ember/modifier';
 import { tracked } from '@glimmer/tracking';
 
 export default class AudioPlayerComponent extends Component {
@@ -437,7 +434,6 @@ Last but not least, we attach the modifier to the `audio` element:
 
 ```gjs {data-filename="app/components/audio-player.gjs" data-diff="+4,-18,+19"}
 import Component from "@glimmer/component";
-import { on } from '@ember/modifier';
 import { tracked } from '@glimmer/tracking';
 import playWhen from 'my-app/modifiers/play-when';
 
@@ -537,7 +533,6 @@ We could then use the `modal` component this way:
 ```gjs {data-filename="app/components/sidebar.gjs"}
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { on } from '@ember/modifier';
 import Modal from 'my-app/components/modal';
 
 export default class SidebarComponent extends Component {

--- a/guides/release/getting-started/quick-start.md
+++ b/guides/release/getting-started/quick-start.md
@@ -331,7 +331,6 @@ attach some JavaScript to the component.
 Let's use the [`on` modifier](../../components/template-lifecycle-dom-and-modifiers/#toc_event-handlers) to handle click events on the button:
 
 ```gjs {data-filename="app/components/people-list.gjs"}
-import { on } from '@ember/modifier'
 
 function showPerson(clickEvent) {
   alert(`You clicked on a button labeled ${clickEvent.target.innerHTML}`);
@@ -353,9 +352,6 @@ function showPerson(clickEvent) {
 Now let's extend our example to pass the Person to our event handler as an argument. We can use the [`fn` helper](../../components/component-state-and-actions/#toc_passing-arguments-to-actions):
 
 ```gjs {data-filename="app/components/people-list.gjs"}
-import { on } from '@ember/modifier'
-import { fn } from '@ember/helper';
-
 function showPerson(person) {
   alert(`You clicked on ${person}`);
 }
@@ -376,8 +372,6 @@ function showPerson(person) {
 Many components will need to maintain some state. Let's introduce a `currentPerson` that keeps track of which Person the user clicked on last. The idiomatic way to keep state in an Ember component is to use [`@tracked`](../../in-depth-topics/autotracking-in-depth/) on a component class:
 
 ```gjs {data-filename="app/components/people-list.gjs"}
-import { on } from '@ember/modifier'
-import { fn } from '@ember/helper';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 

--- a/guides/release/in-depth-topics/autotracking-in-depth.md
+++ b/guides/release/in-depth-topics/autotracking-in-depth.md
@@ -107,7 +107,6 @@ action, as in this example component.
 ``` gjs { data-filename=app/components/hello.gjs data-diff="+3,+18,+19,+20,+21,+25,+26,+27,+28,+29,+30" }
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 
 export default class HelloComponent extends Component {
   @tracked language = 'en';
@@ -151,7 +150,6 @@ load the user's preferred language:
 ``` gjs { data-filename=app/components/hello.gjs data-diff="+6,+7,+8,+9,+10,+11,+12,+13,+14,+15" }
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 
 export default class HelloComponent extends Component {
   constructor() {
@@ -205,7 +203,6 @@ works through _methods_ or _functions_ as well:
 ``` gjs { data-diff="+17,+18,+19,+20,+21,+24,+25,+26,+27" }
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 
 export default class HelloComponent extends Component {
   constructor() {
@@ -294,8 +291,6 @@ export default class ApplicationRoute extends Route {
 
 ```gjs {data-filename=app/templates/application.gjs}
 import Component from '@glimmer/component';
-import { on } from '@ember/modifier';
-import { fn } from '@ember/helper';
 
 export default class ApplicationRouteComponent extends Component {
   updateName = (title, name) => {

--- a/guides/release/in-depth-topics/patterns-for-actions.md
+++ b/guides/release/in-depth-topics/patterns-for-actions.md
@@ -79,7 +79,6 @@ So, to hook up the button to toggle the `isConfirming` property, we'll define a 
 ```gjs {data-filename=app/components/button-with-confirmation.gjs}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 
 export default class ButtonWithConfirmationComponent extends Component {
   @tracked isConfirming = false;
@@ -114,7 +113,6 @@ of the modal buttons, so we can add a couple more actions to handle that:
 ```gjs {data-filename=app/components/button-with-confirmation.gjs}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 
 export default class ButtonWithConfirmationComponent extends Component {
   @tracked isConfirming = false;
@@ -241,7 +239,6 @@ user wants to take the action they indicated by clicking the button:
 ```gjs {data-filename=app/components/button-with-confirmation.gjs}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 
 export default class ButtonWithConfirmationComponent extends Component {
   @tracked isConfirming = false;
@@ -311,7 +308,6 @@ the confirmation modal. We can use an `async` function to handle that promise:
 ```gjs {data-filename=app/components/button-with-confirmation.gjs}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 
 export default class ButtonWithConfirmationComponent extends Component {
   @tracked isConfirming = false;
@@ -386,7 +382,6 @@ child. For example, if we want to use the button to send a message of type
 
 ```gjs {data-filename=app/components/send-message.gjs}
 import Component from '@glimmer/component';
-import { fn } from '@ember/helper';
 import ButtonWithConfirmation from 'my-app/components/button-with-confirmation';
 
 export default class SendMessageComponent extends Component {
@@ -638,7 +633,6 @@ only the user's account `id` string.
 
 ```gjs {data-filename=app/components/system-preferences-editor.gjs}
 import Component from '@glimmer/component';
-import { fn } from '@ember/helper';
 import UserProfile from 'my-app/components/user-profile';
 
 export default class SystemPreferencesEditorComponent extends Component {
@@ -674,7 +668,6 @@ the parent `system-preferences-editor.gjs` and pass the local `deleteUser` actio
 ```gjs {data-filename=app/components/system-preferences-editor.gjs}
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
-import { fn } from '@ember/helper';
 import UserProfile from 'my-app/components/user-profile';
 
 export default class SystemPreferencesEditorComponent extends Component {

--- a/guides/release/in-depth-topics/patterns-for-components.md
+++ b/guides/release/in-depth-topics/patterns-for-components.md
@@ -216,7 +216,6 @@ The `component` helper is often used when yielding components to blocks. For exa
 
 ```gjs {data-filename=app/components/super-form.gjs}
 import Component from '@glimmer/component';
-import { hash } from '@ember/helper';
 import SuperInput from 'my-app/components/super-input';
 import SuperTextarea from 'my-app/components/super-textarea';
 import SuperSubmit from 'my-app/components/super-submit';
@@ -260,7 +259,6 @@ We can even use helpers and modifiers in the same way. Let's extend the SuperFor
 
 ```gjs {data-filename=app/components/super-form.gjs}
 import Component from '@glimmer/component';
-import { hash } from '@ember/helper';
 import SuperInput from 'my-app/components/super-input';
 import SuperTextarea from 'my-app/components/super-textarea';
 import SuperSubmit from 'my-app/components/super-submit';

--- a/guides/release/in-depth-topics/rendering-values.md
+++ b/guides/release/in-depth-topics/rendering-values.md
@@ -53,8 +53,6 @@ For Helpers, there is a specific syntax that only helpers may reside in
 ```
 or nested in a sub-expression
 ```gjs
-import { hash } from '@ember/helper';
-
 <template>
   {{yield (hash key=(theHelper) key2=(theHelper with args)) }}
 </template>

--- a/guides/release/routing/specifying-a-routes-model.md
+++ b/guides/release/routing/specifying-a-routes-model.md
@@ -251,7 +251,6 @@ If a route you are trying to link to has multiple dynamic segments, like `/photo
 
 ```gjs
 import { LinkTo } from '@ember/routing';
-import { array } from '@ember/helper';
 
 <template>
   <LinkTo @route="photos.photo.comments.comment" @models={{array 4 18}}>

--- a/guides/release/services/index.md
+++ b/guides/release/services/index.md
@@ -127,8 +127,6 @@ Below we add a remove action to the `cart-contents` component.
 ```gjs {data-filename=app/components/cart-contents.gjs}
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
-import { on } from '@ember/modifier';
-import { fn } from '@ember/helper';
 
 export default class CartContentsComponent extends Component {
   @service('shopping-cart') cart;

--- a/guides/release/testing/test-types.md
+++ b/guides/release/testing/test-types.md
@@ -111,17 +111,17 @@ Rendering tests let you test components using Ember's rendering engine. This mea
 
 Consider a button component. For simplicity, assume that the component keeps track of the number of clicks and displays it as label. (In other words, this component doesn't allow arguments or actions to be passed.)
 
-```javascript {data-filename=tests/integration/components/simple-button-test.js}
+```javascript {data-filename=tests/integration/components/simple-button-test.gjs}
 import { click, render } from '@ember/test-helpers';
+import SimpleButton from 'my-app-name/components/simple-button';
 import { setupRenderingTest } from 'my-app-name/tests/helpers';
-import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 
 module('Integration | Component | simple-button', function(hooks) {
   setupRenderingTest(hooks);
 
   test('should keep track of clicks', async function(assert) {
-    await render(hbs`<SimpleButton />`);
+    await render(<template><SimpleButton /></template>);
     assert.dom('[data-test-label]').hasText('0 clicks');
 
     await click('[data-test-button]');
@@ -133,7 +133,7 @@ module('Integration | Component | simple-button', function(hooks) {
 });
 ```
 
-Note, we imported `render` and `click` from [@ember/test-helpers](https://github.com/emberjs/ember-test-helpers/blob/master/API.md) to show and interact with the component. We also imported `hbs` from [ember-cli-htmlbars](https://github.com/ember-cli/ember-cli-htmlbars) to help with inline template definitions. With these methods, we can check if clicking on the component correctly updates its output to the user.
+Note, we imported `render` and `click` from [@ember/test-helpers](https://github.com/emberjs/ember-test-helpers/blob/master/API.md) to show and interact with the component. With these methods, we can check if clicking on the component correctly updates its output to the user.
 
 Here are more examples where rendering tests are ideal:
 

--- a/guides/release/testing/testing-components.md
+++ b/guides/release/testing/testing-components.md
@@ -212,7 +212,6 @@ Imagine you have the following component that changes its title when a button is
 
 ```gjs {data-filename="app/components/magic-title.gjs"}
 import Component from '@glimmer/component';
-import { on } from '@ember/modifier';
 import { tracked } from '@glimmer/tracking';
 
 export default class MagicTitleComponent extends Component {
@@ -272,7 +271,6 @@ passing along the form's data:
 ```gjs {data-filename="app/components/comment-form.gjs"}
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 
 export default class CommentFormComponent extends Component {
   @tracked comment = '';
@@ -542,7 +540,6 @@ Imagine you have a typeahead component that uses [`debounce`](https://api.emberj
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { debounce } from '@ember/runloop';
-import { on } from '@ember/modifier';
 
 export default class DelayedTypeaheadComponent extends Component {
   @tracked searchValue = '';

--- a/guides/release/testing/testing-routes.md
+++ b/guides/release/testing/testing-routes.md
@@ -15,7 +15,7 @@ sub-routes and controllers.
 > By default, Ember CLI does not generate a file for its application route.  To
 > extend the behavior of the ember application route we will run the command
 > `ember generate route application`.  Ember CLI does however generate an application
-> template, so when asked whether we want to overwrite `app/templates/application.hbs`
+> template, so when asked whether we want to overwrite `app/templates/application.gjs`
 > we will answer 'n'.
 
 ```javascript {data-filename=app/routes/application.js}

--- a/guides/release/typescript/core-concepts/invokables.md
+++ b/guides/release/typescript/core-concepts/invokables.md
@@ -85,7 +85,6 @@ There, we defined component which accepted a `srcUrl` argument and used a `play-
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import playWhen from 'my-app/modifiers/play-when';
-import { on } from '@ember/modifier';
 
 export default class AudioPlayer extends Component {
   @tracked isPlaying = false;
@@ -119,7 +118,6 @@ We can define a signature with those `Args` on it and apply it to the component 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import playWhen from 'my-app/modifiers/play-when';
-import { on } from '@ember/modifier';
 
 interface AudioPlayerSignature {
   Args: {
@@ -155,7 +153,6 @@ Now, let's expand on this example to give callers the ability to apply attribute
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import playWhen from 'my-app/modifiers/play-when';
-import { on } from '@ember/modifier';
 
 interface AudioPlayerSignature {
   Args: {
@@ -192,7 +189,6 @@ We can also let the user provide a fallback for the case where the audio element
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import playWhen from 'my-app/modifiers/play-when';
-import { on } from '@ember/modifier';
 
 interface AudioPlayerSignature {
   Args: {
@@ -238,7 +234,6 @@ To represent this, we will update the `default` block to be named `fallback` ins
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import playWhen from 'my-app/modifiers/play-when';
-import { on } from '@ember/modifier';
 
 interface AudioPlayerSignature {
   Args: {
@@ -291,7 +286,6 @@ When working in JavaScript, we can provide the exact same information using JSDo
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import playWhen from 'my-app/modifiers/play-when';
-import { on } from '@ember/modifier';
 
 /**
  * @typedef AudioPlayerSignature


### PR DESCRIPTION
- remove imports that are built-in starting at ember 7.1
- cleanup some vestigial use of "component's template"
- cleanup a remaining use of hbs-backtick instead of template tag