### PR TITLE
Rewriting template tag page

### DIFF
--- a/.local.dic
+++ b/.local.dic
@@ -80,6 +80,7 @@ EmberData
 EmberObject
 enumerables
 erroring
+eq
 Evented
 facto
 fallbacks

--- a/guides/release/components/helper-functions.md
+++ b/guides/release/components/helper-functions.md
@@ -302,7 +302,7 @@ discussing state in the next chapter), or requiring access to a [service](../../
 ## Built-in and Common Helpers
 
 Below you will find some useful template helpers documented.
-For the full list of available helpers, you can check the [template helpers API](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/) and [@ember/helpers](https://api.emberjs.com/ember/release/classes/@ember%2Fhelper) documentation.
+For the full list of available helpers, you can check the [Ember Helper](https://api.emberjs.com/ember/release/modules/@ember%2Fhelper) documentation.
 
 ### The `get` helper
 
@@ -426,6 +426,11 @@ const person = { givenName: 'George', familyName: 'Washington' };
 Now, as long as your template is wrapped in the `let` helper, you can access the
 capitalized given name and family name as `givenName` and `familyName` instead of
 `(capitalize this.person.givenName)`.
+
+Notice that `let` did not need to be imported. It's a core feature of the
+templating language. Everything on the [Keywords
+List](https://api.emberjs.com/ember/release/modules/@ember%2Fhelper) is always
+available without an explicit import.
 
 ### The `array` helper
 

--- a/guides/release/components/template-tag-format.md
+++ b/guides/release/components/template-tag-format.md
@@ -16,45 +16,37 @@ Template Tag became the default component authoring format [starting at Ember 6.
   </div>
 </div>
 
-## Writing template tag components
+## Template Tag Syntax
 
-Just like with separate JavaScript and Glimmer template files, the template tag format has the concept of template-only components and class-based components. Let's take a closer look at how these concepts compare between both component formats in the next section.
+When you use the `.gjs` (or `.gts`) file extension, you're adding one extra syntax feature to JavaScript (or TypeScript): the `<template>` tag.
 
-### Template-only components
+`<template>` can be used in two different positions: as expressions and inside class bodies.
 
-The following template-only component was created in a [previous section](../component-arguments-and-html-attributes/) to extract an avatar layout into a reusable component.
+### Template-tags as Expressions
 
-```handlebars {data-filename="app/components/avatar.hbs"}
-<aside>
-  <div class="avatar" title={{@title}}>{{@initial}}</div>
-</aside>
+When you use a `<template>` tag as an expression, you're defining a template-only component:
+
+```gjs
+const Greeting = <template>Hello World</template>
 ```
 
-This layout can be turned into a template tag component by wrapping the code in a `<template>` tag and changing the file extension to `.gjs`.
+And if you put a `<template>` tag expression by itself in module scope:
 
-```gjs {data-filename="app/components/avatar.gjs"}
-<template>
-  <aside>
-    <div class="avatar" title={{@title}}>{{@initial}}</div>
-  </aside>
-</template>
+
+```gjs
+<template>Hello World</template>
 ```
 
-The top-level template tag is exported as the default component from the file. You *can* write this export explicitly, but it's not necessary. The following example is equivalent to the previous one.
+That is shorthand for also saying `export default`:
 
-```gjs {data-filename="app/components/avatar.gjs"}
-export default <template>
-  <aside>
-    <div class="avatar" title={{@title}}>{{@initial}}</div>
-  </aside>
-</template>;
+```gjs
+export default <template>Hello World</template>
 ```
+### Template-tags in Classes
 
-### Class-based components
+A `<template>` tag can also be embedded inside a class body:
 
-A `<template>` tag can also be embedded inside a class definition of a component. This is useful when you need to add state or other logic to your component. Take for example the following "Avatar" component, where a default title is added when the `title` argument is not provided.
-
-```gjs {data-filename="app/components/avatar.gjs"}
+```gjs
 import Component from '@glimmer/component';
 
 export default class Avatar extends Component {
@@ -70,164 +62,15 @@ export default class Avatar extends Component {
 }
 ```
 
-## Importing components, helpers, and modifiers
+This associates the template with the class. When the resulting `Avatar`
+component is invoked, it's the `<template>` that will be rendered, with `this`
+bound to an instance of the `Avatar` class.
 
-In Ember templates, **“invokables”** are things you can *invoke* in a template. These include [components](./introducing-components/), [helpers](./helper-functions/), and [modifiers](./template-lifecycle-dom-and-modifiers/). In the template tag format, these invokables need to be imported before they can be used. This makes it easier to understand where values come from and what they do, as well as unlocks build optimizations.
+## Accessing JavaScript Scope
 
-
-### Importing invokables from your own app
-
-When making use of the "Avatar" component as defined before in a different component file, it first needs to be imported. This is done using the `import` statement, just like you would import any other JavaScript module.
-
-```gjs {data-filename="app/components/message.gjs"}
-import Avatar from './avatar';
-
-<template>
-  <Avatar
-    @title={{@avatarTitle}}
-    @initial={{@avatarInitial}}
-  />
-  <section>
-    {{@message}}
-  </section>
-</template>
-```
-
-The example above demonstrates defining a "Message" template-only component. The import syntax for class-based components is the same.
-
-<div class="cta">
-  <div class="cta-note">
-    <div class="cta-note-body">
-      <div class="cta-note-heading">Zoey says...</div>
-      <div class="cta-note-message">
-        The components that are imported are not required to use template tag format. This is intentional, and very powerful, as it <strong>allows incremental conversion</strong> from the older HBS format.
-        <br><br>
-        The only prerequisite is that the component is defined using the <a href="https://rfcs.emberjs.com/id/0481-component-templates-co-location">template-colocation structure</a> instead of splitting up the JavaScript and Glimmer template files into separate folders.
-      </div>
-    </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="">
-  </div>
-</div>
-
-#### Nested components
-
-Component files can be organized in nested directory structures on the file system. Prior to the template tag format, the file path from the root component directory had be specified before to the component name, separated with `::`.
-
-For example, when moving the "Avatar" component to the `app/components/messages` namespace, referencing it using double colons would be done as follows.
-
-```handlebars {data-filename="app/components/avatar-usage.hbs"}
-<Messages::Avatar
-  @title="Picture of Zoey"
-  @initial="Zoey"
-/>
-```
-
-This quirk is no longer necessary with the template tag format. Instead, importing now works the same as importing any other JavaScript module.
-
-```gjs {data-filename="app/components/avatar-usage.gjs"}
-import Avatar from './messages/avatar';
-
-<template>
-  <Avatar
-    @title="Picture of Zoey"
-    @initial="Zoey"
-  />
-</template>
-```
-
-#### Helpers and modifiers
-
-Importing helpers and modifiers from your own app also follows the same principle of using standard JavaScript import syntax. Instead of importing from `app/components`, the path to import from is `app/helpers` and `app/modifiers` respectively.
-
-Prior to the template tag format, helpers and modifiers were referenced based on their name in the "kebab-case" convention. For example, a `randomNumber` function as helper would be referenced as `{{random-number}}` in a template. In the new way of doing things, standard module import conventions are used. This means that the helper is referenced using the name it is exported as, which is `randomNumber` in this case.
-
-```gjs {data-filename="app/components/random-number.gjs"}
-import randomNumber from '../helpers/random-number';
-
-<template>
-  {{randomNumber}}
-</template>
-```
-
-### Importing from addons
-
-Just as with components, helpers, and modifiers from your own app, external invokables from addons also have to be imported. This is done using the same `import` statement, but with a path referencing the addon.
-
-The structure of files within Ember addons is mostly standardized. This means that the path to import from can be derived from the addon's name. For example, an addon that is named `ember-foo` will likely have its components, helpers, and modifiers available as default import from the following locations:
+`<template>` tags have access to the surrounding JavaScript scope. For example:
 
 ```gjs
-ember-foo/components/example-component
-ember-foo/helpers/example-helper
-ember-foo/modifiers/example-modifier
-```
-
-To import the "ExampleComponent" component from the `ember-foo` addon, the following import statement can be used.
-
-```js
-import ExampleComponent from 'ember-foo/components/example-component';
-```
-
-Some addons may choose to re-export their invokables from the root index as named exports. Usually addons will document this usage in their README, if supported, which may look like:
-
-```js
-import { ExampleComponent } from 'ember-foo';
-```
-
-### Importing built-ins
-
-The Ember built-in helpers, modifiers, and components are available for import from the following locations.
-
-```js
-// Built-in helpers
-import { array } from '@ember/helper';
-import { concat } from '@ember/helper';
-import { fn } from '@ember/helper';
-import { get } from '@ember/helper';
-import { hash } from '@ember/helper';
-import { uniqueId } from '@ember/helper';
-
-// Built-in modifiers
-import { on } from '@ember/modifier';
-
-// Built-in components
-import { Input } from '@ember/component';
-import { LinkTo } from '@ember/routing';
-import { Textarea } from '@ember/component';
-```
-
-#### Keywords
-
-While most items should be imported into scope explicitly, some of the existing constructs in the language are not importable and are available as keywords instead:
-
-`action`, `debugger`, `each-in`, `each`, `has-block-params`, `has-block`, `hasBlock`, `if`, `in-element`, `let`, `link-to`  (non-block form curly invocations), `loc`, `log`, `mount`, `mut`, `outlet`, `query-params`, `readonly`, `unbound`, `unless`, `with`, and `yield`
-
-These keywords do not have to be imported into scope and will always be available.
-
-<div class="cta">
-  <div class="cta-note">
-    <div class="cta-note-body">
-      <div class="cta-note-heading">Zoey says...</div>
-      <div class="cta-note-message">
-        Feeling a bit lost with remembering all import paths?
-        <br><br>
-        Make sure to look at your editor setup to see if it can help you with auto-completion of import paths. See the <a href="#toc_editor-integrations">Editor Integrations</a> section for more information.
-      </div>
-    </div>
-    <img src="/images/mascots/zoey.png" role="presentation" alt="">
-  </div>
-</div>
-
-## New capabilities
-
-In the examples above, functionality that was already available before was covered using the template tag format. The template tag format, however, unlocks a number of new capabilities that were not possible before.
-
-### Locally-scoped values
-
-The template tag format follows JavaScript module syntax. Any value that isn't exported is only available locally within the file. This is useful for defining helper functions that are only used within the component, or for defining constants that are used multiple times within the template.
-
-In the following example, a "Square" component is defined that calculates the square of a number. The `value` constant is defined locally, and the `square` helper function is only available within the component.
-
-```gjs {data-filename="app/components/square.gjs"}
 const value = 2;
 
 function square(number) {
@@ -243,11 +86,11 @@ This will render to `The square of 2 equals 4`.
 
 ### Multiple components per file
 
-The template tag format allows defining multiple components within a single file. This is useful for defining components that are closely related to each other, but are not used in other parts of the app.
+Because we have `<template>` tag expressions and access to local scope, you can
+define multiple components in a single JavaScript module and let them call each
+other:
 
-The following example defines a "CustomSelect" component that renders a `<select>` element with a list of options. The locally-defined "Option" component is used to render each option in the list.
-
-```gjs {data-filename="app/components/custom-select.gjs"}
+```gjs
 const Option = <template>
   <option selected={{@selected}} value={{@value}}>
     {{@value}}
@@ -269,6 +112,17 @@ export default CustomSelect;
 ```
 
 This can be a powerful refactoring technique to break up large components into smaller ones. (where it makes sense!)
+
+## Importing components, helpers, and modifiers
+
+In Ember templates, **“invokables”** are things you can *invoke* in a template. These include [components](./introducing-components/), [helpers](./helper-functions/), and [modifiers](./template-lifecycle-dom-and-modifiers/). In the template tag format, most invokables need to be in JavaScript scope. Therefore your module must either define them or import them.
+
+### Built-in invokables
+
+A small number of commonly-used invokables are always available, without needing to import them. This includes [on](https://api.emberjs.com/ember/release/functions/Keywords/on) for event handling, boolean logic helpers like [and](https://api.emberjs.com/ember/release/functions/Keywords/and), comparisons like [eq](https://api.emberjs.com/ember/release/functions/Keywords/eq), and others. See the full list on the [Ember Helpers API Docs](https://api.emberjs.com/ember/release/modules/@ember%2Fhelper).
+
+Built-in invokables have lower precedence than your local JavaScript scope, so that future built-ins will never break your existing code.
+
 
 ## Low-level, Pure-JavaScript format
 
@@ -383,19 +237,9 @@ The above example is the *only* way you should implement the `eval` callback. It
 
 ## Testing
 
-Historically, Ember's integration tests have been written using the `hbs` tagged template literal. This is no longer necessary with the template tag format. Instead, use the `<template>` tag to define a template to render.
+`<template>` tag expressions make it easy to write component tests. See [Testing Components](../../testing/testing-components/) for details.
 
-The following example showcases how the "Avatar" component can be tested using the template tag format.
-
-```gjs {data-filename="tests/integration/components/avatar-test.gjs"}
-import Avatar from 'app/components/avatar';
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
-
-module('Integration | Component | avatar', function (hooks) {
-  setupRenderingTest(hooks);
-
+```gjs
   test('renders name argument', async function (assert) {
     const initial = 'Zoey';
     await render(
@@ -408,11 +252,9 @@ module('Integration | Component | avatar', function (hooks) {
 });
 ```
 
-Notice how the same semantics now apply to tests as well: local values in scope can be referenced directly, and invokables from your own app or addons need to be imported.
+## Integration with external tooling
 
-### Integration with external tooling
-
-You may need to upgrade dependency versions or install additional plugins to have proper integration with external tools. The following commonly-used tools are supported:
+These tools have minimum versions to support Template Tag:
 
 - [ember-template-lint](https://github.com/ember-template-lint/ember-template-lint): Versions 5.8.0 and up.
 - [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember): Versions 11.6.0 and up.


### PR DESCRIPTION
The dedicated Template Tag page in guides was written before the guides went all-template-tag in general.

Now it serves a more focused purpose and shouldn't talk so much about historical comparisons.