### PR TITLE
Documented how to enable syntax highlighting and language server protocol in Sublime Text

### DIFF
--- a/.local.dic
+++ b/.local.dic
@@ -31,6 +31,7 @@ chainable
 cheatsheet
 checkboxes
 Checkboxes
+Cmd
 coc-ember
 CodeLobster
 CoffeeScript
@@ -38,6 +39,7 @@ ColorSafe
 componentized
 composable
 cron
+Ctrl
 Ctrl-C
 customizable
 Customizable

--- a/guides/release/code-editors/index.md
+++ b/guides/release/code-editors/index.md
@@ -127,9 +127,3 @@ Various tools for working with Ember.js projects.
 ## Sublime Text
 
 A sophisticated text editor for code, markup and prose.
-
-[ember-cli-sublime-snippets](https://github.com/terminalvelocity/ember-cli-sublime-snippets) -
-Ember CLI snippets for Sublime Text 3.
-
-[ember-component-template-split-view](https://github.com/mmitchellgarcia/ember-component-template-split-view) -
-Super simple Sublime Text plugin that will let you open corresponding template or route files with Ember.js components.

--- a/guides/release/code-editors/index.md
+++ b/guides/release/code-editors/index.md
@@ -127,3 +127,17 @@ Various tools for working with Ember.js projects.
 ## Sublime Text
 
 A sophisticated text editor for code, markup and prose.
+
+### Syntax Highlighting
+
+Use [Package Control](https://packagecontrol.io) to install 3 packages: [`GJS`, `GTS`](https://github.com/ijlee2/sublime-syntax-definition-template-tag), and `Handlebars`.
+
+1. Open Sublime Text.
+1. Open Package Control by pressing <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> (Mac) or <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> (Windows). Alternatively, in the menu bar, click on `Sublime Text` > `Settings` > `Package Control`.
+1. Type `install` in the search bar so that you can quickly find and select `Package Control: Install Package`.
+1. Search for `GJS`, then select to install. Repeat the step for `GTS` and `Handlebars`.
+1. Restart Sublime Text.
+
+### Language Server
+
+Use [Package Control](https://packagecontrol.io) to install 3 packages: `LSP`, [`LSP-ember`](https://github.com/ijlee2/LSP-ember), and `LSP-typescript`. Restart Sublime Text.


### PR DESCRIPTION
## Background

I created [LSP-ember](https://github.com/ijlee2/LSP-ember) to help write code in Sublime Text. The package depends on Glint v2 and the packages for syntax highlighting, [GJS and GTS](https://github.com/ijlee2/sublime-syntax-definition-template-tag).


## What changed?

I documented how to enable syntax highlighting and language server protocol for Sublime Text. The instructions are valid once [package_control_channel#9559](https://github.com/sublimehq/package_control_channel/pull/9559#issuecomment-5615075897) and [repository#173](https://github.com/sublimelsp/repository/pull/173) are approved and merged (i.e. once the packages become available on [Package Control](https://packagecontrol.io)).

I removed [ember-cli-sublime-snippets](https://github.com/terminalvelocity/ember-cli-sublime-snippets), because it shows code patterns from Ember 2.x (removed in 2.16 in the Guides). I also removed [ember-component-template-split-view](https://github.com/mmitchellgarcia/ember-component-template-split-view), because the repo no longer exists.
